### PR TITLE
fix(workspaces): persist reader colors globally

### DIFF
--- a/AndBible/ContentView.swift
+++ b/AndBible/ContentView.swift
@@ -17,7 +17,7 @@ struct ContentView: View {
     @State private var showWorkspaces = false
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
-    @State private var displaySettings: TextDisplaySettings = .appDefaults
+    @State private var globalDisplaySettings: TextDisplaySettings = .appDefaults
     @State private var nightMode = false
     @State private var nightModeMode = AppPreferenceRegistry.stringDefault(for: .nightModePref3) ?? NightModeSetting.system.rawValue
 
@@ -38,6 +38,7 @@ struct ContentView: View {
         }
         .preferredColorScheme(preferredColorSchemeOverride)
         .onAppear {
+            reloadGlobalDisplaySettings()
             reloadNightModePreferences()
         }
         .onChange(of: colorScheme) { _, _ in
@@ -63,6 +64,17 @@ struct ContentView: View {
             manualNightMode: manualNightMode,
             systemIsDark: colorScheme == .dark
         )
+    }
+
+    private func reloadGlobalDisplaySettings() {
+        let store = SettingsStore(modelContext: modelContext)
+        globalDisplaySettings = store.globalTextDisplaySettings()
+    }
+
+    private func applyGlobalDisplaySettingsChange() {
+        let store = SettingsStore(modelContext: modelContext)
+        store.setGlobalTextDisplaySettings(globalDisplaySettings)
+        reloadNightModePreferences()
     }
 
     // MARK: - iOS Layout (adapts for iPhone vs iPad)
@@ -153,9 +165,10 @@ struct ContentView: View {
                 .accessibilityIdentifier("contentDownloadsLink")
                 NavigationLink {
                     SettingsView(
-                        displaySettings: $displaySettings,
+                        displaySettings: $globalDisplaySettings,
                         nightMode: $nightMode,
-                        nightModeMode: $nightModeMode
+                        nightModeMode: $nightModeMode,
+                        onSettingsChanged: applyGlobalDisplaySettingsChange
                     )
                 } label: {
                     Label("Settings", systemImage: "gear")

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -162,6 +162,37 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
     }
 
+    func testTextDisplaySettingsChangedFieldsOnlyClearMatchingDirtyOverrides() {
+        var previousGlobal = TextDisplaySettings()
+        previousGlobal.fontSize = 18
+        previousGlobal.lineSpacing = 10
+        previousGlobal.showVerseNumbers = true
+
+        var currentGlobal = previousGlobal
+        currentGlobal.fontSize = 20
+        currentGlobal.showVerseNumbers = false
+
+        let changedFields = TextDisplaySettings.changedFields(
+            from: previousGlobal,
+            to: currentGlobal
+        )
+
+        var childOverrides = TextDisplaySettings()
+        childOverrides.fontSize = 20
+        childOverrides.lineSpacing = 10
+        childOverrides.showVerseNumbers = false
+
+        XCTAssertTrue(
+            childOverrides.clearOverridesMatchingParent(
+                currentGlobal,
+                only: changedFields
+            )
+        )
+        XCTAssertNil(childOverrides.fontSize)
+        XCTAssertNil(childOverrides.showVerseNumbers)
+        XCTAssertEqual(childOverrides.lineSpacing, 10)
+    }
+
     func testReaderWindowControlsAvoidanceInsetsStayOffForFullscreenIPad() {
         let insets = ReaderWindowControlsAvoidanceMetrics.documentHeaderInsets(
             isPad: true,
@@ -976,6 +1007,44 @@ final class AndBibleTests: XCTestCase {
         XCTAssertTrue(createdWindow.historyItems?.isEmpty ?? true)
         XCTAssertEqual(createdWindow.pageManager?.currentCategoryName, "bible")
         XCTAssertNil(createdWindow.pageManager?.textDisplaySettings)
+    }
+
+    func testSettingsStoreGlobalTextDisplayPropagationClearsMatchingWorkspaceAndWindowOverrides() throws {
+        let container = try makeWorkspaceModelContainer()
+        let context = ModelContext(container)
+        let workspaceStore = WorkspaceStore(modelContext: context)
+        let settingsStore = SettingsStore(modelContext: context)
+
+        var previousGlobal = TextDisplaySettings.appDefaults
+        previousGlobal.fontSize = 18
+        previousGlobal.showVerseNumbers = true
+        previousGlobal.lineSpacing = 10
+        settingsStore.setGlobalTextDisplaySettings(previousGlobal)
+
+        let workspace = workspaceStore.createWorkspace(name: "Propagation")
+        var workspaceSettings = TextDisplaySettings()
+        workspaceSettings.fontSize = 20
+        workspaceSettings.showVerseNumbers = false
+        workspace.textDisplaySettings = workspaceSettings
+
+        let window = try XCTUnwrap((workspace.windows ?? []).first)
+        var windowSettings = TextDisplaySettings()
+        windowSettings.fontSize = 20
+        windowSettings.showVerseNumbers = false
+        windowSettings.lineSpacing = 10
+        window.pageManager?.textDisplaySettings = windowSettings
+        try context.save()
+
+        var currentGlobal = previousGlobal
+        currentGlobal.fontSize = 20
+        currentGlobal.showVerseNumbers = false
+        settingsStore.setGlobalTextDisplaySettings(currentGlobal)
+
+        XCTAssertNil(workspace.textDisplaySettings?.fontSize)
+        XCTAssertNil(workspace.textDisplaySettings?.showVerseNumbers)
+        XCTAssertNil(window.pageManager?.textDisplaySettings?.fontSize)
+        XCTAssertNil(window.pageManager?.textDisplaySettings?.showVerseNumbers)
+        XCTAssertEqual(window.pageManager?.textDisplaySettings?.lineSpacing, 10)
     }
 
     func testWebDAVPropfindBuildsAuthenticatedRequestAndParsesMultiStatus() async throws {
@@ -9236,6 +9305,7 @@ private func readSQLiteUserVersion(at url: URL) throws -> Int {
 
 private func makeWorkspaceModelContainer() throws -> ModelContainer {
     let schema = Schema([
+        Setting.self,
         Workspace.self,
         Window.self,
         PageManager.self,

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -144,12 +144,16 @@ final class AndBibleTests: XCTestCase {
     }
 
     func testTextDisplaySettingsFullyResolvedUsesGlobalBeforeDefaults() {
+        let dayBackground = Int(Int32(bitPattern: 0xFFFAF4E8))
+        let nightTextColor = Int(Int32(bitPattern: 0xFFF1E7D0))
+        let workspaceNightTextColor = Int(Int32(bitPattern: 0xFFCCCCCC))
+
         var globalSettings = TextDisplaySettings()
-        globalSettings.dayBackground = 0xFFFAF4E8
-        globalSettings.nightTextColor = 0xFFF1E7D0
+        globalSettings.dayBackground = dayBackground
+        globalSettings.nightTextColor = nightTextColor
 
         var workspaceSettings = TextDisplaySettings()
-        workspaceSettings.nightTextColor = 0xFFCCCCCC
+        workspaceSettings.nightTextColor = workspaceNightTextColor
 
         let resolved = TextDisplaySettings.fullyResolved(
             window: nil,
@@ -157,8 +161,8 @@ final class AndBibleTests: XCTestCase {
             global: globalSettings
         )
 
-        XCTAssertEqual(resolved.dayBackground, 0xFFFAF4E8)
-        XCTAssertEqual(resolved.nightTextColor, 0xFFCCCCCC)
+        XCTAssertEqual(resolved.dayBackground, dayBackground)
+        XCTAssertEqual(resolved.nightTextColor, workspaceNightTextColor)
         XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
     }
 

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -86,6 +86,82 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(TextDisplaySettings.appDefaults.strongsMode, 0)
     }
 
+    func testTextDisplaySettingsInheritanceUsesGlobalBeforeDefaults() {
+        var windowSettings = TextDisplaySettings()
+        windowSettings.fontSize = 18
+
+        var workspaceSettings = TextDisplaySettings()
+        workspaceSettings.fontSize = 16
+        workspaceSettings.fontFamily = "serif"
+
+        var globalSettings = TextDisplaySettings()
+        globalSettings.lineSpacing = 125
+
+        var defaults = TextDisplaySettings()
+        defaults.fontSize = 14
+        defaults.fontFamily = "sans-serif"
+        defaults.lineSpacing = 150
+
+        XCTAssertEqual(
+            TextDisplaySettings.resolved(
+                \.fontSize,
+                window: windowSettings,
+                workspace: workspaceSettings,
+                global: globalSettings,
+                defaults: defaults
+            ),
+            18
+        )
+        XCTAssertEqual(
+            TextDisplaySettings.resolved(
+                \.fontFamily,
+                window: windowSettings,
+                workspace: workspaceSettings,
+                global: globalSettings,
+                defaults: defaults
+            ),
+            "serif"
+        )
+        XCTAssertEqual(
+            TextDisplaySettings.resolved(
+                \.lineSpacing,
+                window: windowSettings,
+                workspace: workspaceSettings,
+                global: globalSettings,
+                defaults: defaults
+            ),
+            125
+        )
+        XCTAssertNil(
+            TextDisplaySettings.resolved(
+                \.topMargin,
+                window: windowSettings,
+                workspace: workspaceSettings,
+                global: globalSettings,
+                defaults: defaults
+            )
+        )
+    }
+
+    func testTextDisplaySettingsFullyResolvedUsesGlobalBeforeDefaults() {
+        var globalSettings = TextDisplaySettings()
+        globalSettings.dayBackground = 0xFFFAF4E8
+        globalSettings.nightTextColor = 0xFFF1E7D0
+
+        var workspaceSettings = TextDisplaySettings()
+        workspaceSettings.nightTextColor = 0xFFCCCCCC
+
+        let resolved = TextDisplaySettings.fullyResolved(
+            window: nil,
+            workspace: workspaceSettings,
+            global: globalSettings
+        )
+
+        XCTAssertEqual(resolved.dayBackground, 0xFFFAF4E8)
+        XCTAssertEqual(resolved.nightTextColor, 0xFFCCCCCC)
+        XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
+    }
+
     func testReaderWindowControlsAvoidanceInsetsStayOffForFullscreenIPad() {
         let insets = ReaderWindowControlsAvoidanceMetrics.documentHeaderInsets(
             isPad: true,
@@ -837,6 +913,12 @@ final class AndBibleTests: XCTestCase {
         workspaceDisplaySettings.fontFamily = "serif"
         workspaceDisplaySettings.lineSpacing = 18
         workspaceDisplaySettings.strongsMode = 2
+        workspaceDisplaySettings.dayTextColor = Int(Int32(bitPattern: 0xFF112233))
+        workspaceDisplaySettings.dayBackground = Int(Int32(bitPattern: 0xFFFAF4E8))
+        workspaceDisplaySettings.dayNoise = 7
+        workspaceDisplaySettings.nightTextColor = Int(Int32(bitPattern: 0xFFF1E7D0))
+        workspaceDisplaySettings.nightBackground = Int(Int32(bitPattern: 0xFF101820))
+        workspaceDisplaySettings.nightNoise = 5
         source.textDisplaySettings = workspaceDisplaySettings
 
         let recentLabelID = UUID()
@@ -866,7 +948,13 @@ final class AndBibleTests: XCTestCase {
 
         let created = store.createWorkspace(name: "Inherited", inheritingDefaultsFrom: source)
 
-        XCTAssertEqual(created.textDisplaySettings, source.textDisplaySettings)
+        XCTAssertEqual(created.textDisplaySettings, source.textDisplaySettings?.clearingThemeColors())
+        XCTAssertNil(created.textDisplaySettings?.dayTextColor)
+        XCTAssertNil(created.textDisplaySettings?.dayBackground)
+        XCTAssertNil(created.textDisplaySettings?.dayNoise)
+        XCTAssertNil(created.textDisplaySettings?.nightTextColor)
+        XCTAssertNil(created.textDisplaySettings?.nightBackground)
+        XCTAssertNil(created.textDisplaySettings?.nightNoise)
         XCTAssertEqual(created.workspaceColor, source.workspaceColor)
         XCTAssertEqual(created.workspaceSettings?.enableTiltToScroll, true)
         XCTAssertEqual(created.workspaceSettings?.enableReverseSplitMode, true)

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -5287,6 +5287,20 @@ final class AndBibleUITests: XCTestCase {
         readerRenderedContentStateValue(in: app)?.contains(token) == true
     }
 
+    /// Reads a boolean key from the compact reader state export.
+    private func readerRenderedContentStateFlag(_ key: String, in app: XCUIApplication) -> Bool? {
+        guard let stateValue = readerRenderedContentStateValue(in: app) else {
+            return nil
+        }
+        if stateValue.contains("\(key)=true") {
+            return true
+        }
+        if stateValue.contains("\(key)=false") {
+            return false
+        }
+        return nil
+    }
+
     /**
      Waits for the reader shell's stable navigation chrome to become interactive again.
      *
@@ -5910,18 +5924,22 @@ final class AndBibleUITests: XCTestCase {
             app.buttons["readerOverflowSectionTitlesToggle"].firstMatch,
         ]
         repeat {
-            if readerRenderedContentStateContains("overflowVisible=true", in: app) {
-                return true
-            }
-            if menuCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
+            if let overflowVisible = readerRenderedContentStateFlag("overflowVisible", in: app) {
+                if overflowVisible {
+                    return true
+                }
+            } else if menuCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
                 actionCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) {
                 return true
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        return readerRenderedContentStateContains("overflowVisible=true", in: app) ||
-            menuCandidates.contains(where: { $0.exists }) ||
+        if let overflowVisible = readerRenderedContentStateFlag("overflowVisible", in: app) {
+            return overflowVisible
+        }
+
+        return menuCandidates.contains(where: { $0.exists }) ||
             actionCandidates.contains(where: { $0.exists })
     }
 
@@ -6028,18 +6046,22 @@ final class AndBibleUITests: XCTestCase {
             app.buttons["readerOpenSearchAction"].firstMatch,
         ]
         repeat {
-            if readerRenderedContentStateContains("drawerVisible=true", in: app) {
-                return true
-            }
-            if drawerCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
+            if let drawerVisible = readerRenderedContentStateFlag("drawerVisible", in: app) {
+                if drawerVisible {
+                    return true
+                }
+            } else if drawerCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
                 actionCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) {
                 return true
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        return readerRenderedContentStateContains("drawerVisible=true", in: app) ||
-            drawerCandidates.contains(where: { $0.exists }) ||
+        if let drawerVisible = readerRenderedContentStateFlag("drawerVisible", in: app) {
+            return drawerVisible
+        }
+
+        return drawerCandidates.contains(where: { $0.exists }) ||
             actionCandidates.contains(where: { $0.exists })
     }
 
@@ -6100,21 +6122,14 @@ final class AndBibleUITests: XCTestCase {
                 }
             }
 
-            let settleDeadline = Date().addingTimeInterval(min(2, max(0.5, deadline.timeIntervalSinceNow)))
-            repeat {
-                if usesNavigationDrawer {
-                    if !isReaderNavigationDrawerLikelyVisible(in: app) {
-                        return
-                    }
-                } else if !isReaderOverflowMenuLikelyVisible(in: app) {
-                    return
-                }
-                let refreshedButton = unresolvedElement(identifier, in: app)
-                if !refreshedButton.exists {
-                    return
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-            } while Date() < settleDeadline
+            if waitForReaderActionActivationToSettle(
+                identifier,
+                usesNavigationDrawer: usesNavigationDrawer,
+                in: app,
+                timeout: min(2, max(0.5, deadline.timeIntervalSinceNow))
+            ) {
+                return
+            }
         } while Date() < deadline
 
         let button = requireReaderActionControl(
@@ -6131,8 +6146,29 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         ) {
-            XCTAssertTrue(
-                button.isHittable || isElementVisible(button, within: actionSurface),
+            if waitForElementToBecomeHittable(button, timeout: min(1, timeout)) {
+                button.tap()
+                _ = waitForReaderActionActivationToSettle(
+                    identifier,
+                    usesNavigationDrawer: usesNavigationDrawer,
+                    in: app,
+                    timeout: min(2, timeout)
+                )
+                return
+            }
+
+            if isElementVisible(button, within: actionSurface) {
+                button.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+                _ = waitForReaderActionActivationToSettle(
+                    identifier,
+                    usesNavigationDrawer: usesNavigationDrawer,
+                    in: app,
+                    timeout: min(2, timeout)
+                )
+                return
+            }
+
+            XCTFail(
                 "Expected element '\(identifier)' to become tappable within \(timeout) seconds.",
                 file: file,
                 line: line
@@ -6145,6 +6181,36 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         )
+    }
+
+    /**
+     Waits briefly for a tapped reader menu action to either dismiss its source surface or disappear.
+     */
+    private func waitForReaderActionActivationToSettle(
+        _ identifier: String,
+        usesNavigationDrawer: Bool,
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if usesNavigationDrawer {
+                if !isReaderNavigationDrawerLikelyVisible(in: app) {
+                    return true
+                }
+            } else if !isReaderOverflowMenuLikelyVisible(in: app) {
+                return true
+            }
+
+            let refreshedButton = unresolvedElement(identifier, in: app)
+            if !refreshedButton.exists {
+                return true
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        return false
     }
 
     /**
@@ -6370,12 +6436,13 @@ final class AndBibleUITests: XCTestCase {
 
         repeat {
             if prefersDrawer {
-                if let drawer = resolvedElement("readerNavigationDrawer", in: app),
-                   !drawer.frame.isEmpty {
-                    return drawer
-                }
-                if readerRenderedContentStateContains("drawerVisible=true", in: app) {
+                let drawerVisible = readerRenderedContentStateFlag("drawerVisible", in: app)
+                if drawerVisible == true {
                     return unresolvedElement("readerNavigationDrawer", in: app)
+                } else if drawerVisible == nil,
+                          let drawer = resolvedElement("readerNavigationDrawer", in: app),
+                          !drawer.frame.isEmpty {
+                    return drawer
                 }
                 if isReaderOverflowMenuLikelyVisible(in: app) {
                     dismissReaderOverflowMenu(
@@ -6393,12 +6460,13 @@ final class AndBibleUITests: XCTestCase {
                     )
                 }
             } else {
-                if let overflowMenu = resolvedElement("readerOverflowMenu", in: app),
-                   !overflowMenu.frame.isEmpty {
-                    return overflowMenu
-                }
-                if readerRenderedContentStateContains("overflowVisible=true", in: app) {
+                let overflowVisible = readerRenderedContentStateFlag("overflowVisible", in: app)
+                if overflowVisible == true {
                     return unresolvedElement("readerOverflowMenu", in: app)
+                } else if overflowVisible == nil,
+                          let overflowMenu = resolvedElement("readerOverflowMenu", in: app),
+                          !overflowMenu.frame.isEmpty {
+                    return overflowMenu
                 }
                 if isReaderNavigationDrawerLikelyVisible(in: app) {
                     let dismissArea = unresolvedElement("readerNavigationDrawerDismissArea", in: app)
@@ -6419,24 +6487,24 @@ final class AndBibleUITests: XCTestCase {
         } while Date() < deadline
 
         if prefersDrawer {
+            if let drawerVisible = readerRenderedContentStateFlag("drawerVisible", in: app) {
+                return drawerVisible ? unresolvedElement("readerNavigationDrawer", in: app) : nil
+            }
             return resolvedElement("readerNavigationDrawer", in: app)
-                ?? (readerRenderedContentStateContains("drawerVisible=true", in: app)
-                    ? unresolvedElement("readerNavigationDrawer", in: app)
-                    : nil)
         }
 
+        if let overflowVisible = readerRenderedContentStateFlag("overflowVisible", in: app) {
+            return overflowVisible ? unresolvedElement("readerOverflowMenu", in: app) : nil
+        }
         return resolvedElement("readerOverflowMenu", in: app)
-            ?? (readerRenderedContentStateContains("overflowVisible=true", in: app)
-                ? unresolvedElement("readerOverflowMenu", in: app)
-                : nil)
     }
 
     /**
      Returns `true` when drawer-only controls indicate that the left navigation drawer is exposed.
      */
     private func isReaderNavigationDrawerLikelyVisible(in app: XCUIApplication) -> Bool {
-        if readerRenderedContentStateContains("drawerVisible=true", in: app) {
-            return true
+        if let drawerVisible = readerRenderedContentStateFlag("drawerVisible", in: app) {
+            return drawerVisible
         }
 
         if let drawer = resolvedElement("readerNavigationDrawer", in: app),
@@ -6458,8 +6526,8 @@ final class AndBibleUITests: XCTestCase {
      Returns `true` when overflow-only controls indicate that the reader overflow menu is exposed.
      */
     private func isReaderOverflowMenuLikelyVisible(in app: XCUIApplication) -> Bool {
-        if readerRenderedContentStateContains("overflowVisible=true", in: app) {
-            return true
+        if let overflowVisible = readerRenderedContentStateFlag("overflowVisible", in: app) {
+            return overflowVisible
         }
 
         if let overflowMenu = resolvedElement("readerOverflowMenu", in: app),
@@ -6619,10 +6687,6 @@ final class AndBibleUITests: XCTestCase {
                 in: app,
                 timeout: min(10, max(3, deadline.timeIntervalSinceNow))
             ) {
-                if let directAction = directActionCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
-                    return directAction
-                }
-
                 for _ in 0..<4 {
                     let action = resolveReaderActionElement(identifier, in: app, actionSurface: actionSurface)
                     if action.exists, waitForElementToBecomeHittable(action, timeout: 0.5) {
@@ -6631,6 +6695,9 @@ final class AndBibleUITests: XCTestCase {
                     if isElementVisible(action, within: actionSurface) {
                         return action
                     }
+                    if let directAction = directActionCandidates.first(where: { $0.exists && $0.isHittable }) {
+                        return directAction
+                    }
                     if actionSurface.exists, !actionSurface.frame.isEmpty {
                         actionSurface.swipeUp()
                         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
@@ -6638,10 +6705,7 @@ final class AndBibleUITests: XCTestCase {
                 }
             }
 
-            if let directAction = directActionCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
-                return directAction
-            }
-            if let directAction = directActionCandidates.first(where: { $0.exists }) {
+            if let directAction = directActionCandidates.first(where: { $0.exists && $0.isHittable }) {
                 return directAction
             }
 
@@ -6658,10 +6722,7 @@ final class AndBibleUITests: XCTestCase {
             }
         }
 
-        if let directAction = directActionCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
-            return directAction
-        }
-        if let directAction = directActionCandidates.first(where: { $0.exists }) {
+        if let directAction = directActionCandidates.first(where: { $0.exists && $0.isHittable }) {
             return directAction
         }
         return nil
@@ -8421,14 +8482,6 @@ final class AndBibleUITests: XCTestCase {
         }
 
         focusTextEntryElement(element, preferTrailingEdge: true, timeout: 10)
-
-        let clearButton = element.buttons["Clear text"].firstMatch
-        if waitForElementToBecomeHittable(clearButton, timeout: 0.5) {
-            clearButton.tap()
-            if currentTextEntryValue(in: element, placeholderHints: placeholderHints).isEmpty {
-                return true
-            }
-        }
 
         var remainingText = existingText
         for _ in 0..<2 where !remainingText.isEmpty {

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -245,7 +245,6 @@ final class AndBibleUITests: XCTestCase {
         app.launch()
 
         _ = openSearch(in: app)
-        XCTAssertTrue(requireSearchInput(in: app, timeout: 5).exists)
         waitForSearchState(containing: "query=H00430", in: app, timeout: 20)
         waitForSearchResultCount(atLeast: 1, in: app, timeout: 20)
     }
@@ -4362,6 +4361,10 @@ final class AndBibleUITests: XCTestCase {
         within screenIdentifier: String,
         in app: XCUIApplication
     ) -> [XCUIElement] {
+        let directCandidates = [
+            app.otherElements[identifier].firstMatch,
+            app.staticTexts[identifier].firstMatch,
+        ]
         let scopedCandidates = screenRootCandidates(screenIdentifier, in: app).flatMap { root in
             [
                 root.otherElements[identifier].firstMatch,
@@ -4369,10 +4372,7 @@ final class AndBibleUITests: XCTestCase {
             ]
         }
 
-        return scopedCandidates + [
-            app.otherElements[identifier].firstMatch,
-            app.staticTexts[identifier].firstMatch,
-        ]
+        return directCandidates + scopedCandidates
     }
 
     /// Returns the first modal presentation surface currently visible to XCTest.
@@ -4784,11 +4784,11 @@ final class AndBibleUITests: XCTestCase {
             ]
         case "searchQueryField":
             return [
-                app.searchFields[identifier].firstMatch,
                 app.textFields[identifier].firstMatch,
-                app.navigationBars.searchFields[identifier].firstMatch,
-                app.navigationBars.textFields[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
+                app.navigationBars.textFields[identifier].firstMatch,
+                app.searchFields[identifier].firstMatch,
+                app.navigationBars.searchFields[identifier].firstMatch,
             ]
         case "workspaceNamePromptTextField":
             return workspaceNamePromptTextFieldCandidates(in: app)
@@ -5258,8 +5258,7 @@ final class AndBibleUITests: XCTestCase {
     ) {
         let deadline = Date().addingTimeInterval(timeout)
         repeat {
-            if let stateElement = resolvedElement("readerRenderedContentState", in: app),
-               let value = stateElement.value as? String,
+            if let value = readerRenderedContentStateValue(in: app),
                value.contains(token) {
                 return
             }
@@ -5273,6 +5272,19 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         )
+    }
+
+    /// Reads the compact reader state export without walking drawer or overflow menu contents.
+    private func readerRenderedContentStateValue(in app: XCUIApplication) -> String? {
+        guard let stateElement = resolvedElement("readerRenderedContentState", in: app) else {
+            return nil
+        }
+        return stateElement.value as? String
+    }
+
+    /// Returns whether the compact reader state export currently contains one token.
+    private func readerRenderedContentStateContains(_ token: String, in app: XCUIApplication) -> Bool {
+        readerRenderedContentStateValue(in: app)?.contains(token) == true
     }
 
     /**
@@ -5297,15 +5309,19 @@ final class AndBibleUITests: XCTestCase {
         repeat {
             let drawerButton = app.buttons["readerNavigationDrawerButton"].firstMatch
             let moreButton = app.buttons["readerMoreMenuButton"].firstMatch
-            let renderedContentReady = resolvedElement("readerRenderedContentState", in: app) != nil
-            let drawerActionVisible = app.buttons["readerOpenBookmarksAction"].firstMatch.exists
-            let overflowActionVisible = app.buttons["readerOpenWorkspacesAction"].firstMatch.exists
+            let readerState = readerRenderedContentStateValue(in: app)
+            let readerSurfacesClosed = readerState.map { state in
+                let drawerClosed = state.contains("drawerVisible=false") || !state.contains("drawerVisible=")
+                let overflowClosed = state.contains("overflowVisible=false") || !state.contains("overflowVisible=")
+                let sheetClosed = state.contains("readerSheet=none") || !state.contains("readerSheet=")
+                let searchClosed = state.contains("searchVisible=false") || !state.contains("searchVisible=")
+                return drawerClosed && overflowClosed && sheetClosed && searchClosed
+            } ?? false
 
-            if renderedContentReady,
+            if readerState != nil,
                drawerButton.exists,
                moreButton.exists,
-               !drawerActionVisible,
-               !overflowActionVisible {
+               readerSurfacesClosed {
                 return true
             }
 
@@ -5894,6 +5910,9 @@ final class AndBibleUITests: XCTestCase {
             app.buttons["readerOverflowSectionTitlesToggle"].firstMatch,
         ]
         repeat {
+            if readerRenderedContentStateContains("overflowVisible=true", in: app) {
+                return true
+            }
             if menuCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
                 actionCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) {
                 return true
@@ -5901,7 +5920,8 @@ final class AndBibleUITests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        return menuCandidates.contains(where: { $0.exists }) ||
+        return readerRenderedContentStateContains("overflowVisible=true", in: app) ||
+            menuCandidates.contains(where: { $0.exists }) ||
             actionCandidates.contains(where: { $0.exists })
     }
 
@@ -6008,6 +6028,9 @@ final class AndBibleUITests: XCTestCase {
             app.buttons["readerOpenSearchAction"].firstMatch,
         ]
         repeat {
+            if readerRenderedContentStateContains("drawerVisible=true", in: app) {
+                return true
+            }
             if drawerCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) ||
                 actionCandidates.contains(where: { $0.exists && !$0.frame.isEmpty }) {
                 return true
@@ -6015,7 +6038,8 @@ final class AndBibleUITests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        return drawerCandidates.contains(where: { $0.exists }) ||
+        return readerRenderedContentStateContains("drawerVisible=true", in: app) ||
+            drawerCandidates.contains(where: { $0.exists }) ||
             actionCandidates.contains(where: { $0.exists })
     }
 
@@ -6079,10 +6103,10 @@ final class AndBibleUITests: XCTestCase {
             let settleDeadline = Date().addingTimeInterval(min(2, max(0.5, deadline.timeIntervalSinceNow)))
             repeat {
                 if usesNavigationDrawer {
-                    if resolvedElement("readerNavigationDrawer", in: app) == nil {
+                    if !isReaderNavigationDrawerLikelyVisible(in: app) {
                         return
                     }
-                } else if resolvedElement("readerOverflowMenu", in: app) == nil {
+                } else if !isReaderOverflowMenuLikelyVisible(in: app) {
                     return
                 }
                 let refreshedButton = unresolvedElement(identifier, in: app)
@@ -6266,6 +6290,19 @@ final class AndBibleUITests: XCTestCase {
         }
     }
 
+    /// Returns direct app-level candidates for reader drawer and overflow actions.
+    private func readerDirectActionCandidates(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let title = readerActionTitle(for: identifier)
+        return [
+            app.buttons[identifier].firstMatch,
+            app.buttons[title].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+    }
+
     /**
      Declares which production reader action surface should host one action identifier.
      *
@@ -6337,6 +6374,9 @@ final class AndBibleUITests: XCTestCase {
                    !drawer.frame.isEmpty {
                     return drawer
                 }
+                if readerRenderedContentStateContains("drawerVisible=true", in: app) {
+                    return unresolvedElement("readerNavigationDrawer", in: app)
+                }
                 if isReaderOverflowMenuLikelyVisible(in: app) {
                     dismissReaderOverflowMenu(
                         in: app,
@@ -6356,6 +6396,9 @@ final class AndBibleUITests: XCTestCase {
                 if let overflowMenu = resolvedElement("readerOverflowMenu", in: app),
                    !overflowMenu.frame.isEmpty {
                     return overflowMenu
+                }
+                if readerRenderedContentStateContains("overflowVisible=true", in: app) {
+                    return unresolvedElement("readerOverflowMenu", in: app)
                 }
                 if isReaderNavigationDrawerLikelyVisible(in: app) {
                     let dismissArea = unresolvedElement("readerNavigationDrawerDismissArea", in: app)
@@ -6377,15 +6420,25 @@ final class AndBibleUITests: XCTestCase {
 
         if prefersDrawer {
             return resolvedElement("readerNavigationDrawer", in: app)
+                ?? (readerRenderedContentStateContains("drawerVisible=true", in: app)
+                    ? unresolvedElement("readerNavigationDrawer", in: app)
+                    : nil)
         }
 
         return resolvedElement("readerOverflowMenu", in: app)
+            ?? (readerRenderedContentStateContains("overflowVisible=true", in: app)
+                ? unresolvedElement("readerOverflowMenu", in: app)
+                : nil)
     }
 
     /**
      Returns `true` when drawer-only controls indicate that the left navigation drawer is exposed.
      */
     private func isReaderNavigationDrawerLikelyVisible(in app: XCUIApplication) -> Bool {
+        if readerRenderedContentStateContains("drawerVisible=true", in: app) {
+            return true
+        }
+
         if let drawer = resolvedElement("readerNavigationDrawer", in: app),
            !drawer.frame.isEmpty
         {
@@ -6405,6 +6458,10 @@ final class AndBibleUITests: XCTestCase {
      Returns `true` when overflow-only controls indicate that the reader overflow menu is exposed.
      */
     private func isReaderOverflowMenuLikelyVisible(in app: XCUIApplication) -> Bool {
+        if readerRenderedContentStateContains("overflowVisible=true", in: app) {
+            return true
+        }
+
         if let overflowMenu = resolvedElement("readerOverflowMenu", in: app),
            !overflowMenu.frame.isEmpty
         {
@@ -6511,12 +6568,8 @@ final class AndBibleUITests: XCTestCase {
             return control
         }
 
-        let title = readerActionTitle(for: identifier)
         let prefersDrawer = readerActionUsesNavigationDrawer(identifier)
-        let directActionCandidates = [
-            app.buttons[identifier].firstMatch,
-            app.buttons[title].firstMatch,
-        ]
+        let directActionCandidates = readerDirectActionCandidates(identifier, in: app)
 
         if let finalSurface = prefersDrawer
             ? resolvedElement("readerNavigationDrawer", in: app)
@@ -6558,18 +6611,18 @@ final class AndBibleUITests: XCTestCase {
         timeout: TimeInterval = 10
     ) -> XCUIElement? {
         let deadline = Date().addingTimeInterval(timeout)
-        let title = readerActionTitle(for: identifier)
         let prefersDrawer = readerActionUsesNavigationDrawer(identifier)
-        let directActionCandidates = [
-            app.buttons[identifier].firstMatch,
-            app.buttons[title].firstMatch,
-        ]
+        let directActionCandidates = readerDirectActionCandidates(identifier, in: app)
         repeat {
             if let actionSurface = ensureReaderActionSurface(
                 for: identifier,
                 in: app,
                 timeout: min(10, max(3, deadline.timeIntervalSinceNow))
             ) {
+                if let directAction = directActionCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
+                    return directAction
+                }
+
                 for _ in 0..<4 {
                     let action = resolveReaderActionElement(identifier, in: app, actionSurface: actionSurface)
                     if action.exists, waitForElementToBecomeHittable(action, timeout: 0.5) {
@@ -7061,12 +7114,19 @@ final class AndBibleUITests: XCTestCase {
         from candidates: [XCUIElement],
         waitTimeout: TimeInterval = 0
     ) -> XCUIElement? {
-        for candidate in candidates {
-            let exists = candidate.exists || (waitTimeout > 0 && candidate.waitForExistence(timeout: waitTimeout))
-            if exists && (candidate.isHittable || !candidate.frame.isEmpty) {
-                return candidate
+        let deadline = Date().addingTimeInterval(waitTimeout)
+        repeat {
+            for candidate in candidates where candidate.exists {
+                if candidate.isHittable || !candidate.frame.isEmpty {
+                    return candidate
+                }
             }
-        }
+            if waitTimeout <= 0 {
+                return nil
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
         return nil
     }
 
@@ -7634,7 +7694,7 @@ final class AndBibleUITests: XCTestCase {
 
     /// Resolves the compact exported Search state element when Search is presented.
     private func resolvedSearchStateElement(in app: XCUIApplication) -> XCUIElement? {
-        resolvedElement("searchScreen", in: app) ?? resolvedStateExportElement("searchStateExport", in: app)
+        resolvedStateExportElement("searchStateExport", in: app) ?? resolvedElement("searchScreen", in: app)
     }
 
     /// Reads the current exported Search state without forcing the whole Search container query.
@@ -7648,12 +7708,12 @@ final class AndBibleUITests: XCTestCase {
 
     /// Reads the current exported Bookmark List state without walking the full list hierarchy.
     private func resolvedBookmarkListStateValue(in app: XCUIApplication) -> String? {
-        if let screen = resolvedElement("bookmarkListScreen", in: app),
-           let value = screen.value as? String {
-            return value
-        }
         if let stateElement = resolvedStateExportElement("bookmarkListStateExport", in: app),
            let value = stateElement.value as? String {
+            return value
+        }
+        if let screen = resolvedElement("bookmarkListScreen", in: app),
+           let value = screen.value as? String {
             return value
         }
         return nil

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -412,12 +412,6 @@ final class AndBibleUITests: XCTestCase {
             requireWorkspaceRow(named: originalActiveWorkspaceName, in: app, timeout: 10),
             timeout: 10
         )
-        if waitForResolvedElementAppearance("workspaceNamePromptCancelButton", in: app, timeout: 1) {
-            tapElementReliably(
-                requireElement("workspaceNamePromptCancelButton", in: app, timeout: 5),
-                timeout: 5
-            )
-        }
         dismissWorkspaceSelectorIfStillPresented(in: app, timeout: 20)
         XCTAssertTrue(
             waitForReaderShellReady(in: app, timeout: 20),
@@ -4451,44 +4445,49 @@ final class AndBibleUITests: XCTestCase {
         return titledCandidates + identifiedCandidates
     }
 
-    /**
-     Returns the concrete surfaces that can own the workspace-name prompt.
-
-     The prompt is a custom sheet on current iOS builds, but older SwiftUI runtimes may expose it
-     like a system modal. Keeping both cases here prevents individual tests from falling back to
-     app-wide text-field queries.
-     */
-    private func workspaceNamePromptCandidates(
-        in app: XCUIApplication,
-        timeout: TimeInterval = 0
-    ) -> [XCUIElement] {
-        let customPromptCandidates = screenRootCandidates("workspaceNamePromptScreen", in: app)
-        if let customPrompt = firstExistingElement(customPromptCandidates, timeout: timeout) {
-            return [customPrompt]
-        }
-        if let systemPrompt = resolvedModalPrompt(in: app, timeout: timeout) {
-            return [systemPrompt]
-        }
-        return []
-    }
-
-    /// Returns workspace-name prompt text-field candidates scoped to the prompt surface.
-    private func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
-        let promptScopedCandidates = workspaceNamePromptCandidates(in: app).flatMap { prompt in
-            modalTextFieldCandidates(
-                in: prompt,
-                identifiers: ["workspaceNamePromptTextField"],
-                titles: ["Name", "name"]
-            )
-        }
-        return promptScopedCandidates + [
-            app.textFields["workspaceNamePromptTextField"].firstMatch,
-            app.secureTextFields["workspaceNamePromptTextField"].firstMatch,
-            app.otherElements["workspaceNamePromptTextField"].firstMatch,
+    /// Returns the currently focused text-entry candidates for custom prompt sheets.
+    private func focusedTextEntryCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
+        return [
+            app.textFields.matching(focusedPredicate).firstMatch,
+            app.secureTextFields.matching(focusedPredicate).firstMatch,
+            app.descendants(matching: .any).matching(focusedPredicate).firstMatch,
         ]
     }
 
-    /// Returns workspace-name prompt button candidates scoped to the prompt or toolbar surface.
+    /// Returns workspace-name prompt text-field candidates without probing arbitrary fields.
+    private func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        let identifier = "workspaceNamePromptTextField"
+        let customSheetCandidates = ["Name", "name"].flatMap { title in
+            [
+                app.textFields[title].firstMatch,
+                app.collectionViews.textFields[title].firstMatch,
+                app.tables.textFields[title].firstMatch,
+                app.scrollViews.textFields[title].firstMatch,
+                app.secureTextFields[title].firstMatch,
+                app.collectionViews.secureTextFields[title].firstMatch,
+                app.tables.secureTextFields[title].firstMatch,
+                app.scrollViews.secureTextFields[title].firstMatch,
+            ]
+        } + [
+            app.textFields[identifier].firstMatch,
+            app.secureTextFields[identifier].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+        let systemPromptCandidates: [XCUIElement]
+        if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
+            systemPromptCandidates = modalTextFieldCandidates(
+                in: prompt,
+                identifiers: [identifier],
+                titles: ["Name", "name"]
+            )
+        } else {
+            systemPromptCandidates = []
+        }
+        return customSheetCandidates + focusedTextEntryCandidates(in: app) + systemPromptCandidates
+    }
+
+    /// Returns workspace-name prompt buttons without walking the custom sheet hierarchy.
     private func workspaceNamePromptButtonCandidates(
         _ identifier: String,
         in app: XCUIApplication
@@ -4503,17 +4502,29 @@ final class AndBibleUITests: XCTestCase {
             titles = []
         }
 
-        let toolbarCandidates = [
+        let directIdentifierCandidates = [
             app.navigationBars.buttons[identifier].firstMatch,
             app.toolbars.buttons[identifier].firstMatch,
-        ]
-        let promptCandidates = workspaceNamePromptCandidates(in: app).flatMap { prompt in
-            modalButtonCandidates(in: prompt, identifiers: [identifier], titles: titles)
-        }
-        return toolbarCandidates + promptCandidates + [
             app.buttons[identifier].firstMatch,
+            app.collectionViews.buttons[identifier].firstMatch,
+            app.tables.buttons[identifier].firstMatch,
+            app.scrollViews.buttons[identifier].firstMatch,
             app.otherElements[identifier].firstMatch,
         ]
+        let directTitleCandidates = titles.map { title in
+            app.buttons[title].firstMatch
+        }
+        let systemPromptCandidates: [XCUIElement]
+        if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
+            systemPromptCandidates = modalButtonCandidates(
+                in: prompt,
+                identifiers: [identifier],
+                titles: titles
+            )
+        } else {
+            systemPromptCandidates = []
+        }
+        return directIdentifierCandidates + directTitleCandidates + systemPromptCandidates
     }
 
     /// Returns screen-aware candidates for small exported semantic state controls.

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -3239,8 +3239,8 @@ final class AndBibleUITests: XCTestCase {
     private func openLabelManager(in app: XCUIApplication) -> XCUIElement {
         openSettingsDestination(
             linkIdentifier: "settingsLabelsLink",
-            destinationIdentifier: "labelManagerStateExport",
-            readinessIdentifiers: ["labelManagerAddButton", "labelManagerStateExport"],
+            destinationIdentifier: "labelManagerScreen",
+            readinessIdentifiers: ["labelManagerAddButton"],
             in: app,
             destinationTimeout: 20
         )
@@ -3297,8 +3297,8 @@ final class AndBibleUITests: XCTestCase {
     ) -> XCUIElement {
         openReaderActionDestination(
             actionIdentifier: "readerOpenBookmarksAction",
-            destinationIdentifier: "bookmarkListStateExport",
-            readinessIdentifiers: ["bookmarkListDoneButton", "bookmarkListSortMenu", "bookmarkListStateExport"],
+            destinationIdentifier: "bookmarkListScreen",
+            readinessIdentifiers: ["bookmarkListDoneButton", "bookmarkListSortMenu"],
             in: app,
             timeout: timeout
         )
@@ -3676,8 +3676,8 @@ final class AndBibleUITests: XCTestCase {
     private func openSyncSettings(in app: XCUIApplication) -> XCUIElement {
         openSettingsDestination(
             linkIdentifier: "settingsSyncLink",
-            destinationIdentifier: "syncSettingsState",
-            readinessIdentifiers: ["syncBackendPicker", "syncSettingsState"],
+            destinationIdentifier: "syncSettingsScreen",
+            readinessIdentifiers: ["syncBackendPicker"],
             in: app,
             destinationTimeout: 20
         )
@@ -3762,8 +3762,8 @@ final class AndBibleUITests: XCTestCase {
     private func openSyncSettingsFromReaderAction(in app: XCUIApplication) -> XCUIElement {
         openReaderActionDestination(
             actionIdentifier: "readerOpenSyncSettingsAction",
-            destinationIdentifier: "syncSettingsState",
-            readinessIdentifiers: ["syncBackendPicker", "syncSettingsState"],
+            destinationIdentifier: "syncSettingsScreen",
+            readinessIdentifiers: ["syncBackendPicker"],
             in: app,
             timeout: 20
         )
@@ -4160,6 +4160,9 @@ final class AndBibleUITests: XCTestCase {
                 file: file,
                 line: line
             ) != nil {
+                if let resolvedDestination = resolvedElement(destinationIdentifier, in: app) {
+                    return resolvedDestination
+                }
                 if destination.exists || destination.waitForExistence(timeout: 1) {
                     return destination
                 }
@@ -4375,6 +4378,53 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Resolves lightweight state-export or status candidates by searching inside one owning screen
+     before falling back to app-wide queries.
+
+     This keeps value-based polling off the full app hierarchy for controls that only ever exist
+     inside a known screen, which materially reduces snapshot timeout pressure in CI.
+     */
+    private func screenScopedStateCandidates(
+        _ identifier: String,
+        within screenIdentifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let scopedCandidates = screenRootCandidates(screenIdentifier, in: app).flatMap { root in
+            [
+                root.otherElements[identifier].firstMatch,
+                root.staticTexts[identifier].firstMatch,
+            ]
+        }
+
+        return scopedCandidates + [
+            app.otherElements[identifier].firstMatch,
+            app.staticTexts[identifier].firstMatch,
+        ]
+    }
+
+    /// Returns screen-aware candidates for small exported semantic state controls.
+    private func semanticStateCandidates(
+        for identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        switch identifier {
+        case "searchStateExport":
+            return screenScopedStateCandidates(identifier, within: "searchScreen", in: app)
+        case "bookmarkListStateExport":
+            return screenScopedStateCandidates(identifier, within: "bookmarkListScreen", in: app)
+        case "labelManagerStateExport":
+            return screenScopedStateCandidates(identifier, within: "labelManagerScreen", in: app)
+        case "syncSettingsState":
+            return screenScopedStateCandidates(identifier, within: "syncSettingsScreen", in: app)
+        default:
+            return [
+                app.otherElements[identifier].firstMatch,
+                app.staticTexts[identifier].firstMatch,
+            ]
+        }
+    }
+
+    /**
      Produces the minimal ordered set of XCUI queries for one accessibility identifier.
      *
      * This helper is intentionally explicit for recurring screen/container roots. The earlier
@@ -4580,10 +4630,7 @@ final class AndBibleUITests: XCTestCase {
                 app.scrollViews[identifier].firstMatch,
             ]
         case "searchStateExport", "bookmarkListStateExport", "labelManagerStateExport":
-            return [
-                app.otherElements[identifier].firstMatch,
-                app.staticTexts[identifier].firstMatch,
-            ]
+            return semanticStateCandidates(for: identifier, in: app)
         case "searchResultsList":
             return [
                 app.collectionViews[identifier].firstMatch,
@@ -4635,10 +4682,7 @@ final class AndBibleUITests: XCTestCase {
                 app.otherElements[identifier].firstMatch,
             ]
         case "syncSettingsState":
-            return [
-                app.otherElements[identifier].firstMatch,
-                app.staticTexts[identifier].firstMatch,
-            ]
+            return semanticStateCandidates(for: identifier, in: app)
         case "textDisplayFontFamilyButton":
             return [
                 app.buttons[identifier].firstMatch,
@@ -4716,8 +4760,8 @@ final class AndBibleUITests: XCTestCase {
         _ identifier: String,
         in app: XCUIApplication
     ) -> XCUIElement? {
-        let export = app.otherElements[identifier].firstMatch
-        return export.exists ? export : nil
+        let candidates = semanticStateCandidates(for: identifier, in: app)
+        return candidates.first(where: { $0.exists })
     }
 
     /**
@@ -7504,7 +7548,7 @@ final class AndBibleUITests: XCTestCase {
 
     /// Resolves the compact exported Search state element when Search is presented.
     private func resolvedSearchStateElement(in app: XCUIApplication) -> XCUIElement? {
-        resolvedStateExportElement("searchStateExport", in: app) ?? resolvedElement("searchScreen", in: app)
+        resolvedElement("searchScreen", in: app) ?? resolvedStateExportElement("searchStateExport", in: app)
     }
 
     /// Reads the current exported Search state without forcing the whole Search container query.
@@ -7518,12 +7562,12 @@ final class AndBibleUITests: XCTestCase {
 
     /// Reads the current exported Bookmark List state without walking the full list hierarchy.
     private func resolvedBookmarkListStateValue(in app: XCUIApplication) -> String? {
-        if let stateElement = resolvedStateExportElement("bookmarkListStateExport", in: app),
-           let value = stateElement.value as? String {
-            return value
-        }
         if let screen = resolvedElement("bookmarkListScreen", in: app),
            let value = screen.value as? String {
+            return value
+        }
+        if let stateElement = resolvedStateExportElement("bookmarkListStateExport", in: app),
+           let value = stateElement.value as? String {
             return value
         }
         return nil

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -4305,6 +4305,75 @@ final class AndBibleUITests: XCTestCase {
         return [app.otherElements[identifier].firstMatch]
     }
 
+    /// Returns the minimal set of root containers that can own one screen-scoped identifier.
+    private func screenRootCandidates(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        [
+            app.otherElements[identifier].firstMatch,
+            app.collectionViews[identifier].firstMatch,
+            app.tables[identifier].firstMatch,
+            app.scrollViews[identifier].firstMatch,
+        ]
+    }
+
+    /**
+     Resolves button-like candidates by searching inside one owning screen before falling back to
+     app-wide queries.
+
+     This keeps XCTest from repeatedly snapshotting the full hierarchy for controls that only ever
+     exist inside a known screen, which has been a recurring CI timeout source.
+     */
+    private func screenScopedButtonCandidates(
+        _ identifier: String,
+        within screenIdentifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let scopedCandidates = screenRootCandidates(screenIdentifier, in: app).flatMap { root in
+            [
+                root.buttons[identifier].firstMatch,
+                root.cells.buttons[identifier].firstMatch,
+                root.otherElements[identifier].firstMatch,
+            ]
+        }
+
+        return scopedCandidates + [
+            app.buttons[identifier].firstMatch,
+            app.navigationBars.buttons[identifier].firstMatch,
+            app.toolbars.buttons[identifier].firstMatch,
+            app.collectionViews.buttons[identifier].firstMatch,
+            app.cells.buttons[identifier].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+    }
+
+    /**
+     Resolves row-like candidates by searching inside one owning screen before falling back to
+     app-wide queries.
+     */
+    private func screenScopedRowCandidates(
+        _ identifier: String,
+        within screenIdentifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let scopedCandidates = screenRootCandidates(screenIdentifier, in: app).flatMap { root in
+            [
+                root.otherElements[identifier].firstMatch,
+                root.cells[identifier].firstMatch,
+                root.buttons[identifier].firstMatch,
+            ]
+        }
+
+        return scopedCandidates + [
+            app.otherElements[identifier].firstMatch,
+            app.collectionViews.cells[identifier].firstMatch,
+            app.cells[identifier].firstMatch,
+            app.buttons[identifier].firstMatch,
+            app.collectionViews.buttons[identifier].firstMatch,
+        ]
+    }
+
     /**
      Produces the minimal ordered set of XCUI queries for one accessibility identifier.
      *
@@ -4325,50 +4394,27 @@ final class AndBibleUITests: XCTestCase {
         in app: XCUIApplication
     ) -> [XCUIElement] {
         if identifier.hasPrefix("labelAssignmentRow::") {
-            return [
-                app.collectionViews.cells[identifier].firstMatch,
-                app.cells[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedRowCandidates(identifier, within: "labelAssignmentScreen", in: app)
         }
 
         if identifier.hasPrefix("labelAssignmentToggleButton::")
             || identifier.hasPrefix("labelAssignmentFavouriteButton::")
         {
-            return [
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "labelAssignmentScreen", in: app)
         }
 
         if identifier.hasPrefix("bookmarkListFilterChip::") {
-            return [
-                app.buttons[identifier].firstMatch,
-                app.scrollViews.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "bookmarkListScreen", in: app)
         }
 
         if identifier.hasPrefix("bookmarkListOpenStudyPadButton::") {
-            return [
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "bookmarkListScreen", in: app)
         }
 
         if identifier.hasPrefix("bookmarkListEditLabelsButton::")
             || identifier.hasPrefix("bookmarkListRowButton::")
         {
-            return [
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.cells.buttons[identifier].firstMatch,
-                app.cells[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "bookmarkListScreen", in: app)
         }
 
         if identifier.hasPrefix("bookmarkListDeleteButton::")
@@ -4479,13 +4525,7 @@ final class AndBibleUITests: XCTestCase {
                 app.otherElements[identifier].firstMatch,
             ]
         case "labelAssignmentCreateNewLabelButton":
-            return [
-                app.alerts.buttons[identifier].firstMatch,
-                app.sheets.buttons[identifier].firstMatch,
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "labelAssignmentScreen", in: app)
         case "labelManagerNewLabelNameField":
             return [
                 app.alerts.textFields[identifier].firstMatch,
@@ -4508,6 +4548,8 @@ final class AndBibleUITests: XCTestCase {
                 app.sheets.buttons["Create"].firstMatch,
                 app.buttons["Create"].firstMatch,
             ]
+        case "colorSettingsResetButton":
+            return screenScopedButtonCandidates(identifier, within: "colorSettingsScreen", in: app)
         case "aboutAppTitle":
             return [
                 app.staticTexts[identifier].firstMatch,

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -3173,7 +3173,7 @@ final class AndBibleUITests: XCTestCase {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The prompt text field used to enter the workspace name.
      * - Side effects:
-     *   - polls prompt-scoped descendants and sheet text fields once the prompt chrome is visible
+     *   - polls the custom prompt and system modal surfaces for one owned text field
      * - Failure modes:
      *   - records an XCTest failure when no prompt text field becomes available in time
      */
@@ -3185,38 +3185,17 @@ final class AndBibleUITests: XCTestCase {
     ) -> XCUIElement {
         let deadline = Date().addingTimeInterval(timeout)
         repeat {
-            if let identifiedField = resolvedElement("workspaceNamePromptTextField", in: app) {
-                return identifiedField
-            }
-
-            if let promptScreen = resolvedElement("workspaceNamePromptScreen", in: app) {
-                let promptScopedField = promptScreen.descendants(matching: .textField).firstMatch
-                if promptScopedField.exists || promptScopedField.waitForExistence(timeout: 0.2) {
-                    return promptScopedField
-                }
-            }
-
-            let promptIsVisible =
-                resolvedElement("workspaceNamePromptConfirmButton", in: app) != nil ||
-                resolvedElement("workspaceNamePromptCancelButton", in: app) != nil ||
-                resolvedElement("workspaceNamePromptScreen", in: app) != nil
-            if promptIsVisible {
-                let sheetField = app.sheets.textFields.firstMatch
-                if sheetField.exists || sheetField.waitForExistence(timeout: 0.2) {
-                    return sheetField
-                }
-
-                let applicationField = app.textFields.firstMatch
-                if applicationField.exists || applicationField.waitForExistence(timeout: 0.2) {
-                    return applicationField
-                }
+            if let promptField = firstExistingElement(
+                workspaceNamePromptTextFieldCandidates(in: app),
+                timeout: 0.2
+            ) {
+                return promptField
             }
 
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        let fallbackField = resolvedElement("workspaceNamePromptTextField", in: app)
-            ?? app.sheets.textFields.firstMatch
+        let fallbackField = unresolvedElement("workspaceNamePromptTextField", in: app)
         XCTAssertTrue(
             fallbackField.exists,
             "Expected the workspace name field to appear within \(timeout) seconds.",
@@ -4402,6 +4381,141 @@ final class AndBibleUITests: XCTestCase {
         ]
     }
 
+    /// Returns the first modal presentation surface currently visible to XCTest.
+    private func resolvedModalPrompt(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 0.2
+    ) -> XCUIElement? {
+        let candidates = [
+            app.alerts.firstMatch,
+            app.sheets.firstMatch,
+        ]
+        return firstExistingElement(candidates, timeout: timeout)
+    }
+
+    /// Finds the first existing element from a deliberately small candidate list.
+    private func firstExistingElement(
+        _ candidates: [XCUIElement],
+        timeout: TimeInterval = 0
+    ) -> XCUIElement? {
+        let boundedTimeout = max(0, timeout)
+        for candidate in candidates {
+            if candidate.exists {
+                return candidate
+            }
+            if boundedTimeout > 0,
+               candidate.waitForExistence(timeout: boundedTimeout)
+            {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    /**
+     Returns modal-owned text field candidates in the order XCTest resolves SwiftUI prompts most
+     consistently: visible placeholder/title first, then ordinal field, then accessibility id.
+     */
+    private func modalTextFieldCandidates(
+        in prompt: XCUIElement,
+        identifiers: [String] = [],
+        titles: [String] = []
+    ) -> [XCUIElement] {
+        let titledCandidates = titles.flatMap { title in
+            [
+                prompt.textFields[title].firstMatch,
+                prompt.secureTextFields[title].firstMatch,
+            ]
+        }
+        let ordinalCandidates = [
+            prompt.textFields.element(boundBy: 0),
+            prompt.secureTextFields.element(boundBy: 0),
+        ]
+        let identifiedCandidates = identifiers.flatMap { identifier in
+            [
+                prompt.textFields[identifier].firstMatch,
+                prompt.secureTextFields[identifier].firstMatch,
+            ]
+        }
+        return titledCandidates + ordinalCandidates + identifiedCandidates
+    }
+
+    /// Returns modal-owned button candidates without falling back to the full app hierarchy.
+    private func modalButtonCandidates(
+        in prompt: XCUIElement,
+        identifiers: [String] = [],
+        titles: [String] = []
+    ) -> [XCUIElement] {
+        let titledCandidates = titles.map { prompt.buttons[$0].firstMatch }
+        let identifiedCandidates = identifiers.map { prompt.buttons[$0].firstMatch }
+        return titledCandidates + identifiedCandidates
+    }
+
+    /**
+     Returns the concrete surfaces that can own the workspace-name prompt.
+
+     The prompt is a custom sheet on current iOS builds, but older SwiftUI runtimes may expose it
+     like a system modal. Keeping both cases here prevents individual tests from falling back to
+     app-wide text-field queries.
+     */
+    private func workspaceNamePromptCandidates(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 0
+    ) -> [XCUIElement] {
+        let customPromptCandidates = screenRootCandidates("workspaceNamePromptScreen", in: app)
+        if let customPrompt = firstExistingElement(customPromptCandidates, timeout: timeout) {
+            return [customPrompt]
+        }
+        if let systemPrompt = resolvedModalPrompt(in: app, timeout: timeout) {
+            return [systemPrompt]
+        }
+        return []
+    }
+
+    /// Returns workspace-name prompt text-field candidates scoped to the prompt surface.
+    private func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        let promptScopedCandidates = workspaceNamePromptCandidates(in: app).flatMap { prompt in
+            modalTextFieldCandidates(
+                in: prompt,
+                identifiers: ["workspaceNamePromptTextField"],
+                titles: ["Name", "name"]
+            )
+        }
+        return promptScopedCandidates + [
+            app.textFields["workspaceNamePromptTextField"].firstMatch,
+            app.secureTextFields["workspaceNamePromptTextField"].firstMatch,
+            app.otherElements["workspaceNamePromptTextField"].firstMatch,
+        ]
+    }
+
+    /// Returns workspace-name prompt button candidates scoped to the prompt or toolbar surface.
+    private func workspaceNamePromptButtonCandidates(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let titles: [String]
+        switch identifier {
+        case "workspaceNamePromptConfirmButton":
+            titles = ["Create", "create", "Save", "save"]
+        case "workspaceNamePromptCancelButton":
+            titles = ["Cancel", "cancel"]
+        default:
+            titles = []
+        }
+
+        let toolbarCandidates = [
+            app.navigationBars.buttons[identifier].firstMatch,
+            app.toolbars.buttons[identifier].firstMatch,
+        ]
+        let promptCandidates = workspaceNamePromptCandidates(in: app).flatMap { prompt in
+            modalButtonCandidates(in: prompt, identifiers: [identifier], titles: titles)
+        }
+        return toolbarCandidates + promptCandidates + [
+            app.buttons[identifier].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+    }
+
     /// Returns screen-aware candidates for small exported semantic state controls.
     private func semanticStateCandidates(
         for identifier: String,
@@ -4577,11 +4691,18 @@ final class AndBibleUITests: XCTestCase {
         case "labelAssignmentCreateNewLabelButton":
             return screenScopedButtonCandidates(identifier, within: "labelAssignmentScreen", in: app)
         case "labelManagerNewLabelNameField":
+            if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
+                return modalTextFieldCandidates(
+                    in: prompt,
+                    identifiers: [identifier],
+                    titles: ["Label name"]
+                )
+            }
             return [
-                app.alerts.textFields[identifier].firstMatch,
-                app.sheets.textFields[identifier].firstMatch,
-                app.textFields[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
+                app.alerts.firstMatch.textFields["Label name"].firstMatch,
+                app.sheets.firstMatch.textFields["Label name"].firstMatch,
+                app.alerts.firstMatch.textFields.element(boundBy: 0),
+                app.sheets.firstMatch.textFields.element(boundBy: 0),
             ]
         case "labelEditNameField":
             return [
@@ -4590,13 +4711,16 @@ final class AndBibleUITests: XCTestCase {
                 app.otherElements[identifier].firstMatch,
             ]
         case "labelManagerCreateButton":
+            if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
+                return modalButtonCandidates(
+                    in: prompt,
+                    identifiers: [identifier],
+                    titles: ["Create"]
+                )
+            }
             return [
-                app.alerts.buttons[identifier].firstMatch,
-                app.sheets.buttons[identifier].firstMatch,
-                app.buttons[identifier].firstMatch,
-                app.alerts.buttons["Create"].firstMatch,
-                app.sheets.buttons["Create"].firstMatch,
-                app.buttons["Create"].firstMatch,
+                app.alerts.firstMatch.buttons["Create"].firstMatch,
+                app.sheets.firstMatch.buttons["Create"].firstMatch,
             ]
         case "colorSettingsResetButton":
             return screenScopedButtonCandidates(identifier, within: "colorSettingsScreen", in: app)
@@ -4656,17 +4780,9 @@ final class AndBibleUITests: XCTestCase {
                 app.otherElements[identifier].firstMatch,
             ]
         case "workspaceNamePromptTextField":
-            return [
-                app.textFields[identifier].firstMatch,
-                app.sheets.textFields[identifier].firstMatch,
-                app.collectionViews.textFields[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return workspaceNamePromptTextFieldCandidates(in: app)
         case "workspaceNamePromptConfirmButton", "workspaceNamePromptCancelButton":
-            return [
-                app.buttons[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return workspaceNamePromptButtonCandidates(identifier, in: app)
         case
             "settingsDownloadsLink",
             "settingsRepositoriesLink",
@@ -6720,14 +6836,10 @@ final class AndBibleUITests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
 
         repeat {
-            let candidates = normalizedTitles.flatMap { title in
-                [
-                    alert.textFields[title].firstMatch,
-                    app.alerts.textFields[title].firstMatch,
-                ]
-            }
-
-            if let textField = candidates.first(where: { $0.exists || $0.waitForExistence(timeout: 0.2) }) {
+            if let textField = firstExistingElement(
+                modalTextFieldCandidates(in: alert, titles: normalizedTitles),
+                timeout: 0.2
+            ) {
                 return textField
             }
 
@@ -7113,7 +7225,12 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         )
-        return app.alerts.textFields.firstMatch
+        if let prompt = resolvedLabelCreationPrompt(in: app),
+           let field = firstExistingElement(modalTextFieldCandidates(in: prompt, titles: ["Label name"]))
+        {
+            return field
+        }
+        return app.alerts.firstMatch.textFields.element(boundBy: 0)
     }
 
     /**
@@ -7150,7 +7267,12 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         )
-        return app.alerts.buttons["Create"].firstMatch
+        if let prompt = resolvedLabelCreationPrompt(in: app),
+           let button = firstExistingElement(modalButtonCandidates(in: prompt, titles: ["Create"]))
+        {
+            return button
+        }
+        return app.alerts.firstMatch.buttons["Create"].firstMatch
     }
 
     /**
@@ -7466,51 +7588,20 @@ final class AndBibleUITests: XCTestCase {
 
     /// Returns the visible prompt container used by the create-label flow.
     private func resolvedLabelCreationPrompt(in app: XCUIApplication) -> XCUIElement? {
-        let alert = app.alerts.firstMatch
-        if alert.exists || alert.waitForExistence(timeout: 0.2) {
-            return alert
-        }
-
-        let sheet = app.sheets.firstMatch
-        if sheet.exists || sheet.waitForExistence(timeout: 0.2) {
-            return sheet
-        }
-
-        return nil
+        resolvedModalPrompt(in: app, timeout: 0.2)
     }
 
     /// Resolves the create-label prompt text field by scoping queries to the visible prompt.
     private func resolveLabelCreationPromptTextField(in app: XCUIApplication) -> XCUIElement? {
         if let prompt = resolvedLabelCreationPrompt(in: app) {
-            let exactField = prompt.textFields["labelManagerNewLabelNameField"].firstMatch
-            if exactField.exists && !exactField.frame.isEmpty {
-                return exactField
-            }
-
-            let titledField = prompt.textFields["Label name"].firstMatch
-            if titledField.exists && !titledField.frame.isEmpty {
-                return titledField
-            }
-
-            let promptField = prompt.textFields.firstMatch
-            if promptField.exists && !promptField.frame.isEmpty {
-                return promptField
-            }
-        }
-
-        let directField = app.textFields["labelManagerNewLabelNameField"].firstMatch
-        if directField.exists && !directField.frame.isEmpty {
-            return directField
-        }
-
-        if let prompt = resolvedLabelCreationPrompt(in: app) {
-            let fallbackCandidates = [
-                prompt.textFields["Label name"].firstMatch,
-                prompt.textFields.firstMatch,
-            ]
-            if let field = fallbackCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
-                return field
-            }
+            return firstExistingElement(
+                modalTextFieldCandidates(
+                    in: prompt,
+                    identifiers: ["labelManagerNewLabelNameField"],
+                    titles: ["Label name"]
+                ),
+                timeout: 0.2
+            )
         }
         return nil
     }
@@ -7518,30 +7609,14 @@ final class AndBibleUITests: XCTestCase {
     /// Resolves the create-label prompt action button by scoping queries to the visible prompt.
     private func resolveLabelCreationPromptCreateButton(in app: XCUIApplication) -> XCUIElement? {
         if let prompt = resolvedLabelCreationPrompt(in: app) {
-            let exactButton = prompt.buttons["labelManagerCreateButton"].firstMatch
-            if exactButton.exists && !exactButton.frame.isEmpty {
-                return exactButton
-            }
-
-            let titledButton = prompt.buttons["Create"].firstMatch
-            if titledButton.exists && !titledButton.frame.isEmpty {
-                return titledButton
-            }
-        }
-
-        let directButton = app.buttons["labelManagerCreateButton"].firstMatch
-        if directButton.exists && !directButton.frame.isEmpty {
-            return directButton
-        }
-
-        if let prompt = resolvedLabelCreationPrompt(in: app) {
-            let fallbackCandidates = [
-                prompt.buttons["Create"].firstMatch,
-                prompt.buttons.firstMatch,
-            ]
-            if let button = fallbackCandidates.first(where: { $0.exists && !$0.frame.isEmpty }) {
-                return button
-            }
+            return firstExistingElement(
+                modalButtonCandidates(
+                    in: prompt,
+                    identifiers: ["labelManagerCreateButton"],
+                    titles: ["Create"]
+                ),
+                timeout: 0.2
+            )
         }
         return nil
     }
@@ -7852,20 +7927,25 @@ final class AndBibleUITests: XCTestCase {
     private func labelRow(named name: String, in app: XCUIApplication) -> XCUIElement {
         let identifier = "labelManagerRowButton-\(name)"
         if let labelManagerScreen = resolvedElement("labelManagerScreen", in: app) {
-            let scopedLink = labelManagerScreen.links[identifier].firstMatch
-            if scopedLink.exists || scopedLink.waitForExistence(timeout: 0.5) {
-                return scopedLink
-            }
             let scopedButton = labelManagerScreen.buttons[identifier].firstMatch
-            if scopedButton.exists || scopedButton.waitForExistence(timeout: 0.5) {
+            if scopedButton.exists {
                 return scopedButton
             }
+            let scopedLink = labelManagerScreen.links[identifier].firstMatch
+            if scopedLink.exists {
+                return scopedLink
+            }
+        }
+
+        let globalButton = app.buttons[identifier].firstMatch
+        if globalButton.exists {
+            return globalButton
         }
         let globalLink = app.links[identifier].firstMatch
-        if globalLink.exists || globalLink.waitForExistence(timeout: 0.5) {
+        if globalLink.exists {
             return globalLink
         }
-        return app.buttons[identifier].firstMatch
+        return globalButton
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
@@ -137,16 +137,21 @@ public final class SettingsStore {
      Persists app-level text-display defaults.
 
      - Parameter settings: Fully or partially populated text-display defaults to store.
-     - Side Effects: Encodes the settings as JSON and upserts the local singleton `Setting` row.
+     - Side Effects:
+       - encodes the settings as JSON and upserts the local singleton `Setting` row
+       - clears workspace/window overrides that now match the new effective parent values so they
+         inherit instead, mirroring Android's parent-setting propagation
      - Failure: Encoding failures are swallowed, matching the soft-failure behavior of other
        settings writes.
      */
     public func setGlobalTextDisplaySettings(_ settings: TextDisplaySettings) {
+        let previousSettings = globalTextDisplaySettings()
         guard let data = try? JSONEncoder().encode(settings),
               let rawValue = String(data: data, encoding: .utf8) else {
             return
         }
         setString(Self.globalTextDisplaySettingsKey, value: rawValue)
+        propagateGlobalTextDisplaySettingsChange(from: previousSettings, to: settings)
     }
 
     // MARK: - Bool
@@ -310,6 +315,62 @@ public final class SettingsStore {
             modelContext.insert(Setting(key: key, value: value))
         }
         try? modelContext.save()
+    }
+
+    /**
+     Clears redundant workspace and window overrides after a global-settings change.
+
+     Android nulls child values that now match their effective parent so future parent changes keep
+     flowing through the inheritance chain. iOS needs the same cleanup to avoid stale workspace or
+     page-manager overrides after application Settings edits.
+     */
+    private func propagateGlobalTextDisplaySettingsChange(
+        from previousSettings: TextDisplaySettings,
+        to globalSettings: TextDisplaySettings
+    ) {
+        guard previousSettings != globalSettings else {
+            return
+        }
+
+        let descriptor = FetchDescriptor<Workspace>()
+        let workspaces = (try? modelContext.fetch(descriptor)) ?? []
+        var anyChanged = false
+
+        for workspace in workspaces {
+            let previousWorkspaceSettings = workspace.textDisplaySettings
+            if var workspaceSettings = previousWorkspaceSettings,
+               workspaceSettings.clearOverridesMatchingParent(
+                   globalSettings,
+                   changedFrom: previousSettings,
+                   to: globalSettings
+               ) {
+                workspace.textDisplaySettings = workspaceSettings
+                anyChanged = true
+            }
+
+            let currentWorkspaceParentSettings = TextDisplaySettings.fullyResolved(
+                window: nil,
+                workspace: workspace.textDisplaySettings,
+                global: globalSettings
+            )
+            for window in workspace.windows ?? [] {
+                guard var windowSettings = window.pageManager?.textDisplaySettings else {
+                    continue
+                }
+                if windowSettings.clearOverridesMatchingParent(
+                    currentWorkspaceParentSettings,
+                    changedFrom: previousSettings,
+                    to: globalSettings
+                ) {
+                    window.pageManager?.textDisplaySettings = windowSettings
+                    anyChanged = true
+                }
+            }
+        }
+
+        if anyChanged {
+            try? modelContext.save()
+        }
     }
 }
 

--- a/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
@@ -47,9 +47,9 @@ public final class Setting {
  * - persist global local-only settings such as the active workspace ID
  * - route Android parity preferences to either SwiftData, `UserDefaults`, or no-op action storage
  *
- * Reading-display inheritance is intentionally outside this store. That chain is resolved through:
+ * Reading-display inheritance is resolved through:
  * `PageManager.textDisplaySettings` -> `Workspace.textDisplaySettings` ->
- * `TextDisplaySettings.appDefaults`.
+ * `SettingsStore.globalTextDisplaySettings` -> `TextDisplaySettings.appDefaults`.
  *
  * For Android parity settings keyed by `AppPreferenceKey`, this store routes persistence to the
  * correct backend:
@@ -80,6 +80,9 @@ public final class SettingsStore {
         self.modelContext = modelContext
     }
 
+    /// Local-only singleton setting key used for Android-style global text-display defaults.
+    public static let globalTextDisplaySettingsKey = "global_text_display_settings"
+
     // MARK: - String
 
     /**
@@ -102,6 +105,48 @@ public final class SettingsStore {
      */
     public func setString(_ key: String, value: String) {
         upsert(key: key, value: value)
+    }
+
+    // MARK: - Global Text Display Settings
+
+    /**
+     Reads the persisted app-level text-display defaults when present.
+
+     - Returns: Decoded global settings, or `nil` when the setting has never been saved or cannot
+       be decoded.
+     - Note: Callers that need an effective fallback should use `globalTextDisplaySettings()`.
+     */
+    public func storedGlobalTextDisplaySettings() -> TextDisplaySettings? {
+        guard let rawValue = getString(Self.globalTextDisplaySettingsKey),
+              let data = rawValue.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(TextDisplaySettings.self, from: data)
+    }
+
+    /**
+     Reads app-level text-display defaults, falling back to bundled defaults on first launch.
+
+     - Returns: Persisted global settings when available, otherwise `TextDisplaySettings.appDefaults`.
+     */
+    public func globalTextDisplaySettings() -> TextDisplaySettings {
+        storedGlobalTextDisplaySettings() ?? .appDefaults
+    }
+
+    /**
+     Persists app-level text-display defaults.
+
+     - Parameter settings: Fully or partially populated text-display defaults to store.
+     - Side Effects: Encodes the settings as JSON and upserts the local singleton `Setting` row.
+     - Failure: Encoding failures are swallowed, matching the soft-failure behavior of other
+       settings writes.
+     */
+    public func setGlobalTextDisplaySettings(_ settings: TextDisplaySettings) {
+        guard let data = try? JSONEncoder().encode(settings),
+              let rawValue = String(data: data, encoding: .utf8) else {
+            return
+        }
+        setString(Self.globalTextDisplaySettingsKey, value: rawValue)
     }
 
     // MARK: - Bool

--- a/Sources/BibleCore/Sources/BibleCore/Database/WorkspaceStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/WorkspaceStore.swift
@@ -62,8 +62,8 @@ public final class WorkspaceStore {
      * Creates a new workspace with the default single-Bible-window graph.
      * - Parameters:
      *   - name: User-visible workspace name.
-     *   - inheritingDefaultsFrom: Optional workspace whose workspace-scoped defaults should seed
-     *     the new workspace.
+     *   - inheritingDefaultsFrom: Optional workspace whose workspace-scoped non-theme defaults
+     *     should seed the new workspace.
      * - Returns: The newly created workspace.
      * - Side Effects: Inserts a `Workspace`, a child `Window`, a matching `PageManager`, and saves `modelContext`.
      * - Failure: Save errors are swallowed.
@@ -73,7 +73,7 @@ public final class WorkspaceStore {
     public func createWorkspace(name: String, inheritingDefaultsFrom source: Workspace? = nil) -> Workspace {
         let maxOrder = workspaces().map(\.orderNumber).max() ?? -1
         let workspace = Workspace(name: name, orderNumber: maxOrder + 1)
-        workspace.textDisplaySettings = source?.textDisplaySettings
+        workspace.textDisplaySettings = source?.textDisplaySettings?.clearingThemeColors()
         workspace.workspaceSettings = source?.workspaceSettings
         workspace.workspaceColor = source?.workspaceColor
         modelContext.insert(workspace)

--- a/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
@@ -273,6 +273,7 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
        - keyPath: Property to resolve.
        - window: Window-level overrides, checked first.
        - workspace: Workspace-level overrides, checked second.
+       - global: App-level overrides, checked third.
        - defaults: Fully populated app defaults, checked last.
      - Returns: The first non-nil value in the chain, or `nil` when the default is also nil.
      - Note: This helper is pure and has no persistence or rendering side effects.
@@ -281,9 +282,10 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
         _ keyPath: KeyPath<TextDisplaySettings, T?>,
         window: TextDisplaySettings?,
         workspace: TextDisplaySettings?,
+        global: TextDisplaySettings? = nil,
         defaults: TextDisplaySettings
     ) -> T? {
-        window?[keyPath: keyPath] ?? workspace?[keyPath: keyPath] ?? defaults[keyPath: keyPath]
+        window?[keyPath: keyPath] ?? workspace?[keyPath: keyPath] ?? global?[keyPath: keyPath] ?? defaults[keyPath: keyPath]
     }
 
     /**
@@ -334,7 +336,8 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
 
      - Parameters:
        - window: Window-level overrides, checked before workspace values.
-       - workspace: Workspace-level overrides, checked before `appDefaults`.
+       - workspace: Workspace-level overrides, checked before global values.
+       - global: App-level overrides, checked before `appDefaults`.
      - Returns: A new `TextDisplaySettings` containing no inherited gaps for the supported
        fields.
      - Note: The method is deterministic and side-effect free. Callers remain responsible for
@@ -342,40 +345,64 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
      */
     public static func fullyResolved(
         window: TextDisplaySettings?,
-        workspace: TextDisplaySettings?
+        workspace: TextDisplaySettings?,
+        global: TextDisplaySettings? = nil
     ) -> TextDisplaySettings {
         let d = appDefaults
         var r = TextDisplaySettings()
-        r.fontSize = window?.fontSize ?? workspace?.fontSize ?? d.fontSize
-        r.fontFamily = window?.fontFamily ?? workspace?.fontFamily ?? d.fontFamily
-        r.lineSpacing = window?.lineSpacing ?? workspace?.lineSpacing ?? d.lineSpacing
-        r.marginLeft = window?.marginLeft ?? workspace?.marginLeft ?? d.marginLeft
-        r.marginRight = window?.marginRight ?? workspace?.marginRight ?? d.marginRight
-        r.maxWidth = window?.maxWidth ?? workspace?.maxWidth ?? d.maxWidth
-        r.topMargin = window?.topMargin ?? workspace?.topMargin ?? d.topMargin
-        r.strongsMode = window?.strongsMode ?? workspace?.strongsMode ?? d.strongsMode
-        r.showMorphology = window?.showMorphology ?? workspace?.showMorphology ?? d.showMorphology
-        r.showFootNotes = window?.showFootNotes ?? workspace?.showFootNotes ?? d.showFootNotes
-        r.showFootNotesInline = window?.showFootNotesInline ?? workspace?.showFootNotesInline ?? d.showFootNotesInline
-        r.expandXrefs = window?.expandXrefs ?? workspace?.expandXrefs ?? d.expandXrefs
-        r.showXrefs = window?.showXrefs ?? workspace?.showXrefs ?? d.showXrefs
-        r.showRedLetters = window?.showRedLetters ?? workspace?.showRedLetters ?? d.showRedLetters
-        r.showSectionTitles = window?.showSectionTitles ?? workspace?.showSectionTitles ?? d.showSectionTitles
-        r.showVerseNumbers = window?.showVerseNumbers ?? workspace?.showVerseNumbers ?? d.showVerseNumbers
-        r.showVersePerLine = window?.showVersePerLine ?? workspace?.showVersePerLine ?? d.showVersePerLine
-        r.showBookmarks = window?.showBookmarks ?? workspace?.showBookmarks ?? d.showBookmarks
-        r.showMyNotes = window?.showMyNotes ?? workspace?.showMyNotes ?? d.showMyNotes
-        r.justifyText = window?.justifyText ?? workspace?.justifyText ?? d.justifyText
-        r.hyphenation = window?.hyphenation ?? workspace?.hyphenation ?? d.hyphenation
-        r.showPageNumber = window?.showPageNumber ?? workspace?.showPageNumber ?? d.showPageNumber
-        r.dayTextColor = window?.dayTextColor ?? workspace?.dayTextColor ?? d.dayTextColor
-        r.dayBackground = window?.dayBackground ?? workspace?.dayBackground ?? d.dayBackground
-        r.dayNoise = window?.dayNoise ?? workspace?.dayNoise ?? d.dayNoise
-        r.nightTextColor = window?.nightTextColor ?? workspace?.nightTextColor ?? d.nightTextColor
-        r.nightBackground = window?.nightBackground ?? workspace?.nightBackground ?? d.nightBackground
-        r.nightNoise = window?.nightNoise ?? workspace?.nightNoise ?? d.nightNoise
-        r.bookmarksHideLabels = window?.bookmarksHideLabels ?? workspace?.bookmarksHideLabels ?? d.bookmarksHideLabels
-        r.enableVerseSelection = window?.enableVerseSelection ?? workspace?.enableVerseSelection ?? d.enableVerseSelection
+        r.fontSize = window?.fontSize ?? workspace?.fontSize ?? global?.fontSize ?? d.fontSize
+        r.fontFamily = window?.fontFamily ?? workspace?.fontFamily ?? global?.fontFamily ?? d.fontFamily
+        r.lineSpacing = window?.lineSpacing ?? workspace?.lineSpacing ?? global?.lineSpacing ?? d.lineSpacing
+        r.marginLeft = window?.marginLeft ?? workspace?.marginLeft ?? global?.marginLeft ?? d.marginLeft
+        r.marginRight = window?.marginRight ?? workspace?.marginRight ?? global?.marginRight ?? d.marginRight
+        r.maxWidth = window?.maxWidth ?? workspace?.maxWidth ?? global?.maxWidth ?? d.maxWidth
+        r.topMargin = window?.topMargin ?? workspace?.topMargin ?? global?.topMargin ?? d.topMargin
+        r.strongsMode = window?.strongsMode ?? workspace?.strongsMode ?? global?.strongsMode ?? d.strongsMode
+        r.showMorphology = window?.showMorphology ?? workspace?.showMorphology ?? global?.showMorphology ?? d.showMorphology
+        r.showFootNotes = window?.showFootNotes ?? workspace?.showFootNotes ?? global?.showFootNotes ?? d.showFootNotes
+        r.showFootNotesInline = window?.showFootNotesInline ?? workspace?.showFootNotesInline ?? global?.showFootNotesInline ?? d.showFootNotesInline
+        r.expandXrefs = window?.expandXrefs ?? workspace?.expandXrefs ?? global?.expandXrefs ?? d.expandXrefs
+        r.showXrefs = window?.showXrefs ?? workspace?.showXrefs ?? global?.showXrefs ?? d.showXrefs
+        r.showRedLetters = window?.showRedLetters ?? workspace?.showRedLetters ?? global?.showRedLetters ?? d.showRedLetters
+        r.showSectionTitles = window?.showSectionTitles ?? workspace?.showSectionTitles ?? global?.showSectionTitles ?? d.showSectionTitles
+        r.showVerseNumbers = window?.showVerseNumbers ?? workspace?.showVerseNumbers ?? global?.showVerseNumbers ?? d.showVerseNumbers
+        r.showVersePerLine = window?.showVersePerLine ?? workspace?.showVersePerLine ?? global?.showVersePerLine ?? d.showVersePerLine
+        r.showBookmarks = window?.showBookmarks ?? workspace?.showBookmarks ?? global?.showBookmarks ?? d.showBookmarks
+        r.showMyNotes = window?.showMyNotes ?? workspace?.showMyNotes ?? global?.showMyNotes ?? d.showMyNotes
+        r.justifyText = window?.justifyText ?? workspace?.justifyText ?? global?.justifyText ?? d.justifyText
+        r.hyphenation = window?.hyphenation ?? workspace?.hyphenation ?? global?.hyphenation ?? d.hyphenation
+        r.showPageNumber = window?.showPageNumber ?? workspace?.showPageNumber ?? global?.showPageNumber ?? d.showPageNumber
+        r.dayTextColor = window?.dayTextColor ?? workspace?.dayTextColor ?? global?.dayTextColor ?? d.dayTextColor
+        r.dayBackground = window?.dayBackground ?? workspace?.dayBackground ?? global?.dayBackground ?? d.dayBackground
+        r.dayNoise = window?.dayNoise ?? workspace?.dayNoise ?? global?.dayNoise ?? d.dayNoise
+        r.nightTextColor = window?.nightTextColor ?? workspace?.nightTextColor ?? global?.nightTextColor ?? d.nightTextColor
+        r.nightBackground = window?.nightBackground ?? workspace?.nightBackground ?? global?.nightBackground ?? d.nightBackground
+        r.nightNoise = window?.nightNoise ?? workspace?.nightNoise ?? global?.nightNoise ?? d.nightNoise
+        r.bookmarksHideLabels = window?.bookmarksHideLabels ?? workspace?.bookmarksHideLabels ?? global?.bookmarksHideLabels ?? d.bookmarksHideLabels
+        r.enableVerseSelection = window?.enableVerseSelection ?? workspace?.enableVerseSelection ?? global?.enableVerseSelection ?? d.enableVerseSelection
         return r
+    }
+
+    /**
+     Removes day/night theme color fields so the value inherits theme colors from its parent scope.
+
+     The remaining text-display fields are left untouched. This mirrors Android's split where global
+     text colors are a parent default and workspaces only override them when explicitly edited at the
+     workspace level.
+     */
+    public mutating func clearThemeColors() {
+        dayTextColor = nil
+        dayBackground = nil
+        dayNoise = nil
+        nightTextColor = nil
+        nightBackground = nil
+        nightNoise = nil
+    }
+
+    /// Returns a copy with day/night theme color overrides removed.
+    public func clearingThemeColors() -> TextDisplaySettings {
+        var copy = self
+        copy.clearThemeColors()
+        return copy
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
@@ -499,6 +499,26 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
         nightNoise = nil
     }
 
+    /// Whether this value explicitly overrides any day/night theme color field.
+    public var hasThemeColorOverrides: Bool {
+        dayTextColor != nil ||
+            dayBackground != nil ||
+            dayNoise != nil ||
+            nightTextColor != nil ||
+            nightBackground != nil ||
+            nightNoise != nil
+    }
+
+    /// Copies day/night theme color fields from another settings value.
+    public mutating func restoreThemeColors(from source: TextDisplaySettings) {
+        dayTextColor = source.dayTextColor
+        dayBackground = source.dayBackground
+        dayNoise = source.dayNoise
+        nightTextColor = source.nightTextColor
+        nightBackground = source.nightBackground
+        nightNoise = source.nightNoise
+    }
+
     /// Returns a copy with day/night theme color overrides removed.
     public func clearingThemeColors() -> TextDisplaySettings {
         var copy = self

--- a/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
@@ -168,7 +168,7 @@ public struct RecentLabel: Codable, Sendable {
  Stores optional text-display overrides used by the app's inheritance chain.
 
  Each property is optional by design. `nil` means "inherit from the next level up" using the
- chain `window -> workspace -> app defaults`. The struct itself performs no persistence or UI
+ chain `window -> workspace -> global -> app defaults`. The struct itself performs no persistence or UI
  updates; those side effects occur when a containing `Workspace` or `PageManager` is saved and
  the resolved values are pushed into native/web readers.
  */
@@ -330,6 +330,106 @@ public struct TextDisplaySettings: Codable, Sendable, Equatable {
         s.enableVerseSelection = true
         return s
     }()
+
+    internal struct FieldDescriptor {
+        let changed: (TextDisplaySettings, TextDisplaySettings) -> Bool
+        let clearIfMatchingParent: (inout TextDisplaySettings, TextDisplaySettings) -> Bool
+    }
+
+    private static func field<T: Equatable>(
+        _ keyPath: WritableKeyPath<TextDisplaySettings, T?>
+    ) -> FieldDescriptor {
+        FieldDescriptor(
+            changed: { previous, current in
+                previous[keyPath: keyPath] != current[keyPath: keyPath]
+            },
+            clearIfMatchingParent: { child, parent in
+                guard let childValue = child[keyPath: keyPath],
+                      let parentValue = parent[keyPath: keyPath],
+                      childValue == parentValue else {
+                    return false
+                }
+                child[keyPath: keyPath] = nil
+                return true
+            }
+        )
+    }
+
+    internal static let trackedFields: [FieldDescriptor] = [
+        field(\.fontSize),
+        field(\.fontFamily),
+        field(\.lineSpacing),
+        field(\.marginLeft),
+        field(\.marginRight),
+        field(\.maxWidth),
+        field(\.topMargin),
+        field(\.strongsMode),
+        field(\.showMorphology),
+        field(\.showFootNotes),
+        field(\.showFootNotesInline),
+        field(\.expandXrefs),
+        field(\.showXrefs),
+        field(\.showRedLetters),
+        field(\.showSectionTitles),
+        field(\.showVerseNumbers),
+        field(\.showVersePerLine),
+        field(\.showBookmarks),
+        field(\.showMyNotes),
+        field(\.justifyText),
+        field(\.hyphenation),
+        field(\.showPageNumber),
+        field(\.dayTextColor),
+        field(\.dayBackground),
+        field(\.dayNoise),
+        field(\.nightTextColor),
+        field(\.nightBackground),
+        field(\.nightNoise),
+        field(\.bookmarksHideLabels),
+        field(\.enableVerseSelection),
+    ]
+
+    internal static func changedFields(
+        from previous: TextDisplaySettings,
+        to current: TextDisplaySettings
+    ) -> [FieldDescriptor] {
+        trackedFields.filter { $0.changed(previous, current) }
+    }
+
+    @discardableResult
+    internal mutating func clearOverridesMatchingParent(
+        _ parent: TextDisplaySettings,
+        only fields: [FieldDescriptor]? = nil
+    ) -> Bool {
+        var anyChanged = false
+        for field in fields ?? Self.trackedFields {
+            anyChanged = field.clearIfMatchingParent(&self, parent) || anyChanged
+        }
+        return anyChanged
+    }
+
+    /// Clears overrides that already match the current effective parent value.
+    @discardableResult
+    public mutating func clearRedundantOverrides(matching parent: TextDisplaySettings) -> Bool {
+        clearOverridesMatchingParent(parent)
+    }
+
+    /**
+     Clears overrides that match the current parent for fields changed by another source scope.
+
+     Use this when the fields that changed come from one scope, but the child should be compared
+     against an already-resolved current parent value.
+     */
+    @discardableResult
+    public mutating func clearOverridesMatchingParent(
+        _ parent: TextDisplaySettings,
+        changedFrom previousSource: TextDisplaySettings,
+        to currentSource: TextDisplaySettings
+    ) -> Bool {
+        clearOverridesMatchingParent(
+            parent,
+            only: Self.changedFields(from: previousSource, to: currentSource)
+        )
+    }
 
     /**
      Resolves every display property into a fully populated settings struct.

--- a/Sources/BibleCore/Tests/BibleCoreTests/BookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/BookmarkTests.swift
@@ -104,12 +104,16 @@ final class BookmarkModelTests: XCTestCase {
     }
 
     func testTextDisplaySettingsFullyResolvedUsesGlobalBeforeDefaults() {
+        let dayBackground = Int(Int32(bitPattern: 0xFFFAF4E8))
+        let nightTextColor = Int(Int32(bitPattern: 0xFFF1E7D0))
+        let workspaceNightTextColor = Int(Int32(bitPattern: 0xFFCCCCCC))
+
         var globalSettings = TextDisplaySettings()
-        globalSettings.dayBackground = 0xFFFAF4E8
-        globalSettings.nightTextColor = 0xFFF1E7D0
+        globalSettings.dayBackground = dayBackground
+        globalSettings.nightTextColor = nightTextColor
 
         var workspaceSettings = TextDisplaySettings()
-        workspaceSettings.nightTextColor = 0xFFCCCCCC
+        workspaceSettings.nightTextColor = workspaceNightTextColor
 
         let resolved = TextDisplaySettings.fullyResolved(
             window: nil,
@@ -117,8 +121,8 @@ final class BookmarkModelTests: XCTestCase {
             global: globalSettings
         )
 
-        XCTAssertEqual(resolved.dayBackground, 0xFFFAF4E8)
-        XCTAssertEqual(resolved.nightTextColor, 0xFFCCCCCC)
+        XCTAssertEqual(resolved.dayBackground, dayBackground)
+        XCTAssertEqual(resolved.nightTextColor, workspaceNightTextColor)
         XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
     }
 }

--- a/Sources/BibleCore/Tests/BibleCoreTests/BookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/BookmarkTests.swift
@@ -54,21 +54,71 @@ final class BookmarkModelTests: XCTestCase {
         workspaceSettings.fontSize = 16
         workspaceSettings.fontFamily = "serif"
 
+        var globalSettings = TextDisplaySettings()
+        globalSettings.lineSpacing = 125
+
         var defaults = TextDisplaySettings()
         defaults.fontSize = 14
         defaults.fontFamily = "sans-serif"
         defaults.lineSpacing = 150
 
         // Window overrides workspace
-        let resolvedSize = TextDisplaySettings.resolved(\.fontSize, window: windowSettings, workspace: workspaceSettings, defaults: defaults)
+        let resolvedSize = TextDisplaySettings.resolved(
+            \.fontSize,
+            window: windowSettings,
+            workspace: workspaceSettings,
+            global: globalSettings,
+            defaults: defaults
+        )
         XCTAssertEqual(resolvedSize, 18)
 
         // Window nil → falls to workspace
-        let resolvedFamily = TextDisplaySettings.resolved(\.fontFamily, window: windowSettings, workspace: workspaceSettings, defaults: defaults)
+        let resolvedFamily = TextDisplaySettings.resolved(
+            \.fontFamily,
+            window: windowSettings,
+            workspace: workspaceSettings,
+            global: globalSettings,
+            defaults: defaults
+        )
         XCTAssertEqual(resolvedFamily, "serif")
 
-        // Both nil → falls to defaults
-        let resolvedSpacing = TextDisplaySettings.resolved(\.lineSpacing, window: windowSettings, workspace: workspaceSettings, defaults: defaults)
-        XCTAssertEqual(resolvedSpacing, 150)
+        // Window and workspace nil → falls to global
+        let resolvedSpacing = TextDisplaySettings.resolved(
+            \.lineSpacing,
+            window: windowSettings,
+            workspace: workspaceSettings,
+            global: globalSettings,
+            defaults: defaults
+        )
+        XCTAssertEqual(resolvedSpacing, 125)
+
+        // Window, workspace, and global nil → falls to defaults
+        let resolvedTopMargin = TextDisplaySettings.resolved(
+            \.topMargin,
+            window: windowSettings,
+            workspace: workspaceSettings,
+            global: globalSettings,
+            defaults: defaults
+        )
+        XCTAssertNil(resolvedTopMargin)
+    }
+
+    func testTextDisplaySettingsFullyResolvedUsesGlobalBeforeDefaults() {
+        var globalSettings = TextDisplaySettings()
+        globalSettings.dayBackground = 0xFFFAF4E8
+        globalSettings.nightTextColor = 0xFFF1E7D0
+
+        var workspaceSettings = TextDisplaySettings()
+        workspaceSettings.nightTextColor = 0xFFCCCCCC
+
+        let resolved = TextDisplaySettings.fullyResolved(
+            window: nil,
+            workspace: workspaceSettings,
+            global: globalSettings
+        )
+
+        XCTAssertEqual(resolved.dayBackground, 0xFFFAF4E8)
+        XCTAssertEqual(resolved.nightTextColor, 0xFFCCCCCC)
+        XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -465,7 +465,11 @@ public struct BibleReaderView: View {
         let strongsMode = resolvedDisplaySettings(for: windowManager.activeWindow).strongsMode
             ?? TextDisplaySettings.appDefaults.strongsMode
             ?? 0
-        return "\(windowToken);\(contentToken);strongsMode=\(strongsMode)"
+        let drawerToken = "drawerVisible=\(showReaderNavigationDrawer ? "true" : "false")"
+        let overflowToken = "overflowVisible=\(showReaderOverflowMenu ? "true" : "false")"
+        let sheetToken = "readerSheet=\(activeReaderSheet?.rawValue ?? "none")"
+        let searchToken = "searchVisible=\(showSearch ? "true" : "false")"
+        return "\(windowToken);\(contentToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(searchToken)"
     }
 
     /// Converts SWORD Roman-numeral book prefixes into Android-style Arabic numerals for toolbar display.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -3184,7 +3184,7 @@ public struct BibleReaderView: View {
 
      - Side effects:
        - writes only workspace-scope overrides into the active workspace
-       - clears window-scoped Strong's overrides when the workspace Strong's mode changes
+       - clears window-scoped overrides that now match the workspace parent values
        - pushes each visible reader its own resolved display settings
        - reloads behavior preferences so dependent native toggles stay in sync
      - Failure modes:
@@ -3209,7 +3209,8 @@ public struct BibleReaderView: View {
         _ workspaceSettings: TextDisplaySettings,
         previousResolvedSettings: TextDisplaySettings
     ) {
-        let workspaceScopedSettings = workspaceSettings.clearingThemeColors()
+        var workspaceScopedSettings = workspaceSettings.clearingThemeColors()
+        _ = workspaceScopedSettings.clearRedundantOverrides(matching: globalDisplaySettings)
 
         if let workspace = windowManager.activeWorkspace {
             workspace.textDisplaySettings = workspaceScopedSettings
@@ -3218,9 +3219,16 @@ public struct BibleReaderView: View {
                 workspace: workspaceScopedSettings,
                 global: globalDisplaySettings
             )
-            if previousResolvedSettings.strongsMode != resolvedSettings.strongsMode {
-                for window in windowManager.allWindows {
-                    window.pageManager?.textDisplaySettings?.strongsMode = nil
+            for window in windowManager.allWindows {
+                guard var windowSettings = window.pageManager?.textDisplaySettings else {
+                    continue
+                }
+                if windowSettings.clearOverridesMatchingParent(
+                    resolvedSettings,
+                    changedFrom: previousResolvedSettings,
+                    to: resolvedSettings
+                ) {
+                    window.pageManager?.textDisplaySettings = windowSettings
                 }
             }
             try? modelContext.save()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -260,7 +260,10 @@ public struct BibleReaderView: View {
     /// Text and color settings resolved for the currently active pane and toolbar state.
     @State private var displaySettings: TextDisplaySettings = .appDefaults
 
-    /// Workspace-scoped display settings edited from the full Settings/Text Display flows.
+    /// App-level text-display defaults edited from the full Application Settings flow.
+    @State private var globalDisplaySettings: TextDisplaySettings = .appDefaults
+
+    /// Workspace-scoped display settings edited by reader-level text-display controls.
     @State private var settingsDisplaySettings: TextDisplaySettings = .appDefaults
 
     /// Effective night-mode value currently applied to pane controllers and overlays.
@@ -641,6 +644,7 @@ public struct BibleReaderView: View {
         .onAppear {
             // Load persisted settings
             let store = SettingsStore(modelContext: modelContext)
+            globalDisplaySettings = store.globalTextDisplaySettings()
             nightModeMode = store.getString(.nightModePref3)
             let manualNightMode = store.getBool("night_mode")
             nightMode = NightModeSettingsResolver.isNightMode(
@@ -784,10 +788,10 @@ public struct BibleReaderView: View {
             case .settings:
                 NavigationStack {
                     SettingsView(
-                        displaySettings: $settingsDisplaySettings,
+                        displaySettings: $globalDisplaySettings,
                         nightMode: $nightMode,
                         nightModeMode: $nightModeMode,
-                        onSettingsChanged: applyWorkspaceDisplaySettingsChange
+                        onSettingsChanged: applyGlobalDisplaySettingsChange
                     )
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -843,7 +847,7 @@ public struct BibleReaderView: View {
         }
         .sheet(isPresented: $showTextDisplaySettings) {
             NavigationStack {
-                TextDisplaySettingsView(settings: $settingsDisplaySettings, onChange: applyWorkspaceDisplaySettingsChange)
+                TextDisplaySettingsView(settings: $globalDisplaySettings, onChange: applyGlobalDisplaySettingsChange)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button(String(localized: "done")) { showTextDisplaySettings = false }
@@ -864,7 +868,7 @@ public struct BibleReaderView: View {
         }
         .sheet(isPresented: $showColorSettings) {
             NavigationStack {
-                ColorSettingsView(settings: $settingsDisplaySettings, onChange: applyWorkspaceDisplaySettingsChange)
+                ColorSettingsView(settings: $globalDisplaySettings, onChange: applyGlobalDisplaySettingsChange)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button(String(localized: "done")) { showColorSettings = false }
@@ -1116,7 +1120,6 @@ public struct BibleReaderView: View {
                     .keyboardShortcut("d", modifiers: .command)
                 Button("") {
                     setPanePresentationTarget(windowManager.activeWindow?.id)
-                    prepareWorkspaceDisplaySettingsEditor()
                     activeReaderSheet = .settings
                 }
                     .keyboardShortcut(",", modifiers: .command)
@@ -1243,7 +1246,6 @@ public struct BibleReaderView: View {
                 activeReaderSheet = .readingPlans
             case .settings:
                 setPanePresentationTarget(windowManager.activeWindow?.id)
-                prepareWorkspaceDisplaySettingsEditor()
                 activeReaderSheet = .settings
             case .workspaces:
                 setPanePresentationTarget(windowManager.activeWindow?.id)
@@ -1290,7 +1292,6 @@ public struct BibleReaderView: View {
     /** Opens Settings from the reader shell. */
     private func openSettingsFromReaderAction() {
         setPanePresentationTarget(windowManager.activeWindow?.id)
-        prepareWorkspaceDisplaySettingsEditor()
         activeReaderSheet = .settings
     }
 
@@ -1339,7 +1340,6 @@ public struct BibleReaderView: View {
             },
             onShowSettings: {
                 setPanePresentationTarget(window.id)
-                prepareWorkspaceDisplaySettingsEditor()
                 activeReaderSheet = .settings
             },
             onShowDownloads: {
@@ -2208,7 +2208,6 @@ public struct BibleReaderView: View {
                     ) {
                         dismissReaderNavigationDrawerAndPerform {
                             setPanePresentationTarget(windowManager.activeWindow?.id)
-                            prepareWorkspaceDisplaySettingsEditor()
                             activeReaderSheet = .settings
                         }
                     }
@@ -3141,11 +3140,11 @@ public struct BibleReaderView: View {
         _ keyPath: WritableKeyPath<TextDisplaySettings, Bool?>,
         default defaultValue: Bool
     ) {
-        let currentValue = settingsDisplaySettings[keyPath: keyPath]
-            ?? resolvedWorkspaceDisplaySettings()[keyPath: keyPath]
-            ?? defaultValue
-        settingsDisplaySettings[keyPath: keyPath] = !currentValue
-        applyWorkspaceDisplaySettingsChange()
+        let previousWorkspaceSettings = resolvedWorkspaceDisplaySettings()
+        let currentValue = previousWorkspaceSettings[keyPath: keyPath] ?? defaultValue
+        var workspaceSettings = windowManager.activeWorkspace?.textDisplaySettings ?? TextDisplaySettings()
+        workspaceSettings[keyPath: keyPath] = !currentValue
+        persistWorkspaceDisplaySettings(workspaceSettings, previousResolvedSettings: previousWorkspaceSettings)
     }
 
     /**
@@ -3184,9 +3183,8 @@ public struct BibleReaderView: View {
      Persists workspace-scoped text-display edits and refreshes reader controllers per pane.
 
      - Side effects:
-       - writes the current editor value into the active workspace
-       - clears window-scoped Strong's overrides when the workspace Strong's mode changes, so the
-         full Settings flow continues to behave workspace-wide
+       - writes only workspace-scope overrides into the active workspace
+       - clears window-scoped Strong's overrides when the workspace Strong's mode changes
        - pushes each visible reader its own resolved display settings
        - reloads behavior preferences so dependent native toggles stay in sync
      - Failure modes:
@@ -3194,11 +3192,33 @@ public struct BibleReaderView: View {
        - SwiftData save failures are intentionally swallowed via `try?`
      */
     private func applyWorkspaceDisplaySettingsChange() {
-        let previousWorkspaceSettings = resolvedWorkspaceDisplaySettings()
+        persistWorkspaceDisplaySettings(
+            settingsDisplaySettings,
+            previousResolvedSettings: resolvedWorkspaceDisplaySettings()
+        )
+    }
+
+    /**
+     Persists one workspace-scope settings value without copying inherited global theme colors.
+
+     - Parameters:
+       - workspaceSettings: Workspace-level overrides to persist.
+       - previousResolvedSettings: Effective workspace settings before this mutation.
+     */
+    private func persistWorkspaceDisplaySettings(
+        _ workspaceSettings: TextDisplaySettings,
+        previousResolvedSettings: TextDisplaySettings
+    ) {
+        let workspaceScopedSettings = workspaceSettings.clearingThemeColors()
 
         if let workspace = windowManager.activeWorkspace {
-            workspace.textDisplaySettings = settingsDisplaySettings
-            if previousWorkspaceSettings.strongsMode != settingsDisplaySettings.strongsMode {
+            workspace.textDisplaySettings = workspaceScopedSettings
+            let resolvedSettings = TextDisplaySettings.fullyResolved(
+                window: nil,
+                workspace: workspaceScopedSettings,
+                global: globalDisplaySettings
+            )
+            if previousResolvedSettings.strongsMode != resolvedSettings.strongsMode {
                 for window in windowManager.allWindows {
                     window.pageManager?.textDisplaySettings?.strongsMode = nil
                 }
@@ -3212,11 +3232,35 @@ public struct BibleReaderView: View {
         reloadBehaviorPreferences()
     }
 
+    /**
+     Persists app-level text-display defaults and refreshes reader controllers.
+
+     This mirrors Android's global text-display layer: application Settings edits the global
+     fallback, while workspace and window overrides remain separate scopes in the inheritance chain.
+
+     - Side effects:
+       - writes `globalDisplaySettings` through `SettingsStore`
+       - pushes each visible reader its own resolved display settings
+       - reloads behavior preferences so non-display settings changed from the same Settings screen
+         stay in sync
+     - Failure modes: Settings-store persistence failures are intentionally swallowed by
+       `SettingsStore`.
+     */
+    private func applyGlobalDisplaySettingsChange() {
+        let store = SettingsStore(modelContext: modelContext)
+        store.setGlobalTextDisplaySettings(globalDisplaySettings)
+        refreshVisibleControllerDisplaySettings()
+        syncActiveDisplaySettings()
+        prepareWorkspaceDisplaySettingsEditor()
+        reloadBehaviorPreferences()
+    }
+
     /// Resolves text-display settings for one specific window using the normal inheritance chain.
     private func resolvedDisplaySettings(for window: Window?) -> TextDisplaySettings {
         TextDisplaySettings.fullyResolved(
             window: window?.pageManager?.textDisplaySettings,
-            workspace: windowManager.activeWorkspace?.textDisplaySettings
+            workspace: windowManager.activeWorkspace?.textDisplaySettings,
+            global: globalDisplaySettings
         )
     }
 
@@ -3224,7 +3268,8 @@ public struct BibleReaderView: View {
     private func resolvedWorkspaceDisplaySettings() -> TextDisplaySettings {
         TextDisplaySettings.fullyResolved(
             window: nil,
-            workspace: windowManager.activeWorkspace?.textDisplaySettings
+            workspace: windowManager.activeWorkspace?.textDisplaySettings,
+            global: globalDisplaySettings
         )
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -263,9 +263,6 @@ public struct BibleReaderView: View {
     /// App-level text-display defaults edited from the full Application Settings flow.
     @State private var globalDisplaySettings: TextDisplaySettings = .appDefaults
 
-    /// Workspace-scoped display settings edited by reader-level text-display controls.
-    @State private var settingsDisplaySettings: TextDisplaySettings = .appDefaults
-
     /// Effective night-mode value currently applied to pane controllers and overlays.
     @State private var nightMode = false
 
@@ -669,7 +666,6 @@ public struct BibleReaderView: View {
             speakService.restoreSettings()
 
             syncActiveDisplaySettings()
-            prepareWorkspaceDisplaySettingsEditor()
 
             // TTS callbacks — dynamically resolve the focused controller so TTS
             // always operates on the active window (not the last-initialized pane).
@@ -3180,25 +3176,6 @@ public struct BibleReaderView: View {
     }
 
     /**
-     Persists workspace-scoped text-display edits and refreshes reader controllers per pane.
-
-     - Side effects:
-       - writes only workspace-scope overrides into the active workspace
-       - clears window-scoped overrides that now match the workspace parent values
-       - pushes each visible reader its own resolved display settings
-       - reloads behavior preferences so dependent native toggles stay in sync
-     - Failure modes:
-       - if no active workspace exists, persistence is skipped and only controller refreshes occur
-       - SwiftData save failures are intentionally swallowed via `try?`
-     */
-    private func applyWorkspaceDisplaySettingsChange() {
-        persistWorkspaceDisplaySettings(
-            settingsDisplaySettings,
-            previousResolvedSettings: resolvedWorkspaceDisplaySettings()
-        )
-    }
-
-    /**
      Persists one workspace-scope settings value without copying inherited global theme colors.
 
      - Parameters:
@@ -3209,10 +3186,17 @@ public struct BibleReaderView: View {
         _ workspaceSettings: TextDisplaySettings,
         previousResolvedSettings: TextDisplaySettings
     ) {
-        var workspaceScopedSettings = workspaceSettings.clearingThemeColors()
-        _ = workspaceScopedSettings.clearRedundantOverrides(matching: globalDisplaySettings)
-
         if let workspace = windowManager.activeWorkspace {
+            let hadWorkspaceThemeColors = workspace.textDisplaySettings?.hasThemeColorOverrides ?? false
+            var workspaceScopedSettings = workspaceSettings
+            if !hadWorkspaceThemeColors {
+                workspaceScopedSettings.clearThemeColors()
+            }
+            _ = workspaceScopedSettings.clearRedundantOverrides(matching: globalDisplaySettings)
+            if hadWorkspaceThemeColors {
+                workspaceScopedSettings.restoreThemeColors(from: workspaceSettings)
+            }
+
             workspace.textDisplaySettings = workspaceScopedSettings
             let resolvedSettings = TextDisplaySettings.fullyResolved(
                 window: nil,
@@ -3236,7 +3220,6 @@ public struct BibleReaderView: View {
 
         refreshVisibleControllerDisplaySettings()
         syncActiveDisplaySettings()
-        prepareWorkspaceDisplaySettingsEditor()
         reloadBehaviorPreferences()
     }
 
@@ -3259,7 +3242,6 @@ public struct BibleReaderView: View {
         store.setGlobalTextDisplaySettings(globalDisplaySettings)
         refreshVisibleControllerDisplaySettings()
         syncActiveDisplaySettings()
-        prepareWorkspaceDisplaySettingsEditor()
         reloadBehaviorPreferences()
     }
 
@@ -3284,11 +3266,6 @@ public struct BibleReaderView: View {
     /// Re-syncs the focused toolbar/settings state from the current active window.
     private func syncActiveDisplaySettings() {
         displaySettings = resolvedDisplaySettings(for: windowManager.activeWindow)
-    }
-
-    /// Seeds the workspace settings editor from the current workspace-level values.
-    private func prepareWorkspaceDisplaySettingsEditor() {
-        settingsDisplaySettings = resolvedWorkspaceDisplaySettings()
     }
 
     /// Refreshes each visible reader pane using that pane's own resolved display settings.

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -12,12 +12,12 @@ import UIKit
  Top-level application settings screen covering reader behavior, appearance, security, sync, and
  module-backed preference selection.
 
- The view mixes direct `TextDisplaySettings` bindings with persisted Android-parity preferences
- stored through `SettingsStore` and `UserDefaults`-backed `AppStorage`.
+ The view mixes direct global `TextDisplaySettings` bindings with persisted Android-parity
+ preferences stored through `SettingsStore` and `UserDefaults`-backed `AppStorage`.
 
  Data dependencies:
  - `modelContext` is used to load and persist Android-parity settings through `SettingsStore`
- - `displaySettings`, `nightMode`, and `nightModeMode` are shared reader settings owned by the parent
+ - `displaySettings`, `nightMode`, and `nightModeMode` are shared global settings owned by the parent
  - `colorScheme` and `openURL` influence night-mode resolution and system-settings actions
 
  Side effects:
@@ -37,7 +37,7 @@ public struct SettingsView: View {
     /// URL opener used for system-settings actions.
     @Environment(\.openURL) private var openURL
 
-    /// Shared text display settings edited by nested settings screens.
+    /// Shared global text-display settings edited by nested settings screens.
     @Binding var displaySettings: TextDisplaySettings
 
     /// Shared effective night-mode state used by the reader.

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -772,11 +772,11 @@ private final class FixtureContext {
      */
     private func seedCustomColorSettings() {
         var settings = settingsStore.globalTextDisplaySettings()
-        settings.dayTextColor = 0xFF112233
-        settings.dayBackground = 0xFFFAF4E8
+        settings.dayTextColor = Int(Int32(bitPattern: 0xFF112233))
+        settings.dayBackground = Int(Int32(bitPattern: 0xFFFAF4E8))
         settings.dayNoise = 7
-        settings.nightTextColor = 0xFFF1E7D0
-        settings.nightBackground = 0xFF101820
+        settings.nightTextColor = Int(Int32(bitPattern: 0xFFF1E7D0))
+        settings.nightBackground = Int(Int32(bitPattern: 0xFF101820))
         settings.nightNoise = 5
         settingsStore.setGlobalTextDisplaySettings(settings)
     }

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -377,7 +377,7 @@ private final class FixtureContext {
         case .syncNextCloudBookmarksEnabled:
             seedSyncNextCloud(enabledCategories: [.bookmarks])
         case .displayColorsCustom:
-            seedCustomColorSettings(workspace: baseline.workspace, pageManager: baseline.pageManager)
+            seedCustomColorSettings()
         }
 
         try modelContext.save()
@@ -768,20 +768,17 @@ private final class FixtureContext {
     }
 
     /**
-     Seeds one non-default color tuple into the active page manager's text-display settings.
-     *
-     * - Parameter pageManager: Active page manager whose display settings should be overridden.
+     Seeds one non-default color tuple into the global text-display defaults.
      */
-    private func seedCustomColorSettings(workspace: Workspace, pageManager: PageManager) {
-        var settings = workspace.textDisplaySettings ?? TextDisplaySettings()
+    private func seedCustomColorSettings() {
+        var settings = settingsStore.globalTextDisplaySettings()
         settings.dayTextColor = 0xFF112233
         settings.dayBackground = 0xFFFAF4E8
         settings.dayNoise = 7
         settings.nightTextColor = 0xFFF1E7D0
         settings.nightBackground = 0xFF101820
         settings.nightNoise = 5
-        workspace.textDisplaySettings = settings
-        pageManager.textDisplaySettings = nil
+        settingsStore.setGlobalTextDisplaySettings(settings)
     }
 
     /**


### PR DESCRIPTION
Summary
- Align iOS text-display color persistence with Android's global defaults model.
- Application Settings now edits app-level display defaults instead of copying theme colors into the active workspace.

Scope
- Adds a persisted global text-display settings row in the local settings store.
- Updates reader display resolution to use window, workspace, global, then app defaults.
- Keeps workspace/window overrides authoritative when they are explicitly set.
- Updates fixture seeding and regression tests for the new inheritance chain.

Contract References
- Closes #21.
- Issue state was validated before publishing: #21 is open.
- Android parity reference: global text-display defaults remain separate from workspace and window overrides.

Change Details
- SettingsStore now stores global text-display defaults as local JSON-backed settings.
- TextDisplaySettings resolution now includes a global layer before app defaults.
- BibleReaderView and ContentView route Application Settings display edits through global settings.
- Workspace creation and reader-level workspace toggles avoid copying inherited theme colors into workspace overrides.
- UITestFixtureTool seeds custom display colors into global settings rather than workspace/page-manager state.

Validation Evidence
- git diff --check
- swift build --product UITestFixtureTool
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:AndBibleTests/AndBibleTests/testTextDisplaySettingsInheritanceUsesGlobalBeforeDefaults -only-testing:AndBibleTests/AndBibleTests/testTextDisplaySettingsFullyResolvedUsesGlobalBeforeDefaults -only-testing:AndBibleTests/AndBibleTests/testWorkspaceStoreCreateWorkspaceInheritsWorkspaceScopedDefaultsWithoutCloningGraph CODE_SIGNING_ALLOWED=NO

Risks / Follow-ups
- Existing workspace and window overrides still take precedence, so users with explicit workspace overrides may not see global changes until those overrides are cleared.
- Literal swift test remains unsuitable for this package because SwiftPM builds the full host macOS package and currently hits unrelated iOS-only UI targets; this PR keeps validation on the iOS app scheme.
