### PR TITLE
test(reader): cover compare bridge workflow

### DIFF
--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -1070,6 +1070,39 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(bridge.dispatchMessage(method: "missingMethod", args: []), .unhandled)
     }
 
+    func testReaderCompareBridgeRequestBuildsNativePresentationPayload() throws {
+        let bridge = BibleBridge()
+        let controller = BibleReaderController(bridge: bridge)
+        let secondCorinthians = try XCTUnwrap(
+            controller.bookList.first(where: { $0.osisId == "2Cor" })?.name
+        )
+
+        controller.navigateTo(book: secondCorinthians, chapter: 2, verse: 1)
+
+        var receivedPayload: (
+            book: String,
+            chapter: Int,
+            moduleName: String,
+            startVerse: Int?,
+            endVerse: Int?
+        )?
+        controller.onCompareVerses = { book, chapter, moduleName, startVerse, endVerse in
+            receivedPayload = (book, chapter, moduleName, startVerse, endVerse)
+        }
+
+        XCTAssertEqual(
+            bridge.dispatchMessage(method: "compare", args: ["KJV", 45, 47]),
+            .handled
+        )
+
+        let payload = try XCTUnwrap(receivedPayload)
+        XCTAssertEqual(payload.book, secondCorinthians)
+        XCTAssertEqual(payload.chapter, 2)
+        XCTAssertEqual(payload.moduleName, "KJV")
+        XCTAssertEqual(payload.startVerse, 5)
+        XCTAssertEqual(payload.endVerse, 7)
+    }
+
     func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {
         let bridge = BibleBridge()
         let controller = BibleReaderController(bridge: bridge)

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -1076,8 +1076,16 @@ final class AndBibleTests: XCTestCase {
         let secondCorinthians = try XCTUnwrap(
             controller.bookList.first(where: { $0.osisId == "2Cor" })?.name
         )
+        let chapter = 2
+        let startVerse = 5
+        let endVerse = 7
+        let activeModuleName = controller.activeModuleName
 
-        controller.navigateTo(book: secondCorinthians, chapter: 2, verse: 1)
+        func ordinal(for verse: Int) -> Int {
+            (chapter - 1) * 40 + verse
+        }
+
+        controller.navigateTo(book: secondCorinthians, chapter: chapter, verse: 1)
 
         var receivedPayload: (
             book: String,
@@ -1091,16 +1099,19 @@ final class AndBibleTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            bridge.dispatchMessage(method: "compare", args: ["KJV", 45, 47]),
+            bridge.dispatchMessage(
+                method: "compare",
+                args: [activeModuleName, ordinal(for: startVerse), ordinal(for: endVerse)]
+            ),
             .handled
         )
 
         let payload = try XCTUnwrap(receivedPayload)
         XCTAssertEqual(payload.book, secondCorinthians)
-        XCTAssertEqual(payload.chapter, 2)
-        XCTAssertEqual(payload.moduleName, "KJV")
-        XCTAssertEqual(payload.startVerse, 5)
-        XCTAssertEqual(payload.endVerse, 7)
+        XCTAssertEqual(payload.chapter, chapter)
+        XCTAssertEqual(payload.moduleName, activeModuleName)
+        XCTAssertEqual(payload.startVerse, startVerse)
+        XCTAssertEqual(payload.endVerse, endVerse)
     }
 
     func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {

--- a/docs/parity/reader/README.md
+++ b/docs/parity/reader/README.md
@@ -2,7 +2,7 @@
 
 This directory is meant to help the next person understand how close the iOS `reader` currently is to Android, where the remaining gaps are, and which parts are easy to break by accident.
 
-It covers the main reading experience, including the reader shell, toolbar chrome, drawer/overflow navigation, history handoff, workspace switching, and the Strong's / dictionary modal path.
+It covers the main reading experience, including the reader shell, toolbar chrome, drawer/overflow navigation, history handoff, workspace switching, compare presentation, and the Strong's / dictionary modal path.
 
 If you are new to this area, start here and read top to bottom once. The matrix
 is useful, but the surrounding notes are where the intent and the remaining rough edges are easier to understand.
@@ -27,6 +27,7 @@ Primary code references:
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift`
+- `Sources/BibleUI/Sources/BibleUI/Bible/CompareView.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/StrongsSheetView.swift`
 - `Sources/BibleView/Sources/BibleView/WebViewCoordinator.swift`
 - `Sources/BibleUI/Sources/BibleUI/Shared/HistoryView.swift`

--- a/docs/parity/reader/guardrails.md
+++ b/docs/parity/reader/guardrails.md
@@ -74,6 +74,7 @@ At minimum, reader-adjacent changes should keep the focused workflow subset in
 - history jump-back plus clear/delete persistence
 - workspace selector create/switch from the reader shell
 - restored-position highlight behavior
+- bridge-driven compare presentation payload construction
 
 If a change touches one of the still-partial areas, it is worth raising the bar
 and adding focused coverage instead of leaning only on the current reader
@@ -84,8 +85,8 @@ subset.
 - The repo currently has focused reader-shell UI coverage for drawer/overflow
   routing, history workflows, and workspace switching plus unit regressions for
   restored-position highlight behavior, reader config payloads, double-tap
-  fullscreen gating, horizontal swipe-mode mapping, and auto-fullscreen
-  threshold behavior.
+  fullscreen gating, compare presentation payload construction, horizontal
+  swipe-mode mapping, and auto-fullscreen threshold behavior.
 - In practice, current protection is a mix of:
   - reader workflow tests in `AndBibleUITests`
   - reader-adjacent payload regressions in `AndBibleTests`
@@ -95,5 +96,4 @@ subset.
 ## Useful Next Improvements
 
 - add focused regression coverage for the Strong's / dictionary modal
-- add focused workflow coverage for compare presentation
 - add a tighter guardrail around reader config emission into the embedded document client

--- a/docs/parity/reader/regression-report.md
+++ b/docs/parity/reader/regression-report.md
@@ -1,6 +1,6 @@
 # READER-702 Regression Report
 
-Date: 2026-05-08
+Date: 2026-05-09
 
 ## Scope
 
@@ -13,6 +13,7 @@ This is the current validation snapshot for the reader surface. It covers:
 - restored-position highlight behavior in the emitted reader payload
 - reader config/appSettings payload construction for embedded-client display and active-window state
 - double-tap fullscreen preference gating
+- bridge-driven compare presentation payload construction
 - horizontal swipe-mode dispatch policy
 - auto-fullscreen scroll-threshold policy
 
@@ -40,6 +41,7 @@ Related domain references:
   - reader-adjacent unit regressions for payload-level restore/highlight behavior
   - focused reader/controller payload subset on `test/reader-config-payload-coverage`
   - focused reader gesture/fullscreen policy subset on `test/reader-fullscreen-swipe-coverage`
+  - focused reader compare bridge subset on `test/reader-compare-workflow-coverage`
 
 ## Tests Executed
 
@@ -50,6 +52,7 @@ Related domain references:
 - `AndBibleTests/testReaderConfigPayloadIncludesDisplaySettingsAndActiveWindowState`
 - `AndBibleTests/testReaderConfigPayloadMarksInactiveWindowWithoutActiveIndicator`
 - `AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest`
+- `AndBibleTests/testReaderCompareBridgeRequestBuildsNativePresentationPayload`
 - `AndBibleTests/testReaderHorizontalSwipePolicyMapsConfiguredModes`
 - `AndBibleTests/testAutoFullscreenPolicyAccumulatesThresholdByDirection`
 - `AndBibleTests/testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock`
@@ -112,11 +115,23 @@ Related domain references:
   changes, enter/exit fullscreen only after the threshold, reset when disabled,
   and do not auto-toggle when fullscreen was entered by double tap
 
+### Compare presentation payload
+
+- embedded-client `compare` bridge messages are classified as handled and reach
+  the controller's native compare presentation callback
+- the callback receives the active reader book, chapter, current module name,
+  and normalized start/end verse numbers derived from the web ordinal range
+
 ## Current Result
 
-Latest full non-UI XCTest validation passed on 2026-05-08:
+Latest focused reader compare validation passed on 2026-05-09:
 
-- `AndBibleTests`: `206/206`
+- focused issue #41 subset: `1/1`
+- command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testReaderCompareBridgeRequestBuildsNativePresentationPayload`
+
+Latest full non-UI XCTest validation passed on 2026-05-09:
+
+- `AndBibleTests`: `207/207`
 - command: `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests`
 
 Latest focused reader gesture/fullscreen validation passed on 2026-05-08:
@@ -146,6 +161,7 @@ Taken together, this gives the reader domain current regression evidence for:
 - payload-level restore/highlight behavior
 - payload-level config/appSettings propagation into the embedded document client
 - double-tap fullscreen preference gating
+- bridge-driven compare presentation payload construction
 - horizontal swipe-mode dispatch policy
 - auto-fullscreen threshold and lockout policy
 
@@ -155,12 +171,11 @@ branches we still have not isolated with their own focused checks.
 
 ## What Is Still Not Well Locked Yet
 
-The reader shell baseline is in much better shape now. The parts that still
-need tighter protection are:
+The reader shell baseline is in much better shape now. The part that still
+needs tighter protection is:
 
 - dedicated Strong's / dictionary modal regression coverage
-- compare presentation workflows
 
-Those areas are implemented and documented, but they are not yet locked by
-focused reader-domain regression coverage, so they still show up as `Partial`
+That area is implemented and documented, but it is not yet locked by focused
+reader-domain regression coverage, so it still shows up as `Partial`
 in [verification-matrix.md](verification-matrix.md).

--- a/docs/parity/reader/verification-matrix.md
+++ b/docs/parity/reader/verification-matrix.md
@@ -1,6 +1,6 @@
 # READER-701 Verification Matrix (Android Reader -> iOS)
 
-Date: 2026-05-08
+Date: 2026-05-09
 
 ## Scope and Method
 
@@ -30,9 +30,9 @@ trust than proof.
 
 ## Summary
 
-- `Pass`: 7
+- `Pass`: 8
 - `Adapted Pass`: 1
-- `Partial`: 2
+- `Partial`: 1
 
 ## Matrix
 
@@ -46,5 +46,5 @@ trust than proof.
 | Strong's / dictionary modal uses the dedicated Strong's document path with per-dictionary tabs and recursive in-modal navigation | `BibleReaderController.buildStrongsMultiDocJSON()`, `StrongsSheetView.swift`, `DocumentBroker.vue`, `StrongsDocument.vue`, `TabNavigation.vue` | Partial | The richer modal path is there now and it feels much better, but we are still leaning on implementation confidence more than focused regression coverage for this surface. |
 | Horizontal swipe modes and auto-fullscreen thresholds are implemented natively | `WebViewCoordinator.swift` native swipe/scroll callbacks; `BibleReaderView.handleHorizontalSwipe(...)`; `BibleReaderInteractionPolicies.swift`; unit tests `testReaderHorizontalSwipePolicyMapsConfiguredModes`, `testAutoFullscreenPolicyAccumulatesThresholdByDirection`, `testAutoFullscreenPolicyHonorsDisabledAndDoubleTapLock` | Pass | The gesture callbacks still stay native, while the decision logic is now covered at the policy layer instead of depending on flaky web-view gesture timing. |
 | Double-tap fullscreen remains owned by the native reader shell | `BibleBridge.dispatchMessage(method:args:)`, `BibleReaderController.bridgeDidRequestToggleFullScreen(...)`, `BibleReaderView` fullscreen state/overlay ownership; unit test `testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest`; documented in `dispositions.md` | Pass | The bridge path now has focused coverage proving the `double_tap_to_fullscreen` preference gate is honored before native fullscreen state changes. |
-| Compare requests are presented through native iOS sheet flow | `BibleReaderController.compareSelection()`, `BibleReaderController.bridge(_:compareVerses:startOrdinal:endOrdinal:)`, `BibleReaderView.showCompare`, `presentCompareView(...)`; documented in `dispositions.md` | Partial | The entry points are in place, but this is still one of the places where a future regression could slip through unless we add a focused workflow check. |
+| Compare requests are presented through native iOS sheet flow | `BibleReaderController.compareSelection()`, `BibleReaderController.bridge(_:compareVerses:startOrdinal:endOrdinal:)`, `BibleReaderView.showCompare`, `presentCompareView(...)`; unit test `testReaderCompareBridgeRequestBuildsNativePresentationPayload`; documented in `dispositions.md` | Pass | The bridge-driven path now has focused coverage proving a compare request reaches the native presentation callback with the active book, chapter, module, and normalized verse range. |
 | Reader config pushes active-window and display state into the embedded client | `BibleReaderController.buildConfigJSON()`, `BibleReaderController.updateConfig()`, `BibleReaderView.updateDisplaySettings(...)`; unit tests `testReaderConfigPayloadIncludesDisplaySettingsAndActiveWindowState`, `testReaderConfigPayloadMarksInactiveWindowWithoutActiveIndicator` | Pass | Focused payload-level coverage now locks the config/appSettings key shape, representative display settings, app preference values, workspace label state, and active/inactive window indicator behavior. |

--- a/docs/parity/status-overview.md
+++ b/docs/parity/status-overview.md
@@ -1,6 +1,6 @@
 # Parity Status Overview
 
-Date: 2026-05-08
+Date: 2026-05-09
 
 ## Purpose
 
@@ -29,7 +29,7 @@ give you the fuller human context behind it.
 | [bookmarks](bookmarks/README.md) | Strong bookmark-list coverage, thinner note-document UI coverage: `4 Pass`, `2 Adapted Pass`, `3 Partial` | Focused bookmark UI workflows plus note-persistence unit regressions | Generic-bookmark visible workflows, My Notes visible note mutation, and broader StudyPad mutation breadth |
 | [search](search/README.md) | Strong semantic coverage: `5 Pass`, `2 Adapted Pass`, `1 Partial` | Focused search UI workflows plus Strong's unit regressions | Multi-translation search still lacks focused regression coverage |
 | [reading-plans](reading-plans/README.md) | Strong sync and progression coverage: `5 Pass`, `1 Adapted Pass`, `3 Partial` | Focused daily-reading UI coverage plus restore/upload/patch unit coverage | Custom plan import, reading-plan list/start/import breadth, and additive iOS-only plan lifecycle coverage |
-| [reader](reader/README.md) | Reader shell/menu parity is stronger, with remaining gaps concentrated in modal/workflow branches: `7 Pass`, `1 Adapted Pass`, `2 Partial` | Focused reader-shell UI coverage, restored-position/config-payload/gesture-policy unit regressions, and full local UI validation | Strong's modal and compare coverage still need tighter focused regression locking |
+| [reader](reader/README.md) | Reader shell/menu parity is stronger, with the remaining gap concentrated in the Strong's modal branch: `8 Pass`, `1 Adapted Pass`, `1 Partial` | Focused reader-shell UI coverage, restored-position/config-payload/gesture-policy/compare-payload unit regressions, and full local UI validation | Strong's modal coverage still needs tighter focused regression locking |
 | [bridge](bridge/README.md) | StudyPad handoff, async `callId` flows, and shared iOS bridge subset are present; full Android bridge breadth remains partial: `2 Pass`, `1 Adapted Pass`, `5 Partial` | Focused StudyPad handoff, async `callId`, note-persistence regressions, bridge guardrails, machine-readable gap inventory, and local Android-backed drift checking | Visible My Notes lifecycle coverage, Android-only bridge method breadth, delegate branch coverage, and payload-schema breadth |
 
 ## How To Read Each Domain


### PR DESCRIPTION
## Summary
Adds focused reader compare regression coverage for issue #41 so bridge-driven compare requests stay locked to the active reader context.

This updates the reader parity evidence from partial to covered for compare payload handling.

## Scope
In scope:
- Unit regression coverage for embedded-client compare bridge dispatch reaching the native compare callback.
- Reader parity documentation updates for compare evidence and status counts.

Out of scope:
- Compare UI redesign.
- New compare features.
- Full UI automation for the compare sheet.

## Contract References
- `../commit-message-standard.md`
- `docs/parity/reader/contract.md`
- `docs/parity/reader/dispositions.md`
- `docs/parity/reader/verification-matrix.md`
- `docs/parity/reader/regression-report.md`
- #41

## Change Details
- Adds `testReaderCompareBridgeRequestBuildsNativePresentationPayload`.
- The regression navigates the reader to 2 Corinthians 2, dispatches a valid `compare` bridge message, and verifies the native callback receives the expected book, chapter, module, and normalized verse range.
- Updates reader parity docs and the global status overview so compare presentation moves from `Partial` to `Pass`.

## Validation Evidence
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testReaderCompareBridgeRequestBuildsNativePresentationPayload`
  - Passed: 1/1
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests`
  - Passed: 207/207
- `git diff --check`
  - Passed

## Risks / Follow-ups
- Risk is low; this is test and documentation coverage only.
- Follow-up: Strong's / dictionary modal coverage remains the reader domain's remaining partial area.

## Screenshots
none

## Closes
Closes #41
