### PR TITLE
test(reading-plans): cover list start delete import flow

### DIFF
--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -311,6 +311,52 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Verifies the visible reading-plan list can start and delete a built-in plan and reach the
+     custom import path from the available-plan picker.
+     *
+     * - Side effects:
+     *   - launches the reader shell with empty reading-plan state
+     *   - opens the real Reading Plans list, starts the first Android-parity built-in template,
+     *     deletes it from the active-plan row swipe action, then opens the import picker path
+     * - Failure modes:
+     *   - fails if the list state does not publish the expected active-plan counts
+     *   - fails if the built-in template cannot be started from the picker
+     *   - fails if the row-level delete action is missing or does not remove the active plan
+     *   - fails if the custom import affordance does not request file-picker presentation
+     */
+    func testReadingPlanListStartDeleteAndImportAffordanceFlow() {
+        let builtInPlanCode = "y1ot1nt1_OTthenNT"
+        let builtInPlanToken = readingPlanStateToken(builtInPlanCode)
+        let app = makeApp()
+        app.launch()
+
+        _ = openReadingPlans(in: app, timeout: 20)
+        waitForReadingPlanListState(containing: "active=0", in: app, timeout: 10)
+
+        tapElementReliably(requireElement("readingPlanStartButton", in: app, timeout: 10), timeout: 10)
+        _ = requireElement("availablePlansScreen", in: app, timeout: 10)
+        waitForAvailablePlansState(containing: builtInPlanToken, in: app, timeout: 10)
+
+        tapElementReliably(requireElement("readingPlanTemplateButton", in: app, timeout: 15), timeout: 10)
+        waitForReadingPlanListState(containing: "active=1", in: app, timeout: 15)
+        waitForReadingPlanListState(containing: builtInPlanToken, in: app, timeout: 10)
+
+        let activePlan = requireElement("readingPlanActivePlanLink", in: app, timeout: 10)
+        activePlan.swipeLeft()
+        tapElementReliably(
+            requireElement(readingPlanDeleteButtonIdentifier(for: builtInPlanCode), in: app, timeout: 10),
+            timeout: 10
+        )
+        waitForReadingPlanListState(containing: "active=0", in: app, timeout: 10)
+        waitForReadingPlanListState(notContaining: builtInPlanToken, in: app, timeout: 10)
+
+        tapElementReliably(requireElement("readingPlanStartButton", in: app, timeout: 10), timeout: 10)
+        _ = requireElement("availablePlansScreen", in: app, timeout: 10)
+        tapElementReliably(revealAvailablePlansImportButton(in: app, timeout: 10), timeout: 10)
+        waitForAvailablePlansState(containing: "importPickerPresented=true", in: app, timeout: 20)
+    }
+
+    /**
      Verifies that the downloads browser can be opened from the reader shell.
      *
      * - Side effects:
@@ -3594,6 +3640,80 @@ final class AndBibleUITests: XCTestCase {
         "|\(referenceToken)|"
     }
 
+    /// Waits for the Reading Plans list accessibility state to contain one token.
+    private func waitForReadingPlanListState(
+        containing token: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10
+    ) {
+        waitForResolvedSemanticState(
+            named: "readingPlanListStateExport",
+            timeout: timeout,
+            valueProvider: { resolvedReadingPlanListStateValue(in: app) },
+            success: { $0.contains(token) },
+            failureDescription: { finalValue in
+                "Expected element 'readingPlanListStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
+            }
+        )
+    }
+
+    /// Waits for the Reading Plans list accessibility state to stop containing one token.
+    private func waitForReadingPlanListState(
+        notContaining token: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10
+    ) {
+        waitForResolvedSemanticState(
+            named: "readingPlanListStateExport",
+            timeout: timeout,
+            valueProvider: { resolvedReadingPlanListStateValue(in: app) },
+            success: { !$0.contains(token) },
+            missingCountsAsSuccess: true,
+            failureDescription: { _ in
+                "Expected element 'readingPlanListStateExport' to stop containing '\(token)' within \(timeout) seconds."
+            }
+        )
+    }
+
+    /// Waits for the available-plan picker accessibility state to contain one token.
+    private func waitForAvailablePlansState(
+        containing token: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10
+    ) {
+        waitForResolvedSemanticState(
+            named: "availablePlansStateExport",
+            timeout: timeout,
+            valueProvider: { resolvedAvailablePlansStateValue(in: app) },
+            success: { $0.contains(token) },
+            failureDescription: { finalValue in
+                "Expected element 'availablePlansStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
+            }
+        )
+    }
+
+    /// Returns one reading-plan token as serialized by the list accessibility state.
+    private func readingPlanStateToken(_ planCode: String) -> String {
+        "|\(sanitizedReadingPlanStateToken(planCode))|"
+    }
+
+    /// Returns one reading-plan delete button identifier for the visible row swipe action.
+    private func readingPlanDeleteButtonIdentifier(for planCode: String) -> String {
+        "readingPlanDeleteButton::\(sanitizedReadingPlanStateToken(planCode))"
+    }
+
+    /// Sanitizes one reading-plan code to match the production accessibility export.
+    private func sanitizedReadingPlanStateToken(_ value: String) -> String {
+        let mapped = value.unicodeScalars.map { scalar -> String in
+            if CharacterSet.alphanumerics.contains(scalar) {
+                return String(scalar)
+            }
+            return "_"
+        }
+        let collapsed = mapped.joined().replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
+        return collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    }
+
     /// Sanitizes one label token to match the production accessibility export.
     private func sanitizedLabelManagerStateToken(_ value: String) -> String {
         let replaced = value.replacingOccurrences(
@@ -3793,6 +3913,54 @@ final class AndBibleUITests: XCTestCase {
             in: app,
             timeout: timeout
         )
+    }
+
+    /**
+     Reveals and returns the custom reading-plan import button in the available-plan picker.
+     *
+     * - Parameters:
+     *   - app: Running application whose available-plan picker should be visible.
+     *   - timeout: Maximum time to scroll before recording a failure.
+     * - Returns: The resolved import button.
+     * - Side effects:
+     *   - scrolls the picker list downward until the custom-plan section is visible
+     * - Failure modes:
+     *   - fails if the import button cannot be reached within the timeout
+     */
+    private func revealAvailablePlansImportButton(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10
+    ) -> XCUIElement {
+        let scrollSurface = resolvedElement("availablePlansScreen", in: app)
+            ?? unresolvedElement("availablePlansScreen", in: app)
+        if elementHasUsableFrame(scrollSurface) {
+            scrollSurface.swipeUp()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            let directCandidates = [
+                app.buttons["readingPlanImportButton"].firstMatch,
+                app.collectionViews.buttons["readingPlanImportButton"].firstMatch,
+                app.cells.buttons["readingPlanImportButton"].firstMatch,
+                app.otherElements["readingPlanImportButton"].firstMatch,
+            ]
+            if let button = directCandidates.first(where: {
+                $0.exists && waitForElementToBecomeHittable($0, timeout: 0.2)
+            }) {
+                return button
+            }
+
+            if elementHasUsableFrame(scrollSurface) {
+                scrollSurface.swipeUp()
+            } else {
+                app.swipeUp()
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        return requireElement("readingPlanImportButton", in: app, timeout: 1)
     }
 
     /**
@@ -4736,6 +4904,10 @@ final class AndBibleUITests: XCTestCase {
             return screenScopedStateCandidates(identifier, within: "searchScreen", in: app)
         case "bookmarkListStateExport":
             return screenScopedStateCandidates(identifier, within: "bookmarkListScreen", in: app)
+        case "readingPlanListStateExport":
+            return screenScopedStateCandidates(identifier, within: "readingPlanListScreen", in: app)
+        case "availablePlansStateExport":
+            return screenScopedStateCandidates(identifier, within: "availablePlansScreen", in: app)
         case "labelManagerStateExport":
             return screenScopedStateCandidates(identifier, within: "labelManagerScreen", in: app)
         case "syncSettingsState":
@@ -4791,6 +4963,7 @@ final class AndBibleUITests: XCTestCase {
         }
 
         if identifier.hasPrefix("bookmarkListDeleteButton::")
+            || identifier.hasPrefix("readingPlanDeleteButton::")
             || identifier.hasPrefix("historyDeleteButton::")
             || identifier.hasPrefix("bookmarkListSortOption::")
         {
@@ -4965,7 +5138,12 @@ final class AndBibleUITests: XCTestCase {
                 app.collectionViews[identifier].firstMatch,
                 app.scrollViews[identifier].firstMatch,
             ]
-        case "searchStateExport", "bookmarkListStateExport", "labelManagerStateExport":
+        case
+            "searchStateExport",
+            "bookmarkListStateExport",
+            "readingPlanListStateExport",
+            "availablePlansStateExport",
+            "labelManagerStateExport":
             return semanticStateCandidates(for: identifier, in: app)
         case "searchResultsList":
             return [
@@ -5046,7 +5224,7 @@ final class AndBibleUITests: XCTestCase {
                 app.scrollViews[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
             ]
-        case "historyScreen", "readingPlanListScreen", "workspaceNamePromptScreen":
+        case "historyScreen", "readingPlanListScreen", "availablePlansScreen", "workspaceNamePromptScreen":
             return [
                 app.tables[identifier].firstMatch,
                 app.collectionViews[identifier].firstMatch,
@@ -5061,12 +5239,11 @@ final class AndBibleUITests: XCTestCase {
                 app.otherElements[identifier].firstMatch,
             ]
         case "readingPlanTemplateButton":
-            return [
-                app.buttons[identifier].firstMatch,
-                app.collectionViews.buttons[identifier].firstMatch,
-                app.cells[identifier].firstMatch,
-                app.otherElements[identifier].firstMatch,
-            ]
+            return screenScopedButtonCandidates(identifier, within: "availablePlansScreen", in: app)
+        case "readingPlanImportButton":
+            return screenScopedButtonCandidates(identifier, within: "availablePlansScreen", in: app)
+        case "readingPlanStartButton", "readingPlanActivePlanLink":
+            return screenScopedButtonCandidates(identifier, within: "readingPlanListScreen", in: app)
         default:
             return heuristicElementCandidates(for: identifier, in: app)
         }
@@ -8270,6 +8447,32 @@ final class AndBibleUITests: XCTestCase {
             return value
         }
         if let screen = resolvedElement("bookmarkListScreen", in: app),
+           let value = screen.value as? String {
+            return value
+        }
+        return nil
+    }
+
+    /// Reads the current exported Reading Plans list state without walking the full list hierarchy.
+    private func resolvedReadingPlanListStateValue(in app: XCUIApplication) -> String? {
+        if let stateElement = resolvedStateExportElement("readingPlanListStateExport", in: app),
+           let value = stateElement.value as? String {
+            return value
+        }
+        if let screen = resolvedElement("readingPlanListScreen", in: app),
+           let value = screen.value as? String {
+            return value
+        }
+        return nil
+    }
+
+    /// Reads the current exported Available Plans state without walking the full picker hierarchy.
+    private func resolvedAvailablePlansStateValue(in app: XCUIApplication) -> String? {
+        if let stateElement = resolvedStateExportElement("availablePlansStateExport", in: app),
+           let value = stateElement.value as? String {
+            return value
+        }
+        if let screen = resolvedElement("availablePlansScreen", in: app),
            let value = screen.value as? String {
             return value
         }

--- a/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
@@ -59,10 +59,15 @@ public struct ReadingPlanListView: View {
                     description: Text(String(localized: "reading_plan_no_plans_description"))
                 )
                 .accessibilityIdentifier("readingPlanListScreen")
+                .accessibilityValue(readingPlanListAccessibilityValue)
             } else {
                 planList
                     .accessibilityIdentifier("readingPlanListScreen")
+                    .accessibilityValue(readingPlanListAccessibilityValue)
             }
+        }
+        .overlay(alignment: .topLeading) {
+            readingPlanListStateExport
         }
         .navigationTitle(String(localized: "reading_plans"))
         #if os(iOS)
@@ -109,6 +114,7 @@ public struct ReadingPlanListView: View {
                                 modelContext.delete(plan)
                                 try? modelContext.save()
                             }
+                            .accessibilityIdentifier(readingPlanDeleteButtonIdentifier(for: plan))
                         }
                     }
                 }
@@ -123,11 +129,47 @@ public struct ReadingPlanListView: View {
                                     modelContext.delete(plan)
                                     try? modelContext.save()
                                 }
+                                .accessibilityIdentifier(readingPlanDeleteButtonIdentifier(for: plan))
                             }
                     }
                 }
             }
         }
+    }
+
+    /// Stable reading-plan list state exported for UI automation.
+    private var readingPlanListAccessibilityValue: String {
+        let baseState = "total=\(plans.count);active=\(activePlans.count);completed=\(completedPlans.count);showAvailablePlans=\(showAvailablePlans)"
+        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports else {
+            return baseState
+        }
+
+        let activeTokens = activePlans.prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit)
+            .map { "|\(readingPlanAccessibilitySegment($0.planCode))|" }
+            .joined(separator: ",")
+        let completedTokens = completedPlans.prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit)
+            .map { "|\(readingPlanAccessibilitySegment($0.planCode))|" }
+            .joined(separator: ",")
+        return "\(baseState);activeRows=\(activeTokens);completedRows=\(completedTokens)"
+    }
+
+    /// Compact hidden state probe used by UI tests instead of snapshotting the live list surface.
+    @ViewBuilder
+    private var readingPlanListStateExport: some View {
+        if UITestRuntimeConfiguration.enablesDetailedAccessibilityExports {
+            Text(readingPlanListAccessibilityValue)
+                .font(.system(size: 1))
+                .frame(width: 1, height: 1)
+                .opacity(0.01)
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("readingPlanListStateExport")
+                .accessibilityValue(readingPlanListAccessibilityValue)
+        }
+    }
+
+    /// Stable row-level delete button identifier for UI tests.
+    private func readingPlanDeleteButtonIdentifier(for plan: ReadingPlan) -> String {
+        "readingPlanDeleteButton::\(readingPlanAccessibilitySegment(plan.planCode))"
     }
 }
 
@@ -231,6 +273,20 @@ private struct AvailablePlansView: View {
     /// Latest user-visible custom-plan import error.
     @State private var importError: String?
 
+    /// Stable available-plan picker state exported for UI automation.
+    private var availablePlansAccessibilityValue: String {
+        let baseState = "templates=\(ReadingPlanService.availablePlans.count);importPickerPresented=\(showImportPicker)"
+        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports else {
+            return baseState
+        }
+
+        let templateTokens = ReadingPlanService.availablePlans
+            .prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit)
+            .map { "|\(readingPlanAccessibilitySegment($0.code))|" }
+            .joined(separator: ",")
+        return "\(baseState);templateRows=\(templateTokens)"
+    }
+
     /// Builds the built-in template list, custom import action, and error section.
     var body: some View {
         List {
@@ -270,6 +326,7 @@ private struct AvailablePlansView: View {
                 } label: {
                     SwiftUI.Label(String(localized: "reading_plan_import_custom"), systemImage: "arrow.down.doc")
                 }
+                .accessibilityIdentifier("readingPlanImportButton")
             } header: {
                 Text(String(localized: "reading_plan_custom"))
             } footer: {
@@ -285,6 +342,10 @@ private struct AvailablePlansView: View {
             }
         }
         .accessibilityIdentifier("availablePlansScreen")
+        .accessibilityValue(availablePlansAccessibilityValue)
+        .overlay(alignment: .topLeading) {
+            availablePlansStateExport
+        }
         .navigationTitle(String(localized: "reading_plan_available"))
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -300,6 +361,20 @@ private struct AvailablePlansView: View {
             allowsMultipleSelection: false
         ) { result in
             handleCustomPlanImport(result)
+        }
+    }
+
+    /// Compact hidden state probe for the available-plan picker.
+    @ViewBuilder
+    private var availablePlansStateExport: some View {
+        if UITestRuntimeConfiguration.enablesDetailedAccessibilityExports {
+            Text(availablePlansAccessibilityValue)
+                .font(.system(size: 1))
+                .frame(width: 1, height: 1)
+                .opacity(0.01)
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("availablePlansStateExport")
+                .accessibilityValue(availablePlansAccessibilityValue)
         }
     }
 
@@ -337,4 +412,16 @@ private struct AvailablePlansView: View {
             importError = error.localizedDescription
         }
     }
+}
+
+/// Sanitizes one reading-plan code for stable accessibility identifiers and state tokens.
+private func readingPlanAccessibilitySegment(_ value: String) -> String {
+    let mapped = value.unicodeScalars.map { scalar -> String in
+        if CharacterSet.alphanumerics.contains(scalar) {
+            return String(scalar)
+        }
+        return "_"
+    }
+    let collapsed = mapped.joined().replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
+    return collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
 }

--- a/docs/parity/reading-plans/regression-report.md
+++ b/docs/parity/reading-plans/regression-report.md
@@ -1,12 +1,13 @@
 # READING-PLANS-702 Regression Report
 
-Date: 2026-03-16
+Date: 2026-05-15
 
 ## Scope
 
 Regression verification for the current reading-plan parity surface, covering:
 
 - daily-reading progression in the native SwiftUI screen
+- visible reading-plan list start/delete/import affordance flow
 - Android initial-backup snapshot reading and validation
 - raw Android status-payload preservation
 - Android-shaped initial-backup upload
@@ -36,6 +37,8 @@ Verification matrix:
 - `AndBibleTests/testRemoteSyncReadingPlanRestoreRejectsUnknownPlanDefinitionsWithoutMutation`
 - `AndBibleTests/testRemoteSyncReadingPlanRestoreRejectsOrphanStatusesWithoutMutation`
 - `AndBibleTests/testRemoteSyncReadingPlanRestoreRejectsMalformedStatusPayloads`
+- `AndBibleTests/testRemoteSyncReadingPlanStatusStorePersistsAndClearsStatuses`
+- `AndBibleTests/testRemoteSyncReadingPlanStatusStorePreservesRemoteStatusIdentifiers`
 - `AndBibleTests/testRemoteSyncReadingPlanPatchApplyReplaysNewerRowsAndRecordsPatchStatus`
 - `AndBibleTests/testRemoteSyncReadingPlanPatchApplyDeletesStatusesByRemoteIdentifier`
 - `AndBibleTests/testRemoteSyncReadingPlanPatchApplySkipsOlderRows`
@@ -48,15 +51,24 @@ Verification matrix:
 
 ### UI
 
+- `AndBibleUITests/testReadingPlanListStartDeleteAndImportAffordanceFlow`
 - `AndBibleUITests/testReadingPlansStartPlanAndAdvanceDay`
 
 ## Expected Assertions Covered
 
 ### Daily-reading progression
 
-- a seeded active plan opens directly into `DailyReadingView`
+- a built-in plan started from the visible list opens into `DailyReadingView`
 - the current-day label starts on day `1`
 - tapping `Mark as Read` advances the visible day to `2`
+
+### Visible reading-plan list workflow
+
+- the real Reading Plans list starts with no active plans under the baseline fixture
+- the available-plan picker exposes the built-in Android-parity template list
+- starting `y1ot1nt1_OTthenNT` creates one active row in the list state
+- deleting that active row through the swipe action removes it from the list state
+- the custom import affordance requests file-picker presentation
 
 ### Android initial-backup restore
 
@@ -80,17 +92,18 @@ Verification matrix:
 
 ## Current Result
 
-Focused reading-plan validation passed on 2026-03-16:
+Focused reading-plan validation passed on 2026-05-15:
 
-- unit and integration: `14` tests, `0` failures
-- UI: `1` test, `0` failures
-- combined focused subset runtime: about `53s` end-to-end
+- unit and integration: `16` tests, `0` failures
+- UI: `2` tests, `0` failures
 
 This gives the reading-plan domain current regression evidence for:
 
 - Android initial-backup restore
 - all-or-nothing snapshot validation
+- visible list start/delete/import affordance behavior
 - daily-reading advancement
+- reading-plan status-store preservation
 - Android-shaped initial-backup upload
 - sparse patch replay
 - sparse patch upload
@@ -98,11 +111,10 @@ This gives the reading-plan domain current regression evidence for:
 
 ## Remaining Gap
 
-The current reading-plan parity gap is not the sync core. It is:
+The current reading-plan parity gap is not the sync core or visible list workflow. It is:
 
-- list/start/delete/import behavior from the real `ReadingPlanListView`
 - regression coverage for the additive iOS algorithmic plans
-- a focused import regression for custom `.properties` plans
+- a focused parser/import-content regression for custom `.properties` plans
 
 Those areas are implemented, but they are not yet locked by focused regression
 coverage, so they remain `Partial` in `verification-matrix.md`.

--- a/docs/parity/reading-plans/verification-matrix.md
+++ b/docs/parity/reading-plans/verification-matrix.md
@@ -1,6 +1,6 @@
 # READING-PLANS-701 Verification Matrix (Android Reading Plans -> iOS)
 
-Date: 2026-03-16
+Date: 2026-05-15
 
 ## Scope and Method
 
@@ -22,9 +22,9 @@ Date: 2026-03-16
 
 ## Summary
 
-- `Pass`: 5
+- `Pass`: 6
 - `Adapted Pass`: 1
-- `Partial`: 3
+- `Partial`: 2
 
 ## Matrix
 
@@ -32,8 +32,8 @@ Date: 2026-03-16
 |---|---|---|---|
 | Android `.properties` template parsing and custom-plan import syntax | `ReadingPlanService.parseProperties(_:)`, `ReadingPlanService.importCustomPlan(name:propertiesText:)` | Partial | The parser preserves Android-style `dayNumber=OsisRef...` semantics and ignores non-numeric keys, but custom import is not yet locked by focused regression coverage. |
 | Persisted plan creation keeps `currentDay` separate from 1-based day rows | `ReadingPlanService.startPlan(...)`, `DailyReadingView.loadPlan()`, `dispositions.md`; unit tests assert persisted `currentDay` values during restore/apply/upload flows | Adapted Pass | iOS intentionally keeps `ReadingPlan.currentDay` zero-based while generated `ReadingPlanDay.dayNumber` rows remain 1-based. |
-| Reading-plan list groups active vs completed plans and exposes start, delete, and import affordances | `ReadingPlanListView.swift`, `AvailablePlansView` | Partial | The list surface is implemented, but current focused UI coverage starts from a seeded daily-reading route rather than the list/start flow. |
-| Daily-reading progression marks a day complete and advances to the next day | `DailyReadingView.markDayComplete(_:)`, `DailyReadingView.checkPlanCompletion()`, UI test `testReadingPlansStartPlanAndAdvanceDay` | Pass | The current UI gate verifies day `1 -> 2` advancement on a seeded active plan. |
+| Reading-plan list groups active vs completed plans and exposes start, delete, and import affordances | `ReadingPlanListView.swift`, `AvailablePlansView`, UI test `testReadingPlanListStartDeleteAndImportAffordanceFlow` | Pass | Focused UI coverage now opens the real list, starts the built-in Android-parity template, deletes the active row through its swipe action, and verifies the custom import affordance requests file-picker presentation. |
+| Daily-reading progression marks a day complete and advances to the next day | `DailyReadingView.markDayComplete(_:)`, `DailyReadingView.checkPlanCompletion()`, UI test `testReadingPlansStartPlanAndAdvanceDay` | Pass | The current UI gate starts a built-in plan from the visible list, opens the daily view, and verifies day `1 -> 2` advancement. |
 | Android initial-backup restore reads staged `readingplans.sqlite3` snapshots and preserves raw status payloads | `RemoteSyncReadingPlanRestoreService`, `RemoteSyncReadingPlanStatusStore`; unit tests `testRemoteSyncReadingPlanRestoreReadsAndroidSnapshot` and `testRemoteSyncReadingPlanRestoreReplacesLocalPlansAndPreservesAndroidStatuses` | Pass | This locks the initial Android import contract plus raw-status fidelity preservation. |
 | Restore validation rejects unsupported plan definitions, orphan statuses, and malformed status JSON without mutation | `RemoteSyncReadingPlanRestoreService.preparePlans(from:)`; unit tests `testRemoteSyncReadingPlanRestoreRejectsUnknownPlanDefinitionsWithoutMutation`, `testRemoteSyncReadingPlanRestoreRejectsOrphanStatusesWithoutMutation`, `testRemoteSyncReadingPlanRestoreRejectsMalformedStatusPayloads` | Pass | Validation remains all-or-nothing before local reading-plan state is replaced. |
 | Initial-backup upload writes a full Android-shaped database and records patch-zero baseline state | `RemoteSyncInitialBackupUploadService.buildReadingPlanInitialBackup(...)`; unit test `testRemoteSyncInitialBackupUploadWritesReadingPlanDatabaseAndResetsBaseline` | Pass | This protects the create-new remote bootstrap path for reading plans. |

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -21,6 +21,7 @@
   "AndBibleUITests/AndBibleUITests/testHistorySelectionNavigatesReaderToSeededReference": "history-single",
   "AndBibleUITests/AndBibleUITests/testLabelAssignmentTogglesFavouriteAndAssignment": "bookmark-row-label",
   "AndBibleUITests/AndBibleUITests/testLabelManagerCreateRenameDeleteFlow": "baseline",
+  "AndBibleUITests/AndBibleUITests/testReadingPlanListStartDeleteAndImportAffordanceFlow": "baseline",
   "AndBibleUITests/AndBibleUITests/testReadingPlansStartPlanAndAdvanceDay": "baseline",
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchStrongsQueryReturnsBundledResults": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchUsesSeededIndexAndReturnsBundledResults": "search-indexed",


### PR DESCRIPTION
## Summary

Adds focused coverage for the real Reading Plans list workflow requested in #45.

## Scope

- Adds compact UI-test accessibility state exports for `ReadingPlanListView` and `AvailablePlansView`.
- Adds stable row delete and import affordance identifiers.
- Adds `testReadingPlanListStartDeleteAndImportAffordanceFlow` for start, delete, and import-picker presentation from visible UI.
- Updates the UI fixture manifest and reading-plan parity docs.

## Contract References

- `../commit-message-standard.md`
- `docs/parity/reading-plans/verification-matrix.md`
- `docs/parity/reading-plans/regression-report.md`
- GitHub issue #45 is open and maps to this work.

## Change Details

- The list state export reports total, active, completed, and row tokens so UI tests can assert behavior without expensive full-list hierarchy scans.
- The available-plan picker export reports built-in template tokens and import-picker presentation state.
- The new UI test starts `y1ot1nt1_OTthenNT`, verifies the active row appears, deletes it through the row swipe action, then verifies the custom import affordance reaches file-picker presentation.

## Validation Evidence

- Xcode simulator build passed with code signing disabled.
- `AndBibleUITests/AndBibleUITests/testReadingPlanListStartDeleteAndImportAffordanceFlow` passed.
- `AndBibleUITests/AndBibleUITests/testReadingPlansStartPlanAndAdvanceDay` passed.
- Focused reading-plan unit and sync subset passed: 16 tests, 0 failures.
- `git diff --check` passed.
- GitNexus `detect_changes` with scope `all` reported low risk and 0 affected processes.

## Risks / Follow-ups

- Runtime changes are limited to accessibility metadata and UI-test probes.
- Remaining reading-plan parity gaps are algorithmic-plan lifecycle coverage and full custom `.properties` parser/import-content regression coverage.

## Issue Closure Reference

Closes #45
