### PR TITLE
docs(bridge): define memorization progress model

### DIFF
--- a/docs/parity/bridge/README.md
+++ b/docs/parity/bridge/README.md
@@ -7,9 +7,11 @@ the Vue.js client and native iOS code.
 
 1. [contract.md](contract.md): bridge contract and message/event expectations
 2. [dispositions.md](dispositions.md): explicit iOS adaptations and no-op dispositions
-3. [verification-matrix.md](verification-matrix.md): current status by bridge contract area
-4. [regression-report.md](regression-report.md): focused bridge-adjacent validation evidence
-5. [guardrails.md](guardrails.md): maintenance rules for high-risk bridge changes
+3. [memorization-progress-model.md](memorization-progress-model.md): accepted
+   local iOS memorization progress model and Android references
+4. [verification-matrix.md](verification-matrix.md): current status by bridge contract area
+5. [regression-report.md](regression-report.md): focused bridge-adjacent validation evidence
+6. [guardrails.md](guardrails.md): maintenance rules for high-risk bridge changes
 
 Machine-readable tracking:
 

--- a/docs/parity/bridge/contract.md
+++ b/docs/parity/bridge/contract.md
@@ -90,9 +90,11 @@ bookmarks with the reserved paragraph-break label. Memorization bridge state is
 also part of the supported iOS subset: `memorize` adds the selected range as a
 local target and opens the bundled Memorize document, while
 `addMemorizationTarget`, `markAsMemorized`, `removeMemorizationTarget`, and
-`unmarkMemorized` mutate the same local state. Native speech-loop parity is
-implemented by `speakMemorizationLoop`, which validates Android-style bridge
-arguments and repeats the selected range through `SpeakService`.
+`unmarkMemorized` mutate the same local state. The accepted iOS storage and
+payload contract for that state is recorded in
+`memorization-progress-model.md`. Native speech-loop parity is implemented by
+`speakMemorizationLoop`, which validates Android-style bridge arguments and
+repeats the selected range through `SpeakService`.
 
 Android's My Documents bridge family is also accepted as iOS parity work, but
 it remains deferred until iOS has a native My Documents model/storage and

--- a/docs/parity/bridge/dispositions.md
+++ b/docs/parity/bridge/dispositions.md
@@ -71,6 +71,8 @@ Disposition:
   `MemorizeDocument`.
 - Bible and Memorize document payloads now carry `memorizedOrdinals` and
   `targetOrdinals` arrays for the loaded ordinal range.
+- The local model, range-normalization decision, and Android owner references
+  are recorded in `memorization-progress-model.md`.
 - iOS exposes `speakMemorizationLoop` with Android-style
   `(bookInitials, v11n, startOrdinal, endOrdinal)` bridge validation and routes
   it through a native `SpeakService` memorization loop instead of generic

