### PR TITLE
Fix #26: Remove legacy iPad sidebar shell

### DIFF
--- a/AndBible/ContentView.swift
+++ b/AndBible/ContentView.swift
@@ -1,9 +1,7 @@
 // ContentView.swift — Root navigation container
 
 import SwiftUI
-import SwiftData
 import BibleUI
-import BibleCore
 
 /**
  Root content view for the app's reader-first shell.
@@ -11,41 +9,9 @@ import BibleCore
  The Android-parity reader drawer is the supported top-level navigation surface.
  */
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Environment(\.colorScheme) private var colorScheme
-    @State private var nightMode = false
-    @State private var nightModeMode = AppPreferenceRegistry.stringDefault(for: .nightModePref3) ?? NightModeSetting.system.rawValue
-
     var body: some View {
         NavigationStack {
             BibleReaderView()
         }
-        .preferredColorScheme(preferredColorSchemeOverride)
-        .onAppear {
-            reloadNightModePreferences()
-        }
-        .onChange(of: colorScheme) { _, _ in
-            reloadNightModePreferences()
-        }
-    }
-
-    private var preferredColorSchemeOverride: ColorScheme? {
-        switch NightModeSettingsResolver.effectiveMode(from: nightModeMode) {
-        case .system:
-            return nil
-        case .automatic, .manual:
-            return nightMode ? .dark : .light
-        }
-    }
-
-    private func reloadNightModePreferences() {
-        let store = SettingsStore(modelContext: modelContext)
-        nightModeMode = store.getString(.nightModePref3)
-        let manualNightMode = store.getBool("night_mode")
-        nightMode = NightModeSettingsResolver.isNightMode(
-            rawValue: nightModeMode,
-            manualNightMode: manualNightMode,
-            systemIsDark: colorScheme == .dark
-        )
     }
 }

--- a/AndBible/ContentView.swift
+++ b/AndBible/ContentView.swift
@@ -6,39 +6,22 @@ import BibleUI
 import BibleCore
 
 /**
- Root content view managing the app's navigation structure.
+ Root content view for the app's reader-first shell.
 
- On iPhone: Single-column navigation
- On iPad/Mac: Sidebar navigation with split view
+ The Android-parity reader drawer is the supported top-level navigation surface.
  */
 struct ContentView: View {
-    @State private var selectedTab: Tab? = .bible
-    @State private var showSettings = false
-    @State private var showWorkspaces = false
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
-    @State private var globalDisplaySettings: TextDisplaySettings = .appDefaults
     @State private var nightMode = false
     @State private var nightModeMode = AppPreferenceRegistry.stringDefault(for: .nightModePref3) ?? NightModeSetting.system.rawValue
 
-    enum Tab: Hashable {
-        case bible
-        case bookmarks
-        case search
-        case readingPlan
-    }
-
     var body: some View {
-        Group {
-            #if os(macOS)
-            macLayout
-            #else
-            adaptiveLayout
-            #endif
+        NavigationStack {
+            BibleReaderView()
         }
         .preferredColorScheme(preferredColorSchemeOverride)
         .onAppear {
-            reloadGlobalDisplaySettings()
             reloadNightModePreferences()
         }
         .onChange(of: colorScheme) { _, _ in
@@ -64,118 +47,5 @@ struct ContentView: View {
             manualNightMode: manualNightMode,
             systemIsDark: colorScheme == .dark
         )
-    }
-
-    private func reloadGlobalDisplaySettings() {
-        let store = SettingsStore(modelContext: modelContext)
-        globalDisplaySettings = store.globalTextDisplaySettings()
-    }
-
-    private func applyGlobalDisplaySettingsChange() {
-        let store = SettingsStore(modelContext: modelContext)
-        store.setGlobalTextDisplaySettings(globalDisplaySettings)
-        reloadNightModePreferences()
-    }
-
-    // MARK: - iOS Layout (adapts for iPhone vs iPad)
-
-    #if os(iOS)
-    @ViewBuilder
-    private var adaptiveLayout: some View {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            NavigationSplitView {
-                sidebar
-            } detail: {
-                detailView
-            }
-            .navigationSplitViewStyle(.balanced)
-        } else {
-            NavigationStack {
-                BibleReaderView()
-            }
-        }
-    }
-    #endif
-
-    // MARK: - Mac Layout
-
-    #if os(macOS)
-    private var macLayout: some View {
-        NavigationSplitView {
-            sidebar
-        } detail: {
-            detailView
-        }
-    }
-    #endif
-
-    // MARK: - Detail View (driven by sidebar selection)
-
-    @ViewBuilder
-    private var detailView: some View {
-        switch selectedTab {
-        case .bible, .none:
-            BibleReaderView()
-        case .bookmarks:
-            NavigationStack {
-                BookmarkListView { book, chapter in
-                    selectedTab = .bible
-                }
-            }
-        case .search:
-            NavigationStack {
-                SearchView(swordModule: nil) { book, chapter in
-                    selectedTab = .bible
-                }
-            }
-        case .readingPlan:
-            NavigationStack {
-                ReadingPlanListView()
-            }
-        }
-    }
-
-    // MARK: - Sidebar
-
-    private var sidebar: some View {
-        List(selection: $selectedTab) {
-            NavigationLink(value: Tab.bible) {
-                Label("Bible", systemImage: "book")
-            }
-            .accessibilityIdentifier("contentTabBible")
-            NavigationLink(value: Tab.bookmarks) {
-                Label("Bookmarks", systemImage: "bookmark")
-            }
-            .accessibilityIdentifier("contentTabBookmarks")
-            NavigationLink(value: Tab.search) {
-                Label("Search", systemImage: "magnifyingglass")
-            }
-            .accessibilityIdentifier("contentTabSearch")
-            NavigationLink(value: Tab.readingPlan) {
-                Label("Reading Plans", systemImage: "calendar")
-            }
-            .accessibilityIdentifier("contentTabReadingPlans")
-
-            Section {
-                NavigationLink {
-                    ModuleBrowserView()
-                } label: {
-                    Label("Downloads", systemImage: "arrow.down.circle")
-                }
-                .accessibilityIdentifier("contentDownloadsLink")
-                NavigationLink {
-                    SettingsView(
-                        displaySettings: $globalDisplaySettings,
-                        nightMode: $nightMode,
-                        nightModeMode: $nightModeMode,
-                        onSettingsChanged: applyGlobalDisplaySettingsChange
-                    )
-                } label: {
-                    Label("Settings", systemImage: "gear")
-                }
-                .accessibilityIdentifier("contentSettingsLink")
-            }
-        }
-        .navigationTitle("AndBible")
     }
 }

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -278,6 +278,19 @@ final class AndBibleTests: XCTestCase {
         )
     }
 
