### PR TITLE
fix(parity): harden bridge inventory follow-up

### DIFF
--- a/docs/howto/ui-test-sharding.md
+++ b/docs/howto/ui-test-sharding.md
@@ -36,9 +36,9 @@ the shard count is being changed because of current evidence.
 Current local planner output for the checked-in suite is:
 
 ```text
-shard 1: 14 tests, estimated 478.683s
-shard 2: 15 tests, estimated 485.855s
-shard 3: 15 tests, estimated 485.735s
+Shard 1/3: 14 tests, estimated 478.683s
+Shard 2/3: 15 tests, estimated 485.855s
+Shard 3/3: 15 tests, estimated 485.735s
 ```
 
 ## How CI Actually Executes

--- a/scripts/check_bridge_parity_inventory.py
+++ b/scripts/check_bridge_parity_inventory.py
@@ -177,6 +177,12 @@ def validate_inventory(
                 "Android bridge method count drifted: "
                 f"inventory={expected_android_count}, actual={len(android_methods)}"
             )
+        no_ops_missing_from_android = sorted(no_op_methods - set(android_methods))
+        if no_ops_missing_from_android:
+            raise InventoryError(
+                "iOS no-op methods are not present in Android: "
+                + ", ".join(no_ops_missing_from_android)
+            )
         android_only = set(android_methods) - set(ios_methods)
         missing_from_inventory = sorted(android_only - missing_methods)
         stale_inventory = sorted(missing_methods - android_only)

--- a/scripts/test_check_bridge_parity_inventory.py
+++ b/scripts/test_check_bridge_parity_inventory.py
@@ -218,6 +218,36 @@ class BridgeParityInventoryTests(unittest.TestCase):
             ):
                 validate_inventory(inventory, ios_interface, None)
 
+    def test_validate_inventory_requires_no_op_methods_to_exist_in_android(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ios_interface = self.write_ios_interface(
+                root,
+                "    implemented: () => void,\n"
+                "    noOp: () => void,\n",
+            )
+            inventory = self.write_inventory(
+                root,
+                ios_count=2,
+                android_count=1,
+                no_op_methods=[
+                    {"method": "noOp", "status": "ios_no_op_needs_decision"},
+                ],
+            )
+            android_root = root / "android"
+            android_root.mkdir()
+            (android_root / "android.ts").write_text(
+                "export type BibleJavascriptInterface = {\n"
+                "    implemented: () => void,\n"
+                "}\n"
+            )
+
+            with self.assertRaisesRegex(
+                InventoryError,
+                "iOS no-op methods are not present in Android: noOp",
+            ):
+                validate_inventory(inventory, ios_interface, android_root)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate iosNoOpMethods against the Android bridge interface when --android-root is supplied
- add regression coverage for stale no-op inventory entries
- update the UI sharding doc example to match scripts/build_ui_test_shards.py output format

## Validation
- git diff --check
- python3 scripts/check_bridge_parity_inventory.py
- python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible
- python3 -m unittest scripts/test_check_bridge_parity_inventory.py
- python3 -m unittest discover scripts 'test_*.py'
- python3 scripts/check_repo_standards.py docblocks --all-files

Follow-up to post-merge review on #34.