### PR TITLE
test(bookmarks): add generic bookmark visible workflow

### DIFF
--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -1012,6 +1012,71 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Verifies that generic bookmarks are visible from the real bookmark-list path and can be
+     assigned to a label through the same row affordance as Bible bookmarks.
+     *
+     * - Side effects:
+     *   - launches the reader shell with one deterministic generic bookmark and one user label
+     *   - opens the bookmark list from the reader overflow menu
+     *   - confirms the generic bookmark is visible but not included under the unassigned label
+     *     filter
+     *   - assigns that label through Label Assignment and verifies the filtered bookmark list
+     *     includes the generic row after returning
+     * - Failure modes:
+     *   - fails if the generic bookmark is not visible in the bookmark list
+     *   - fails if the label-assignment sheet cannot load the generic bookmark
+     *   - fails if the generic label mutation is not reflected by bookmark-list filtering
+     */
+    func testGenericBookmarkVisibleWorkflowAssignsLabelFromBookmarkList() {
+        let app = makeApp()
+        let genericBookmarkSegment = "UITESTDICT_Entry_1"
+        app.launch()
+
+        _ = openBookmarkList(in: app)
+        waitForBookmarkListState(containing: "count=1", in: app, timeout: 10)
+        waitForBookmarkListState(
+            containing: bookmarkListRowStateToken(genericBookmarkSegment),
+            in: app,
+            timeout: 10
+        )
+
+        selectBookmarkListFilterChip("UI_Test_Seed", in: app, timeout: 10)
+        waitForBookmarkListState(containing: "count=0", in: app, timeout: 10)
+        waitForBookmarkListState(
+            notContaining: bookmarkListRowStateToken(genericBookmarkSegment),
+            in: app,
+            timeout: 10
+        )
+
+        selectBookmarkListFilterChip("all", in: app, timeout: 10)
+        tapElementReliably(
+            requireElement("bookmarkListEditLabelsButton::\(genericBookmarkSegment)", in: app, timeout: 10),
+            timeout: 10
+        )
+        XCTAssertTrue(requireElement("labelAssignmentScreen", in: app, timeout: 10).exists)
+
+        let seedRow = requireElement("labelAssignmentRow::UI_Test_Seed", in: app, timeout: 10)
+        XCTAssertEqual(seedRow.value as? String, "unassigned,notFavourite")
+        requireElement("labelAssignmentToggleButton::UI_Test_Seed", in: app, timeout: 10).tap()
+
+        waitForElementValue(
+            "labelAssignmentRow::UI_Test_Seed",
+            toEqual: "assigned,notFavourite",
+            in: app,
+            timeout: 10
+        )
+
+        dismissLabelAssignmentToBookmarkList(in: app)
+        selectBookmarkListFilterChip("UI_Test_Seed", in: app, timeout: 10)
+        waitForBookmarkListState(containing: "count=1", in: app, timeout: 10)
+        waitForBookmarkListState(
+            containing: bookmarkListRowStateToken(genericBookmarkSegment),
+            in: app,
+            timeout: 10
+        )
+    }
+
+    /**
      Verifies that the about screen can be opened from the reader shell.
      *
      * - Side effects:
@@ -3303,10 +3368,13 @@ final class AndBibleUITests: XCTestCase {
      * - Failure modes:
      *   - fails when the bookmark list or seeded bookmark edit-labels action never appears
      */
