### PR TITLE
test(bridge): add callId and payload regression coverage

### DIFF
--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -30,6 +30,21 @@ final class AndBibleTests: XCTestCase {
     }
     #endif
 
+    private func bridgeJSONObject<T: Encodable>(_ value: T) throws -> [String: Any] {
+        let data = try bridgeEncoder.encode(value)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    private func assertJSONKeys(
+        _ object: [String: Any],
+        _ expectedKeys: Set<String>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(Set(object.keys), expectedKeys, file: file, line: line)
+    }
+
     private var temporarySwordModulePaths: [String] = []
 
     override func tearDown() {
@@ -863,6 +878,152 @@ final class AndBibleTests: XCTestCase {
         )
     }
 
+    func testBridgeCallIdRequestMappingMatchesWebClientContract() {
+        let bridge = BibleBridge()
+
+        XCTAssertEqual(
+            bridge.callIdRequest(method: "requestMoreToBeginning", args: [41]),
+            .requestMoreToBeginning(41)
+        )
+        XCTAssertEqual(
+            bridge.callIdRequest(method: "requestMoreToEnd", args: [42]),
+            .requestMoreToEnd(42)
+        )
+        XCTAssertEqual(
+            bridge.callIdRequest(method: "refChooserDialog", args: [43]),
+            .refChooserDialog(43)
+        )
+        XCTAssertEqual(
+            bridge.callIdRequest(method: "parseRef", args: [44, "Genesis 1:1"]),
+            .parseRef(callId: 44, text: "Genesis 1:1")
+        )
+
+        XCTAssertNil(bridge.callIdRequest(method: "parseRef", args: [44]))
+        XCTAssertNil(bridge.callIdRequest(method: "parseRef", args: ["Genesis 1:1", 44]))
+        XCTAssertNil(bridge.callIdRequest(method: "helpDialog", args: [45]))
+    }
+
+    @MainActor
+    func testBridgeSendResponseEmitsCallIdResponseJavaScript() {
+        let bridge = BibleBridge()
+        var scripts: [String] = []
+        bridge.javaScriptEvaluationObserver = { script in
+            scripts.append(script)
+        }
+
+        bridge.sendResponse(callId: 54, value: "null")
+        bridge.sendResponse(callId: 55, value: ["osisRef": "Gen.1.1"])
+
+        XCTAssertEqual(
+            scripts,
+            [
+                "bibleView.response(54, null);",
+                #"bibleView.response(55, {"osisRef":"Gen.1.1"});"#,
+            ]
+        )
+    }
+
+    func testBridgePayloadKeysMatchWebClientContracts() throws {
+        let fragment = OsisFragment(
+            xml: "<div>In the beginning...</div>",
+            key: "Gen.1",
+            keyName: "Genesis 1",
+            v11n: "KJVA",
+            bookCategory: "BIBLE",
+            bookInitials: "KJV",
+            bookAbbreviation: "Gen",
+            osisRef: "Gen.1",
+            isNewTestament: false,
+            features: OsisFeatures(type: "hebrew", keyName: "H00430"),
+            ordinalRange: [1, 31],
+            language: "en",
+            direction: "ltr"
+        )
+        let fragmentObject = try bridgeJSONObject(fragment)
+        assertJSONKeys(
+            fragmentObject,
+            [
+                "xml",
+                "key",
+                "keyName",
+                "v11n",
+                "bookCategory",
+                "bookInitials",
+                "bookAbbreviation",
+                "osisRef",
+                "isNewTestament",
+                "features",
+                "ordinalRange",
+                "language",
+                "direction",
+            ]
+        )
+        let features = try XCTUnwrap(fragmentObject["features"] as? [String: Any])
+        assertJSONKeys(features, ["type", "keyName"])
+
+        let label = LabelData(
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            name: "Important",
+            style: BookmarkStyleData(
+                color: 0xFFFF0000,
+                isSpeak: true,
+                isParagraphBreak: true,
+                underline: true,
+                underlineWholeVerse: true,
+                markerStyle: true,
+                markerStyleWholeVerse: true,
+                hideStyle: true,
+                hideStyleWholeVerse: true,
+                customIcon: "star"
+            ),
+            isRealLabel: true
+        )
+        let labelObject = try bridgeJSONObject(label)
+        assertJSONKeys(labelObject, ["id", "name", "style", "isRealLabel"])
+
+        let style = try XCTUnwrap(labelObject["style"] as? [String: Any])
+        assertJSONKeys(
+            style,
+            [
+                "color",
+                "isSpeak",
+                "isParagraphBreak",
+                "underline",
+                "underlineWholeVerse",
+                "markerStyle",
+                "markerStyleWholeVerse",
+                "hideStyle",
+                "hideStyleWholeVerse",
+                "customIcon",
+            ]
+        )
+
+        let query = SelectionQuery(
+            bookInitials: "KJV",
+            osisRef: "Gen.1.1-Gen.1.3",
+            startOrdinal: 0,
+            startOffset: 1,
+            endOrdinal: 2,
+            endOffset: 50,
+            bookmarks: ["id1", "id2"],
+            text: "In the beginning God created..."
+        )
+        let queryObject = try bridgeJSONObject(query)
+        assertJSONKeys(
+            queryObject,
+            [
+                "bookInitials",
+                "osisRef",
+                "startOrdinal",
+                "startOffset",
+                "endOrdinal",
+                "endOffset",
+                "bookmarks",
+                "text",
+            ]
+        )
+    }
+
     #if os(iOS)
     func testBuildStrongsMultiDocJSONReturnsInstallFallbackWhenNoStrongsDictionaryIsInstalled() throws {
         let bridge = BibleBridge()
@@ -997,6 +1158,63 @@ final class AndBibleTests: XCTestCase {
             addDocumentsScript.contains("\"originalOrdinalRange\":[5,5]"),
             "Expected explicit verse navigation to preserve the original highlighted target. Script: \(addDocumentsScript)"
         )
+    }
+
+    @MainActor
+    func testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+
+        controller.navigateTo(book: "Genesis", chapter: 2, verse: 1)
+        controller.loadCurrentContent()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        let baselineCount = recordedScripts().count
+        controller.bridge(bridge, requestMoreToBeginning: 3701)
+
+        let responseScript = try XCTUnwrap(
+            recordedScripts().dropFirst(baselineCount).first {
+                $0.contains("bibleView.response(3701")
+            }
+        )
+
+        XCTAssertTrue(
+            responseScript.hasPrefix("bibleView.response(3701, {"),
+            "Expected a document JSON response for the original callId. Script: \(responseScript)"
+        )
+        XCTAssertTrue(
+            responseScript.contains(#""key":"Gen.1""#),
+            "Expected the previous chapter document to be returned. Script: \(responseScript)"
+        )
+        XCTAssertTrue(
+            responseScript.contains(#""osisFragment""#),
+            "Expected the response payload to preserve the Bible document shape. Script: \(responseScript)"
+        )
+    }
+
+    @MainActor
+    func testRefChooserDialogSendsResponseWithOriginalCallId() {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let controller = BibleReaderController(bridge: bridge)
+        controller.onRefChooserDialog = { completion in
+            completion("Gen.1.1")
+        }
+
+        controller.bridge(bridge, refChooserDialog: 3702)
+
+        XCTAssertEqual(recordedScripts().last, #"bibleView.response(3702, "Gen.1.1");"#)
+    }
+
+    @MainActor
+    func testParseRefSendsResponseWithOriginalCallId() {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let controller = BibleReaderController(bridge: bridge)
+
+        controller.bridge(bridge, parseRef: 3703, text: "Genesis 1:1")
+
+        XCTAssertEqual(recordedScripts().last, #"bibleView.response(3703, "Gen.1.1");"#)
     }
     #endif
 

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -883,24 +883,31 @@ final class AndBibleTests: XCTestCase {
 
         XCTAssertEqual(
             bridge.callIdRequest(method: "requestMoreToBeginning", args: [41]),
-            .requestMoreToBeginning(41)
+            .request(.requestMoreToBeginning(41))
         )
         XCTAssertEqual(
             bridge.callIdRequest(method: "requestMoreToEnd", args: [42]),
-            .requestMoreToEnd(42)
+            .request(.requestMoreToEnd(42))
         )
         XCTAssertEqual(
             bridge.callIdRequest(method: "refChooserDialog", args: [43]),
-            .refChooserDialog(43)
+            .request(.refChooserDialog(43))
         )
         XCTAssertEqual(
             bridge.callIdRequest(method: "parseRef", args: [44, "Genesis 1:1"]),
-            .parseRef(callId: 44, text: "Genesis 1:1")
+            .request(.parseRef(callId: 44, text: "Genesis 1:1"))
         )
 
-        XCTAssertNil(bridge.callIdRequest(method: "parseRef", args: [44]))
-        XCTAssertNil(bridge.callIdRequest(method: "parseRef", args: ["Genesis 1:1", 44]))
+        XCTAssertEqual(bridge.callIdRequest(method: "parseRef", args: [44]), .malformed)
+        XCTAssertEqual(bridge.callIdRequest(method: "parseRef", args: ["Genesis 1:1", 44]), .malformed)
         XCTAssertNil(bridge.callIdRequest(method: "helpDialog", args: [45]))
+    }
+
+    func testBridgeCallIdDispatchTreatsKnownMalformedMessagesAsHandled() {
+        let bridge = BibleBridge()
+
+        XCTAssertTrue(bridge.dispatchCallIdRequest(method: "parseRef", args: [44]))
+        XCTAssertFalse(bridge.dispatchCallIdRequest(method: "helpDialog", args: [45]))
     }
 
     @MainActor

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -45,6 +45,19 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(Set(object.keys), expectedKeys, file: file, line: line)
     }
 
+    private var malformedCallIdRequests: [(method: String, args: [Any])] {
+        [
+            ("requestMoreToBeginning", []),
+            ("requestMoreToBeginning", ["41"]),
+            ("requestMoreToEnd", []),
+            ("requestMoreToEnd", ["42"]),
+            ("refChooserDialog", []),
+            ("refChooserDialog", ["43"]),
+            ("parseRef", [44]),
+            ("parseRef", ["Genesis 1:1", 44]),
+        ]
+    }
+
     private var temporarySwordModulePaths: [String] = []
 
     override func tearDown() {
@@ -898,16 +911,34 @@ final class AndBibleTests: XCTestCase {
             .request(.parseRef(callId: 44, text: "Genesis 1:1"))
         )
 
-        XCTAssertEqual(bridge.callIdRequest(method: "parseRef", args: [44]), .malformed)
-        XCTAssertEqual(bridge.callIdRequest(method: "parseRef", args: ["Genesis 1:1", 44]), .malformed)
+        for malformedRequest in malformedCallIdRequests {
+            XCTAssertEqual(
+                bridge.callIdRequest(method: malformedRequest.method, args: malformedRequest.args),
+                .malformed,
+                "Expected \(malformedRequest.method) to reject malformed args"
+            )
+        }
+
         XCTAssertNil(bridge.callIdRequest(method: "helpDialog", args: [45]))
     }
 
-    func testBridgeCallIdDispatchTreatsKnownMalformedMessagesAsHandled() {
+    func testBridgeCallIdDispatchClassifiesKnownMalformedMessages() {
         let bridge = BibleBridge()
 
-        XCTAssertTrue(bridge.dispatchCallIdRequest(method: "parseRef", args: [44]))
-        XCTAssertFalse(bridge.dispatchCallIdRequest(method: "helpDialog", args: [45]))
+        XCTAssertEqual(
+            bridge.dispatchCallIdRequest(method: "requestMoreToBeginning", args: [41]),
+            .handled
+        )
+
+        for malformedRequest in malformedCallIdRequests {
+            XCTAssertEqual(
+                bridge.dispatchCallIdRequest(method: malformedRequest.method, args: malformedRequest.args),
+                .malformed,
+                "Expected \(malformedRequest.method) to classify malformed args"
+            )
+        }
+
+        XCTAssertEqual(bridge.dispatchCallIdRequest(method: "helpDialog", args: [45]), .notCallIdRequest)
     }
 
     @MainActor

--- a/Sources/BibleView/Sources/BibleView/BibleBridge.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleBridge.swift
@@ -30,6 +30,12 @@ enum BibleBridgeCallIdRequestParseResult: Equatable {
     case malformed
 }
 
+enum BibleBridgeCallIdRequestDispatchResult: Equatable {
+    case notCallIdRequest
+    case handled
+    case malformed
+}
+
 /// Protocol for handling bridge events from the Vue.js WebView.
 public protocol BibleBridgeDelegate: AnyObject {
     // MARK: - Navigation & Scroll
@@ -244,8 +250,11 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             onAnyMessage?()
         }
 
-        if dispatchCallIdRequest(method: method, args: args) {
+        switch dispatchCallIdRequest(method: method, args: args) {
+        case .handled, .malformed:
             return
+        case .notCallIdRequest:
+            break
         }
 
         switch method {
@@ -519,9 +528,15 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
     }
 
     @discardableResult
-    func dispatchCallIdRequest(method: String, args: [Any]) -> Bool {
-        guard let parseResult = callIdRequest(method: method, args: args) else { return false }
-        guard case .request(let request) = parseResult else { return true }
+    func dispatchCallIdRequest(method: String, args: [Any]) -> BibleBridgeCallIdRequestDispatchResult {
+        guard let parseResult = callIdRequest(method: method, args: args) else { return .notCallIdRequest }
+        guard case .request(let request) = parseResult else {
+            let argTypes = args.map { String(describing: type(of: $0)) }.joined(separator: ", ")
+            logger.warning(
+                "Malformed callId bridge message: method=\(method, privacy: .public), argCount=\(args.count), argTypes=\(argTypes, privacy: .public)"
+            )
+            return .malformed
+        }
 
         switch request {
         case .requestMoreToBeginning(let callId):
@@ -534,7 +549,7 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             delegate?.bridge(self, parseRef: callId, text: text)
         }
 
-        return true
+        return .handled
     }
 
     // MARK: - Send to JavaScript

--- a/Sources/BibleView/Sources/BibleView/BibleBridge.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleBridge.swift
@@ -18,6 +18,13 @@ public enum NativeHorizontalSwipeDirection: Sendable {
     case right
 }
 
+enum BibleBridgeCallIdRequest: Equatable {
+    case requestMoreToBeginning(Int)
+    case requestMoreToEnd(Int)
+    case refChooserDialog(Int)
+    case parseRef(callId: Int, text: String)
+}
+
 /// Protocol for handling bridge events from the Vue.js WebView.
 public protocol BibleBridgeDelegate: AnyObject {
     // MARK: - Navigation & Scroll
@@ -232,6 +239,11 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             onAnyMessage?()
         }
 
+        if isCallIdRequestMethod(method) {
+            dispatchCallIdRequest(method: method, args: args)
+            return
+        }
+
         switch method {
         // --- Logging & state sync from JavaScript to native ---
         case "console":
@@ -280,14 +292,6 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             if let key = args[safe: 0] as? String, let ordinal = args[safe: 1] as? Int {
                 let atChapterTop = args[safe: 2] as? Bool ?? false
                 delegate?.bridge(self, didScrollToOrdinal: ordinal, key: key, atChapterTop: atChapterTop)
-            }
-        case "requestMoreToBeginning":
-            if let callId = args.first as? Int {
-                delegate?.bridge(self, requestMoreToBeginning: callId)
-            }
-        case "requestMoreToEnd":
-            if let callId = args.first as? Int {
-                delegate?.bridge(self, requestMoreToEnd: callId)
             }
 
         // --- Bookmark CRUD and label assignment ---
@@ -467,14 +471,6 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             }
 
         // --- Dialog and async request entry points ---
-        case "refChooserDialog":
-            if let callId = args.first as? Int {
-                delegate?.bridge(self, refChooserDialog: callId)
-            }
-        case "parseRef":
-            if let callId = args[safe: 0] as? Int, let text = args[safe: 1] as? String {
-                delegate?.bridge(self, parseRef: callId, text: text)
-            }
         case "helpDialog":
             if let content = args[safe: 0] as? String {
                 delegate?.bridge(self, helpDialog: content, title: args[safe: 1] as? String)
@@ -497,6 +493,53 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
     }
 
     // MARK: - Send to JavaScript
+
+    func callIdRequest(method: String, args: [Any]) -> BibleBridgeCallIdRequest? {
+        switch method {
+        case "requestMoreToBeginning":
+            guard let callId = args.first as? Int else { return nil }
+            return .requestMoreToBeginning(callId)
+        case "requestMoreToEnd":
+            guard let callId = args.first as? Int else { return nil }
+            return .requestMoreToEnd(callId)
+        case "refChooserDialog":
+            guard let callId = args.first as? Int else { return nil }
+            return .refChooserDialog(callId)
+        case "parseRef":
+            guard let callId = args[safe: 0] as? Int,
+                  let text = args[safe: 1] as? String else { return nil }
+            return .parseRef(callId: callId, text: text)
+        default:
+            return nil
+        }
+    }
+
+    @discardableResult
+    func dispatchCallIdRequest(method: String, args: [Any]) -> Bool {
+        guard let request = callIdRequest(method: method, args: args) else { return false }
+
+        switch request {
+        case .requestMoreToBeginning(let callId):
+            delegate?.bridge(self, requestMoreToBeginning: callId)
+        case .requestMoreToEnd(let callId):
+            delegate?.bridge(self, requestMoreToEnd: callId)
+        case .refChooserDialog(let callId):
+            delegate?.bridge(self, refChooserDialog: callId)
+        case .parseRef(let callId, let text):
+            delegate?.bridge(self, parseRef: callId, text: text)
+        }
+
+        return true
+    }
+
+    private func isCallIdRequestMethod(_ method: String) -> Bool {
+        switch method {
+        case "requestMoreToBeginning", "requestMoreToEnd", "refChooserDialog", "parseRef":
+            return true
+        default:
+            return false
+        }
+    }
 
     /**
      Sends a raw JSON response payload back to a pending JavaScript bridge call.

--- a/Sources/BibleView/Sources/BibleView/BibleBridge.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleBridge.swift
@@ -25,6 +25,11 @@ enum BibleBridgeCallIdRequest: Equatable {
     case parseRef(callId: Int, text: String)
 }
 
+enum BibleBridgeCallIdRequestParseResult: Equatable {
+    case request(BibleBridgeCallIdRequest)
+    case malformed
+}
+
 /// Protocol for handling bridge events from the Vue.js WebView.
 public protocol BibleBridgeDelegate: AnyObject {
     // MARK: - Navigation & Scroll
@@ -239,8 +244,7 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
             onAnyMessage?()
         }
 
-        if isCallIdRequestMethod(method) {
-            dispatchCallIdRequest(method: method, args: args)
+        if dispatchCallIdRequest(method: method, args: args) {
             return
         }
 
@@ -492,23 +496,23 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
         }
     }
 
-    // MARK: - Send to JavaScript
+    // MARK: - CallId Requests
 
-    func callIdRequest(method: String, args: [Any]) -> BibleBridgeCallIdRequest? {
+    func callIdRequest(method: String, args: [Any]) -> BibleBridgeCallIdRequestParseResult? {
         switch method {
         case "requestMoreToBeginning":
-            guard let callId = args.first as? Int else { return nil }
-            return .requestMoreToBeginning(callId)
+            guard let callId = args.first as? Int else { return .malformed }
+            return .request(.requestMoreToBeginning(callId))
         case "requestMoreToEnd":
-            guard let callId = args.first as? Int else { return nil }
-            return .requestMoreToEnd(callId)
+            guard let callId = args.first as? Int else { return .malformed }
+            return .request(.requestMoreToEnd(callId))
         case "refChooserDialog":
-            guard let callId = args.first as? Int else { return nil }
-            return .refChooserDialog(callId)
+            guard let callId = args.first as? Int else { return .malformed }
+            return .request(.refChooserDialog(callId))
         case "parseRef":
             guard let callId = args[safe: 0] as? Int,
-                  let text = args[safe: 1] as? String else { return nil }
-            return .parseRef(callId: callId, text: text)
+                  let text = args[safe: 1] as? String else { return .malformed }
+            return .request(.parseRef(callId: callId, text: text))
         default:
             return nil
         }
@@ -516,7 +520,8 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
 
     @discardableResult
     func dispatchCallIdRequest(method: String, args: [Any]) -> Bool {
-        guard let request = callIdRequest(method: method, args: args) else { return false }
+        guard let parseResult = callIdRequest(method: method, args: args) else { return false }
+        guard case .request(let request) = parseResult else { return true }
 
         switch request {
         case .requestMoreToBeginning(let callId):
@@ -532,14 +537,7 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
         return true
     }
 
-    private func isCallIdRequestMethod(_ method: String) -> Bool {
-        switch method {
-        case "requestMoreToBeginning", "requestMoreToEnd", "refChooserDialog", "parseRef":
-            return true
-        default:
-            return false
-        }
-    }
+    // MARK: - Send to JavaScript
 
     /**
      Sends a raw JSON response payload back to a pending JavaScript bridge call.

--- a/Sources/BibleView/Tests/BibleViewTests/BridgeTypesTests.swift
+++ b/Sources/BibleView/Tests/BibleViewTests/BridgeTypesTests.swift
@@ -29,6 +29,55 @@ final class BridgeTypesTests: XCTestCase {
         XCTAssertEqual(decoded.ordinalRange, [0, 10])
     }
 
+    func testOsisFragmentPayloadKeysMatchClientObjectContract() throws {
+        let fragment = OsisFragment(
+            xml: "<div>In the beginning...</div>",
+            key: "Gen.1",
+            keyName: "Genesis 1",
+            v11n: "KJVA",
+            bookCategory: "BIBLE",
+            bookInitials: "KJV",
+            bookAbbreviation: "Gen",
+            osisRef: "Gen.1",
+            isNewTestament: false,
+            features: OsisFeatures(type: "hebrew", keyName: "H00430"),
+            ordinalRange: [1, 31],
+            language: "en",
+            direction: "ltr"
+        )
+
+        let object = try bridgeJSONObject(fragment)
+
+        XCTAssertJSONKeys(
+            object,
+            [
+                "xml",
+                "key",
+                "keyName",
+                "v11n",
+                "bookCategory",
+                "bookInitials",
+                "bookAbbreviation",
+                "osisRef",
+                "isNewTestament",
+                "features",
+                "ordinalRange",
+                "language",
+                "direction",
+            ]
+        )
+        XCTAssertEqual(object["keyName"] as? String, "Genesis 1")
+        XCTAssertEqual(object["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(object["bookAbbreviation"] as? String, "Gen")
+        XCTAssertEqual(object["osisRef"] as? String, "Gen.1")
+        XCTAssertEqual(object["direction"] as? String, "ltr")
+
+        let features = try XCTUnwrap(object["features"] as? [String: Any])
+        XCTAssertJSONKeys(features, ["type", "keyName"])
+        XCTAssertEqual(features["type"] as? String, "hebrew")
+        XCTAssertEqual(features["keyName"] as? String, "H00430")
+    }
+
     func testBookmarkStyleDataDefaults() {
         let style = BookmarkStyleData()
         XCTAssertEqual(style.color, 0xFF91A7FF)
@@ -53,6 +102,57 @@ final class BridgeTypesTests: XCTestCase {
         XCTAssertTrue(decoded.style.underline)
     }
 
+    func testLabelPayloadKeysMatchClientObjectContract() throws {
+        let label = LabelData(
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            name: "Important",
+            style: BookmarkStyleData(
+                color: 0xFFFF0000,
+                isSpeak: true,
+                isParagraphBreak: true,
+                underline: true,
+                underlineWholeVerse: true,
+                markerStyle: true,
+                markerStyleWholeVerse: true,
+                hideStyle: true,
+                hideStyleWholeVerse: true,
+                customIcon: "star"
+            ),
+            isRealLabel: true
+        )
+
+        let object = try bridgeJSONObject(label)
+
+        XCTAssertJSONKeys(object, ["id", "name", "style", "isRealLabel"])
+        XCTAssertEqual(object["id"] as? String, "550e8400-e29b-41d4-a716-446655440000")
+        XCTAssertEqual(object["name"] as? String, "Important")
+        XCTAssertEqual(object["isRealLabel"] as? Bool, true)
+
+        let style = try XCTUnwrap(object["style"] as? [String: Any])
+        XCTAssertJSONKeys(
+            style,
+            [
+                "color",
+                "isSpeak",
+                "isParagraphBreak",
+                "underline",
+                "underlineWholeVerse",
+                "markerStyle",
+                "markerStyleWholeVerse",
+                "hideStyle",
+                "hideStyleWholeVerse",
+                "customIcon",
+            ]
+        )
+        XCTAssertEqual(style["color"] as? Int, 0xFFFF0000)
+        XCTAssertEqual(style["isSpeak"] as? Bool, true)
+        XCTAssertEqual(style["isParagraphBreak"] as? Bool, true)
+        XCTAssertEqual(style["underlineWholeVerse"] as? Bool, true)
+        XCTAssertEqual(style["markerStyleWholeVerse"] as? Bool, true)
+        XCTAssertEqual(style["hideStyleWholeVerse"] as? Bool, true)
+        XCTAssertEqual(style["customIcon"] as? String, "star")
+    }
+
     func testSelectionQueryCodable() throws {
         let query = SelectionQuery(
             bookInitials: "KJV",
@@ -73,4 +173,56 @@ final class BridgeTypesTests: XCTestCase {
         XCTAssertEqual(decoded.startOrdinal, 0)
         XCTAssertEqual(decoded.endOrdinal, 2)
     }
+
+    func testSelectionQueryPayloadKeysMatchWebClientContract() throws {
+        let query = SelectionQuery(
+            bookInitials: "KJV",
+            osisRef: "Gen.1.1-Gen.1.3",
+            startOrdinal: 0,
+            startOffset: 1,
+            endOrdinal: 2,
+            endOffset: 50,
+            bookmarks: ["id1", "id2"],
+            text: "In the beginning God created..."
+        )
+
+        let object = try bridgeJSONObject(query)
+
+        XCTAssertJSONKeys(
+            object,
+            [
+                "bookInitials",
+                "osisRef",
+                "startOrdinal",
+                "startOffset",
+                "endOrdinal",
+                "endOffset",
+                "bookmarks",
+                "text",
+            ]
+        )
+        XCTAssertEqual(object["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(object["osisRef"] as? String, "Gen.1.1-Gen.1.3")
+        XCTAssertEqual(object["startOrdinal"] as? Int, 0)
+        XCTAssertEqual(object["startOffset"] as? Int, 1)
+        XCTAssertEqual(object["endOrdinal"] as? Int, 2)
+        XCTAssertEqual(object["endOffset"] as? Int, 50)
+        XCTAssertEqual(object["bookmarks"] as? [String], ["id1", "id2"])
+        XCTAssertEqual(object["text"] as? String, "In the beginning God created...")
+    }
+}
+
+private func bridgeJSONObject<T: Encodable>(_ value: T) throws -> [String: Any] {
+    let data = try bridgeEncoder.encode(value)
+    let object = try JSONSerialization.jsonObject(with: data)
+    return try XCTUnwrap(object as? [String: Any])
+}
+
+private func XCTAssertJSONKeys(
+    _ object: [String: Any],
+    _ expectedKeys: Set<String>,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertEqual(Set(object.keys), expectedKeys, file: file, line: line)
 }

--- a/docs/parity/bridge/guardrails.md
+++ b/docs/parity/bridge/guardrails.md
@@ -28,7 +28,8 @@ rules explicit for changes in:
 
    The frontend still sends positional `args` arrays, not keyed payload objects,
    for many calls. Reordering arguments in Swift without a coordinated client
-   change is a silent runtime break.
+   change is a silent runtime break. Async methods must keep `callId` as the
+   first argument unless the shared web-client bridge changes with it.
 
 3. Treat the `window.android` compatibility shim as contract surface.
 
@@ -89,6 +90,21 @@ Bridge-surface changes should also run:
 python3 scripts/check_bridge_parity_inventory.py
 ```
 
+Changes that touch async request/response handling or payload models should also
+run the focused shared-scheme bridge subset:
+
+```bash
+xcodebuild -project AndBible.xcodeproj -scheme AndBible \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  CODE_SIGNING_ALLOWED=NO test \
+  -only-testing:AndBibleTests/AndBibleTests/testBridgeCallIdRequestMappingMatchesWebClientContract \
+  -only-testing:AndBibleTests/AndBibleTests/testBridgeSendResponseEmitsCallIdResponseJavaScript \
+  -only-testing:AndBibleTests/AndBibleTests/testBridgePayloadKeysMatchWebClientContracts \
+  -only-testing:AndBibleTests/AndBibleTests/testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId \
+  -only-testing:AndBibleTests/AndBibleTests/testRefChooserDialogSendsResponseWithOriginalCallId \
+  -only-testing:AndBibleTests/AndBibleTests/testParseRefSendsResponseWithOriginalCallId
+```
+
 For parity-sensitive bridge work, run the Android alignment check against a
 local Android checkout. The expected sibling checkout path is `../and-bible`:
 
@@ -130,6 +146,8 @@ indirect note/document workflows alone.
     the checked-in iOS bundle and inventory
   - local Android-backed drift detection through
     `python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible`
+  - shared-scheme unit checks for async `callId` dispatch/response handling and
+    representative bridge payload key shapes
   - explicit parity documentation in `contract.md`, `dispositions.md`, and
     `bridge-guide.md`
   - review discipline on `BibleBridge`, `BibleWebView`, `BridgeTypes`, and the
@@ -141,4 +159,3 @@ indirect note/document workflows alone.
   ledger when implementation work begins
 - add a lightweight parity checker for `BridgeTypes.swift` versus selected
   TypeScript type definitions
-- add dedicated focused coverage for `callId` request/response flows

--- a/docs/parity/bridge/regression-report.md
+++ b/docs/parity/bridge/regression-report.md
@@ -1,6 +1,6 @@
 # BRIDGE-702 Regression Report
 
-Date: 2026-05-06
+Date: 2026-05-07
 
 ## Scope
 
@@ -9,6 +9,8 @@ covers:
 
 - StudyPad document handoff from a real bookmark workflow
 - the native persistence paths that support those embedded note surfaces
+- representative async `callId` request/response bridge flows
+- representative Swift bridge payload key shapes consumed by `bibleview-js`
 - local Android bridge surface comparison
 - machine-readable gap inventory for Android-only and iOS no-op bridge methods
 - pasteable bridge inventory summaries for parity issues and PR validation notes
@@ -45,6 +47,12 @@ Related domain references:
 - `AndBibleTests/testBookmarkServiceClearingBibleBookmarkNoteDeletesPersistedNoteRow`
 - `AndBibleTests/testBookmarkServiceClearingBibleBookmarkNoteRemovesBookmarkFromMyNotesQuery`
 - `AndBibleTests/testBookmarkServiceUpdatingBibleBookmarkNoteReusesPersistedNoteRow`
+- `AndBibleTests/testBridgeCallIdRequestMappingMatchesWebClientContract`
+- `AndBibleTests/testBridgeSendResponseEmitsCallIdResponseJavaScript`
+- `AndBibleTests/testBridgePayloadKeysMatchWebClientContracts`
+- `AndBibleTests/testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId`
+- `AndBibleTests/testRefChooserDialogSendsResponseWithOriginalCallId`
+- `AndBibleTests/testParseRefSendsResponseWithOriginalCallId`
 
 ### UI
 
@@ -67,21 +75,41 @@ Related domain references:
 - rebuilding the My Notes bookmark query after note deletion removes the bookmark from the
   resulting note-backed surface
 
+### Async callId flows
+
+- bridge dispatch keeps `callId` as the first positional argument for content expansion and
+  native reference dialog/parser requests
+- `BibleBridge.sendResponse(...)` emits `bibleView.response(callId, value)` with the original
+  call identifier
+- content expansion can return a previous-chapter Bible document payload for the original
+  `requestMoreToBeginning` call ID
+- native `refChooserDialog` and `parseRef` controller handlers send their responses through the
+  original call ID
+
+### Payload shapes
+
+- representative `OsisFragment`, label/style, and selection-query payloads preserve the key names
+  expected by `bibleview-js/src/types/client-objects.ts` and `bibleview-js/src/composables/android.ts`
+
 ## Historical Result And Current Interpretation
 
 Focused bridge-adjacent validation passed on 2026-03-16, but the original UI result is now stale
 because four UI tests from that report no longer exist in `AndBibleUITests`. The current rerunnable
 named subset in this report is:
 
-- Unit: `3` tests
+- Unit: `9` tests
 - UI: `1` test
 
-This doc refresh did not rerun the simulator suite, so do not treat the old UI runtime/count as
-current evidence. The checked-in named subset gives the bridge domain rerunnable evidence for:
+This doc refresh reran the new focused callId/payload subset locally, but did not rerun the full
+bridge-adjacent simulator suite. Do not treat the old UI runtime/count as current evidence. The
+checked-in named subset gives the bridge domain rerunnable evidence for:
 
 - service-layer note persistence
 - StudyPad document handoff
 - bookmark-note persistence feeding those embedded surfaces
+- async `callId` request/response transport for representative content expansion and native
+  reference workflows
+- representative bridge payload key shapes for OSIS fragments, labels/styles, and selection query
 
 So the bridge story is not "everything is shaky." It is more specific than
 that: the StudyPad handoff and note persistence support are present, while the visible My Notes
@@ -98,10 +126,10 @@ The pieces that still need tighter protection are:
 - the tracked bridge gap inventory: 26 missing Android methods plus 3 iOS no-op methods that
   still need implementation or explicit product divergence
 - raw `window.android.*` compatibility-shim behavior on a per-method basis
-- `callId` async request/response flows for content expansion and native dialogs
 - Strong's sheet bridge coverage, especially the dedicated `contentType: "strongs"` route
-- fullscreen, compare, help, and reference-dialog bridge workflows
-- explicit payload-shape guardrails between `BridgeTypes.swift` and `bibleview-js/src/types/`
+- fullscreen, compare, help, and full reference-dialog UI workflows
+- generated or full-surface payload-shape parity checks between `BridgeTypes.swift` and
+  `bibleview-js/src/types/` beyond the current representative key-shape tests
 
 Those areas are implemented and documented, but they are not yet locked by
 focused bridge-domain regression coverage, so they still show up as `Partial`

--- a/docs/parity/bridge/verification-matrix.md
+++ b/docs/parity/bridge/verification-matrix.md
@@ -1,6 +1,6 @@
 # BRIDGE-701 Verification Matrix (Android WebView Bridge -> iOS)
 
-Date: 2026-05-06
+Date: 2026-05-07
 
 ## Scope and Method
 
@@ -14,7 +14,8 @@ Date: 2026-05-06
     `docs/parity/bridge/baselines/android-bridge-gap-inventory.json`, checked by
     `python3 scripts/check_bridge_parity_inventory.py`
   - focused unit and simulator-backed regression coverage for StudyPad handoff
-    and note-persistence support
+    note-persistence support, representative async `callId` flows, and selected
+    bridge payload key shapes
 - Regression evidence: `docs/parity/bridge/regression-report.md`
 
 Use this as a map of what currently feels solid versus what still needs better
@@ -33,9 +34,9 @@ strongly than they are tested.
 
 ## Summary
 
-- `Pass`: 1
+- `Pass`: 2
 - `Adapted Pass`: 1
-- `Partial`: 6
+- `Partial`: 5
 
 ## Matrix
 
@@ -45,8 +46,8 @@ strongly than they are tested.
 | My Notes visible document lifecycle and note mutation remain connected to native persistence | `BibleBridge.swift`, `BibleReaderController.swift`; unit tests `testBookmarkServiceClearingBibleBookmarkNoteDeletesPersistedNoteRow`, `testBookmarkServiceClearingBibleBookmarkNoteRemovesBookmarkFromMyNotesQuery`, `testBookmarkServiceUpdatingBibleBookmarkNoteReusesPersistedNoteRow` | Partial | The route and service support still exist, but the previous focused My Notes UI regressions are no longer present. |
 | iOS preserves the shared Android-style `window.android.*` call subset and synchronous `getActiveLanguages()` behavior via an injected shim | `BibleWebView.swift` shim injection and `BibleBridge.updateActiveLanguages(_:)`; documented in `dispositions.md` | Adapted Pass | The transport path is intentionally different, and the iOS-packaged frontend boots against the Android-oriented API subset used by this repo. This is not full bridge parity. |
 | Full current Android bridge surface breadth | Local comparison of iOS `bibleview-js/src/composables/android.ts` with the Android reference checkout's `app/bibleview-js/src/composables/android.ts`; `android-bridge-gap-inventory.json` | Partial | iOS currently exposes 62 bridge methods in its bundled frontend type, while Android exposes 88. The inventory tracks 26 missing Android methods plus 3 iOS no-op methods that need implementation or explicit product divergence. |
-| Async `callId` request/response flows remain available for content expansion and native dialogs | `BibleBridge.sendResponse(...)`; `BibleReaderController` handlers for `requestMoreToBeginning`, `requestMoreToEnd`, `refChooserDialog`, and `parseRef` | Partial | The plumbing is there, but we still do not have a focused regression gate for `callId` request/response semantics. |
+| Async `callId` request/response flows remain available for content expansion and native dialogs | `BibleBridge.sendResponse(...)`; `BibleReaderController` handlers for `requestMoreToBeginning`, `requestMoreToEnd`, `refChooserDialog`, and `parseRef`; unit tests `testBridgeCallIdRequestMappingMatchesWebClientContract`, `testBridgeSendResponseEmitsCallIdResponseJavaScript`, `testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId`, `testRefChooserDialogSendsResponseWithOriginalCallId`, `testParseRefSendsResponseWithOriginalCallId` | Pass | Focused shared-scheme coverage now locks the web-client `callId` argument position, response JavaScript shape, content expansion document response, and native dialog/parser responses preserving the original call ID. |
 | Bookmark, label, and StudyPad delegate dispatch remains centralized in `BibleBridge` | `BibleBridge.userContentController(...)` bookmark and StudyPad switch branches; `BridgeTypes.swift` payload models | Partial | The dispatcher is still nicely centralized, but it is broad enough that argument-order or method-name drift could still sneak through without a dedicated suite. |
 | Strong's sheet reuses the same bridge transport while depending on a dedicated `contentType: \"strongs\"` document route | `StrongsSheetView.swift` dedicated `BibleBridge`, `BibleReaderController.buildStrongsMultiDocJSON()`, `DocumentBroker.vue`, and `StrongsDocument.vue` | Partial | This one matters more now because losing `contentType: \"strongs\"` does not fail loudly; it quietly falls back to generic multi-document rendering. |
 | Fullscreen, compare, help, external-link, and reference-dialog entry points remain exposed through the bridge | `BibleBridge.swift` switch branches for `toggleFullScreen`, `compare`, `helpDialog`, `openExternalLink`, and `refChooserDialog`; `BibleReaderController.swift` handlers | Partial | These branches are real and still parity-relevant, but they are not yet backed by focused bridge-domain regression coverage. |
-| Swift bridge payloads remain centralized and expected to stay aligned with `bibleview-js` type expectations | `BridgeTypes.swift`; `bibleview-js/src/types/`; summarized in `bridge-guide.md` | Partial | The contract is at least explicit now, but we still lack an automated parity diff or generated-schema guard that would make this safer. |
+| Swift bridge payloads remain centralized and expected to stay aligned with `bibleview-js` type expectations | `BridgeTypes.swift`; `bibleview-js/src/types/`; unit test `testBridgePayloadKeysMatchWebClientContracts`; summarized in `bridge-guide.md` | Partial | Representative `OsisFragment`, `Label`/`BookmarkStyle`, and `SelectionQuery` key sets are now regression-gated, but we still lack an automated parity diff or generated-schema guard for the full payload surface. |


### PR DESCRIPTION
## Summary

Adds focused bridge regression coverage for async callId request/response flows and representative payload key shapes.

## Scope

- Centralizes testable parsing for bridge callId request methods.
- Adds shared-scheme AndBibleTests coverage for callId argument mapping, response JavaScript, content expansion, refChooserDialog, parseRef, and representative payload keys.
- Adds package-level BridgeTypes payload key tests near the Codable models.
- Updates bridge parity guardrails, regression report, and verification matrix.

## Contract references

- Issue #37: [Parity P1] Add bridge payload and callId regression coverage.
- Bridge parity docs: docs/parity/bridge/verification-matrix.md, docs/parity/bridge/regression-report.md, docs/parity/bridge/guardrails.md.
- Bridge payload contracts: Sources/BibleView/Sources/BibleView/BridgeTypes.swift and bibleview-js/src/types/.

## Change details

- Extracted callId request parsing in BibleBridge so method names and positional argument contracts can be tested without constructing WKScriptMessage.
- Locked bridge response formatting through tests around bibleView.response(callId, value).
- Covered requestMoreToBeginning at the controller/bridge layer by asserting the original call ID receives a previous-chapter document payload.
- Covered native reference dialog and parser responses preserving their original call IDs.
- Added key-set assertions for OsisFragment, Label/BookmarkStyle, and SelectionQuery payloads.

## Validation evidence

- xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO test with the six focused bridge AndBibleTests: 6 tests, 0 failures.
- python3 scripts/check_bridge_parity_inventory.py: passed.
- python3 scripts/check_bridge_parity_inventory.py --android-root ../and-bible: passed.
- git diff --check: passed.

## Risks/follow-ups

- Payload coverage is representative, not a generated full-surface Swift-vs-TypeScript schema diff.
- Full reference-dialog UI workflows and broader bridge method families remain tracked as partial in the bridge matrix.

## Issue closure reference

Closes #37

Issue #37 was verified open before publishing this PR.