--- a/docs/parity/bridge/memorization-progress-model.md
+++ b/docs/parity/bridge/memorization-progress-model.md
@@ -1,0 +1,112 @@
+# iOS Memorization Progress Model
+
+This records the iOS model decision for #77. It is intentionally narrower than
+Android's full progress feature: the first iOS slice gives the bridge and
+embedded Memorize document local state to read and mutate, while Android
+`progress` sync compatibility remains separate #73 work.
+
+## Android Owner References
+
+Android's memorization progress surface is owned by the progress database and
+progress controller:
+
+- `../and-bible/app/src/main/java/net/bible/android/database/progress/ProgressEntities.kt`
+  defines `MemorizedVerse`, `MemorizationTarget`, and global progress settings.
+- `../and-bible/app/src/main/java/net/bible/android/database/progress/ProgressDao.kt`
+  owns persistence queries for memorized KJV ordinals and target ranges.
+- `../and-bible/app/src/main/java/net/bible/android/database/migrations/ProgressMigrations.kt`
+  creates `MemorizationTarget` and progress settings schema.
+- `../and-bible/app/src/main/java/net/bible/android/control/progress/ProgressControl.kt`
+  normalizes incoming verse ranges to KJVA, mutates memorized verses and
+  targets, computes range membership, and emits change events.
+- `../and-bible/app/src/main/java/net/bible/android/control/page/ClientPageObjects.kt`
+  decorates Bible and Memorize documents with `memorizedOrdinals` and
+  `targetOrdinals`.
+
+Android's durable identity is the KJVA ordinal. A memorized verse is one KJVA
+ordinal with a timestamp, while a memorization target is an inclusive KJVA
+ordinal range.
+
+## iOS Ownership
+
+iOS owns the first local slice in:
+
+- `Sources/BibleCore/Sources/BibleCore/Database/MemorizationProgressStore.swift`
+- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
+
+`MemorizationProgressStore` persists a `MemorizationProgressSnapshot` as JSON in
+`SettingsStore` under `memorization_progress_state_v1`. The snapshot has two
+range lists:
+
+- `memorizedRanges`
+- `targetRanges`
+
+Each range stores:
+
+- `bookInitials`
+- `startOrdinal`
+- `endOrdinal`
+
+The store keeps ranges normalized, sorted, and non-overlapping within a
+`bookInitials` scope. Adding a range merges overlapping or adjacent ranges.
+Removing a range subtracts intersections and can split an existing target.
+
+This is not a SwiftData model and does not introduce a schema migration. That
+is deliberate: the first slice is small enough to test through store behavior,
+bridge mutations, and document payloads without porting the full Android
+progress database.
+
+## Range Normalization
+
+Android converts incoming ranges to KJVA before persistence. iOS accepts that
+as the remote compatibility direction, but the current local model keeps the
+embedded reader ordinals plus `bookInitials`.
+
+That choice is intentional for the first slice:
+
+- iOS does not yet have the Android progress database or the full KJVA sync
+  mapping needed by #73.
+- Scoping local ordinals by `bookInitials` prevents collisions between loaded
+  documents while preserving the reader's current ordinal semantics.
+- Bridge calls still preserve Android's `endOrdinal < 0` single-verse contract
+  before values reach the store.
+
+Future #73 work must make any KJVA migration explicit. It should define how
+local `bookInitials`-scoped ranges map to Android `progress` rows, how existing
+local JSON state is adopted or rewritten, and how conflicts are reconciled with
+remote progress data.
+
+## Document Payload Contract
+
+The embedded Memorize document needs enough state to render a practice session
+and enough range identity to show memorized and target indicators:
+
+- `type`: `memorize`
+- `texts`: ordered verse keys and text for the selected range
+- `state.memorize.mode`: currently `blur`
+- `state.memorize.modeConfig`: currently an empty object
+- `bookInitials`
+- `v11n`: currently `KJVA`
+- `osisRef`
+- `startOrdinal`
+- `endOrdinal`
+- `memorizedOrdinals`
+- `targetOrdinals`
+
+Normal Bible document payloads also include `memorizedOrdinals` and
+`targetOrdinals`. Those arrays are filtered to the loaded document's
+`bookInitials` and inclusive ordinal range. They are empty when the local store
+is unavailable or has no matching state.
+
+## Follow-Up Boundaries
+
+This model unblocks local memorization bridge behavior and focused regression
+coverage, but it does not close the broader progress parity surface.
+
+- Bridge follow-ups can depend on the local store and payload contract without
+  adding Android remote sync.
+- #73 owns Android `progress` sync compatibility, KJVA persistence mapping,
+  remote adoption behavior, and conflict handling.
+- #85 and its follow-ups own reading-progress model/settings work. Reading
+  progress must stay separate from memorized-verses and memorization-target
+  state unless a later compatibility decision explicitly combines them.

--- a/docs/parity/sync/dispositions.md
+++ b/docs/parity/sync/dispositions.md
@@ -100,8 +100,9 @@ Disposition:
   folded into `readingplans` without an explicit compatibility decision. The
   #52 reading-progress bridge disposition keeps this blocked on the native
   reading-progress model/storage and settings contract in #85. The #50
-  memorization bridge state slice now has local iOS storage, but remote
-  Android `progress` sync compatibility still belongs to #73.
+  memorization bridge state slice now has local iOS storage, with the #77 model
+  recorded in `../bridge/memorization-progress-model.md`, but remote Android
+  `progress` sync compatibility still belongs to #73.
 
 Reason:
 


### PR DESCRIPTION
## Summary

Documents the accepted iOS memorization progress model for #77 so bridge and sync follow-ups have a concrete contract to depend on.

## Scope

- Adds a dedicated bridge parity document for the iOS memorization progress model.
- Links that model from bridge reading order, bridge contract/dispositions, and sync dispositions.
- Keeps this PR documentation-only; it does not add bridge behavior or remote progress sync.

## Contract references

- Issue #77 defines the iOS model decision scope.
- Issue #73 remains the owner for Android `progress` sync compatibility.
- Issue #50 is the existing local memorization bridge state slice.
- Android references recorded in the new doc: `ProgressEntities.kt`, `ProgressDao.kt`, `ProgressMigrations.kt`, `ProgressControl.kt`, and `ClientPageObjects.kt`.
- iOS references recorded in the new doc: `MemorizationProgressStore.swift` and `BibleReaderController.swift`.

## Change details

- Records the Android KJVA ordinal persistence model for memorized verses and memorization targets.
- Records the iOS `SettingsStore` JSON model, including `memorizedRanges`, `targetRanges`, and `bookInitials` scoped ordinals.
- Defines the current range-normalization decision and the future #73 migration boundary.
- Defines the Memorize and Bible document payload fields for `memorizedOrdinals` and `targetOrdinals`.

## Validation evidence

- `gh issue view 77 --json number,title,state,body,labels,url`
- `git diff --check`
- `git diff --cached --check`
- GitNexus staged impact analysis: low risk, no affected processes.

## Risks/follow-ups

- Risk is low because this is documentation only.
- #73 still needs to define Android `progress` sync compatibility, KJVA persistence mapping, remote adoption, and conflict handling.
- #85 and follow-ups still own reading-progress model/settings behavior.

## Issue closure reference

Closes #77
