### PR TITLE
test(reader): cover fullscreen and swipe regressions

### DIFF
--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -1070,6 +1070,171 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(bridge.dispatchMessage(method: "missingMethod", args: []), .unhandled)
     }
 
+    func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {
+        let bridge = BibleBridge()
+        let controller = BibleReaderController(bridge: bridge)
+        let settingsStore = try makeInMemorySettingsStore()
+        controller.settingsStore = settingsStore
+
+        var toggleCount = 0
+        controller.onToggleFullScreen = { toggleCount += 1 }
+
+        XCTAssertEqual(bridge.dispatchMessage(method: "toggleFullScreen", args: []), .handled)
+        XCTAssertEqual(toggleCount, 1)
+
+        settingsStore.setBool(.doubleTapToFullscreen, value: false)
+        XCTAssertEqual(bridge.dispatchMessage(method: "toggleFullScreen", args: []), .handled)
+        XCTAssertEqual(toggleCount, 1)
+
+        settingsStore.setBool(.doubleTapToFullscreen, value: true)
+        XCTAssertEqual(bridge.dispatchMessage(method: "toggleFullScreen", args: []), .handled)
+        XCTAssertEqual(toggleCount, 2)
+    }
+
+    func testReaderHorizontalSwipePolicyMapsConfiguredModes() {
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "CHAPTER",
+                direction: .left,
+                hasActiveSelection: false
+            ),
+            .navigateNextChapter
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "CHAPTER",
+                direction: .right,
+                hasActiveSelection: false
+            ),
+            .navigatePreviousChapter
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "PAGE",
+                direction: .left,
+                hasActiveSelection: false
+            ),
+            .scrollPageDown
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "PAGE",
+                direction: .right,
+                hasActiveSelection: false
+            ),
+            .scrollPageUp
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "NONE",
+                direction: .left,
+                hasActiveSelection: false
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "PAGE",
+                direction: .left,
+                hasActiveSelection: true
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "unexpected",
+                direction: .left,
+                hasActiveSelection: false
+            ),
+            .navigateNextChapter
+        )
+    }
+
+    func testAutoFullscreenPolicyAccumulatesThresholdByDirection() {
+        var tracking = ReaderAutoFullscreenTracking()
+
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: 20,
+                isEnabled: true,
+                isFullScreen: false,
+                fullscreenLockedByDoubleTap: false,
+                tracking: &tracking
+            ),
+            .none
+        )
+        XCTAssertEqual(tracking.directionDown, true)
+        XCTAssertEqual(tracking.distance, 20)
+
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: 36,
+                isEnabled: true,
+                isFullScreen: false,
+                fullscreenLockedByDoubleTap: false,
+                tracking: &tracking
+            ),
+            .enterFullscreen
+        )
+        XCTAssertEqual(tracking.directionDown, true)
+        XCTAssertEqual(tracking.distance, 0)
+
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: -10,
+                isEnabled: true,
+                isFullScreen: true,
+                fullscreenLockedByDoubleTap: false,
+                tracking: &tracking
+            ),
+            .none
+        )
+        XCTAssertEqual(tracking.directionDown, false)
+        XCTAssertEqual(tracking.distance, 10)
+
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: -46,
+                isEnabled: true,
+                isFullScreen: true,
+                fullscreenLockedByDoubleTap: false,
+                tracking: &tracking
+            ),
+            .exitFullscreen
+        )
+        XCTAssertEqual(tracking.distance, 0)
+    }
+
+    func testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock() {
+        var tracking = ReaderAutoFullscreenTracking(directionDown: true, distance: 24)
+
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: 10,
+                isEnabled: false,
+                isFullScreen: false,
+                fullscreenLockedByDoubleTap: false,
+                tracking: &tracking
+            ),
+            .none
+        )
+        XCTAssertEqual(tracking, ReaderAutoFullscreenTracking())
+
+        tracking = ReaderAutoFullscreenTracking()
+        XCTAssertEqual(
+            ReaderAutoFullscreenPolicy.action(
+                deltaY: -56,
+                isEnabled: true,
+                isFullScreen: true,
+                fullscreenLockedByDoubleTap: true,
+                tracking: &tracking
+            ),
+            .none
+        )
+        XCTAssertEqual(tracking.directionDown, false)
+        XCTAssertEqual(tracking.distance, 0)
+    }
+
     @MainActor
     func testBridgeSendResponseEmitsCallIdResponseJavaScript() {
         let bridge = BibleBridge()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
@@ -1,0 +1,102 @@
+// BibleReaderInteractionPolicies.swift - Pure reader gesture behavior policies
+
+import BibleView
+
+/// Horizontal swipe modes for Bible panes, mirroring the Android preference values.
+enum BibleSwipeMode: String {
+    /// Swiping left or right changes chapter.
+    case chapter = "CHAPTER"
+
+    /// Swiping left or right scrolls by page height within the current document.
+    case page = "PAGE"
+
+    /// Horizontal swipe gestures are ignored.
+    case none = "NONE"
+}
+
+/// Native action selected for a horizontal Bible-view swipe.
+enum ReaderHorizontalSwipeAction: Equatable {
+    case navigateNextChapter
+    case navigatePreviousChapter
+    case scrollPageDown
+    case scrollPageUp
+    case none
+}
+
+/// Resolves configured Bible-view swipe behavior without touching view or controller state.
+enum ReaderHorizontalSwipePolicy {
+    static func action(
+        modeRawValue: String,
+        direction: NativeHorizontalSwipeDirection,
+        hasActiveSelection: Bool
+    ) -> ReaderHorizontalSwipeAction {
+        guard !hasActiveSelection else { return .none }
+
+        switch BibleSwipeMode(rawValue: modeRawValue) ?? .chapter {
+        case .chapter:
+            return direction == .left ? .navigateNextChapter : .navigatePreviousChapter
+        case .page:
+            return direction == .left ? .scrollPageDown : .scrollPageUp
+        case .none:
+            return .none
+        }
+    }
+}
+
+/// Mutable scroll accumulation used by Android-style auto-fullscreen behavior.
+struct ReaderAutoFullscreenTracking: Equatable {
+    var directionDown: Bool? = nil
+    var distance: Double = 0
+
+    mutating func reset() {
+        directionDown = nil
+        distance = 0
+    }
+}
+
+/// Native fullscreen action selected for a user-driven vertical scroll.
+enum ReaderAutoFullscreenAction: Equatable {
+    case enterFullscreen
+    case exitFullscreen
+    case none
+}
+
+/// Resolves auto-fullscreen threshold behavior without touching SwiftUI state.
+enum ReaderAutoFullscreenPolicy {
+    static let defaultScrollThreshold: Double = 56.0
+
+    static func action(
+        deltaY: Double,
+        isEnabled: Bool,
+        isFullScreen: Bool,
+        fullscreenLockedByDoubleTap: Bool,
+        threshold: Double = defaultScrollThreshold,
+        tracking: inout ReaderAutoFullscreenTracking
+    ) -> ReaderAutoFullscreenAction {
+        guard isEnabled else {
+            tracking.reset()
+            return .none
+        }
+        guard deltaY != 0 else { return .none }
+
+        let isDirectionDown = deltaY > 0
+        if tracking.directionDown != isDirectionDown {
+            tracking.directionDown = isDirectionDown
+            tracking.distance = 0
+        }
+
+        tracking.distance += abs(deltaY)
+        guard tracking.distance >= threshold else { return .none }
+        tracking.distance = 0
+
+        guard !fullscreenLockedByDoubleTap else { return .none }
+
+        if !isFullScreen && isDirectionDown {
+            return .enterFullscreen
+        }
+        if isFullScreen && !isDirectionDown {
+            return .exitFullscreen
+        }
+        return .none
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
@@ -3,7 +3,7 @@
 import BibleView
 
 /// Horizontal swipe modes for Bible panes, mirroring the Android preference values.
-enum BibleSwipeMode: String {
+private enum BibleSwipeMode: String {
     /// Swiping left or right changes chapter.
     case chapter = "CHAPTER"
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -333,11 +333,8 @@ public struct BibleReaderView: View {
     /// Tracks whether fullscreen was last entered by the double-tap gesture instead of scrolling.
     @State private var lastFullScreenByDoubleTap = false
 
-    /// Cached scroll direction used to accumulate auto-fullscreen distance per direction.
-    @State private var autoFullscreenDirectionDown: Bool?
-
-    /// Accumulated user scroll distance toward the auto-fullscreen threshold.
-    @State private var autoFullscreenDistance: Double = 0
+    /// Accumulated user scroll state toward the auto-fullscreen threshold.
+    @State private var autoFullscreenTracking = ReaderAutoFullscreenTracking()
 
     /// Initial query forwarded into `SearchView`, usually from Strong's lookups.
     @State private var searchInitialQuery = ""
@@ -357,9 +354,6 @@ public struct BibleReaderView: View {
     /// Motion-driven scroll helper used when tilt-to-scroll is enabled for the workspace.
     @State private var tiltScrollService = TiltScrollService()
     #endif
-
-    /// Minimum cumulative scroll distance before auto-fullscreen toggles the reader chrome.
-    private let autoFullscreenScrollThreshold: Double = 56.0
 
     /**
      The focused window's controller resolved from `WindowManager`'s single source of truth.
@@ -2378,8 +2372,7 @@ public struct BibleReaderView: View {
 
     /// Clears accumulated scroll-direction state for auto-fullscreen tracking.
     private func resetAutoFullscreenTracking() {
-        autoFullscreenDirectionDown = nil
-        autoFullscreenDistance = 0
+        autoFullscreenTracking.reset()
     }
 
     /**
@@ -2396,30 +2389,21 @@ public struct BibleReaderView: View {
      */
     private func handleAutoFullscreenScroll(from window: Window, deltaY: Double) {
         guard windowManager.activeWindow?.id == window.id else { return }
-        guard autoFullscreenPref else {
-            resetAutoFullscreenTracking()
-            return
-        }
-        guard deltaY != 0 else { return }
+        let action = ReaderAutoFullscreenPolicy.action(
+            deltaY: deltaY,
+            isEnabled: autoFullscreenPref,
+            isFullScreen: isFullScreen,
+            fullscreenLockedByDoubleTap: lastFullScreenByDoubleTap,
+            tracking: &autoFullscreenTracking
+        )
 
-        let isDirectionDown = deltaY > 0
-        if autoFullscreenDirectionDown != isDirectionDown {
-            autoFullscreenDirectionDown = isDirectionDown
-            autoFullscreenDistance = 0
-        }
-
-        autoFullscreenDistance += abs(deltaY)
-        guard autoFullscreenDistance >= autoFullscreenScrollThreshold else { return }
-        autoFullscreenDistance = 0
-
-        // Match Android: when fullscreen was entered by double-tap, scrolling
-        // should not auto-toggle fullscreen until fullscreen has been exited.
-        guard !lastFullScreenByDoubleTap else { return }
-
-        if !isFullScreen && isDirectionDown {
+        switch action {
+        case .enterFullscreen:
             withAnimation(.easeInOut(duration: 0.2)) { isFullScreen = true }
-        } else if isFullScreen && !isDirectionDown {
+        case .exitFullscreen:
             withAnimation(.easeInOut(duration: 0.2)) { isFullScreen = false }
+        case .none:
+            break
         }
     }
 
@@ -2438,21 +2422,19 @@ public struct BibleReaderView: View {
     private func handleHorizontalSwipe(from window: Window, direction: NativeHorizontalSwipeDirection) {
         guard windowManager.activeWindow?.id == window.id else { return }
         guard let ctrl = windowManager.controllers[window.id] as? BibleReaderController else { return }
-        guard !ctrl.hasActiveSelection else { return }
-
-        switch BibleSwipeMode(rawValue: bibleViewSwipeMode) ?? .chapter {
-        case .chapter:
-            if direction == .left {
-                ctrl.navigateNext()
-            } else {
-                ctrl.navigatePrevious()
-            }
-        case .page:
-            if direction == .left {
-                ctrl.scrollPageDown()
-            } else {
-                ctrl.scrollPageUp()
-            }
+        switch ReaderHorizontalSwipePolicy.action(
+            modeRawValue: bibleViewSwipeMode,
+            direction: direction,
+            hasActiveSelection: ctrl.hasActiveSelection
+        ) {
+        case .navigateNextChapter:
+            ctrl.navigateNext()
+        case .navigatePreviousChapter:
+            ctrl.navigatePrevious()
+        case .scrollPageDown:
+            ctrl.scrollPageDown()
+        case .scrollPageUp:
+            ctrl.scrollPageUp()
         case .none:
             return
         }
@@ -2543,18 +2525,6 @@ enum StrongsMode: Int, CaseIterable, Identifiable {
         case .hidden: String(localized: "strongs_hidden")
         }
     }
-}
-
-/// Horizontal swipe modes for Bible panes, mirroring the Android preference values.
-private enum BibleSwipeMode: String {
-    /// Swiping left or right changes chapter.
-    case chapter = "CHAPTER"
-
-    /// Swiping left or right scrolls by page height within the current document.
-    case page = "PAGE"
-
-    /// Horizontal swipe gestures are ignored.
-    case none = "NONE"
 }
 
 /// Gesture mappings for the Bible and commentary toolbar buttons.

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -4,8 +4,10 @@ This subtree holds cross-platform parity material.
 
 Recommended reading order:
 
-1. [status-overview.md](status-overview.md): current parity posture and automation state by domain
-2. domain `README.md` files: scoped reading order for each domain
+1. [android-parity-contract.md](android-parity-contract.md): global functional,
+   visual, and architecture standard
+2. [status-overview.md](status-overview.md): current parity posture and automation state by domain
+3. domain `README.md` files: scoped reading order for each domain
 
 Use domain folders so each parity area can carry, as needed:
 
@@ -33,6 +35,7 @@ Current maturity:
 
 Current domains:
 
+- [android-parity-contract.md](android-parity-contract.md)
 - [status-overview.md](status-overview.md)
 - [bridge/](bridge/README.md)
 - [reader/](reader/README.md)

--- a/docs/parity/android-parity-contract.md
+++ b/docs/parity/android-parity-contract.md
@@ -1,0 +1,215 @@
+# Android Parity Contract
+
+Date: 2026-05-08
+
+## Purpose
+
+This contract defines the long-term target for `and-bible-ios`: functional and
+visual parity with Android AndBible.
+
+Swift, SwiftUI, UIKit, WKWebView, and SwiftData do not need to mirror Android's
+Kotlin, Android View, WebView, and Room internals. The user-facing result should
+still be indistinguishable in behavior and presentation unless an explicit iOS
+platform constraint is documented.
+
+Use this document as the parent contract for every domain-specific parity file
+under `docs/parity/`.
+
+## Source Of Truth
+
+The Android checkout is the behavior and visual oracle.
+
+When a question is not settled by iOS code or docs, inspect the local Android
+checkout at a configurable sibling path such as `../and-bible`. Do not hardcode
+that path into tracked source.
+
+Relevant Android evidence can include:
+
+- Kotlin controllers, services, activities, fragments, and adapters
+- Android XML layouts, menus, drawables, and string resources
+- `app/bibleview-js/src/` shared document client code
+- Android database schemas and sync table definitions
+- Android tests and production behavior when available
+
+## Parity Standard
+
+A parity area is complete only when all three dimensions are satisfied.
+
+### Functional Parity
+
+iOS must expose the same user-visible capabilities as Android:
+
+- the same primary actions, secondary actions, destructive actions, and disabled
+  states
+- the same state transitions and persistence semantics
+- the same data import, export, sync, and conflict behavior
+- the same bridge method names, argument order, payload shapes, response timing,
+  and error handling for shared WebView-facing APIs
+- the same visible error, empty, loading, authentication, and confirmation states
+
+Implementation can differ. Observable behavior should not differ.
+
+### Visual Parity
+
+iOS screens should match Android's visible product contract:
+
+- same screen purpose, entry points, and navigation hierarchy
+- same control set, labels, ordering, grouping, and destructive/cancel affordances
+- same reader chrome concepts, document presentation, modal/dialog structure, and
+  transient overlays
+- same icon semantics where platform iconography permits
+- same state-specific content, including empty/loading/error/authentication states
+- same localization meaning, not just presence of string keys
+
+Platform-native controls are allowed only when they preserve the same visual
+information architecture and user outcome. A native iOS sheet can replace an
+Android dialog, for example, but the offered choices, default/cancel/destructive
+semantics, and follow-up behavior must remain equivalent.
+
+### Architecture Parity
+
+Architecture exists to keep functional and visual parity easy to verify.
+
+iOS should not mirror Android implementation classes one-for-one. Instead, iOS
+should preserve Android contracts through small, named adapters:
+
+- bridge adapters for `window.android.*` and async `callId` behavior
+- sync adapters for Android sync category and table semantics
+- data mappers for Android-shaped snapshots, patches, and payloads
+- view models or coordinators for screens with nontrivial state machines
+- focused SwiftUI views for visual surfaces
+
+If a parity behavior requires reading one very large view/controller to understand
+both UI and business behavior, that is architectural drift even if the feature
+works today.
+
+## Explicit Divergence
+
+iOS may diverge only when at least one condition is true:
+
+- iOS does not expose the necessary platform capability.
+- Apple platform policy or API constraints prevent the Android behavior.
+- Product scope intentionally excludes the Android feature on iOS.
+- The Android UI pattern is replaced by a native iOS presentation that preserves
+  the same choices and outcome.
+
+Every divergence must have:
+
+- the Android behavior being diverged from
+- the iOS behavior users will see
+- the reason for divergence
+- the validation that prevents accidental expansion or regression
+- a re-evaluation trigger, if platform or product constraints may change
+
+Undocumented absence is a parity gap, not a divergence.
+
+## Status Vocabulary
+
+Use these statuses consistently across domain matrices and tracking issues:
+
+- `Pass`: implemented and backed by code evidence plus focused validation.
+- `Visual Pass`: implemented and backed by visual/screenshot or UI hierarchy
+  validation against Android-equivalent expectations.
+- `Adapted Pass`: different implementation or presentation, explicitly
+  documented, with equivalent user outcome.
+- `Partial`: implemented or exposed, but missing focused evidence or visual
+  validation.
+- `Missing`: Android has user-visible or bridge/API behavior that iOS does not
+  implement.
+- `Documented Divergence`: intentionally different, with a written reason and
+  validation boundary.
+- `Automation Gap`: behavior is documented but not protected by a repeatable
+  guardrail, unit test, UI test, screenshot comparison, or machine-readable
+  inventory.
+
+Do not use `Pass` for a visually important surface that has only service-level
+unit coverage. Use `Partial` until the user-visible path is covered.
+
+## Anti-God-Class Guardrails
+
+Large parity classes make drift harder to see. These are review triggers, not
+mechanical failure thresholds:
+
+- A parity-sensitive view/controller over 800 lines needs a named owner for each
+  responsibility and a clear extraction path.
+- A type that owns more than one of UI layout, navigation, persistence, bridge
+  dispatch, payload building, sync orchestration, and domain mutation should not
+  gain another responsibility without extracting one first.
+- New Android-alignment work should prefer a small adapter, service, view model,
+  mapper, or subview over adding another branch to a reader, settings, or bridge
+  hub.
+- Bridge dispatch can remain centralized for routing, but domain behavior should
+  live outside the dispatcher.
+- SwiftUI files may compose screens, but nontrivial state machines should move to
+  testable coordinators or models.
+
+When extraction competes with shipping a parity fix, ship the behavior behind a
+clear seam and create a follow-up extraction task in the same parity domain.
+
+## Required Ledgers
+
+Each parity-sensitive domain should maintain or link to ledgers that answer:
+
+- Android surface: what Android exposes.
+- iOS surface: what iOS exposes.
+- Status: pass, adapted pass, partial, missing, divergence, or automation gap.
+- Evidence: tests, screenshots, guardrail scripts, direct source references.
+- Owner area: the iOS file or adapter responsible for keeping the contract.
+- Next action: implement, document divergence, add visual validation, or add
+  machine-readable guardrail.
+
+Existing examples:
+
+- `settings/baselines/` for localization guardrails
+- `bridge/baselines/android-bridge-gap-inventory.json` for bridge method breadth
+
+Future ledgers should be added where repeated manual comparison is currently
+required, especially visual screen structure and shared payload schemas.
+
+## Validation Ladder
+
+Use the cheapest validation that proves the user-facing claim.
+
+1. Contract inspection: Android and iOS source references agree.
+2. Unit or service test: state transition, parser, mapper, payload, or sync
+   behavior is deterministic.
+3. UI test: the visible workflow is exercised through the real screen.
+4. Visual check: screenshots or UI hierarchy assertions verify screen structure,
+   controls, labels, and state-specific presentation.
+5. Drift guardrail: a script or machine-readable inventory fails when Android or
+   iOS changes the contract silently.
+
+For visual parity claims, step 3 alone is not enough unless the UI test asserts
+the visible structure and state, not just navigation success.
+
+## Change Rules
+
+When changing parity-sensitive code:
+
+1. Identify the Android behavior or visual surface first.
+2. Decide whether the change is implementation, visual, behavioral, divergence,
+   or automation work.
+3. Keep Android-facing contracts stable unless Android and iOS are changed
+   together.
+4. Update the domain contract, disposition, verification matrix, and regression
+   report when status changes.
+5. Add or update the relevant ledger when the changed surface can drift again.
+6. Avoid expanding parity-critical hub files unless there is no smaller adapter
+   or coordinator to own the behavior.
+
+## Current Priority Interpretation
+
+Under this contract, the current repo is strongest where there are
+machine-readable ledgers or focused user-visible workflows:
+
+- settings localization and preference contracts
+- bridge method gap inventory
+- supported sync categories
+- core bookmark-list, search, reading-plan, reader-shell workflows
+
+The remaining priority is not a full architecture rewrite. The priority is to
+turn each current `Partial`, `Missing`, or `Automation Gap` into one of:
+
+- implemented and visually/functionally validated parity
+- documented iOS divergence
+- a small adapter/coordinator plus a repeatable drift check

--- a/docs/parity/reader/contract.md
+++ b/docs/parity/reader/contract.md
@@ -12,6 +12,8 @@ Primary code references:
   `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
 - main document controller:
   `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
+- reader gesture/fullscreen policies:
+  `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift`
 - web view coordinator and swipe handling:
   `Sources/BibleView/Sources/BibleView/WebViewCoordinator.swift`
 - pane shell:

--- a/docs/parity/reader/guardrails.md
+++ b/docs/parity/reader/guardrails.md
@@ -7,6 +7,7 @@ someone is changing:
 
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
+- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/StrongsSheetView.swift`
 - `Sources/BibleView/Sources/BibleView/WebViewCoordinator.swift`
@@ -41,11 +42,11 @@ someone is changing:
    The reader is where active workspace changes become visible. Create, rename,
    clone, and delete all need to keep the reader-shell invariants intact.
 
-5. Fullscreen, swipe-mode, and auto-fullscreen behavior are parity-sensitive,
-   even where coverage is still partial.
+5. Fullscreen, swipe-mode, and auto-fullscreen behavior are parity-sensitive.
 
    These branches are easy to break through gesture or layout refactors. Thin
-   coverage is not a good reason to simplify them casually.
+   policy coverage is useful, but it is not a good reason to simplify them
+   casually.
 
 6. Reader config emission into the embedded client is part of the parity
    surface.
@@ -82,7 +83,9 @@ subset.
 
 - The repo currently has focused reader-shell UI coverage for drawer/overflow
   routing, history workflows, and workspace switching plus unit regressions for
-  restored-position highlight behavior.
+  restored-position highlight behavior, reader config payloads, double-tap
+  fullscreen gating, horizontal swipe-mode mapping, and auto-fullscreen
+  threshold behavior.
 - In practice, current protection is a mix of:
   - reader workflow tests in `AndBibleUITests`
   - reader-adjacent payload regressions in `AndBibleTests`
@@ -92,6 +95,5 @@ subset.
 ## Useful Next Improvements
 
 - add focused regression coverage for the Strong's / dictionary modal
-- add focused regression coverage for fullscreen, swipe-mode, and auto-fullscreen behavior
 - add focused workflow coverage for compare presentation
 - add a tighter guardrail around reader config emission into the embedded document client

--- a/docs/parity/reader/regression-report.md
+++ b/docs/parity/reader/regression-report.md
@@ -12,6 +12,9 @@ This is the current validation snapshot for the reader surface. It covers:
 - workspace selector create/switch flow from the reader shell
 - restored-position highlight behavior in the emitted reader payload
 - reader config/appSettings payload construction for embedded-client display and active-window state
+- double-tap fullscreen preference gating
+- horizontal swipe-mode dispatch policy
+- auto-fullscreen scroll-threshold policy
 
 Contract reference:
 
@@ -36,6 +39,7 @@ Related domain references:
   - reader-relevant workflow assertions exercised within that suite
   - reader-adjacent unit regressions for payload-level restore/highlight behavior
   - focused reader/controller payload subset on `test/reader-config-payload-coverage`
+  - focused reader gesture/fullscreen policy subset on `test/reader-fullscreen-swipe-coverage`
 
 ## Tests Executed
 
@@ -45,6 +49,10 @@ Related domain references:
 - `AndBibleTests/testLoadCurrentContentHighlightsExplicitVerseNavigationTarget`
 - `AndBibleTests/testReaderConfigPayloadIncludesDisplaySettingsAndActiveWindowState`
 - `AndBibleTests/testReaderConfigPayloadMarksInactiveWindowWithoutActiveIndicator`
+- `AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest`
+- `AndBibleTests/testReaderHorizontalSwipePolicyMapsConfiguredModes`
+- `AndBibleTests/testAutoFullscreenPolicyAccumulatesThresholdByDirection`
+- `AndBibleTests/testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock`
 
 ### UI
 
@@ -92,7 +100,31 @@ Related domain references:
 - active windows with multiple visible panes emit `hasActiveIndicator: true`; inactive panes emit
   both `activeWindow: false` and `hasActiveIndicator: false`
 
+### Fullscreen and swipe behavior
+
+- embedded-client `toggleFullScreen` bridge messages honor the
+  `double_tap_to_fullscreen` preference before invoking the native fullscreen
+  toggle callback
+- `CHAPTER`, `PAGE`, and `NONE` horizontal swipe modes resolve to the expected
+  native navigation, page-scroll, or no-op action
+- active text selection suppresses horizontal swipe actions
+- auto-fullscreen scroll deltas accumulate by direction, reset on direction
+  changes, enter/exit fullscreen only after the threshold, reset when disabled,
+  and do not auto-toggle when fullscreen was entered by double tap
+
 ## Current Result
+
+Latest full non-UI XCTest validation passed on 2026-05-08:
+
+- `AndBibleTests`: `206/206`
+- command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests`
+- result bundle: `~/Library/Developer/Xcode/DerivedData/AndBible-fxmuikolbspefdbpaozhvagfvbdj/Logs/Test/Test-AndBible-2026.05.08_18-10-34--0400.xcresult`
+
+Latest focused reader gesture/fullscreen validation passed on 2026-05-08:
+
+- focused issue #40 subset: `4/4`
+- command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest -only-testing:AndBibleTests/AndBibleTests/testReaderHorizontalSwipePolicyMapsConfiguredModes -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyAccumulatesThresholdByDirection -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock`
+- result bundle: `~/Library/Developer/Xcode/DerivedData/AndBible-fxmuikolbspefdbpaozhvagfvbdj/Logs/Test/Test-AndBible-2026.05.08_18-08-54--0400.xcresult`
 
 Latest focused reader/controller validation passed on 2026-05-08:
 
@@ -115,6 +147,9 @@ Taken together, this gives the reader domain current regression evidence for:
 - workspace selector create/switch handoff
 - payload-level restore/highlight behavior
 - payload-level config/appSettings propagation into the embedded document client
+- double-tap fullscreen preference gating
+- horizontal swipe-mode dispatch policy
+- auto-fullscreen threshold and lockout policy
 
 That is a much healthier place than the branch was in earlier. The remaining
 reader risk is no longer the basic shell/menu flow; it is the deeper behavior
@@ -126,8 +161,6 @@ The reader shell baseline is in much better shape now. The parts that still
 need tighter protection are:
 
 - dedicated Strong's / dictionary modal regression coverage
-- swipe-mode and auto-fullscreen behavior
-- double-tap fullscreen behavior
 - compare presentation workflows
 
 Those areas are implemented and documented, but they are not yet locked by

--- a/docs/parity/reader/regression-report.md
+++ b/docs/parity/reader/regression-report.md
@@ -118,13 +118,11 @@ Latest full non-UI XCTest validation passed on 2026-05-08:
 
 - `AndBibleTests`: `206/206`
 - command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests`
-- result bundle: `~/Library/Developer/Xcode/DerivedData/AndBible-fxmuikolbspefdbpaozhvagfvbdj/Logs/Test/Test-AndBible-2026.05.08_18-10-34--0400.xcresult`
 
 Latest focused reader gesture/fullscreen validation passed on 2026-05-08:
 
 - focused issue #40 subset: `4/4`
 - command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest -only-testing:AndBibleTests/AndBibleTests/testReaderHorizontalSwipePolicyMapsConfiguredModes -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyAccumulatesThresholdByDirection -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock`
-- result bundle: `~/Library/Developer/Xcode/DerivedData/AndBible-fxmuikolbspefdbpaozhvagfvbdj/Logs/Test/Test-AndBible-2026.05.08_18-08-54--0400.xcresult`
 
 Latest focused reader/controller validation passed on 2026-05-08:
 

--- a/docs/parity/reader/verification-matrix.md
+++ b/docs/parity/reader/verification-matrix.md
@@ -30,9 +30,9 @@ trust than proof.
 
 ## Summary
 
-- `Pass`: 5
+- `Pass`: 7
 - `Adapted Pass`: 1
-- `Partial`: 4
+- `Partial`: 2
 
 ## Matrix
 
@@ -44,7 +44,7 @@ trust than proof.
 | Workspace selection and switching remain coordinated by the reader shell | `BibleReaderView.swift`, `WorkspaceSelectorView.swift`, `WindowManager`; UI test `testWorkspaceSelectorCreateAndSwitchFlow` | Pass | The current check is doing useful work here: it covers creation, activation, and a clean return to the reader shell, not just low-level persistence. |
 | Restored reading position avoids stale verse highlighting while explicit verse navigation preserves its target highlight | `BibleReaderController.swift`; unit tests `testLoadCurrentContentDoesNotHighlightRestoredReadingPosition`, `testLoadCurrentContentHighlightsExplicitVerseNavigationTarget` | Pass | This is a small detail, but it is a very visible one when it breaks, so it is good to have it locked at the payload-emission layer. |
 | Strong's / dictionary modal uses the dedicated Strong's document path with per-dictionary tabs and recursive in-modal navigation | `BibleReaderController.buildStrongsMultiDocJSON()`, `StrongsSheetView.swift`, `DocumentBroker.vue`, `StrongsDocument.vue`, `TabNavigation.vue` | Partial | The richer modal path is there now and it feels much better, but we are still leaning on implementation confidence more than focused regression coverage for this surface. |
-| Horizontal swipe modes and auto-fullscreen thresholds are implemented natively | `WebViewCoordinator.swift` native swipe/scroll callbacks; `BibleReaderView.handleNativeHorizontalSwipe(_:)` and auto-fullscreen tracking in `BibleReaderView` | Partial | The code paths exist, but we still do not have the kind of focused regression that would make this feel safely locked. |
-| Double-tap fullscreen remains owned by the native reader shell | `BibleReaderController.handleToggleFullscreen()` and `BibleReaderView` fullscreen state/overlay ownership; documented in `dispositions.md` | Partial | The ownership story is clear, but the dedicated regression story is not there yet. |
+| Horizontal swipe modes and auto-fullscreen thresholds are implemented natively | `WebViewCoordinator.swift` native swipe/scroll callbacks; `BibleReaderView.handleHorizontalSwipe(...)`; `BibleReaderInteractionPolicies.swift`; unit tests `testReaderHorizontalSwipePolicyMapsConfiguredModes`, `testAutoFullscreenPolicyAccumulatesThresholdByDirection`, `testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock` | Pass | The gesture callbacks still stay native, while the decision logic is now covered at the policy layer instead of depending on flaky web-view gesture timing. |
+| Double-tap fullscreen remains owned by the native reader shell | `BibleBridge.dispatchMessage(method:args:)`, `BibleReaderController.bridgeDidRequestToggleFullScreen(...)`, `BibleReaderView` fullscreen state/overlay ownership; unit test `testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest`; documented in `dispositions.md` | Pass | The bridge path now has focused coverage proving the `double_tap_to_fullscreen` preference gate is honored before native fullscreen state changes. |
 | Compare requests are presented through native iOS sheet flow | `BibleReaderController.compareSelection()`, `BibleReaderController.bridge(_:compareVerses:startOrdinal:endOrdinal:)`, `BibleReaderView.showCompare`, `presentCompareView(...)`; documented in `dispositions.md` | Partial | The entry points are in place, but this is still one of the places where a future regression could slip through unless we add a focused workflow check. |
 | Reader config pushes active-window and display state into the embedded client | `BibleReaderController.buildConfigJSON()`, `BibleReaderController.updateConfig()`, `BibleReaderView.updateDisplaySettings(...)`; unit tests `testReaderConfigPayloadIncludesDisplaySettingsAndActiveWindowState`, `testReaderConfigPayloadMarksInactiveWindowWithoutActiveIndicator` | Pass | Focused payload-level coverage now locks the config/appSettings key shape, representative display settings, app preference values, workspace label state, and active/inactive window indicator behavior. |

--- a/docs/parity/status-overview.md
+++ b/docs/parity/status-overview.md
@@ -1,14 +1,15 @@
 # Parity Status Overview
 
-Date: 2026-05-06
+Date: 2026-05-08
 
 ## Purpose
 
 This is the quickest way to get oriented on Android parity in
 `and-bible-ios`.
 
-If you are touching a parity-sensitive area, this file should help you answer
-four questions without having to reconstruct repo history first:
+Start with [android-parity-contract.md](android-parity-contract.md) for the
+global functional, visual, and architecture standard. Then use this file to
+answer four questions without having to reconstruct repo history first:
 
 1. what domains are formally documented
 2. what their current parity posture is
@@ -28,8 +29,8 @@ give you the fuller human context behind it.
 | [bookmarks](bookmarks/README.md) | Strong bookmark-list coverage, thinner note-document UI coverage: `4 Pass`, `2 Adapted Pass`, `3 Partial` | Focused bookmark UI workflows plus note-persistence unit regressions | Generic-bookmark visible workflows, My Notes visible note mutation, and broader StudyPad mutation breadth |
 | [search](search/README.md) | Strong semantic coverage: `5 Pass`, `2 Adapted Pass`, `1 Partial` | Focused search UI workflows plus Strong's unit regressions | Multi-translation search still lacks focused regression coverage |
 | [reading-plans](reading-plans/README.md) | Strong sync and progression coverage: `5 Pass`, `1 Adapted Pass`, `3 Partial` | Focused daily-reading UI coverage plus restore/upload/patch unit coverage | Custom plan import, reading-plan list/start/import breadth, and additive iOS-only plan lifecycle coverage |
-| [reader](reader/README.md) | Reader shell/menu parity is stronger, but deeper gesture/modal/config branches remain partial: `4 Pass`, `1 Adapted Pass`, `5 Partial` | Focused reader-shell UI coverage, restored-position unit regressions, and full local UI validation | Strong's modal, fullscreen, swipe-mode, compare, and config-bridge coverage still need tighter focused regression locking |
-| [bridge](bridge/README.md) | StudyPad handoff and shared iOS bridge subset are present; full Android bridge breadth remains partial: `1 Pass`, `1 Adapted Pass`, `6 Partial` | Focused StudyPad handoff, note-persistence regressions, bridge guardrails, machine-readable gap inventory, and local Android-backed drift checking | Visible My Notes lifecycle coverage, Android-only bridge method breadth, payloads, and async `callId` flows |
+| [reader](reader/README.md) | Reader shell/menu parity is stronger, with remaining gaps concentrated in modal/workflow branches: `7 Pass`, `1 Adapted Pass`, `2 Partial` | Focused reader-shell UI coverage, restored-position/config-payload/gesture-policy unit regressions, and full local UI validation | Strong's modal and compare coverage still need tighter focused regression locking |
+| [bridge](bridge/README.md) | StudyPad handoff, async `callId` flows, and shared iOS bridge subset are present; full Android bridge breadth remains partial: `2 Pass`, `1 Adapted Pass`, `5 Partial` | Focused StudyPad handoff, async `callId`, note-persistence regressions, bridge guardrails, machine-readable gap inventory, and local Android-backed drift checking | Visible My Notes lifecycle coverage, Android-only bridge method breadth, delegate branch coverage, and payload-schema breadth |
 
 ## How To Read Each Domain
 
@@ -103,6 +104,8 @@ This repo is no longer in a "parity planning only" state.
 
 It now has:
 
+- a top-level Android parity contract for functional, visual, and architecture
+  expectations
 - a documented parity contract for every current domain
 - explicit iOS adaptations for every current domain
 - a verification snapshot for every current domain
@@ -119,7 +122,8 @@ every domain. That is deliberate for now. The current posture is:
 - strong bookmark-list evidence in `bookmarks`, with visible My Notes and broader
   StudyPad mutation still partial
 - meaningful but still partial protection in `reader` and `bridge` where the
-  remaining gaps are mostly boundary and protocol behaviors
+  remaining gaps are mostly focused workflow coverage, Android-only breadth, and
+  payload-schema breadth
 
 That means the docs matter. In some areas they are still the clearest way to
 understand not just what the app does, but why we are treating a behavior as
@@ -129,13 +133,15 @@ understand not just what the app does, but why we are treating a behavior as
 
 When you are changing a parity-sensitive area:
 
-1. start with this overview
-2. open the target domain `README.md`
-3. read `contract.md` and `dispositions.md`
-4. check `verification-matrix.md` for current status
-5. use `regression-report.md` and `guardrails.md` to choose the validation bar
+1. start with [android-parity-contract.md](android-parity-contract.md)
+2. use this overview to find the target domain
+3. open the target domain `README.md`
+4. read `contract.md` and `dispositions.md`
+5. check `verification-matrix.md` for current status
+6. use `regression-report.md` and `guardrails.md` to choose the validation bar
 
 If a change meaningfully shifts the parity story, update both:
 
 - the domain docs
 - this overview
+- the global contract when the standard itself changes


### PR DESCRIPTION
## Summary

Adds focused regression coverage for reader fullscreen and horizontal swipe behavior from issue #40.

## Scope

- Adds pure reader interaction policies for horizontal swipe mode and auto-fullscreen decisions.
- Routes the reader SwiftUI handlers through those policies.
- Adds unit tests for double-tap fullscreen preference gating, swipe-mode mapping, auto-fullscreen thresholds, disabled reset behavior, and double-tap lockout.
- Updates reader parity docs and the parity status overview.
- Includes the local global Android parity contract doc that this branch carried forward.

## Contract references

- GitHub issue #40: [Parity P2] Add reader fullscreen and swipe-mode regression coverage.
- docs/parity/android-parity-contract.md.
- docs/parity/reader/contract.md.
- docs/parity/reader/verification-matrix.md.
- docs/parity/reader/regression-report.md.

## Change details

- `BibleReaderInteractionPolicies.swift` owns deterministic swipe and auto-fullscreen decisions.
- `BibleReaderView.swift` keeps native gesture callbacks, but delegates decision logic to policy helpers.
- `AndBibleTests.swift` now locks representative fullscreen and swipe behavior without relying on WKWebView gesture timing.
- Reader parity status now marks fullscreen, swipe, and auto-fullscreen coverage as passing, leaving Strong and compare workflows as the remaining reader partials.

## Validation evidence

- `git diff --check`.
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest -only-testing:AndBibleTests/AndBibleTests/testReaderHorizontalSwipePolicyMapsConfiguredModes -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyAccumulatesThresholdByDirection -only-testing:AndBibleTests/AndBibleTests/testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock`.
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests` passed: 206 tests, 0 failures.
- `xcodebuild build -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C -derivedDataPath build/LocalRunDerivedData CODE_SIGNING_ALLOWED=NO`.
- Installed and launched the app on the booted iPhone 17 simulator with `xcrun simctl install` and `xcrun simctl launch`.

## Risks/follow-ups

- Normal local simulator build still fails while signing the generated `AndBible_BibleCore.bundle`; local build and test validation used `CODE_SIGNING_ALLOWED=NO`.
- This PR covers policy-level fullscreen, swipe, and auto-fullscreen behavior. Strong modal and compare workflow coverage remain follow-up reader gaps.
- The parity contract doc is included because it was already part of the local branch context and is referenced by the updated parity overview.

## Issue closure reference

Closes #40