### PR TITLE
test(sync): cover adopt/create confirmation UI

### DIFF
--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -298,7 +298,8 @@ struct AndBibleApp: App {
             sync.startMonitoring(container: container)
 
             if ProcessInfo.processInfo.environment["UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH"] == "1" {
-                DispatchQueue.main.async {
+                // Give XCTest time to finish launch bookkeeping before the bootstrap process exits.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                     Darwin.exit(EXIT_SUCCESS)
                 }
             }

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -1893,8 +1893,12 @@ final class AndBibleTests: XCTestCase {
         controller.activeWindow = window
         controller.navigateTo(book: "Genesis", chapter: 1, verse: 1)
 
+        let persisted = expectation(description: "Visible verse state persisted after debounce")
         var persistCount = 0
-        controller.onPersistState = { persistCount += 1 }
+        controller.onPersistState = {
+            persistCount += 1
+            persisted.fulfill()
+        }
 
         controller.bridge(bridge, didScrollToOrdinal: 5, key: "Gen.1", atChapterTop: false)
 
@@ -1902,7 +1906,7 @@ final class AndBibleTests: XCTestCase {
         XCTAssertEqual(controller.currentVerse, 5)
         XCTAssertEqual(pageManager.bibleVerseNo, 5)
 
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
+        wait(for: [persisted], timeout: 2.0)
 
         XCTAssertEqual(persistCount, 1)
     }

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -1894,7 +1894,6 @@ final class AndBibleUITests: XCTestCase {
         }
 
         if usedXCTestBootstrap {
-            app.launchEnvironment["UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH"] = "1"
             app.launch()
             if let bootstrappedPath = waitForInstalledAppDataContainer(
                 simulatorID: simulatorID,
@@ -1902,7 +1901,7 @@ final class AndBibleUITests: XCTestCase {
                 timeout: 45
             ) {
                 XCTAssertTrue(
-                    waitForAppToStop(app, timeout: 30) || terminateAppReliably(
+                    terminateAppReliably(
                         app,
                         bundleIdentifier: bundleIdentifier,
                         simulatorID: simulatorID
@@ -1911,11 +1910,10 @@ final class AndBibleUITests: XCTestCase {
                     file: file,
                     line: line
                 )
-                app.launchEnvironment.removeValue(forKey: "UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH")
                 return bootstrappedPath
             }
             XCTAssertTrue(
-                waitForAppToStop(app, timeout: 30) || terminateAppReliably(
+                terminateAppReliably(
                     app,
                     bundleIdentifier: bundleIdentifier,
                     simulatorID: simulatorID
@@ -1924,7 +1922,6 @@ final class AndBibleUITests: XCTestCase {
                 file: file,
                 line: line
             )
-            app.launchEnvironment.removeValue(forKey: "UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH")
         }
 
         if let bootstrappedPath = waitForInstalledAppDataContainer(
@@ -2004,28 +2001,6 @@ final class AndBibleUITests: XCTestCase {
             }
             RunLoop.current.run(until: Date().addingTimeInterval(1))
         }
-
-        return app.state == .notRunning
-    }
-
-    /**
-     Waits for one XCUIApplication handle to report a stopped state.
-     *
-     * - Parameters:
-     *   - app: Application handle that should eventually stop.
-     *   - timeout: Maximum time to wait for `.notRunning`.
-     * - Returns: `true` when the app stops within the timeout, otherwise `false`.
-     * - Side effects: Pumps the current run loop while waiting for state propagation.
-     * - Failure modes: This helper does not record XCTest failures directly.
-     */
-    private func waitForAppToStop(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if app.state == .notRunning {
-                return true
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-        } while Date() < deadline
 
         return app.state == .notRunning
     }

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -4825,14 +4825,14 @@ final class AndBibleUITests: XCTestCase {
             ]
         case "readerNavigationDrawerButton":
             return [
-                app.otherElements["readerDocumentHeader"].buttons[identifier].firstMatch,
                 app.buttons[identifier].firstMatch,
+                app.otherElements["readerDocumentHeader"].buttons[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
             ]
         case "readerMoreMenuButton", "bookChooserButton":
             return [
-                app.otherElements["readerDocumentHeader"].buttons[identifier].firstMatch,
                 app.buttons[identifier].firstMatch,
+                app.otherElements["readerDocumentHeader"].buttons[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
             ]
         case "readerStrongsToolbarButton":

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -1894,6 +1894,7 @@ final class AndBibleUITests: XCTestCase {
         }
 
         if usedXCTestBootstrap {
+            app.launchEnvironment["UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH"] = "1"
             app.launch()
             if let bootstrappedPath = waitForInstalledAppDataContainer(
                 simulatorID: simulatorID,
@@ -1901,7 +1902,7 @@ final class AndBibleUITests: XCTestCase {
                 timeout: 45
             ) {
                 XCTAssertTrue(
-                    terminateAppReliably(
+                    waitForAppToStop(app, timeout: 30) || terminateAppReliably(
                         app,
                         bundleIdentifier: bundleIdentifier,
                         simulatorID: simulatorID
@@ -1910,10 +1911,11 @@ final class AndBibleUITests: XCTestCase {
                     file: file,
                     line: line
                 )
+                app.launchEnvironment.removeValue(forKey: "UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH")
                 return bootstrappedPath
             }
             XCTAssertTrue(
-                terminateAppReliably(
+                waitForAppToStop(app, timeout: 30) || terminateAppReliably(
                     app,
                     bundleIdentifier: bundleIdentifier,
                     simulatorID: simulatorID
@@ -1922,6 +1924,7 @@ final class AndBibleUITests: XCTestCase {
                 file: file,
                 line: line
             )
+            app.launchEnvironment.removeValue(forKey: "UITEST_EXIT_AFTER_BOOTSTRAP_LAUNCH")
         }
 
         if let bootstrappedPath = waitForInstalledAppDataContainer(
@@ -2001,6 +2004,28 @@ final class AndBibleUITests: XCTestCase {
             }
             RunLoop.current.run(until: Date().addingTimeInterval(1))
         }
+
+        return app.state == .notRunning
+    }
+
+    /**
+     Waits for one XCUIApplication handle to report a stopped state.
+     *
+     * - Parameters:
+     *   - app: Application handle that should eventually stop.
+     *   - timeout: Maximum time to wait for `.notRunning`.
+     * - Returns: `true` when the app stops within the timeout, otherwise `false`.
+     * - Side effects: Pumps the current run loop while waiting for state propagation.
+     * - Failure modes: This helper does not record XCTest failures directly.
+     */
+    private func waitForAppToStop(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if app.state == .notRunning {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        } while Date() < deadline
 
         return app.state == .notRunning
     }

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -1369,6 +1369,62 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Verifies that the visible adopt-versus-create confirmation can drive the create-new branch.
+     *
+     * - Side effects:
+     *   - launches Sync Settings with deterministic NextCloud settings and a UI-test remote
+     *     backend that reports one existing same-named bookmark sync folder
+     *   - enables bookmark sync through the production category row
+     *   - chooses "Copy from this device to Cloud" in the adopt-versus-create prompt and confirms
+     *     the destructive reset-cloud branch
+     * - Failure modes:
+     *   - fails if the first adopt/create prompt never appears
+     *   - fails if the create-new choice does not surface the reset-cloud confirmation
+     *   - fails if confirming the reset-cloud branch does not complete synchronization with the
+     *     bookmarks category enabled
+     */
+    func testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow() {
+        let app = makeApp(remoteSyncBootstrapScenario: "adopt-existing")
+        app.launch()
+
+        _ = openSyncSettingsFromReaderAction(in: app)
+        waitForSyncState(["backend": "NEXT_CLOUD", "enabled": "none"], in: app, timeout: 10)
+
+        toggleSyncCategory(
+            "syncCategoryToggle::bookmarks",
+            in: app,
+            expectedTokens: [
+                "backend": "NEXT_CLOUD",
+                "enabled": "bookmarks",
+                "bootstrapPrompt": "adoptOrCreate:bookmarks",
+            ],
+            timeout: 15
+        )
+
+        let createFromDeviceButton = app.alerts.firstMatch.buttons["Copy from this device to Cloud"].firstMatch
+        XCTAssertTrue(
+            createFromDeviceButton.waitForExistence(timeout: 10),
+            "Expected the adopt-versus-create alert to expose the create-new choice."
+        )
+        tapElementReliably(createFromDeviceButton, timeout: 10)
+
+        waitForSyncState(["pendingConfirmation": "resetCloud:bookmarks"], in: app, timeout: 10)
+        tapAlertButton("OK", in: app, timeout: 10)
+
+        waitForSyncState(
+            [
+                "backend": "NEXT_CLOUD",
+                "enabled": "bookmarks",
+                "bootstrapPrompt": "none",
+                "pendingConfirmation": "none",
+                "lastConfirmation": "resetCloud:bookmarks",
+            ],
+            in: app,
+            timeout: 20
+        )
+    }
+
+    /**
      Verifies that disabling one seeded NextCloud sync category updates the exported Sync screen
      state.
      *
@@ -1634,7 +1690,10 @@ final class AndBibleUITests: XCTestCase {
     /**
      Builds the XCUIApplication instance used by each UI test.
      *
-     * - Parameter searchQuery: Optional search query to type into Search after the sheet opens.
+     * - Parameters:
+     *   - searchQuery: Optional search query to type into Search after the sheet opens.
+     *   - remoteSyncBootstrapScenario: Optional deterministic remote-sync backend scenario for
+     *     UI-only confirmation workflows.
      * - Returns: App handle configured with deterministic per-test metadata.
      * - Side effects:
      *   - terminates any previously tracked app process so each test starts from a clean launch
@@ -1642,7 +1701,10 @@ final class AndBibleUITests: XCTestCase {
      *   - stores one optional Search query for later use by `openSearch(in:)`
      * - Failure modes: This helper cannot fail.
      */
-    private func makeApp(searchQuery: String? = nil) -> XCUIApplication {
+    private func makeApp(
+        searchQuery: String? = nil,
+        remoteSyncBootstrapScenario: String? = nil
+    ) -> XCUIApplication {
         if let trackedApp, trackedApp.state != .notRunning {
             _ = terminateAppReliably(trackedApp)
         }
@@ -1652,6 +1714,10 @@ final class AndBibleUITests: XCTestCase {
         app.launchEnvironment["UITEST_ENABLE_DETAILED_ACCESSIBILITY_EXPORTS"] = "1"
         app.launchArguments += ["-UITEST_ENABLE_DETAILED_ACCESSIBILITY_EXPORTS"]
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        if let remoteSyncBootstrapScenario {
+            app.launchEnvironment["UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"] = remoteSyncBootstrapScenario
+            app.launchArguments += ["-UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO", remoteSyncBootstrapScenario]
+        }
         if let searchQuery {
             app.launchEnvironment["UITEST_SEARCH_QUERY"] = searchQuery
             app.launchArguments += ["-UITEST_SEARCH_QUERY", searchQuery]
@@ -1666,6 +1732,8 @@ final class AndBibleUITests: XCTestCase {
      * - Side effects:
      *   - resolves the app data container from the current simulator UDID
      *   - runs `UITestFixtureTool reset` and `seed` against that installed app container
+     *   - skips host-side fixture work when the manifest uses the `none` sentinel for a
+     *     launch-configuration-only test
      * - Failure modes:
      *   - records an XCTest failure when the fixture tool path, simulator UDID, or data container
      *     cannot be resolved from the current test-host environment
@@ -1682,6 +1750,9 @@ final class AndBibleUITests: XCTestCase {
             file: file,
             line: line
         ) else {
+            return
+        }
+        guard scenario != "none" else {
             return
         }
         guard let fixtureToolPath = resolveFixtureToolPath(

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -727,6 +727,8 @@ public struct SearchView: View {
                 ForEach(results) { hit in
                     Button(action: { navigateTo(hit) }) {
                         searchHitRow(hit)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier(searchResultIdentifier(for: hit))

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -89,6 +89,9 @@ public struct SyncSettingsView: View {
     /// Global remote-sync error message shown in an alert after a category sync failure.
     @State private var remoteSyncErrorMessage: String?
 
+    /// Last successfully completed confirmation branch exported only for UI-test assertions.
+    @State private var lastRemoteConfirmationAction: String?
+
     /**
      Represents the last manual WebDAV connection-test result shown in the status section.
 
@@ -659,7 +662,7 @@ public struct SyncSettingsView: View {
      The token captures the active backend plus the currently enabled remote categories so UI tests
      can assert state changes without relying on localized row text or SwiftUI switch internals.
 
-     - Returns: A deterministic `backend=<raw>;enabled=<csv-or-none>;remoteStatus=<token>` token.
+     - Returns: A deterministic token describing backend, enabled categories, and remote prompt state.
      - Side effects: none.
      - Failure modes: This helper cannot fail.
      */
@@ -669,7 +672,49 @@ public struct SyncSettingsView: View {
             .map(\.rawValue)
             .sorted()
         let enabledToken = enabledCategories.isEmpty ? "none" : enabledCategories.joined(separator: ",")
-        return "backend=\(selectedBackend.rawValue);enabled=\(enabledToken);remoteStatus=\(remoteStatusAccessibilityValue)"
+        return [
+            "backend=\(selectedBackend.rawValue)",
+            "enabled=\(enabledToken)",
+            "remoteStatus=\(remoteStatusAccessibilityValue)",
+            "bootstrapPrompt=\(remoteBootstrapPromptAccessibilityToken)",
+            "pendingConfirmation=\(remoteConfirmationAccessibilityToken)",
+            "lastConfirmation=\(lastRemoteConfirmationAction ?? "none")",
+        ]
+        .joined(separator: ";")
+    }
+
+    /**
+     Accessibility-exported token for the visible adopt-versus-create prompt.
+     *
+     * - Returns: `adoptOrCreate:<category>` when the first prompt is visible, otherwise `none`.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    private var remoteBootstrapPromptAccessibilityToken: String {
+        guard let pendingRemoteAdoption else {
+            return "none"
+        }
+        return "adoptOrCreate:\(pendingRemoteAdoption.category.rawValue)"
+    }
+
+    /**
+     Accessibility-exported token for the visible destructive confirmation branch.
+     *
+     * - Returns: Branch and category tokens when the second confirmation is visible, otherwise `none`.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    private var remoteConfirmationAccessibilityToken: String {
+        guard let pendingRemoteConfirmation else {
+            return "none"
+        }
+
+        switch pendingRemoteConfirmation {
+        case .resetLocal(let candidate):
+            return "resetLocal:\(candidate.category.rawValue)"
+        case .resetCloud(let candidate):
+            return "resetCloud:\(candidate.category.rawValue)"
+        }
     }
 
     /**
@@ -858,6 +903,21 @@ public struct SyncSettingsView: View {
             return
         }
 
+        if UITestRuntimeConfiguration.remoteSyncBootstrapScenario == .adoptExisting {
+            selectedBackend = .nextCloud
+            serverURL = "https://example.invalid/remote.php/dav/files/ui-test"
+            username = "ui-test"
+            password = "ui-test"
+            folderPath = ""
+            remoteCategoryEnabled = Dictionary(
+                uniqueKeysWithValues: RemoteSyncCategory.allCases.map { category in
+                    (category, false)
+                }
+            )
+            hasLoadedSettings = true
+            return
+        }
+
         selectedBackend = remoteSettingsStore.selectedBackend
 
         if let configuration = remoteSettingsStore.loadWebDAVConfiguration() {
@@ -965,6 +1025,7 @@ public struct SyncSettingsView: View {
     @MainActor
     private func beginRemoteSynchronization(for category: RemoteSyncCategory) async {
         persistRemoteSettings()
+        lastRemoteConfirmationAction = nil
 
         do {
             if selectedBackend == .googleDrive && !googleDriveAuthService.isReadyForSync {
@@ -1029,6 +1090,7 @@ public struct SyncSettingsView: View {
             let service = try makeRemoteSynchronizationService()
             let settingsStore = SettingsStore(modelContext: modelContext)
             let report: RemoteSyncCategorySynchronizationReport
+            let completedAction: String
 
             switch confirmation {
             case .resetLocal(let candidate):
@@ -1038,6 +1100,7 @@ public struct SyncSettingsView: View {
                     modelContext: modelContext,
                     settingsStore: settingsStore
                 )
+                completedAction = "resetLocal"
             case .resetCloud(let candidate):
                 report = try await service.createRemoteFolderAndSynchronize(
                     for: candidate.category,
@@ -1045,10 +1108,12 @@ public struct SyncSettingsView: View {
                     modelContext: modelContext,
                     settingsStore: settingsStore
                 )
+                completedAction = "resetCloud"
             }
 
             remoteCategoryStatuses[category] = .idle
             finishRemoteSynchronization(with: report, for: category)
+            lastRemoteConfirmationAction = "\(completedAction):\(category.rawValue)"
         } catch {
             handleRemoteSynchronizationError(error, for: category, revertEnablement: false)
         }
@@ -1089,6 +1154,7 @@ public struct SyncSettingsView: View {
         remoteSettingsStore.setSyncEnabled(false, for: category)
         remoteCategoryEnabled[category] = false
         remoteCategoryStatuses[category] = .idle
+        lastRemoteConfirmationAction = nil
     }
 
     /**
@@ -1158,6 +1224,15 @@ public struct SyncSettingsView: View {
      */
     private func makeRemoteSynchronizationService() throws -> RemoteSyncSynchronizationService {
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "org.andbible.ios"
+        if UITestRuntimeConfiguration.remoteSyncBootstrapScenario == .adoptExisting {
+            return RemoteSyncSynchronizationService(
+                adapter: UITestRemoteSyncAdapter(bundleIdentifier: bundleIdentifier),
+                bundleIdentifier: bundleIdentifier,
+                deviceIdentifier: remoteSettingsStore.deviceIdentifier(),
+                nowProvider: { 1_735_689_900_000 }
+            )
+        }
+
         let factory = RemoteSyncSynchronizationServiceFactory(
             bundleIdentifier: bundleIdentifier,
             googleDriveAccessTokenProvider: { [googleDriveAuthService] in

--- a/Sources/BibleUI/Sources/BibleUI/Settings/UITestRemoteSyncAdapter.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/UITestRemoteSyncAdapter.swift
@@ -1,0 +1,171 @@
+import Foundation
+import BibleCore
+
+/**
+ Deterministic remote-sync adapter used only for UI automation launch scenarios.
+
+ The adapter gives Sync Settings a same-named remote folder without requiring live WebDAV or
+ Google Drive credentials. Normal app launches never instantiate this type; `SyncSettingsView`
+ only uses it when the UI-test runtime configuration explicitly requests the adopt-existing
+ bootstrap branch.
+ */
+actor UITestRemoteSyncAdapter: RemoteSyncAdapting {
+    private let bundleIdentifier: String
+
+    /**
+     Creates a UI-test adapter bound to the current app bundle identifier.
+     *
+     * - Parameter bundleIdentifier: App bundle identifier used to derive Android-style sync folder names.
+     * - Side effects: none.
+     * - Failure modes: This initializer cannot fail.
+     */
+    init(bundleIdentifier: String) {
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    /**
+     Lists one synthetic same-named top-level category folder, then no child files.
+     *
+     * - Parameters:
+     *   - parentIDs: Remote parent identifiers requested by the sync coordinator.
+     *   - name: Optional exact name filter.
+     *   - mimeType: Optional MIME type filter.
+     *   - modifiedAtLeast: Optional lower bound for patch discovery.
+     * - Returns: A synthetic category folder for top-level adoption discovery, otherwise empty.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func listFiles(
+        parentIDs: [String]?,
+        name: String?,
+        mimeType: String?,
+        modifiedAtLeast: Date?
+    ) async throws -> [RemoteSyncFile] {
+        guard parentIDs == nil,
+              mimeType == nil,
+              let name,
+              RemoteSyncCategory.allCases.contains(where: {
+                  $0.syncFolderName(bundleIdentifier: bundleIdentifier) == name
+              }) else {
+            return []
+        }
+
+        return [
+            RemoteSyncFile(
+                id: "/uitest-existing-\(name)",
+                name: name,
+                size: 0,
+                timestamp: 1_735_689_600_000,
+                parentID: "/",
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ]
+    }
+
+    /**
+     Creates a synthetic remote folder descriptor.
+     *
+     * - Parameters:
+     *   - name: Requested remote folder name.
+     *   - parentID: Optional parent folder identifier.
+     * - Returns: Synthetic folder metadata matching the requested location.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func createNewFolder(name: String, parentID: String?) async throws -> RemoteSyncFile {
+        let resolvedParentID = parentID ?? "/"
+        let folderID: String
+        if let parentID {
+            folderID = "\(parentID)/\(name)"
+        } else {
+            folderID = "/uitest-created-\(name)"
+        }
+
+        return RemoteSyncFile(
+            id: folderID,
+            name: name,
+            size: 0,
+            timestamp: 1_735_689_700_000,
+            parentID: resolvedParentID,
+            mimeType: NextCloudSyncAdapter.folderMimeType
+        )
+    }
+
+    /**
+     Downloads a synthetic remote payload.
+     *
+     * - Parameter id: Remote identifier requested by the sync coordinator.
+     * - Returns: Empty data because the issue #44 workflow validates the create-new branch.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func download(id: String) async throws -> Data {
+        Data()
+    }
+
+    /**
+     Uploads a synthetic remote file descriptor while consuming the local file payload.
+     *
+     * - Parameters:
+     *   - name: Remote filename to create.
+     *   - fileURL: Local file whose contents should be uploaded.
+     *   - parentID: Remote parent folder identifier.
+     *   - contentType: MIME type for the upload.
+     * - Returns: Synthetic metadata sized to the local payload.
+     * - Side effects: reads the local file so upload failures still surface during UI tests.
+     * - Failure modes: Rethrows local file-read errors.
+     */
+    func upload(
+        name: String,
+        fileURL: URL,
+        parentID: String,
+        contentType: String
+    ) async throws -> RemoteSyncFile {
+        let data = try Data(contentsOf: fileURL)
+        return RemoteSyncFile(
+            id: "\(parentID)/\(name)",
+            name: name,
+            size: Int64(data.count),
+            timestamp: 1_735_689_800_000,
+            parentID: parentID,
+            mimeType: contentType
+        )
+    }
+
+    /**
+     Deletes a synthetic remote file or folder.
+     *
+     * - Parameter id: Remote identifier requested for deletion.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func delete(id: String) async throws {}
+
+    /**
+     Reports that no stored ownership marker is valid.
+     *
+     * - Parameters:
+     *   - syncFolderID: Stored sync folder identifier.
+     *   - secretFileName: Stored secret marker filename.
+     * - Returns: Always `false` so the UI test reaches the adoption prompt.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func isSyncFolderKnown(syncFolderID: String, secretFileName: String) async throws -> Bool {
+        false
+    }
+
+    /**
+     Creates a deterministic synthetic ownership marker name.
+     *
+     * - Parameters:
+     *   - syncFolderID: Sync folder receiving the marker.
+     *   - deviceIdentifier: Stable device identifier from remote sync settings.
+     * - Returns: Synthetic marker filename.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func makeSyncFolderKnown(syncFolderID: String, deviceIdentifier: String) async throws -> String {
+        "uitest-\(deviceIdentifier)-secret"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Shared/UITestRuntimeConfiguration.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/UITestRuntimeConfiguration.swift
@@ -6,6 +6,13 @@ enum UITestRuntimeConfiguration {
     private static let detailedAccessibilityExportsArgument = "-UITEST_ENABLE_DETAILED_ACCESSIBILITY_EXPORTS"
     private static let myNotesAppendTextEnvironmentKey = "UITEST_MY_NOTES_APPEND_TEXT"
     private static let myNotesAppendTextArgument = "-UITEST_MY_NOTES_APPEND_TEXT"
+    private static let remoteSyncBootstrapScenarioEnvironmentKey = "UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"
+    private static let remoteSyncBootstrapScenarioArgument = "-UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"
+
+    /// Test-only remote sync bootstrap paths that can replace live backend transport in UI tests.
+    enum RemoteSyncBootstrapScenario: String {
+        case adoptExisting = "adopt-existing"
+    }
 
     /// Upper bound for test-only row-token exports embedded into accessibility state strings.
     static let detailedAccessibilityRowTokenLimit = 50
@@ -28,6 +35,18 @@ enum UITestRuntimeConfiguration {
             return nil
         }
         return value
+    }
+
+    /// Optional deterministic remote-sync bootstrap path requested by UI automation.
+    static var remoteSyncBootstrapScenario: RemoteSyncBootstrapScenario? {
+        if let value = ProcessInfo.processInfo.environment[remoteSyncBootstrapScenarioEnvironmentKey],
+           !value.isEmpty {
+            return RemoteSyncBootstrapScenario(rawValue: value)
+        }
+        guard let value = argumentValue(after: remoteSyncBootstrapScenarioArgument), !value.isEmpty else {
+            return nil
+        }
+        return RemoteSyncBootstrapScenario(rawValue: value)
     }
 
     /**

--- a/docs/parity/sync/regression-report.md
+++ b/docs/parity/sync/regression-report.md
@@ -1,6 +1,6 @@
 # SYNC-702 Regression Report
 
-Date: 2026-04-28
+Date: 2026-05-15
 
 ## Scope
 
@@ -13,6 +13,7 @@ Regression verification for the current sync parity surface, covering:
   workspaces, and reading plans
 - ready-state patch replay and steady-state outbound upload
 - Sync settings backend/category mutation and reopen persistence
+- Sync settings adopt-versus-create confirmation branch
 - the parked Google Drive auth and adapter contract
 - local Android reference comparison
 
@@ -89,6 +90,7 @@ Operational setup reference:
 - `AndBibleUITests/testSyncSettingsNextCloudInvalidURLShowsValidationStatus`
 - `AndBibleUITests/testSyncSettingsCategoryToggleMutatesExportedState`
 - `AndBibleUITests/testSyncSettingsCategoryDisablePersistsAcrossDirectReopen`
+- `AndBibleUITests/testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow`
 - `AndBibleUITests/testSyncSettingsBackendSwitchMutatesVisibleSection`
 - `AndBibleUITests/testSyncSettingsBackendSwitchPersistsAcrossDirectReopen`
 
@@ -100,6 +102,8 @@ Operational setup reference:
 - Android-compatible raw keys persist NextCloud/WebDAV credentials and per-category enablement
 - backend and category mutations persist across direct Sync Settings reopen
 - invalid NextCloud URL input surfaces the expected UI validation state
+- the visible adopt/create prompt can drive the create-new cloud replacement branch and complete
+  synchronization with the selected category enabled
 
 ### Bootstrap and baseline handling
 
@@ -144,16 +148,15 @@ The checked-in shared-scheme test set gives the sync domain rerunnable regressio
 - ready-state synchronization for bookmark, workspace, and reading-plan categories
 - parked Google Drive auth and adapter contracts
 - Sync settings backend/category mutation plus reopen persistence
+- Sync settings adopt-versus-create confirmation UI coverage
 
 ## Remaining Gap
 
 The current sync parity gap is not the core bootstrap or patch engine. It is:
 
-- a focused UI workflow that drives the explicit adopt-versus-create confirmation sheet end to end
 - Android category breadth beyond iOS's supported `bookmarks`, `workspaces`, and `readingplans`
   categories: Android also exposes `mydocuments`, `ai_settings`, and `progress`
 
-That branch is already covered in unit and integration tests through the coordinator and
-synchronization service. It remains `Partial` because the user-facing confirmation path is not yet
-locked by a focused simulator workflow, and the remaining Android-only categories are not
-implemented on iOS yet.
+The adopt-versus-create branch is now covered both below the UI through coordinator and
+synchronization tests and through a focused simulator workflow. The remaining `Partial` sync parity
+area is Android category breadth beyond the currently supported iOS categories.

--- a/docs/parity/sync/verification-matrix.md
+++ b/docs/parity/sync/verification-matrix.md
@@ -1,6 +1,6 @@
 # SYNC-701 Verification Matrix (Android Sync -> iOS)
 
-Date: 2026-04-28
+Date: 2026-05-15
 
 ## Scope and Method
 
@@ -27,9 +27,9 @@ Date: 2026-04-28
 
 ## Summary
 
-- `Pass`: 6
+- `Pass`: 7
 - `Adapted Pass`: 2
-- `Partial`: 2
+- `Partial`: 1
 
 ## Matrix
 
@@ -44,4 +44,4 @@ Date: 2026-04-28
 | Sync settings UI supports backend switching and category persistence across reopen | `SyncSettingsView.swift`; UI tests `testSettingsSyncLinkOpensSyncSettings`, `testSyncSettingsCategoryToggleMutatesExportedState`, `testSyncSettingsCategoryDisablePersistsAcrossDirectReopen`, `testSyncSettingsBackendSwitchMutatesVisibleSection`, `testSyncSettingsBackendSwitchPersistsAcrossDirectReopen` | Pass | The current gate is focused on persisted state and visible section changes, not just navigation smoke. |
 | Google Drive uses the Android-aligned OAuth + Drive API model but is operationally parked until real iOS OAuth provisioning exists | `GoogleDriveAuthService.swift`, `GoogleDriveSyncAdapter.swift`, `RemoteSyncSynchronizationServiceFactory`; unit tests `testGoogleDriveSyncAdapterListsFilesFromAppDataFolderWithPagination`, `testGoogleDriveSyncAdapterCreatesFolderUnderAppDataRoot`, `testGoogleDriveSyncAdapterUploadsMultipartPatchArchive`, `testGoogleDriveSyncAdapterUsesFolderExistenceForOwnershipProof`, `testGoogleDriveOAuthConfigurationParsesValidInfoDictionary`, `testGoogleDriveOAuthConfigurationRejectsMissingURLScheme`, `testGoogleDriveAuthServiceRestoresPreviousSignInOnceAndBecomesReadyForSync`, `testRemoteSyncSynchronizationServiceFactoryBuildsGoogleDriveAdapter`; documented in `dispositions.md` | Adapted Pass | The code path is regression-backed, but live end-user sign-in remains intentionally parked until release OAuth credentials exist. |
 | iCloud remains a first-class backend alongside Android-aligned remote sync | `RemoteSyncBackend.iCloud`, `SyncSettingsView.swift`, `dispositions.md` | Adapted Pass | This is an intentional iOS extension and does not redefine the Android parity contract for remote backends. |
-| UI coverage for the adopt-versus-create confirmation branch itself | `SyncSettingsView.swift` confirmation flow exists, but current focused UI subset does not drive the explicit adopt/create sheet end to end | Partial | The branch is well-covered in coordinator and synchronization unit tests, but not yet by a focused user-visible confirmation workflow test. |
+| UI coverage for the adopt-versus-create confirmation branch itself | `SyncSettingsView.swift`; UI test `testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow` | Pass | The focused workflow drives the visible adopt/create sheet, chooses the create-new cloud replacement branch, confirms the destructive reset-cloud alert, and waits for the bookmarks category to finish enabled with `lastConfirmation=resetCloud:bookmarks`. |

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -33,6 +33,7 @@
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsPrimaryNavigationRows": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsSyncLinkOpensSyncSettings": "baseline",
+  "AndBibleUITests/AndBibleUITests/testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow": "none",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchMutatesVisibleSection": "sync-nextcloud",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchPersistsAcrossDirectReopen": "sync-nextcloud",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsCategoryDisablePersistsAcrossDirectReopen": "sync-nextcloud-bookmarks-enabled",


### PR DESCRIPTION
## Summary

Adds focused simulator coverage for the Sync Settings adopt-versus-create confirmation branch and includes the CI hardening needed to keep the expanded UI suite stable.

## Scope

- Adds a UI-test-only remote sync bootstrap scenario and synthetic remote adapter.
- Adds one focused XCUITest for the visible adopt/create confirmation flow.
- Hardens shared reader header button lookup used by bookmark drawer UI tests after a CI timeout.
- Hardens fixture-backed UI test bootstrap so XCTest does not race an immediate app exit while creating the data container.
- Makes Search result rows fill their tappable width so result selection reliably dismisses Search and navigates the reader.
- Stabilizes the visible-verse debounce unit test by waiting for the callback instead of sleeping for a fixed interval.
- Updates sync parity docs from Partial to Pass for this branch.
- Keeps live NextCloud and Google Drive network access out of scope.

## Contract references

- GitHub issue #44 acceptance criteria.
- `docs/parity/sync/verification-matrix.md` and `docs/parity/sync/regression-report.md` sync parity evidence.
- `../commit-message-standard.md` PR description requirements.

## Change details

- `SyncSettingsView` exports deterministic prompt and confirmation tokens for UI assertions.
- `UITestRuntimeConfiguration` accepts `UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO=adopt-existing`.
- `UITestRemoteSyncAdapter` supplies deterministic same-named remote-folder discovery without live network.
- `scripts/ui_test_fixture_manifest.json` marks this workflow fixture-free so the test can rely on launch configuration only.
- Shared reader header control lookup now prefers app-level button queries before nested header descendant queries to avoid slow XCTest snapshot resolution.
- Fixture bootstrap keeps the self-stopping XCTest launch path but delays the test-only exit briefly so XCTest can finish launch bookkeeping before fixture seeding continues.
- Search result buttons now use a full-width row label and rectangular content shape for reliable row taps.
- The debounced visible-verse persistence unit test now waits on an XCTest expectation fulfilled by the persistence callback.

## Validation evidence

- `swift build --product UITestFixtureTool`
- Focused UI test: `testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow`
- Focused UI test: `testBookmarkRowDeletePreservesOtherRowsAcrossReopen`
- Focused UI test: `testBookmarkListLabelAssignmentRemovalHidesBookmarkUnderFilter` on a fresh simulator exercising first-launch bootstrap
- Focused UI test pair: `testBookmarkListFilterAndSearchResetAcrossReopen` and `testBookmarkListLabelAssignmentRemovalHidesBookmarkUnderFilter`
- Focused UI test: `testSearchResultSelectionNavigatesReaderToBundledReference` with the `search-indexed` fixture
- Focused unit test: `testDidScrollToOrdinalDebouncesPersistenceWithinCurrentChapter`
- Targeted sync service tests for remote adoption and create-folder paths
- GitNexus `detect_changes` on current edits reported low risk and no affected execution flows; `impact` for `SearchView.multiResultsSection` reported medium import-level fanout and no affected processes
- `python3 scripts/check_repo_standards.py docblocks --rev-range HEAD`
- `git diff --check`
- `git diff --cached --check`

## Risks / follow-ups

Production risk is low: the synthetic sync adapter is only selected through an explicit UI-test launch flag, fixture bootstrap changes are test-only, and the Search change only expands the tappable area of existing result rows without changing result data or navigation logic. Broader Android-only sync category breadth remains outside this PR.

## Issue closure reference

Closes #44