-    private func openLabelAssignmentFromBookmarkList(in app: XCUIApplication) -> XCUIElement {
+    private func openLabelAssignmentFromBookmarkList(
+        in app: XCUIApplication,
+        referenceSegment: String = "Genesis_1_1"
+    ) -> XCUIElement {
         _ = openBookmarkList(in: app)
         tapElementReliably(
-            requireElement("bookmarkListEditLabelsButton::Genesis_1_1", in: app, timeout: 10),
+            requireElement("bookmarkListEditLabelsButton::\(referenceSegment)", in: app, timeout: 10),
             timeout: 10
         )
         return requireElement("labelAssignmentScreen", in: app, timeout: 10)

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -5,7 +5,7 @@ import SwiftData
 import BibleCore
 
 /**
- Displays a searchable, filterable, and sortable list of Bible bookmarks from SwiftData.
+ Displays a searchable, filterable, and sortable list of Bible and generic bookmarks from SwiftData.
 
  `BookmarkListView` is the main bookmark-browser surface. It excludes note-bearing bookmarks that
  belong in the My Notes flow, supports label-chip filtering, search-by-reference text, and
@@ -13,7 +13,8 @@ import BibleCore
 
  Data dependencies:
  - `modelContext` is used for bookmark deletion
- - `bookmarks` queries all `BibleBookmark` records for in-memory filtering and sorting
+ - `bibleBookmarks` queries all `BibleBookmark` records for in-memory filtering and sorting
+ - `genericBookmarks` queries all `GenericBookmark` records for in-memory filtering and sorting
  - `labels` queries all labels so the view can build filter chips and label-manager entry points
 
  Side effects:
@@ -29,8 +30,11 @@ public struct BookmarkListView: View {
     /// Dismiss action for closing the bookmark sheet.
     @Environment(\.dismiss) private var dismiss
 
-    /// Raw bookmark query used as the source set for filtering and sorting.
-    @Query(sort: \BibleBookmark.createdAt, order: .reverse) private var bookmarks: [BibleBookmark]
+    /// Raw Bible bookmark query used as part of the source set for filtering and sorting.
+    @Query(sort: \BibleBookmark.createdAt, order: .reverse) private var bibleBookmarks: [BibleBookmark]
+
+    /// Raw generic bookmark query used as part of the source set for filtering and sorting.
+    @Query(sort: \GenericBookmark.createdAt, order: .reverse) private var genericBookmarks: [GenericBookmark]
 
     /// Raw label query used to build filter chips and label-management affordances.
     @Query(sort: \BibleCore.Label.name) private var labels: [BibleCore.Label]
@@ -74,44 +78,47 @@ public struct BookmarkListView: View {
     /**
      Bookmarks after note suppression, label filtering, text filtering, and sort application.
      */
-    private var filteredBookmarks: [BibleBookmark] {
-        // Hide bookmarks that have notes (those belong in My Notes)
-        var result = bookmarks.filter { $0.notes == nil || $0.notes!.notes.isEmpty }
+    private var filteredBookmarks: [BookmarkListItem] {
+        var result = bookmarkListItems
 
         // Filter by label
         if let labelId = selectedLabelId {
-            result = result.filter { bookmark in
-                bookmark.bookmarkToLabels?.contains { $0.label?.id == labelId } ?? false
-            }
+            result = result.filter { $0.labels.contains { $0.id == labelId } }
         }
 
         // Filter by search text
         if !searchText.isEmpty {
-            result = result.filter { bookmark in
-                let ref = Self.verseReference(for: bookmark)
-                let noteText = bookmark.notes?.notes ?? ""
-                return ref.localizedCaseInsensitiveContains(searchText) ||
-                    noteText.localizedCaseInsensitiveContains(searchText)
-            }
+            result = result.filter { $0.searchableText.localizedCaseInsensitiveContains(searchText) }
         }
 
         // Sort
         switch sortOrder {
         case .bibleOrder:
-            result.sort { $0.kjvOrdinalStart < $1.kjvOrdinalStart }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.documentSortKey, ascending: true) }
         case .bibleOrderDesc:
-            result.sort { $0.kjvOrdinalStart > $1.kjvOrdinalStart }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.documentSortKey, ascending: false) }
         case .createdAt:
-            result.sort { $0.createdAt < $1.createdAt }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.createdAt, ascending: true) }
         case .createdAtDesc:
-            result.sort { $0.createdAt > $1.createdAt }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.createdAt, ascending: false) }
         case .lastUpdated:
-            result.sort { $0.lastUpdatedOn > $1.lastUpdatedOn }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.lastUpdatedOn, ascending: false) }
         case .orderNumber:
-            result.sort { $0.kjvOrdinalStart < $1.kjvOrdinalStart }
+            result.sort { Self.compareBookmarkListItems($0, $1, by: \.documentSortKey, ascending: true) }
         }
 
         return result
