### PR TITLE
fix(downloads): restore unavailable pseudo modules

### DIFF
--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -218,7 +218,9 @@ final class AndBibleUITests: XCTestCase {
         _ = openSearch(in: app)
         waitForSearchQuery("noah", in: app, timeout: 20)
 
-        let noahResult = requireElement("searchResultRow::Genesis_6_8", in: app, timeout: 20)
+        let noahResultIdentifier = "searchResultRow::Genesis_6_8"
+        waitForSearchResultRow(noahResultIdentifier, in: app, shouldExist: true, timeout: 20)
+        let noahResult = requireElement(noahResultIdentifier, in: app, timeout: 20)
         tapElementReliably(noahResult, timeout: 10)
 
         let updatedReference = waitForReaderReferenceValueToChange(
@@ -4408,6 +4410,29 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Resolves Search result rows inside the Search sheet/list before using any broader fallback.
+
+     Search result UI tests already wait for the compact Search state export before tapping a row.
+     Keeping the row query scoped avoids repeated full-app snapshots across the underlying reader
+     web view, which can time out in CI while the result list itself is already settled.
+     */
+    private func searchResultRowCandidates(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        let roots = screenRootCandidates("searchResultsList", in: app) +
+            screenRootCandidates("searchScreen", in: app)
+
+        return roots.flatMap { root in
+            [
+                root.buttons[identifier].firstMatch,
+                root.cells[identifier].firstMatch,
+                root.otherElements[identifier].firstMatch,
+            ]
+        }
+    }
+
+    /**
      Resolves lightweight state-export or status candidates without probing broad `Other` queries.
 
      The app emits these probes as tiny static text nodes specifically so polling their value does
@@ -4639,13 +4664,7 @@ final class AndBibleUITests: XCTestCase {
         }
 
         if identifier.hasPrefix("searchResultRow::") {
-            return [
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.collectionViews.cells[identifier].firstMatch,
-                app.cells[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return searchResultRowCandidates(identifier, in: app)
         }
 
         if identifier.hasPrefix("windowTabButton::") || identifier.hasPrefix("modulePickerRow::") {

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -133,7 +133,8 @@ public struct ModuleBrowserView: View {
             modules = modules.filter {
                 $0.name.localizedCaseInsensitiveContains(searchText) ||
                 $0.description.localizedCaseInsensitiveContains(searchText) ||
-                $0.language.localizedCaseInsensitiveContains(searchText)
+                $0.language.localizedCaseInsensitiveContains(searchText) ||
+                $0.sourceName.localizedCaseInsensitiveContains(searchText)
             }
         }
         return modules.sorted { $0.name < $1.name }
@@ -313,7 +314,7 @@ public struct ModuleBrowserView: View {
                 Text(module.description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .lineLimit(module.isInstallable ? 2 : 3)
                 HStack(spacing: 4) {
                     Text(displayName(for: module.language))
                         .font(.caption2)
@@ -331,6 +332,10 @@ public struct ModuleBrowserView: View {
                     .foregroundStyle(.green)
             } else if installingModules.contains(module.name) {
                 ProgressView()
+            } else if !module.isInstallable {
+                Label("Unavailable", systemImage: "lock.slash")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             } else {
                 Button("Install") {
                     installModule(module)
@@ -365,6 +370,21 @@ public struct ModuleBrowserView: View {
         return languageCode.uppercased()
     }
 
+    /**
+     De-duplicates remote modules by abbreviation while preserving source priority.
+
+     Real SWORD catalog entries are passed before pseudo/unavailable metadata so an installable
+     module keeps precedence over an unavailable placeholder with the same name.
+     */
+    private func deduplicatedModules(from modules: [RemoteModuleInfo]) -> [RemoteModuleInfo] {
+        var seen: Set<String> = []
+        var unique: [RemoteModuleInfo] = []
+        for module in modules where seen.insert(module.name).inserted {
+            unique.append(module)
+        }
+        return unique
+    }
+
     // MARK: - Data Management
 
     /**
@@ -387,17 +407,9 @@ public struct ModuleBrowserView: View {
 
         // Load cached catalog from disk if available modules are empty
         if availableModules.isEmpty {
-            let cached = repository.loadCachedCatalogs()
+            let cached = repository.loadCachedCatalogs() + repository.loadCachedPseudoModules()
             if !cached.isEmpty {
-                // De-duplicate
-                var seen: Set<String> = []
-                var unique: [RemoteModuleInfo] = []
-                for m in cached {
-                    if seen.insert(m.name).inserted {
-                        unique.append(m)
-                    }
-                }
-                availableModules = unique
+                availableModules = deduplicatedModules(from: cached)
             }
         }
     }
@@ -462,14 +474,23 @@ public struct ModuleBrowserView: View {
                 }
             }
 
-            // De-duplicate modules (same name from different sources — keep first)
-            var seen: Set<String> = []
-            var uniqueModules: [RemoteModuleInfo] = []
-            for module in allModules {
-                if seen.insert(module.name).inserted {
-                    uniqueModules.append(module)
+            await MainActor.run {
+                refreshProgress = "Refreshing unavailable modules..."
+            }
+
+            do {
+                let pseudoModules = try await repository.refreshPseudoModules()
+                allModules.append(contentsOf: pseudoModules)
+            } catch {
+                let cachedPseudoModules = repository.loadCachedPseudoModules()
+                if cachedPseudoModules.isEmpty {
+                    errors.append("AndBible metadata: \(error.localizedDescription)")
+                } else {
+                    allModules.append(contentsOf: cachedPseudoModules)
                 }
             }
+
+            let uniqueModules = deduplicatedModules(from: allModules)
 
             await MainActor.run {
                 availableModules = uniqueModules
@@ -503,6 +524,11 @@ public struct ModuleBrowserView: View {
      - repository installation errors are caught and reported without crashing the view
      */
     private func installModule(_ module: RemoteModuleInfo) {
+        guard module.isInstallable else {
+            errorMessage = module.unavailableReason ?? "\(module.name) is not available for installation."
+            return
+        }
+
         guard let source = repository.source(for: module.name) ?? sources.first(where: { $0.name == module.sourceName }) else {
             errorMessage = "Source not found for \(module.name)"
             return

--- a/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
@@ -16,6 +16,12 @@ public struct RemoteSource: Sendable, Identifiable {
     }
 }
 
+/// Installation state for a remote module row.
+public enum RemoteModuleAvailability: String, Sendable {
+    case installable
+    case unavailable
+}
+
 /// Information about a remotely available module.
 public struct RemoteModuleInfo: Sendable, Identifiable {
     /// Module abbreviation (e.g., "KJV").
@@ -33,21 +39,34 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
     /// Source repository name.
     public let sourceName: String
 
+    /// Whether this remote catalog row can be installed.
+    public let availability: RemoteModuleAvailability
+
+    /// User-visible explanation when the module cannot be installed.
+    public let unavailableReason: String?
+
     /// Unique identifier.
     public var id: String { "\(sourceName):\(name)" }
+
+    /// Convenience flag for install controls.
+    public var isInstallable: Bool { availability == .installable }
 
     public init(
         name: String,
         description: String,
         category: ModuleCategory,
         language: String,
-        sourceName: String
+        sourceName: String,
+        availability: RemoteModuleAvailability = .installable,
+        unavailableReason: String? = nil
     ) {
         self.name = name
         self.description = description
         self.category = category
         self.language = language
         self.sourceName = sourceName
+        self.availability = availability
+        self.unavailableReason = unavailableReason
     }
 }
 
@@ -66,6 +85,27 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
  ```
  */
 public final class InstallManager: @unchecked Sendable {
+    private static let defaultConfigVersionMarker = "# AndBibleDefaultSourcesVersion=2"
+
+    private static let defaultSourceLines = [
+        "HTTPSource=CrossWire|crosswire.org|/ftpmirror/pub/sword/raw",
+        "HTTPSource=Crosswire Beta|crosswire.org|/ftpmirror/pub/sword/betaraw",
+        "HTTPSource=AndBible Extra|andbible.github.io|/andbible-extra",
+        "HTTPSource=AndBible|andbible.github.io|/data/andbible",
+        "HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta",
+        "HTTPSource=IBT|ibtrussia.org|/ftpmirror/pub/modsword/raw",
+        "HTTPSource=Wycliffe (CrossWire)|crosswire.org|/ftpmirror/pub/sword/wyclifferaw",
+        "HTTPSource=eBible|ebible.org|/sword",
+        "HTTPSource=Lockman (CrossWire)|crosswire.org|/ftpmirror/pub/sword/lockmanraw",
+        "HTTPSource=STEP Bible (Tyndale)|public.modules.stepbible.org|/catalog",
+        "FTPSource=CrossWire|ftp.crosswire.org|/pub/sword/raw",
+    ]
+
+    private static let upgradeSourceLines = [
+        "HTTPSource=AndBible|andbible.github.io|/data/andbible",
+        "HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta",
+    ]
+
     private let handle: UnsafeMutableRawPointer
     private let queue = DispatchQueue(label: "org.andbible.InstallManager", qos: .userInitiated)
 
@@ -119,7 +159,10 @@ public final class InstallManager: @unchecked Sendable {
         let configPath = (basePath as NSString).appendingPathComponent("InstallMgr.conf")
         let fm = FileManager.default
 
-        guard !fm.fileExists(atPath: configPath) else { return }
+        guard !fm.fileExists(atPath: configPath) else {
+            migrateDefaultConfigIfNeeded(at: configPath)
+            return
+        }
 
         // Sources matching AndBible Android's repositories.txt, in priority order.
         // Format: HTTPSource=Label|host|catalogDirectory
@@ -128,18 +171,74 @@ public final class InstallManager: @unchecked Sendable {
         PassiveFTP=true
 
         [Sources]
-        HTTPSource=CrossWire|crosswire.org|/ftpmirror/pub/sword/raw
-        HTTPSource=eBible|ebible.org|/sword
-        HTTPSource=Lockman (CrossWire)|crosswire.org|/ftpmirror/pub/sword/lockmanraw
-        HTTPSource=Wycliffe (CrossWire)|crosswire.org|/ftpmirror/pub/sword/wyclifferaw
-        HTTPSource=AndBible Extra|andbible.github.io|/andbible-extra
-        HTTPSource=IBT|ibtrussia.org|/ftpmirror/pub/modsword/raw
-        HTTPSource=STEP Bible (Tyndale)|public.modules.stepbible.org|/catalog
-        HTTPSource=Crosswire Beta|crosswire.org|/ftpmirror/pub/sword/betaraw
-        FTPSource=CrossWire|ftp.crosswire.org|/pub/sword/raw
+        \(Self.defaultConfigVersionMarker)
+        \(Self.defaultSourceLines.joined(separator: "\n"))
         """
 
         try? config.write(toFile: configPath, atomically: true, encoding: .utf8)
+    }
+
+    private static func migrateDefaultConfigIfNeeded(at configPath: String) {
+        guard var content = try? String(contentsOfFile: configPath, encoding: .utf8),
+              !content.contains(Self.defaultConfigVersionMarker) else {
+            return
+        }
+
+        let existingSourceNames = Self.sourceNames(in: content)
+        let missingLines = Self.upgradeSourceLines.filter { line in
+            guard let sourceName = Self.sourceName(in: line) else { return false }
+            return !existingSourceNames.contains(sourceName)
+        }
+
+        guard !missingLines.isEmpty else {
+            content = Self.insertingSourceLines([Self.defaultConfigVersionMarker], into: content)
+            try? content.write(toFile: configPath, atomically: true, encoding: .utf8)
+            return
+        }
+
+        content = Self.insertingSourceLines([Self.defaultConfigVersionMarker] + missingLines, into: content)
+        try? content.write(toFile: configPath, atomically: true, encoding: .utf8)
+    }
+
+    private static func insertingSourceLines(_ lines: [String], into content: String) -> String {
+        guard !lines.isEmpty else { return content }
+
+        var configLines = content.components(separatedBy: .newlines)
+        let sourcesIndex = configLines.firstIndex {
+            $0.trimmingCharacters(in: .whitespaces) == "[Sources]"
+        }
+
+        var insertionIndex = configLines.endIndex
+        if let sourcesIndex {
+            insertionIndex = configLines[configLines.index(after: sourcesIndex)...]
+                .firstIndex { line in
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    return trimmed.hasPrefix("[") && trimmed.hasSuffix("]")
+                } ?? configLines.endIndex
+        }
+
+        if insertionIndex == configLines.endIndex,
+           configLines.last == "" {
+            insertionIndex = configLines.index(before: configLines.endIndex)
+        }
+
+        configLines.insert(contentsOf: lines, at: insertionIndex)
+        var updated = configLines.joined(separator: "\n")
+        if !updated.hasSuffix("\n") { updated += "\n" }
+        return updated
+    }
+
+    private static func sourceNames(in content: String) -> Set<String> {
+        Set(content.components(separatedBy: .newlines).compactMap { Self.sourceName(in: $0) })
+    }
+
+    private static func sourceName(in line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("HTTPSource=") || trimmed.hasPrefix("FTPSource=") else {
+            return nil
+        }
+        let value = String(trimmed.drop(while: { $0 != "=" }).dropFirst())
+        return value.components(separatedBy: "|").first
     }
 
     // MARK: - Remote Sources

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -70,6 +70,9 @@ public struct CatalogModule: Sendable, Identifiable {
  ```
  */
 public final class ModuleRepository: @unchecked Sendable {
+    private static let pseudoBooksURL = URL(string: "https://andbible.github.io/data/pseudo_books.json")!
+    private static let unavailablePseudoSourceName = "Not Available"
+
     private let basePath: String
     private let swordPath: String
     private let session: URLSession
@@ -82,6 +85,17 @@ public final class ModuleRepository: @unchecked Sendable {
         let dir = (basePath as NSString).appendingPathComponent("catalog-cache")
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    /// Directory for AndBible metadata files that augment SWORD catalogs.
+    private var metadataCacheDir: String {
+        let dir = (basePath as NSString).appendingPathComponent("andbible-data")
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private var pseudoBooksCachePath: String {
+        (metadataCacheDir as NSString).appendingPathComponent("pseudo_books.json")
     }
 
     public init(basePath: String? = nil, swordPath: String? = nil) {
@@ -140,6 +154,73 @@ public final class ModuleRepository: @unchecked Sendable {
             }
         }
         return sources
+    }
+
+    // MARK: - AndBible Metadata
+
+    private struct PseudoBook: Decodable {
+        let id: String
+        let suggested: String?
+    }
+
+    /// Load cached unavailable module metadata from AndBible's pseudo-books feed.
+    public func loadCachedPseudoModules() -> [RemoteModuleInfo] {
+        guard let data = FileManager.default.contents(atPath: pseudoBooksCachePath) else {
+            return []
+        }
+
+        do {
+            return try Self.pseudoModules(from: data)
+        } catch {
+            logger.warning("Failed to decode cached pseudo books: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Refresh unavailable module metadata from AndBible's pseudo-books feed and cache it locally.
+    public func refreshPseudoModules() async throws -> [RemoteModuleInfo] {
+        let (data, response) = try await session.data(from: Self.pseudoBooksURL)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw ModuleRepositoryError.downloadFailed(
+                "Pseudo books download failed (HTTP \(code))")
+        }
+
+        do {
+            try data.write(to: URL(fileURLWithPath: pseudoBooksCachePath))
+        } catch {
+            logger.warning("Failed to cache pseudo books: \(error.localizedDescription)")
+        }
+
+        return try Self.pseudoModules(from: data)
+    }
+
+    static func pseudoModules(from data: Data) throws -> [RemoteModuleInfo] {
+        try JSONDecoder().decode([PseudoBook].self, from: data)
+            .compactMap { book in
+                let name = book.id.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !name.isEmpty else { return nil }
+
+                let description = Self.pseudoBookDescription(suggested: book.suggested ?? "")
+                return RemoteModuleInfo(
+                    name: name,
+                    description: description,
+                    category: .bible,
+                    language: "en",
+                    sourceName: Self.unavailablePseudoSourceName,
+                    availability: .unavailable,
+                    unavailableReason: description
+                )
+            }
+    }
+
+    private static func pseudoBookDescription(suggested: String) -> String {
+        let base = "This popular translation is not available due to Copyright Holder not granting us distribution permission."
+        let trimmedSuggestion = suggested.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSuggestion.isEmpty else { return base }
+        return "\(base) \(trimmedSuggestion)"
     }
 
     // MARK: - Catalog Cache (Disk)

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -98,14 +98,18 @@ public final class ModuleRepository: @unchecked Sendable {
         (metadataCacheDir as NSString).appendingPathComponent("pseudo_books.json")
     }
 
-    public init(basePath: String? = nil, swordPath: String? = nil) {
+    public init(basePath: String? = nil, swordPath: String? = nil, session: URLSession? = nil) {
         self.basePath = basePath ?? InstallManager.defaultBasePath()
         self.swordPath = swordPath ?? SwordManager.defaultModulePath()
 
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 600
-        self.session = URLSession(configuration: config)
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 30
+            config.timeoutIntervalForResource = 600
+            self.session = URLSession(configuration: config)
+        }
 
         // Ensure sword directories exist
         let fm = FileManager.default
@@ -188,13 +192,15 @@ public final class ModuleRepository: @unchecked Sendable {
                 "Pseudo books download failed (HTTP \(code))")
         }
 
+        let modules = try Self.pseudoModules(from: data)
+
         do {
-            try data.write(to: URL(fileURLWithPath: pseudoBooksCachePath))
+            try data.write(to: URL(fileURLWithPath: pseudoBooksCachePath), options: .atomic)
         } catch {
             logger.warning("Failed to cache pseudo books: \(error.localizedDescription)")
         }
 
-        return try Self.pseudoModules(from: data)
+        return modules
     }
 
     static func pseudoModules(from data: Data) throws -> [RemoteModuleInfo] {

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -28,6 +28,89 @@ final class SwordManagerTests: XCTestCase {
         XCTAssertTrue(info.isUnlocked)
     }
 
+    func testRemoteModuleInfoDefaultsToInstallable() {
+        let info = RemoteModuleInfo(
+            name: "KJV",
+            description: "King James Version",
+            category: .bible,
+            language: "en",
+            sourceName: "CrossWire"
+        )
+
+        XCTAssertTrue(info.isInstallable)
+        XCTAssertEqual(info.availability, .installable)
+        XCTAssertNil(info.unavailableReason)
+    }
+
+    func testPseudoBookMetadataCreatesUnavailableModules() throws {
+        let data = """
+        [
+          {"id": "ESV", "suggested": "Please contact the copyright holder."},
+          {"id": "NIV", "suggested": ""}
+        ]
+        """.data(using: .utf8)!
+
+        let modules = try ModuleRepository.pseudoModules(from: data)
+
+        XCTAssertEqual(modules.map(\.name), ["ESV", "NIV"])
+        XCTAssertEqual(modules.map(\.sourceName), ["Not Available", "Not Available"])
+        XCTAssertTrue(modules.allSatisfy { !$0.isInstallable })
+        XCTAssertTrue(modules.allSatisfy { $0.category == .bible })
+        XCTAssertTrue(modules.allSatisfy { $0.language == "en" })
+        XCTAssertTrue(modules[0].description.contains("not available due to Copyright Holder"))
+        XCTAssertTrue(modules[0].description.contains("Please contact the copyright holder."))
+        XCTAssertEqual(modules[0].unavailableReason, modules[0].description)
+    }
+
+    func testDefaultInstallManagerConfigIncludesAndBibleSources() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        InstallManager.ensureDefaultConfigPublic(at: tempDir.path)
+
+        let configPath = tempDir.appendingPathComponent("InstallMgr.conf")
+        let config = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(config.contains("HTTPSource=AndBible|andbible.github.io|/data/andbible"))
+        XCTAssertTrue(config.contains("HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta"))
+    }
+
+    func testLegacyInstallManagerConfigMigratesAndBibleSourcesOnce() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let configPath = tempDir.appendingPathComponent("InstallMgr.conf")
+        try """
+        [General]
+        PassiveFTP=true
+
+        [Sources]
+        HTTPSource=CrossWire|crosswire.org|/ftpmirror/pub/sword/raw
+        HTTPSource=AndBible Extra|andbible.github.io|/andbible-extra
+        """.write(to: configPath, atomically: true, encoding: .utf8)
+
+        InstallManager.ensureDefaultConfigPublic(at: tempDir.path)
+
+        let migrated = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(migrated.contains("HTTPSource=AndBible|andbible.github.io|/data/andbible"))
+        XCTAssertTrue(migrated.contains("HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta"))
+
+        let withoutAndBible = migrated
+            .components(separatedBy: .newlines)
+            .filter { !$0.hasPrefix("HTTPSource=AndBible|") }
+            .joined(separator: "\n")
+        try withoutAndBible.write(to: configPath, atomically: true, encoding: .utf8)
+
+        InstallManager.ensureDefaultConfigPublic(at: tempDir.path)
+
+        let afterUserDeletion = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertFalse(afterUserDeletion.contains("HTTPSource=AndBible|andbible.github.io|/data/andbible"))
+        XCTAssertTrue(afterUserDeletion.contains("HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta"))
+    }
+
     func testModuleCategoryInit() {
         XCTAssertEqual(ModuleCategory(typeString: "Biblical Texts"), .bible)
         XCTAssertEqual(ModuleCategory(typeString: "Commentaries"), .commentary)

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -62,6 +62,50 @@ final class SwordManagerTests: XCTestCase {
         XCTAssertEqual(modules[0].unavailableReason, modules[0].description)
     }
 
+    func testMalformedPseudoBookRefreshDoesNotOverwriteCachedMetadata() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let validData = """
+        [
+          {"id": "ESV", "suggested": "Please contact the copyright holder."}
+        ]
+        """.data(using: .utf8)!
+        let malformedData = Data("<html>temporary failure</html>".utf8)
+        var responseBodies = [validData, malformedData]
+
+        PseudoBooksMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, responseBodies.removeFirst())
+        }
+        defer { PseudoBooksMockURLProtocol.requestHandler = nil }
+
+        let repository = ModuleRepository(
+            basePath: tempDir.path,
+            swordPath: swordDir.path,
+            session: Self.makePseudoBooksMockSession()
+        )
+
+        let refreshedModules = try await repository.refreshPseudoModules()
+        XCTAssertEqual(refreshedModules.map(\.name), ["ESV"])
+        XCTAssertEqual(repository.loadCachedPseudoModules().map(\.name), ["ESV"])
+
+        do {
+            _ = try await repository.refreshPseudoModules()
+            XCTFail("Expected malformed pseudo book metadata to fail decoding.")
+        } catch {
+            XCTAssertEqual(repository.loadCachedPseudoModules().map(\.name), ["ESV"])
+        }
+    }
+
     func testDefaultInstallManagerConfigIncludesAndBibleSources() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -128,4 +172,39 @@ final class SwordManagerTests: XCTestCase {
         let r = SearchResult(key: "Gen 1:1", moduleName: "KJV")
         XCTAssertEqual(r.id, "KJV:Gen 1:1")
     }
+
+    private static func makePseudoBooksMockSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [PseudoBooksMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private final class PseudoBooksMockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            fatalError("PseudoBooksMockURLProtocol.requestHandler must be set before use")
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION
## Summary
Restores Android-parity unavailable entries in Downloads by loading AndBible pseudo-book metadata and rendering those rows as non-installable.

## Scope
- SwordKit remote module metadata and source defaults.
- ModuleRepository catalog augmentation from pseudo_books.json.
- BibleUI Downloads filtering, row rendering, and install guarding.
- Focused SwordKit tests for pseudo metadata and source migration.

## Contract references
- GitHub issue #63: Restore unavailable ESV/NIV entries in Downloads.
- Android parity behavior from pseudo_books.json and Not Available pseudo books.

## Change details
- Added installable/unavailable state to RemoteModuleInfo.
- Added cached refresh/load support for AndBible pseudo_books.json.
- Merged unavailable pseudo modules after real catalogs so installable catalog entries retain precedence.
- Show unavailable rows with explanatory text and block install attempts.
- Added AndBible and AndBible Beta default sources plus a one-time migration for legacy source configs.

## Validation evidence
- Passed: git diff --check.
- Passed: swift build --target SwordKit.
- Passed: swift build --target SwordKitTests.
- Blocked: swift test --filter SwordKitTests still builds unrelated package targets and fails in BibleView on macOS because UIUserInterfaceIdiom is unavailable.
- Blocked: iOS simulator build because local Xcode reports iOS 26.5 is not installed.
- Blocked: Mac Catalyst build because libsword.xcframework has no Catalyst slice and the app target lacks a development team.

## Risks/follow-ups
- GitNexus risk level: medium, centered on Downloads setup and refresh flow.
- Follow-up: broaden the AndBible metadata loader pattern if future Downloads parity gaps require more data files.

## Issue closure reference
Closes #63