+    func testContentViewDoesNotContainLegacyRootSidebarShell() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let contentViewURL = repoRoot.appendingPathComponent("AndBible/ContentView.swift")
+        let source = try String(contentsOf: contentViewURL, encoding: .utf8)
+
+        XCTAssertFalse(source.contains("NavigationSplitView"))
+        XCTAssertFalse(source.contains("contentTabBible"))
+        XCTAssertFalse(source.contains("contentSettingsLink"))
+    }
+
     func testColorARGBByteClampsIntermediatePickerComponents() {
         XCTAssertEqual(Color.clampedARGBByte(-0.25), 0)
         XCTAssertEqual(Color.clampedARGBByte(0.5), 128)

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -284,11 +284,39 @@ final class AndBibleTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
         let contentViewURL = repoRoot.appendingPathComponent("AndBible/ContentView.swift")
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: contentViewURL.path),
+            "Could not locate AndBible/ContentView.swift at expected path: \(contentViewURL.path). Update this regression test if the project layout changes."
+        )
+
+        guard FileManager.default.fileExists(atPath: contentViewURL.path) else {
+            return
+        }
+
         let source = try String(contentsOf: contentViewURL, encoding: .utf8)
 
-        XCTAssertFalse(source.contains("NavigationSplitView"))
-        XCTAssertFalse(source.contains("contentTabBible"))
-        XCTAssertFalse(source.contains("contentSettingsLink"))
+        guard let navigationSplitViewRange = source.range(of: "NavigationSplitView") else {
+            return
+        }
+
+        let contextStart = source.index(
+            navigationSplitViewRange.lowerBound,
+            offsetBy: -1200,
+            limitedBy: source.startIndex
+        ) ?? source.startIndex
+        let contextEnd = source.index(
+            navigationSplitViewRange.upperBound,
+            offsetBy: 1200,
+            limitedBy: source.endIndex
+        ) ?? source.endIndex
+        let navigationSplitViewContext = String(source[contextStart..<contextEnd])
+
+        XCTAssertFalse(
+            navigationSplitViewContext.contains("contentTabBible")
+                && navigationSplitViewContext.contains("contentSettingsLink"),
+            "ContentView.swift appears to contain the legacy root sidebar shell pattern: NavigationSplitView with contentTabBible/contentSettingsLink in the same root layout region."
+        )
     }
 
     func testColorARGBByteClampsIntermediatePickerComponents() {

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -296,25 +296,38 @@ final class AndBibleTests: XCTestCase {
 
         let source = try String(contentsOf: contentViewURL, encoding: .utf8)
 
-        guard let navigationSplitViewRange = source.range(of: "NavigationSplitView") else {
-            return
+        let searchTerm = "NavigationSplitView"
+        var searchStartIndex = source.startIndex
+        var foundLegacyRootSidebarShell = false
+
+        while searchStartIndex < source.endIndex,
+              let navigationSplitViewRange = source.range(
+                  of: searchTerm,
+                  range: searchStartIndex..<source.endIndex
+              ) {
+            let contextStart = source.index(
+                navigationSplitViewRange.lowerBound,
+                offsetBy: -1200,
+                limitedBy: source.startIndex
+            ) ?? source.startIndex
+            let contextEnd = source.index(
+                navigationSplitViewRange.upperBound,
+                offsetBy: 1200,
+                limitedBy: source.endIndex
+            ) ?? source.endIndex
+            let navigationSplitViewContext = String(source[contextStart..<contextEnd])
+
+            if navigationSplitViewContext.contains("contentTabBible")
+                && navigationSplitViewContext.contains("contentSettingsLink") {
+                foundLegacyRootSidebarShell = true
+                break
+            }
+
+            searchStartIndex = navigationSplitViewRange.upperBound
         }
 
-        let contextStart = source.index(
-            navigationSplitViewRange.lowerBound,
-            offsetBy: -1200,
-            limitedBy: source.startIndex
-        ) ?? source.startIndex
-        let contextEnd = source.index(
-            navigationSplitViewRange.upperBound,
-            offsetBy: 1200,
-            limitedBy: source.endIndex
-        ) ?? source.endIndex
-        let navigationSplitViewContext = String(source[contextStart..<contextEnd])
-
         XCTAssertFalse(
-            navigationSplitViewContext.contains("contentTabBible")
-                && navigationSplitViewContext.contains("contentSettingsLink"),
+            foundLegacyRootSidebarShell,
             "ContentView.swift appears to contain the legacy root sidebar shell pattern: NavigationSplitView with contentTabBible/contentSettingsLink in the same root layout region."
         )
     }


### PR DESCRIPTION
## Summary
Remove the legacy root SwiftUI sidebar shell so the reader-first Android-parity hamburger drawer is the single top-level navigation path.

## Scope
- Simplifies `ContentView` to host `BibleReaderView` directly in a `NavigationStack` on all supported iOS device classes.
- Removes the old `NavigationSplitView` sidebar/tab shell, including the legacy Bible, bookmarks, search, reading plan, downloads, and settings root links.
- Removes duplicate night-mode/color-scheme state from `ContentView`; `BibleReaderView` remains the single owner of reader night-mode and `.preferredColorScheme(...)` behavior.
- Adds and tightens a regression test that guards against reintroducing the legacy root sidebar structure.

## Contract References
- Issue: #26
- Platform parity target: Android-style reader hamburger drawer as the supported navigation surface.

## Change Details
The old iPad root sidebar remained in the SwiftUI shell after the Android-parity drawer was introduced. That left two competing navigation systems in the app, and the legacy one could appear intermittently without adding meaningful behavior. This PR removes that duplicate shell instead of hiding it by device type.

`ContentView` is now intentionally thin: it owns only the root `NavigationStack` and delegates reader state, including night-mode/color-scheme handling, to `BibleReaderView`. That keeps color-scheme behavior in the same place as the reader settings UI and avoids duplicated preference reads after the root shell was simplified.

The regression test now checks for the old root sidebar pattern specifically. It verifies `ContentView.swift` can be located, then scans every `NavigationSplitView` occurrence and fails only if one appears in the same local region as the old root sidebar markers.

## Validation Evidence
- `git diff --check`
- `xcodebuild build -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination generic/platform=iOS Simulator CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.4 -only-testing:AndBibleTests/AndBibleTests/testContentViewDoesNotContainLegacyRootSidebarShell CODE_SIGNING_ALLOWED=NO`
- Installed and manually checked the built app on booted iPhone 17 and iPad Pro 11-inch simulators.

## Risks / Follow-ups
- Risk is limited to top-level app shell behavior because this removes a duplicate navigation path that should no longer be reachable.
- If future macOS support needs a sidebar, it should be introduced intentionally as a separate platform-specific shell instead of reusing this legacy iPad path.

## Issue Closure Reference
Closes #26