+    }
+
+    /// Bookmark rows that belong in the native bookmark browser before label/search filtering.
+    private var bookmarkListItems: [BookmarkListItem] {
+        let bibleItems = bibleBookmarks
+            .filter { ($0.notes?.notes ?? "").isEmpty }
+            .map(BookmarkListItem.init(bibleBookmark:))
+        let genericItems = genericBookmarks
+            .filter { ($0.notes?.notes ?? "").isEmpty }
+            .map(BookmarkListItem.init(genericBookmark:))
+        return bibleItems + genericItems
     }
 
     /// User-created labels that should appear in the filter strip.
@@ -124,7 +131,7 @@ public struct BookmarkListView: View {
      */
     public var body: some View {
         Group {
-            if bookmarks.isEmpty {
+            if bookmarkListItems.isEmpty {
                 ContentUnavailableView(
                     String(localized: "no_bookmarks"),
                     systemImage: "bookmark",
@@ -206,9 +213,7 @@ public struct BookmarkListView: View {
                     } label: {
                         SwiftUI.Label(String(localized: "delete"), systemImage: "trash")
                     }
-                    .accessibilityIdentifier(
-                        "bookmarkListDeleteButton::\(bookmarkListAccessibilitySegment(Self.verseReference(for: bookmark)))"
-                    )
+                    .accessibilityIdentifier("bookmarkListDeleteButton::\(bookmark.accessibilitySegment)")
                 }
                 .contextMenu {
                     Button {
@@ -235,7 +240,7 @@ public struct BookmarkListView: View {
         }
 
         let rowTokens = filteredBookmarks.prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit).map {
-            "|\(bookmarkListAccessibilitySegment(Self.verseReference(for: $0)))|"
+            "|\($0.accessibilitySegment)|"
         }.joined(separator: ",")
         return "\(baseState);rows=\(rowTokens)"
     }
@@ -341,7 +346,7 @@ public struct BookmarkListView: View {
     private func deleteBookmarks(at offsets: IndexSet) {
         let toDelete = offsets.map { filteredBookmarks[$0] }
         for bookmark in toDelete {
-            modelContext.delete(bookmark)
+            deleteBookmarkWithoutSaving(bookmark)
         }
         try? modelContext.save()
     }
@@ -356,9 +361,19 @@ public struct BookmarkListView: View {
      - Failure modes:
        - silently discards save failures because the list has no retry UI for destructive actions
      */
-    private func deleteBookmark(_ bookmark: BibleBookmark) {
-        modelContext.delete(bookmark)
+    private func deleteBookmark(_ bookmark: BookmarkListItem) {
+        deleteBookmarkWithoutSaving(bookmark)
         try? modelContext.save()
+    }
+
+    /// Deletes one bookmark row from SwiftData without saving the context.
+    private func deleteBookmarkWithoutSaving(_ bookmark: BookmarkListItem) {
+        switch bookmark.source {
+        case .bible(let bibleBookmark):
+            modelContext.delete(bibleBookmark)
+        case .generic(let genericBookmark):
+            modelContext.delete(genericBookmark)
+        }
     }
 
     /**
@@ -381,6 +396,42 @@ public struct BookmarkListView: View {
             return "\(bookName) \(startChapter):\(startVerse)-\(endVerse)"
         }
     }
+
+    /**
+     Converts a generic bookmark target into user-visible list text.
+
+     - Parameter bookmark: Generic bookmark whose module/key should be rendered.
+     - Returns: Reference text like `UITESTDICT: Entry 1`.
+     */
+    static func genericReference(for bookmark: GenericBookmark) -> String {
+        let module = bookmark.bookInitials.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = bookmark.key.trimmingCharacters(in: .whitespacesAndNewlines)
+        if module.isEmpty {
+            return key.isEmpty ? "Unknown" : key
+        }
+        if key.isEmpty {
+            return module
+        }
+        return "\(module): \(key)"
+    }
+
+    /// Compares two rows by a primary key and uses reference/id tiebreakers for deterministic UI order.
+    private static func compareBookmarkListItems<Value: Comparable>(
+        _ lhs: BookmarkListItem,
+        _ rhs: BookmarkListItem,
+        by keyPath: KeyPath<BookmarkListItem, Value>,
+        ascending: Bool
+    ) -> Bool {
+        let lhsValue = lhs[keyPath: keyPath]
+        let rhsValue = rhs[keyPath: keyPath]
+        if lhsValue == rhsValue {
+            if lhs.reference == rhs.reference {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.reference < rhs.reference
+        }
+        return ascending ? lhsValue < rhsValue : lhsValue > rhsValue
+    }
 }
 
 // MARK: - UUID Identifiable for sheet(item:)
@@ -389,6 +440,92 @@ public struct BookmarkListView: View {
 extension UUID: @retroactive Identifiable {
     /// Retroactive `Identifiable` conformance value for SwiftUI sheet presentation.
     public var id: UUID { self }
+}
+
+// MARK: - Bookmark List Item
+
+/// Normalized row data for Bible and generic bookmarks shown in `BookmarkListView`.
+private struct BookmarkListItem: Identifiable {
+    /// Original SwiftData model backing the row.
+    enum Source {
+        case bible(BibleBookmark)
+        case generic(GenericBookmark)
+    }
+
+    /// Stable bookmark identifier shared by the row and label-assignment sheet.
+    let id: UUID
+
+    /// Original SwiftData model backing the row.
+    let source: Source
+
+    /// User-visible reference text.
+    let reference: String
+
+    /// Text searched by the bookmark list search field.
+    let searchableText: String
+
+    /// Stable document-order key used by sort options.
+    let documentSortKey: Int
+
+    /// Bookmark creation timestamp.
+    let createdAt: Date
+
+    /// Bookmark last-updated timestamp.
+    let lastUpdatedOn: Date
+
+    /// Optional icon identifier.
+    let customIcon: String?
+
+    /// Optional note preview text.
+    let noteText: String
+
+    /// Labels assigned to the bookmark.
+    let labels: [BibleCore.Label]
+
+    /// Optional reader navigation target for Bible bookmarks.
+    let navigationTarget: (bookName: String, chapter: Int)?
+
+    /// Identifier-safe row reference segment used by UI automation.
+    var accessibilitySegment: String {
+        bookmarkListAccessibilitySegment(reference)
+    }
+
+    /// Creates a normalized row for one Bible bookmark.
+    init(bibleBookmark bookmark: BibleBookmark) {
+        let reference = BookmarkListView.verseReference(for: bookmark)
+        let noteText = bookmark.notes?.notes ?? ""
+        self.id = bookmark.id
+        self.source = .bible(bookmark)
+        self.reference = reference
+        self.searchableText = "\(reference) \(noteText)"
+        self.documentSortKey = bookmark.kjvOrdinalStart
+        self.createdAt = bookmark.createdAt
+        self.lastUpdatedOn = bookmark.lastUpdatedOn
+        self.customIcon = bookmark.customIcon
+        self.noteText = noteText
+        self.labels = bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
+        self.navigationTarget = (
+            bookName: bookmark.book ?? "Genesis",
+            chapter: bookmark.ordinalStart / 40 + 1
+        )
+    }
+
+    /// Creates a normalized row for one generic bookmark.
+    init(genericBookmark bookmark: GenericBookmark) {
+        let reference = BookmarkListView.genericReference(for: bookmark)
+        let noteText = bookmark.notes?.notes ?? ""
+        self.id = bookmark.id
+        self.source = .generic(bookmark)
+        self.reference = reference
+        self.searchableText = "\(reference) \(noteText)"
+        self.documentSortKey = bookmark.ordinalStart
+        self.createdAt = bookmark.createdAt
+        self.lastUpdatedOn = bookmark.lastUpdatedOn
+        self.customIcon = bookmark.customIcon
+        self.noteText = noteText
+        self.labels = bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
+        self.navigationTarget = nil
+    }
 }
 
 // MARK: - Bookmark Row
@@ -401,18 +538,13 @@ extension UUID: @retroactive Identifiable {
  */
 private struct BookmarkRow: View {
     /// Bookmark being rendered.
-    let bookmark: BibleBookmark
+    let bookmark: BookmarkListItem
 
     /// Callback used to navigate to the bookmark's passage.
     var onNavigate: ((String, Int) -> Void)?
 
     /// Callback used to open label editing for the bookmark.
     var onEditLabels: (() -> Void)?
-
-    /// Labels currently assigned to the bookmark, sorted by name.
-    private var assignedLabels: [BibleCore.Label] {
-        bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
-    }
 
     /// Builds the tappable bookmark row.
     var body: some View {
@@ -426,12 +558,12 @@ private struct BookmarkRow: View {
      - Side effects:
        - invokes `onNavigate` with the bookmark's book/chapter when tapped
      - Failure modes: This helper cannot fail.
-     */
+    */
     private var selectionButton: some View {
         Button {
-            let chapter = bookmark.ordinalStart / 40 + 1
-            let bookName = bookmark.book ?? "Genesis"
-            onNavigate?(bookName, chapter)
+            if let target = bookmark.navigationTarget {
+                onNavigate?(target.bookName, target.chapter)
+            }
         } label: {
             VStack(alignment: .leading, spacing: 4) {
                 headerRow
@@ -451,9 +583,9 @@ private struct BookmarkRow: View {
     private var headerRow: some View {
         HStack {
             // Label color dots
-            if !assignedLabels.isEmpty {
+            if !bookmark.labels.isEmpty {
                 HStack(spacing: 2) {
-                    ForEach(Array(assignedLabels.prefix(3).enumerated()), id: \.offset) { _, label in
+                    ForEach(Array(bookmark.labels.prefix(3).enumerated()), id: \.offset) { _, label in
                         Circle()
                             .fill(Color(argbInt: label.color))
                             .frame(width: 10, height: 10)
@@ -466,7 +598,7 @@ private struct BookmarkRow: View {
                     .font(.headline)
             }
 
-            Text(BookmarkListView.verseReference(for: bookmark))
+            Text(bookmark.reference)
                 .font(.headline)
 
             Spacer()
@@ -480,8 +612,8 @@ private struct BookmarkRow: View {
     @ViewBuilder
     /// Optional note-preview text shown when the bookmark has saved note content.
     private var notePreview: some View {
-        if let notes = bookmark.notes, !notes.notes.isEmpty {
-            Text(notes.notes)
+        if !bookmark.noteText.isEmpty {
+            Text(bookmark.noteText)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
@@ -491,9 +623,9 @@ private struct BookmarkRow: View {
     @ViewBuilder
     /// Label tags or add-label affordance shown at the bottom of the bookmark row.
     private var labelTags: some View {
-        if !assignedLabels.isEmpty {
+        if !bookmark.labels.isEmpty {
             HStack(spacing: 4) {
-                ForEach(Array(assignedLabels.prefix(3).enumerated()), id: \.offset) { _, label in
+                ForEach(Array(bookmark.labels.prefix(3).enumerated()), id: \.offset) { _, label in
                     Text(label.name)
                         .font(.caption2)
                         .padding(.horizontal, 6)
@@ -534,9 +666,9 @@ private struct BookmarkRow: View {
      - Returns: Stable identifier derived from the bookmark reference string.
      - Side effects: none.
      - Failure modes: This helper cannot fail.
-     */
+    */
     private func bookmarkRowIdentifier() -> String {
-        "bookmarkListRowButton::\(bookmarkListAccessibilitySegment(BookmarkListView.verseReference(for: bookmark)))"
+        "bookmarkListRowButton::\(bookmark.accessibilitySegment)"
     }
 
     /**
@@ -546,9 +678,9 @@ private struct BookmarkRow: View {
      - Returns: Stable identifier derived from the action prefix and bookmark reference string.
      - Side effects: none.
      - Failure modes: This helper cannot fail.
-     */
+    */
     private func bookmarkInlineActionIdentifier(_ prefix: String) -> String {
-        "\(prefix)::\(bookmarkListAccessibilitySegment(BookmarkListView.verseReference(for: bookmark)))"
+        "\(prefix)::\(bookmark.accessibilitySegment)"
     }
 }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -558,7 +558,7 @@ private struct BookmarkRow: View {
      - Side effects:
        - invokes `onNavigate` with the bookmark's book/chapter when tapped
      - Failure modes: This helper cannot fail.
-    */
+     */
     private var selectionButton: some View {
         Button {
             if let target = bookmark.navigationTarget {
@@ -666,7 +666,7 @@ private struct BookmarkRow: View {
      - Returns: Stable identifier derived from the bookmark reference string.
      - Side effects: none.
      - Failure modes: This helper cannot fail.
-    */
+     */
     private func bookmarkRowIdentifier() -> String {
         "bookmarkListRowButton::\(bookmark.accessibilitySegment)"
     }

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -40,6 +40,7 @@ private enum FixtureScenario: String, CaseIterable {
     case bookmarkMultiRow = "bookmark-multirow"
     case bookmarkFilter = "bookmark-filter"
     case bookmarkRowLabel = "bookmark-row-label"
+    case bookmarkGenericVisible = "bookmark-generic-visible"
     case bookmarkStudyPad = "bookmark-studypad"
     case historySingle = "history-single"
     case historyMultiRow = "history-multirow"
@@ -387,6 +388,8 @@ private final class FixtureContext {
             seedBookmarkFilter()
         case .bookmarkRowLabel:
             seedBookmarkRowLabel()
+        case .bookmarkGenericVisible:
+            seedBookmarkGenericVisible()
         case .bookmarkStudyPad:
             seedBookmarkStudyPad()
         case .historySingle:
@@ -756,6 +759,22 @@ private final class FixtureContext {
             note: nil,
             createdAt: seededDate(offset: 20)
         )
+    }
+
+    /**
+     Seeds one generic bookmark and one initially-unassigned label for visible workflow coverage.
+     */
+    private func seedBookmarkGenericVisible() {
+        _ = ensureUserLabel(name: "UI Test Seed", color: 0xFF91A7FF)
+        let bookmark = bookmarkService.addGenericBookmark(
+            bookInitials: "UITESTDICT",
+            key: "Entry 1",
+            startOrdinal: 7,
+            endOrdinal: 7
+        )
+        bookmark.createdAt = seededDate(offset: 20)
+        bookmark.lastUpdatedOn = seededDate(offset: 20)
+        bookmarkStore.saveChanges()
     }
 
     /**

--- a/docs/parity/bookmarks/regression-report.md
+++ b/docs/parity/bookmarks/regression-report.md
@@ -1,12 +1,13 @@
 # BOOKMARKS-702 Regression Report
 
-Date: 2026-05-10
+Date: 2026-05-14
 
 ## Scope
 
 Regression verification for the current bookmark parity surface, covering:
 
 - native bookmark-list search, filter, sort, selection, and deletion
+- generic bookmark visibility plus label assignment from the native bookmark list
 - label assignment and label-manager mutation flows
 - StudyPad handoff from a real bookmark workflow
 - visible My Notes note update/delete from the production reader path
@@ -44,6 +45,7 @@ Verification matrix:
 - `AndBibleUITests/testBookmarkListSortMenuReordersRows`
 - `AndBibleUITests/testBookmarkListSearchNarrowsAndClearsVisibleRows`
 - `AndBibleUITests/testBookmarkListLabelFilterNarrowsAndClearsVisibleRows`
+- `AndBibleUITests/testGenericBookmarkVisibleWorkflowAssignsLabelFromBookmarkList`
 - `AndBibleUITests/testLabelAssignmentTogglesFavouriteAndAssignment`
 - `AndBibleUITests/testBookmarkListLabelAssignmentCreatesAndAssignsNewLabel`
 - `AndBibleUITests/testBookmarkListLabelAssignmentRemovalHidesBookmarkUnderFilter`
@@ -60,6 +62,9 @@ Verification matrix:
 - changing sort order reorders the visible rows
 - text search narrows and then clears back to the full seeded list
 - label filtering narrows and then clears back to the full seeded list
+- a seeded generic bookmark appears in the native bookmark list by module/key reference
+- assigning a label to the generic bookmark through the visible row makes it appear under that
+  label filter
 
 ### Labels
 
@@ -91,13 +96,14 @@ stale because three UI tests from that report no longer exist in `AndBibleUITest
 rerunnable named subset in this report is:
 
 - unit: `5` tests
-- UI: `11` tests
+- UI: `12` tests
 
 This doc refresh did not rerun the simulator suite, so do not treat the old runtime or the
 old UI count as current evidence. The checked-in named subset still gives the bookmark
 domain rerunnable evidence for:
 
 - bookmark-list search, filter, sort, selection, and deletion
+- generic-bookmark visibility and label assignment from the bookmark list
 - label assignment and label-manager CRUD
 - StudyPad handoff from a selected label
 - visible My Notes update/delete from the reader-owned document path
@@ -105,10 +111,8 @@ domain rerunnable evidence for:
 
 ## Remaining Gap
 
-The current bookmark parity gaps are:
+The current bookmark parity gap is:
 
-- generic-bookmark visible workflows
 - deeper StudyPad mutation coverage beyond handoff
 
-Those areas remain `Partial` in `verification-matrix.md` until they have focused regression
-coverage.
+That area remains `Partial` in `verification-matrix.md` until it has focused regression coverage.

--- a/docs/parity/bookmarks/verification-matrix.md
+++ b/docs/parity/bookmarks/verification-matrix.md
@@ -1,6 +1,6 @@
 # BOOKMARKS-701 Verification Matrix (Android Bookmarks -> iOS)
 
-Date: 2026-05-10
+Date: 2026-05-14
 
 ## Scope and Method
 
@@ -24,9 +24,9 @@ Date: 2026-05-10
 
 ## Summary
 
-- `Pass`: 5
+- `Pass`: 6
 - `Adapted Pass`: 2
-- `Partial`: 2
+- `Partial`: 1
 
 ## Matrix
 
@@ -37,7 +37,7 @@ Date: 2026-05-10
 | Label manager CRUD | `LabelManagerView.swift`; UI test `testLabelManagerCreateRenameDeleteFlow` | Pass | Create, rename, and delete are locked by a real end-to-end UI workflow. |
 | StudyPad handoff from bookmarks | `BookmarkListView.swift`, `BibleReaderController.swift`, `BibleReaderView.swift`; UI test `testBookmarkListOpensStudyPadForSelectedLabel` | Pass | Android exposes `openStudyPad` through `BibleJavascriptInterface` and `LinkControl`; iOS has current UI coverage for the bookmark-label handoff into StudyPad. |
 | My Notes note mutation and delete persistence | `BibleReaderController.swift`, `BibleReaderView.swift`; UI test `testMyNotesNoteUpdateAndDeletePersistsFromVisibleWorkflow`; service-layer tests `testBookmarkServiceClearingBibleBookmarkNoteDeletesPersistedNoteRow`, `testBookmarkServiceClearingBibleBookmarkNoteRemovesBookmarkFromMyNotesQuery`, `testBookmarkServiceUpdatingBibleBookmarkNoteReusesPersistedNoteRow` | Pass | Android exposes `openMyNotes` through `BibleJavascriptInterface` and `LinkControl`. iOS now has focused visible-path coverage that opens My Notes from the reader, updates a note, rebuilds the document, deletes the visible note-backed row, and verifies the rebuilt document stays empty. |
+| Generic bookmark visible workflow parity | `BookmarkListView.swift`, `LabelAssignmentView.swift`, `BookmarkService`; UI test `testGenericBookmarkVisibleWorkflowAssignsLabelFromBookmarkList` | Pass | Generic bookmarks now render in the native bookmark list with module/key references, and the focused UI test verifies visible label assignment plus filtered-list reflection. |
 | Bookmark note persistence split across bookmark rows and separate note entities | `BookmarkService.saveBibleBookmarkNote`, `BookmarkStore`; unit tests `testBookmarkServiceClearingBibleBookmarkNoteDeletesPersistedNoteRow`, `testBookmarkServiceClearingBibleBookmarkNoteRemovesBookmarkFromMyNotesQuery` | Adapted Pass | iOS preserves the Android-compatible data split, but exposes note-centric workflows through a separate My Notes surface. |
 | Native bookmark list plus separate My Notes surface instead of one unified browser | `BookmarkListView.swift` note suppression and `BibleReaderController` My Notes document flow; documented in `dispositions.md`; UI coverage spans the bookmark surface and service coverage spans note persistence | Adapted Pass | The parity goal is shared data semantics and user-visible outcomes, not Android-identical screen structure. |
 | StudyPad ordering, reorder, and delete breadth | `BookmarkService` and `BibleReaderController` StudyPad entry operations exist; no focused UI regression currently covers create, reorder, or delete | Partial | Current UI evidence locks handoff only; the full StudyPad mutation surface still needs focused coverage. |
-| Generic bookmark visible workflow parity | `BookmarkService` and models support generic bookmarks; no focused regression currently exercises generic-bookmark browsing, editing, or label assignment from a visible UI path | Partial | The generic side of the bookmark domain exists in persistence and bridge logic, but it is not yet gated by focused workflow coverage. |

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -1,6 +1,7 @@
 {
   "AndBibleUITests/AndBibleUITests/testAboutScreenOpensFromReaderMenu": "baseline",
   "AndBibleUITests/AndBibleUITests/testBookmarkListFilterAndSearchResetAcrossReopen": "bookmark-filter",
+  "AndBibleUITests/AndBibleUITests/testGenericBookmarkVisibleWorkflowAssignsLabelFromBookmarkList": "bookmark-generic-visible",
   "AndBibleUITests/AndBibleUITests/testBookmarkListLabelAssignmentCreatesAndAssignsNewLabel": "bookmark-row-label",
   "AndBibleUITests/AndBibleUITests/testBookmarkListLabelAssignmentRemovalHidesBookmarkUnderFilter": "bookmark-row-label",
   "AndBibleUITests/AndBibleUITests/testBookmarkListLabelFilterNarrowsAndClearsVisibleRows": "bookmark-filter",


### PR DESCRIPTION
## Summary

Adds focused visible workflow coverage for generic bookmarks so the bookmark parity surface no longer depends only on persistence and bridge support.

## Scope

- Renders generic bookmarks in the native bookmark list alongside Bible bookmarks.
- Seeds one deterministic generic bookmark and one unassigned label for UI testing.
- Adds a UI test that verifies the generic bookmark appears, assigns a label through the visible bookmark-list row affordance, and then appears under the label filter.
- Updates bookmark parity verification and regression docs for the new coverage.

## Contract References

- GitHub issue: #43
- Bookmark parity verification matrix: docs/parity/bookmarks/verification-matrix.md
- Bookmark regression report: docs/parity/bookmarks/regression-report.md

## Change Details

- Normalizes Bible and generic bookmark rows in BookmarkListView so filtering, sorting, delete actions, accessibility exports, and label assignment work across both bookmark types.
- Keeps generic bookmark row navigation inert because generic documents do not map to the existing Bible chapter navigation callback.
- Adds the bookmark-generic-visible fixture scenario to UITestFixtureTool and wires the UI test manifest.

## Validation Evidence

- swift build --product UITestFixtureTool
- xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' -only-testing:AndBibleUITests/AndBibleUITests/testGenericBookmarkVisibleWorkflowAssignsLabelFromBookmarkList test CODE_SIGNING_ALLOWED=NO
- xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' -only-testing:AndBibleTests/AndBibleTests/testBookmarkStoreBibleBookmarksCanFilterByLabel -only-testing:AndBibleTests/AndBibleTests/testBookmarkServiceDeleteLabelDetachesBookmarkRelationships -only-testing:AndBibleTests/AndBibleTests/testBookmarkServiceCreatesParagraphBreakGenericBookmark -only-testing:AndBibleTests/AndBibleTests/testBookmarkServiceCreateAndUpdateStudyPadEntryPersistsText test CODE_SIGNING_ALLOWED=NO
- xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' -skip-testing:AndBibleUITests test CODE_SIGNING_ALLOWED=NO
- python3 scripts/check_repo_standards.py docblocks --rev-range HEAD
- python3 scripts/check_repo_standards.py commits --rev-range HEAD^..HEAD
- git diff --check
- GitHub Actions iOS CI run 25875044690 completed successfully after rerunning the cancelled Unit Tests (Simulator) job.

## Risks/Follow-ups

- StudyPad reorder and delete breadth remains the remaining documented bookmark parity gap.
- Full bookmark UI suite was not rerun; this PR ran the focused new UI workflow plus related service coverage.

## Issue Closure Reference

Closes #43