### PR TITLE
ci(bridge): add recurring Android alignment guardrail

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run repo standards unit tests
         run: python3 -m unittest discover -s scripts -p 'test_*.py'
 
+      - name: Check bridge parity inventory
+        run: python3 scripts/check_bridge_parity_inventory.py
+
       - name: Check commit messages (pull request range)
         if: github.event_name == 'pull_request'
         run: >-
@@ -317,6 +320,7 @@ jobs:
           name: andbible-xcresult-${{ github.run_id }}-unit
           path: .artifacts/*.xcresult
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
@@ -326,6 +330,7 @@ jobs:
           name: andbible-xcresult-${{ github.run_id }}-unit
           path: .artifacts/*.xcresult
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
           overwrite: true
 
@@ -469,6 +474,7 @@ jobs:
           name: andbible-xcresult-${{ github.run_id }}-${{ matrix.artifact_suffix }}
           path: .artifacts/*.xcresult
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
@@ -478,6 +484,7 @@ jobs:
           name: andbible-xcresult-${{ github.run_id }}-${{ matrix.artifact_suffix }}
           path: .artifacts/*.xcresult
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
           overwrite: true
 

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -23,8 +23,10 @@ Current maturity:
   - verification matrix
   - regression report
   - guardrails
-- `settings/` remains the most operationally mature domain because it also has
+- `settings/` remains the most operationally mature domain because it has
   machine-readable baselines plus a dedicated localization guardrail script
+- `bridge/` now has a dedicated inventory checker for the bundled iOS bridge
+  surface and optional local Android-backed drift detection
 - the remaining domains currently rely on focused unit/UI coverage and
   documentation guardrails, with room to add more machine-readable protection
   where it is worth the maintenance cost

--- a/docs/parity/bridge/README.md
+++ b/docs/parity/bridge/README.md
@@ -16,6 +16,17 @@ Machine-readable tracking:
 - [baselines/android-bridge-gap-inventory.json](baselines/android-bridge-gap-inventory.json):
   Android bridge methods and iOS no-op methods that are not true parity yet
 
+Recurring alignment check:
+
+```bash
+python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible
+```
+
+Use `--android-root` for a non-sibling Android checkout, or set
+`ANDBIBLE_ANDROID_ROOT` for repeated local runs. Paste the command summary into
+bridge parity issues and PR validation notes when Android-backed drift was
+checked.
+
 Companion reference:
 
 - [../../bridge-guide.md](../../bridge-guide.md): detailed message/event catalog and

--- a/docs/parity/bridge/guardrails.md
+++ b/docs/parity/bridge/guardrails.md
@@ -89,12 +89,30 @@ Bridge-surface changes should also run:
 python3 scripts/check_bridge_parity_inventory.py
 ```
 
-If a local Android reference checkout is available, include it for stricter
-Android-only method drift detection:
+For parity-sensitive bridge work, run the Android alignment check against a
+local Android checkout. The expected sibling checkout path is `../and-bible`:
 
 ```bash
-python3 scripts/check_bridge_parity_inventory.py --android-root .and-bible-android
+python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible
 ```
+
+If the Android checkout lives somewhere else, pass that path with
+`--android-root` or set `ANDBIBLE_ANDROID_ROOT`. The command prints a compact
+summary that can be pasted into an issue or PR. That summary should show:
+
+- the iOS bundled bridge method count
+- the Android reference method count when an Android checkout is supplied
+- tracked Android-only methods
+- new Android-only methods
+- stale inventory entries
+- iOS no-op methods that still need a disposition decision
+
+Run the Android-backed check when:
+
+- Android has moved since the last parity pass
+- bridge method names, argument ordering, or payloads are touched
+- a PR changes `bibleview-js/src/composables/android.ts`
+- an issue claims a bridge gap has been implemented or intentionally diverged
 
 If a change touches one of the still-partial branches in the bridge matrix,
 raise the bar and add focused regression coverage rather than relying on these
@@ -102,11 +120,16 @@ indirect note/document workflows alone.
 
 ## Current Automation Status
 
-- The repo currently has no dedicated machine-readable bridge drift checker.
+- The repo now has a dedicated machine-readable bridge inventory checker:
+  `scripts/check_bridge_parity_inventory.py`.
 - Current protection is a combination of:
   - focused regression coverage documented in `regression-report.md`
   - machine-readable gap tracking in
     `baselines/android-bridge-gap-inventory.json`
+  - CI execution of `python3 scripts/check_bridge_parity_inventory.py` against
+    the checked-in iOS bundle and inventory
+  - local Android-backed drift detection through
+    `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible`
   - explicit parity documentation in `contract.md`, `dispositions.md`, and
     `bridge-guide.md`
   - review discipline on `BibleBridge`, `BibleWebView`, `BridgeTypes`, and the
@@ -118,6 +141,4 @@ indirect note/document workflows alone.
   ledger when implementation work begins
 - add a lightweight parity checker for `BridgeTypes.swift` versus selected
   TypeScript type definitions
-- restore focused My Notes UI lifecycle coverage if that visible surface remains
-  in scope
 - add dedicated focused coverage for `callId` request/response flows

--- a/docs/parity/bridge/regression-report.md
+++ b/docs/parity/bridge/regression-report.md
@@ -1,6 +1,6 @@
 # BRIDGE-702 Regression Report
 
-Date: 2026-04-28
+Date: 2026-05-06
 
 ## Scope
 
@@ -11,6 +11,7 @@ covers:
 - the native persistence paths that support those embedded note surfaces
 - local Android bridge surface comparison
 - machine-readable gap inventory for Android-only and iOS no-op bridge methods
+- pasteable bridge inventory summaries for parity issues and PR validation notes
 
 Contract reference:
 
@@ -32,6 +33,12 @@ Related domain references:
 - Validation style: focused `xcodebuild test` subset
 
 ## Current Rerunnable Test Set
+
+### Machine-readable guardrails
+
+- `python3 scripts/check_bridge_parity_inventory.py`
+- `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible`
+  when the Android checkout is available locally
 
 ### Unit
 
@@ -85,8 +92,9 @@ lifecycle and rawer transport edges still need more direct protection.
 The pieces that still need tighter protection are:
 
 - visible My Notes open/update/delete workflows
-- full current Android bridge breadth beyond the shared iOS subset (`88` Android methods versus
-  `62` iOS-bundled methods in `bibleview-js/src/composables/android.ts`)
+- full current Android bridge breadth beyond the shared iOS subset (`88` Android
+  methods versus `62` iOS-bundled methods in
+  `bibleview-js/src/composables/android.ts`)
 - the tracked bridge gap inventory: 26 missing Android methods plus 3 iOS no-op methods that
   still need implementation or explicit product divergence
 - raw `window.android.*` compatibility-shim behavior on a per-method basis

--- a/docs/parity/bridge/verification-matrix.md
+++ b/docs/parity/bridge/verification-matrix.md
@@ -1,6 +1,6 @@
 # BRIDGE-701 Verification Matrix (Android WebView Bridge -> iOS)
 
-Date: 2026-04-28
+Date: 2026-05-06
 
 ## Scope and Method
 
@@ -11,7 +11,8 @@ Date: 2026-04-28
   - direct comparison with a local Android reference checkout, especially
     Android's `bibleview-js/src/composables/android.ts` and `BibleJavascriptInterface.kt`
   - machine-readable gap tracking in
-    `docs/parity/bridge/baselines/android-bridge-gap-inventory.json`
+    `docs/parity/bridge/baselines/android-bridge-gap-inventory.json`, checked by
+    `python3 scripts/check_bridge_parity_inventory.py`
   - focused unit and simulator-backed regression coverage for StudyPad handoff
     and note-persistence support
 - Regression evidence: `docs/parity/bridge/regression-report.md`

--- a/docs/parity/status-overview.md
+++ b/docs/parity/status-overview.md
@@ -1,6 +1,6 @@
 # Parity Status Overview
 
-Date: 2026-04-28
+Date: 2026-05-06
 
 ## Purpose
 
@@ -29,7 +29,7 @@ give you the fuller human context behind it.
 | [search](search/README.md) | Strong semantic coverage: `5 Pass`, `2 Adapted Pass`, `1 Partial` | Focused search UI workflows plus Strong's unit regressions | Multi-translation search still lacks focused regression coverage |
 | [reading-plans](reading-plans/README.md) | Strong sync and progression coverage: `5 Pass`, `1 Adapted Pass`, `3 Partial` | Focused daily-reading UI coverage plus restore/upload/patch unit coverage | Custom plan import, reading-plan list/start/import breadth, and additive iOS-only plan lifecycle coverage |
 | [reader](reader/README.md) | Reader shell/menu parity is stronger, but deeper gesture/modal/config branches remain partial: `4 Pass`, `1 Adapted Pass`, `5 Partial` | Focused reader-shell UI coverage, restored-position unit regressions, and full local UI validation | Strong's modal, fullscreen, swipe-mode, compare, and config-bridge coverage still need tighter focused regression locking |
-| [bridge](bridge/README.md) | StudyPad handoff and shared iOS bridge subset are present; full Android bridge breadth remains partial: `1 Pass`, `1 Adapted Pass`, `6 Partial` | Focused StudyPad handoff, note-persistence regressions, bridge guardrails, and a machine-readable gap inventory | Raw bridge drift detection, visible My Notes lifecycle coverage, Android-only bridge method breadth, payloads, and async `callId` flows |
+| [bridge](bridge/README.md) | StudyPad handoff and shared iOS bridge subset are present; full Android bridge breadth remains partial: `1 Pass`, `1 Adapted Pass`, `6 Partial` | Focused StudyPad handoff, note-persistence regressions, bridge guardrails, machine-readable gap inventory, and local Android-backed drift checking | Visible My Notes lifecycle coverage, Android-only bridge method breadth, payloads, and async `callId` flows |
 
 ## How To Read Each Domain
 
@@ -56,11 +56,15 @@ The current parity story has three layers of protection.
 Currently strongest in:
 
 - [settings](settings/README.md)
+- [bridge](bridge/README.md), for bridge inventory drift against the bundled iOS
+  interface and optional local Android checkout
 
 Current mechanisms:
 
 - `scripts/check_settings_localization_guardrails.py`
+- `scripts/check_bridge_parity_inventory.py`
 - committed snapshots in `docs/parity/settings/baselines/`
+- committed bridge gap inventory in `docs/parity/bridge/baselines/`
 - CI integration in `.github/workflows/ios-ci.yml`
 
 ### Tier 2: Focused regression coverage
@@ -107,7 +111,10 @@ It now has:
 What it still does not have is one uniform machine-readable drift check for
 every domain. That is deliberate for now. The current posture is:
 
-- strongest automation in `settings/`
+- strongest automation in `settings`
+- a dedicated bridge inventory drift checker for the local
+  `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible`
+  workflow
 - strong focused regression evidence in `sync`, `search`, and `reading-plans`
 - strong bookmark-list evidence in `bookmarks`, with visible My Notes and broader
   StudyPad mutation still partial

--- a/scripts/check_bridge_parity_inventory.py
+++ b/scripts/check_bridge_parity_inventory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -18,6 +19,8 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_INVENTORY = REPO_ROOT / "docs/parity/bridge/baselines/android-bridge-gap-inventory.json"
+ANDROID_ROOT_ENV = "ANDBIBLE_ANDROID_ROOT"
+RECOMMENDED_ANDROID_ROOT = "../and-bible"
 ALLOWED_MISSING_STATUSES = {"missing_needs_triage"}
 ALLOWED_NO_OP_STATUSES = {"ios_no_op_needs_decision"}
 REQUIRED_REFERENCE_KEYS = {
@@ -51,7 +54,34 @@ def parse_bridge_methods(source: str) -> dict[str, str]:
 
 def load_methods(path: Path) -> dict[str, str]:
     """Load a TypeScript bridge interface file and return method signatures."""
-    return parse_bridge_methods(path.read_text())
+    return parse_bridge_methods(path.read_text(encoding="utf-8"))
+
+
+def display_path(path: Path) -> str:
+    """Format paths consistently for pasteable command output."""
+    resolved = path.expanduser()
+    try:
+        return str(resolved.resolve().relative_to(REPO_ROOT))
+    except (OSError, ValueError):
+        return str(path)
+
+
+def format_method_names(methods: set[str] | list[str]) -> str:
+    """Return a stable, compact representation of method names."""
+    names = sorted(methods)
+    return "none" if not names else ", ".join(names)
+
+
+def resolve_android_root(android_root_arg: Path | None) -> Path | None:
+    """Resolve the optional Android checkout root from CLI or environment."""
+    if android_root_arg is not None:
+        return android_root_arg
+
+    android_root_env = os.environ.get(ANDROID_ROOT_ENV)
+    if android_root_env:
+        return Path(android_root_env).expanduser()
+
+    return None
 
 
 def require_object(value: Any, label: str) -> dict[str, Any]:
@@ -97,7 +127,11 @@ def require_unique_methods(entries: list[Any], section: str) -> set[str]:
     return set(names)
 
 
-def require_allowed_statuses(entries: list[Any], section: str, allowed_statuses: set[str]) -> set[str]:
+def require_allowed_statuses(
+    entries: list[Any],
+    section: str,
+    allowed_statuses: set[str],
+) -> set[str]:
     """Return unexpected statuses after validating every status value is a string."""
     unexpected_statuses: set[str] = set()
     for entry in entries:
@@ -117,8 +151,10 @@ def validate_inventory(
     android_root: Path | None,
 ) -> list[str]:
     """Validate inventory consistency and return informational messages."""
-    inventory = require_object(json.loads(inventory_path.read_text()), "inventory root")
-    messages: list[str] = []
+    inventory = require_object(
+        json.loads(inventory_path.read_text(encoding="utf-8")),
+        "inventory root",
+    )
 
     references = require_references(inventory)
     missing_entries = require_list(inventory, "missingAndroidMethods")
@@ -168,40 +204,77 @@ def validate_inventory(
     if bad_no_op_statuses:
         raise InventoryError(f"unexpected no-op statuses: {bad_no_op_statuses}")
 
+    messages = [
+        "Bridge parity alignment summary",
+        f"- inventory: {display_path(inventory_path)}",
+        f"- iOS interface: {display_path(ios_interface_path)} ({len(ios_methods)} methods)",
+        (
+            "- iOS no-op methods needing decision: "
+            f"{len(no_op_methods)} ({format_method_names(no_op_methods)})"
+        ),
+    ]
+
     if android_root is not None:
         android_interface_path = android_root / references["androidInterfaceRelativePath"]
+        if not android_interface_path.exists():
+            raise InventoryError(
+                "Android bridge interface not found: "
+                f"{android_interface_path}. Set --android-root to the Android repo root "
+                f"(usually {RECOMMENDED_ANDROID_ROOT}) or set {ANDROID_ROOT_ENV}."
+            )
         android_methods = load_methods(android_interface_path)
         expected_android_count = references.get("androidMethodCount")
+        android_method_names = set(android_methods)
+        no_ops_missing_from_android = sorted(no_op_methods - android_method_names)
+        android_only = android_method_names - set(ios_methods)
+        missing_from_inventory = sorted(android_only - missing_methods)
+        stale_inventory = sorted(missing_methods - android_only)
+
+        failures: list[str] = []
         if expected_android_count != len(android_methods):
-            raise InventoryError(
+            failures.append(
                 "Android bridge method count drifted: "
                 f"inventory={expected_android_count}, actual={len(android_methods)}"
             )
-        no_ops_missing_from_android = sorted(no_op_methods - set(android_methods))
         if no_ops_missing_from_android:
-            raise InventoryError(
+            failures.append(
                 "iOS no-op methods are not present in Android: "
                 + ", ".join(no_ops_missing_from_android)
             )
-        android_only = set(android_methods) - set(ios_methods)
-        missing_from_inventory = sorted(android_only - missing_methods)
-        stale_inventory = sorted(missing_methods - android_only)
         if missing_from_inventory:
-            raise InventoryError(
-                "Android-only methods missing from inventory: " + ", ".join(missing_from_inventory)
+            failures.append(
+                "new Android-only methods: " + ", ".join(missing_from_inventory)
             )
         if stale_inventory:
-            raise InventoryError(
-                "inventory methods are no longer Android-only: " + ", ".join(stale_inventory)
-            )
-        messages.append(f"Android comparison checked: {len(android_only)} tracked Android-only methods")
-    else:
-        messages.append("Android comparison skipped; pass --android-root to validate against Android")
+            failures.append("stale inventory entries: " + ", ".join(stale_inventory))
+        if failures:
+            raise InventoryError("\n".join(failures))
 
-    messages.append(
-        f"iOS bridge inventory checked: {len(ios_methods)} iOS methods, "
-        f"{len(missing_methods)} missing Android methods, {len(no_op_methods)} iOS no-op methods"
-    )
+        messages.extend(
+            [
+                (
+                    f"- Android reference: {display_path(android_root)} "
+                    f"({len(android_methods)} methods)"
+                ),
+                f"- tracked Android-only methods: {len(missing_methods)}",
+                "- new Android-only methods: none",
+                "- stale inventory entries: none",
+            ]
+        )
+    else:
+        messages.extend(
+            [
+                (
+                    "- Android reference: not checked "
+                    f"(pass --android-root {RECOMMENDED_ANDROID_ROOT} or set {ANDROID_ROOT_ENV})"
+                ),
+                f"- tracked Android-only methods: {len(missing_methods)} (inventory only)",
+                "- new Android-only methods: not checked",
+                "- stale inventory entries: not checked",
+            ]
+        )
+
+    messages.append("Bridge parity inventory passed.")
     return messages
 
 
@@ -213,11 +286,16 @@ def main() -> int:
         type=Path,
         default=REPO_ROOT / "bibleview-js/src/composables/android.ts",
     )
-    parser.add_argument("--android-root", type=Path)
+    parser.add_argument(
+        "--android-root",
+        type=Path,
+        help=f"Path to Android repo root. Defaults to ${ANDROID_ROOT_ENV} when set.",
+    )
     args = parser.parse_args()
 
     try:
-        for message in validate_inventory(args.inventory, args.ios_interface, args.android_root):
+        android_root = resolve_android_root(args.android_root)
+        for message in validate_inventory(args.inventory, args.ios_interface, android_root):
             print(message)
     except (FileNotFoundError, InventoryError, json.JSONDecodeError) as error:
         print(f"bridge parity inventory check failed: {error}", file=sys.stderr)

--- a/scripts/test_check_bridge_parity_inventory.py
+++ b/scripts/test_check_bridge_parity_inventory.py
@@ -10,10 +10,15 @@ import tempfile
 import unittest
 from pathlib import Path
 import sys
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from check_bridge_parity_inventory import InventoryError, validate_inventory
+from check_bridge_parity_inventory import (
+    InventoryError,
+    resolve_android_root,
+    validate_inventory,
+)
 
 
 class BridgeParityInventoryTests(unittest.TestCase):
@@ -89,7 +94,14 @@ class BridgeParityInventoryTests(unittest.TestCase):
 
             messages = validate_inventory(inventory, ios_interface, android_root)
 
-        self.assertTrue(any("1 tracked Android-only methods" in message for message in messages))
+        self.assertEqual(messages[0], "Bridge parity alignment summary")
+        self.assertIn("- tracked Android-only methods: 1", messages)
+        self.assertIn("- new Android-only methods: none", messages)
+        self.assertIn("- stale inventory entries: none", messages)
+        self.assertTrue(
+            any("iOS no-op methods needing decision: 1 (noOp)" in message for message in messages)
+        )
+        self.assertEqual(messages[-1], "Bridge parity inventory passed.")
 
     def test_validate_inventory_fails_when_missing_method_is_added_to_ios(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -114,6 +126,28 @@ class BridgeParityInventoryTests(unittest.TestCase):
 
             with self.assertRaisesRegex(InventoryError, "marked missing now exist"):
                 validate_inventory(inventory, ios_interface, None)
+
+    def test_validate_inventory_reports_skipped_android_comparison(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ios_interface = self.write_ios_interface(root)
+            inventory = self.write_inventory(root)
+
+            messages = validate_inventory(inventory, ios_interface, None)
+
+        self.assertIn(
+            "- Android reference: not checked "
+            "(pass --android-root ../and-bible or set ANDBIBLE_ANDROID_ROOT)",
+            messages,
+        )
+        self.assertIn("- tracked Android-only methods: 0 (inventory only)", messages)
+        self.assertIn("- new Android-only methods: not checked", messages)
+        self.assertIn("- stale inventory entries: not checked", messages)
+
+    def test_resolve_android_root_uses_environment_when_cli_arg_is_absent(self) -> None:
+        with mock.patch.dict("os.environ", {"ANDBIBLE_ANDROID_ROOT": "/tmp/and-bible"}):
+            self.assertEqual(resolve_android_root(None), Path("/tmp/and-bible"))
+            self.assertEqual(resolve_android_root(Path("../explicit")), Path("../explicit"))
 
     def test_validate_inventory_rejects_non_object_root(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -247,6 +281,33 @@ class BridgeParityInventoryTests(unittest.TestCase):
                 "iOS no-op methods are not present in Android: noOp",
             ):
                 validate_inventory(inventory, ios_interface, android_root)
+
+    def test_validate_inventory_reports_new_and_stale_android_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            ios_interface = self.write_ios_interface(root)
+            inventory = self.write_inventory(
+                root,
+                android_count=2,
+                missing_methods=[
+                    {"method": "stale", "status": "missing_needs_triage"},
+                ],
+            )
+            android_root = root / "android"
+            android_root.mkdir()
+            (android_root / "android.ts").write_text(
+                "export type BibleJavascriptInterface = {\n"
+                "    implemented: () => void,\n"
+                "    newMethod: () => void,\n"
+                "}\n"
+            )
+
+            with self.assertRaises(InventoryError) as context:
+                validate_inventory(inventory, ios_interface, android_root)
+
+        message = str(context.exception)
+        self.assertIn("new Android-only methods: newMethod", message)
+        self.assertIn("stale inventory entries: stale", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds the recurring bridge alignment workflow requested by issue #36 so Android/iOS bridge drift is visible in a repeatable way. Also fixes CI result-bundle uploads for the hidden `.artifacts` directory so future simulator failures retain actionable `.xcresult` diagnostics.

## Scope
In scope:
- Add pasteable bridge inventory summaries for local parity evidence.
- Make the Android checkout path configurable with `--android-root` or `ANDBIBLE_ANDROID_ROOT`.
- Add focused script tests for skipped Android comparison, env-path resolution, and new/stale Android method reporting.
- Run the checked-in inventory guardrail in CI without cloning Android.
- Upload unit/UI `.xcresult` bundles from `.artifacts` with `include-hidden-files: true`.
- Update bridge parity docs and overview docs to describe the recurring workflow.

Out of scope:
- Implementing missing Android bridge methods.
- Requiring CI to clone the Android repository.
- Solving bridge payload or async `callId` coverage from #37.

## Contract References
- #36
- `../commit-message-standard.md`
- `docs/parity/README.md`
- `docs/parity/status-overview.md`
- `docs/parity/bridge/README.md`
- `docs/parity/bridge/guardrails.md`

## Change Details
- `scripts/check_bridge_parity_inventory.py` now emits a compact alignment summary with iOS method count, Android method count when supplied, tracked Android-only methods, new Android-only methods, stale inventory entries, and iOS no-op methods needing decisions.
- The script now supports `ANDBIBLE_ANDROID_ROOT` for repeated local runs while preserving explicit `--android-root` support.
- `.github/workflows/ios-ci.yml` now runs the baseline inventory check against checked-in iOS inventory state.
- `.github/workflows/ios-ci.yml` now opts result-bundle upload steps into hidden-file matching so `.artifacts/*.xcresult` uploads are not silently skipped by `actions/upload-artifact@v6`.
- Bridge parity docs now recommend `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible` as the local Android-backed alignment check.

## Validation Evidence
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible`
- `python3 scripts/check_settings_localization_guardrails.py`
- Local shard-1 reproduction: `xcodebuild test-without-building` for the 14 selected UI tests on iPhone 17 / iOS 26.4 passed.
- GitHub Actions iOS CI run 215 for `ef78282` completed successfully, including UI Tests Shard 1/3.

Android-backed summary from local validation:
- iOS interface: 62 methods
- Android reference: 88 methods
- tracked Android-only methods: 26
- new Android-only methods: none
- stale inventory entries: none

## Risks / Follow-ups
- The Android-backed check remains local by design; CI only validates the checked-in iOS inventory and docs state.
- #37 remains the next roadmap item for bridge payload and async `callId` regression coverage.
- The prior shard-1 CI failure did not reproduce locally or on replacement CI run 215; result-bundle uploads are now available if it recurs.

## Screenshots
none

## Closes
Closes #36