### PR TITLE
feat(sync): restore mydocuments initial backups

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */; };
 		A1B2C3D4E5F60718293A4B5C /* AndBibleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */; };
 		8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */; };
+		D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */; };
 		64688F48FF7396937F81D0B5 /* SwordSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA144AB77AEE518F1465DCC /* SwordSetup.swift */; };
 		793CB31DA9E0B8F6F4AC7677 /* AndBibleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */; };
 		7F60442468E70DF184FADD66 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFA8AEBF4A6CA89CDD4AF5 /* ContentView.swift */; };
@@ -52,6 +53,7 @@
 		A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITests.swift; sourceTree = "<group>"; };
 		8174AF1F3D15BAFB4EB66A1E /* AndBible.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AndBible.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSyncRestoreTests.swift; sourceTree = "<group>"; };
+		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			children = (
 				DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */,
 				9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */,
+				D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */,
 			);
 			path = AndBibleTests;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 			files = (
 				605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */,
 				8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */,
+				D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -661,6 +661,8 @@ struct AndBibleApp: App {
             return String(localized: "workspaces_contents")
         case .readingPlans:
             return String(localized: "reading_plans_content")
+        case .myDocuments:
+            return String(localized: "my_documents_contents")
         }
     }
 

--- a/AndBible/af.lproj/Localizable.strings
+++ b/AndBible/af.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Lees planne en hul statusse";
 "bookmarks_contents" = "Boekmerke, etikette en studieblokkies";
 "workspaces_contents" = "Werkspasies en Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sinchronisasie kategorieë";
 "sync_error" = "Fout het voorgekom in Clud sinchronisasie";
 "sync_cant_fetch" = "";

--- a/AndBible/ar.lproj/Localizable.strings
+++ b/AndBible/ar.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "فئات المزامنة";
 "sync_error" = "حدث خطأ في المزامنة السحابية";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/az.lproj/Localizable.strings
+++ b/AndBible/az.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/bg.lproj/Localizable.strings
+++ b/AndBible/bg.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/bn.lproj/Localizable.strings
+++ b/AndBible/bn.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "পরিকল্পনা এবং তাদের অবস্থা পড়া";
 "bookmarks_contents" = "বুকমার্ক, লেবেল এবং স্টাডি প্যাড";
 "workspaces_contents" = "ওয়ার্কস্পেস এবং উইন্ডোজ";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "সিঙ্ক্রোনাইজেশন বিভাগ";
 "sync_error" = "ক্লাউড সিঙ্ক্রোনাইজেশনে ত্রুটি ঘটেছে৷";
 "sync_cant_fetch" = "ক্লাউডে সংরক্ষিত ডাটাবেস বা প্যাচ ফাইলের সংস্করণ এই অ্যাপ দ্বারা সমর্থিত সংস্করণের চেয়ে বেশি।";

--- a/AndBible/cs.lproj/Localizable.strings
+++ b/AndBible/cs.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Plány čtení a jejich stav";
 "bookmarks_contents" = "Záložky, štítky a studijní složky";
 "workspaces_contents" = "Pracovní prochy a okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorie synchronizace";
 "sync_error" = "Nastala chyba při synchronizaci";
 "sync_cant_fetch" = "Verze databáze nebo souboru opravy uložená na síti je vyšší než verze podporovaná touto aplikací.";

--- a/AndBible/de.lproj/Localizable.strings
+++ b/AndBible/de.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Lesepläne und ihr Stand";
 "bookmarks_contents" = "Lesezeichen, Labels und Studienmappen";
 "workspaces_contents" = "Arbeitsumgebungen und Fenster";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronisationskategorien";
 "sync_error" = "Fehler bei der Synchronisation mit der Cloud";
 "sync_cant_fetch" = "Die in der Cloud gespeicherte Datenbankversion ist höher, als die Anwendung auf dem lokalen Gerät unterstützt.";

--- a/AndBible/el.lproj/Localizable.strings
+++ b/AndBible/el.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Σχέδια ανάγνωσης και η κατάσταση τους";
 "bookmarks_contents" = "Σελιδοδείκτες, Ετικέτες και Μπλοκ Μελέτης";
 "workspaces_contents" = "Χώροι εργασίας και Παράθυρα";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Κατηγορίες συγχρονισμού";
 "sync_error" = "Σφάλμα κατα τον συγχρονισμο cloud";
 "sync_cant_fetch" = "Η έκδοση της βάσης ή του αρχείου επιδιόρθωσης που βρίσκεται στο cloud είναι υψηλότερη της υποστηριζόμενης από αυτή την εφαρμογή";

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -640,6 +640,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/eo.lproj/Localizable.strings
+++ b/AndBible/eo.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "legplanoj kun iliaj progresoj";
 "bookmarks_contents" = "legosignoj, etikedoj, notblokoj";
 "workspaces_contents" = "laborspacoj kaj fenestroj";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorioj de samtempigo";
 "sync_error" = "Eraro okazis dum samtempigi kun nubo";
 "sync_cant_fetch" = "La versio de datumbazo aŭ dosiero konservita en la nubo estas pli alta ol versio subtenata per tiu ĉi aplikaĵo.";

--- a/AndBible/es.lproj/Localizable.strings
+++ b/AndBible/es.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planes de lectura y sus estados";
 "bookmarks_contents" = "Marcadores, Etiquetas y Pizarras de Estudio";
 "workspaces_contents" = "Espacios de trabajo y Ventanas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorías de sincronización";
 "sync_error" = "Error ocurrido en la sincronización con la nube";
 "sync_cant_fetch" = "La versión de base de datos o archivo almacenado en la nube es más alta que la que soporta esta aplicación.";

--- a/AndBible/et.lproj/Localizable.strings
+++ b/AndBible/et.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Järjehoidjad, sildid ja õppemärkmikud";
 "workspaces_contents" = "Tööalad ja Aknad";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sünkroonimise kategooriad";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/fi.lproj/Localizable.strings
+++ b/AndBible/fi.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Lukusuunnitelmat ja niiden tila";
 "bookmarks_contents" = "Kirjanmerkit, kirjanmerkkiryhmät ja opintoalustat";
 "workspaces_contents" = "Työtilat ja ikkunat";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synkronoinnin kategoriat";
 "sync_error" = "Virhe tapahtui synkronoidessa pilvipalveluun";
 "sync_cant_fetch" = "Pilvipalvelussa olevan tietokannan tai patch-tiedoston versio on uudempi kuin se mitä tämä sovellus tukee.";

--- a/AndBible/fr.lproj/Localizable.strings
+++ b/AndBible/fr.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Les plans de lecture et leurs statuts";
 "bookmarks_contents" = "Marque-pages, étiquettes, et bloc-notes";
 "workspaces_contents" = "Espaces et fenêtres";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Catégories à synchroniser";
 "sync_error" = "Une erreur est survenue durant la synchronisation du Cloud";
 "sync_cant_fetch" = "La version de la base de données ou du fichier patch stockée dans le Nuage est supérieure à celle prise en charge par cette application.";

--- a/AndBible/he.lproj/Localizable.strings
+++ b/AndBible/he.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "סביבות עבודה וחלונות";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "קטגוריות לסנכרון";
 "sync_error" = "שגיאה בסנכרון לענן";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/hi.lproj/Localizable.strings
+++ b/AndBible/hi.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/hr.lproj/Localizable.strings
+++ b/AndBible/hr.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planovi čitanja i njihovi statusi";
 "bookmarks_contents" = "Straničnici, Oznake i Radne bilježnice";
 "workspaces_contents" = "Radne površine i Prozori";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije usklađivanja";
 "sync_error" = "Došlo je do pogreške tijekom usklađivanja u oblaku";
 "sync_cant_fetch" = "Verzija baze podataka ili zakrpe koje se drže na oblaku novija je nego ona koju podržava ova aplikacija.";

--- a/AndBible/hu.lproj/Localizable.strings
+++ b/AndBible/hu.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Olvasási tervek és állapotuk";
 "bookmarks_contents" = "Könyvjelzők, Címkék és Jegyzetlapok";
 "workspaces_contents" = "Munkaterületek és ablakok";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Összehangolási kategóriák";
 "sync_error" = "Hiba történt a felhővel való összehangolás közben";
 "sync_cant_fetch" = "A tárhelyen található adatbázis vagy frissítés verziója magasabb mint az alkalmazásé.";

--- a/AndBible/id.lproj/Localizable.strings
+++ b/AndBible/id.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/it.lproj/Localizable.strings
+++ b/AndBible/it.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Piani di lettura e loro stati";
 "bookmarks_contents" = "Segnalibri, Etichette e Appunti di Studio";
 "workspaces_contents" = "Spazi di Lavoro e Finestre";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorie di sincronizzazione";
 "sync_error" = "Errore nella sincronizzazione del Cloud";
 "sync_cant_fetch" = "La versione del database o del file patch memorizzato nel Cloud è superiore a quella supportata da questa app.";

--- a/AndBible/kk.lproj/Localizable.strings
+++ b/AndBible/kk.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Оқу жоспарлары және олардың күйлері";
 "bookmarks_contents" = "Бетбелгілер, белгілер және оқу тақталары";
 "workspaces_contents" = "Жұмыс кеңістігі және Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Синхрондау категориялары";
 "sync_error" = "Бұлтты синхрондауда қателік орын алды";
 "sync_cant_fetch" = "Бұлтта сақталған дерекқордың немесе патч файлының нұсқасы осы қолданба қолдайтын нұсқасынан жоғары.";

--- a/AndBible/ko.lproj/Localizable.strings
+++ b/AndBible/ko.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/lt.lproj/Localizable.strings
+++ b/AndBible/lt.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Skaitymo planai ir jų būsena";
 "bookmarks_contents" = "Žymės, etiketės ir bloknotai";
 "workspaces_contents" = "Darbo sritys ir langai";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sinchronizavimo kategorijos";
 "sync_error" = "Įvyko klaida debesijos sinchronizavime";
 "sync_cant_fetch" = "Debesijoje saugomo duomenų bazės ar pataisos failo versija yra didesnė, nei palaiko ši programėlė.";

--- a/AndBible/ml.lproj/Localizable.strings
+++ b/AndBible/ml.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/my.lproj/Localizable.strings
+++ b/AndBible/my.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/nb.lproj/Localizable.strings
+++ b/AndBible/nb.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/nl.lproj/Localizable.strings
+++ b/AndBible/nl.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Leesplannen en hun statussen";
 "bookmarks_contents" = "Bladwijzers, Labels en Studiepaden";
 "workspaces_contents" = "Werkplek en Vensters";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronisatie categorieën";
 "sync_error" = "Er is een fout opgetreden bij de cloudsynchronisatie";
 "sync_cant_fetch" = "De Cloud-versie van de database of het patch bestand is hoger dan deze app ondersteund.";

--- a/AndBible/pl.lproj/Localizable.strings
+++ b/AndBible/pl.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "plany czytania wraz z postępami";
 "bookmarks_contents" = "zakładki, etykiety, bloczki notatek";
 "workspaces_contents" = "obszary robocze i okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorie synchronizacji";
 "sync_error" = "Wystąpił błąd podczas synchronizacji z chmurą.";
 "sync_cant_fetch" = "Wersja bazy danych lub pliku przechowywana w chmurze jest wyższa niż wersja wspierana przez tą aplikację.";

--- a/AndBible/pt-BR.lproj/Localizable.strings
+++ b/AndBible/pt-BR.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planos de leitura e seus status";
 "bookmarks_contents" = "Conteúdo dos favoritos";
 "workspaces_contents" = "Áreas de trabalho e Janelas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorias de sincronização";
 "sync_error" = "Ocorreu um erro de sincronização na Nuvem";
 "sync_cant_fetch" = "A versão do banco de dados ou arquivo de patch armazenado na nuvem é maior do que a suportada por este aplicativo.";

--- a/AndBible/pt.lproj/Localizable.strings
+++ b/AndBible/pt.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planos de leitura e seus status";
 "bookmarks_contents" = "Conteúdo dos favoritos";
 "workspaces_contents" = "Áreas de trabalho e Janelas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorias de sincronização";
 "sync_error" = "Ocorreu um erro de sincronização na Nuvem";
 "sync_cant_fetch" = "A versão da base de dados ou do ficheiro de correção armazenado na Nuvem é superior à suportada por esta aplicação.";

--- a/AndBible/ro.lproj/Localizable.strings
+++ b/AndBible/ro.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planuri de lectură și starea acestora";
 "bookmarks_contents" = "Semne de carte, Etichete și Notițe de studiu";
 "workspaces_contents" = "Spații de studiu și Ferestre";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorii de sincronizare";
 "sync_error" = "A apărut o eroare în sincronizarea Cloud";
 "sync_cant_fetch" = "Versiunea bazei de date sau a fișierului stocat în Cloud este mai mare decît cea acceptată de această aplicație.";

--- a/AndBible/ru.lproj/Localizable.strings
+++ b/AndBible/ru.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Планы чтения и их статусы";
 "bookmarks_contents" = "Закладки, ярлыки и блокноты";
 "workspaces_contents" = "Рабочие области и окна";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категории синхронизации";
 "sync_error" = "Произошла ошибка при синхронизации с облаком.";
 "sync_cant_fetch" = "Версия базы данных или файла исправления, хранящегося в облаке, выше, чем версия, поддерживаемая этим приложением.";

--- a/AndBible/sk.lproj/Localizable.strings
+++ b/AndBible/sk.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Plány čítania a ich stavy";
 "bookmarks_contents" = "Záložky, Štítky a Študijné zložky";
 "workspaces_contents" = "Pracovné plochy a Okná";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronizačné kategórie";
 "sync_error" = "Vyskytla sa chyba pri synchronizácii s cloudom.";
 "sync_cant_fetch" = "Verzia databázy alebo súboru opravy uložená v cloude je vyššia ako verzia podporovaná touto aplikáciou.";

--- a/AndBible/sl.lproj/Localizable.strings
+++ b/AndBible/sl.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Načrti za branje in njihovo stanje";
 "bookmarks_contents" = "Zaznamki, oznake in študijske beležke";
 "workspaces_contents" = "Delovni prostori in okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije sinhronizacije";
 "sync_error" = "Pri sinhronizaciji v oblaku je prišlo do napake";
 "sync_cant_fetch" = "Različica podatkovne zbirke ali datoteke popravkov, shranjene v oblaku, je višja od različice, ki jo podpira ta aplikacija.";

--- a/AndBible/sr-Latn.lproj/Localizable.strings
+++ b/AndBible/sr-Latn.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Planovi čitanja i njihovi statusi";
 "bookmarks_contents" = "Obeleživači, Oznake i Radne Sveske";
 "workspaces_contents" = "Radne površi i Prozori";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije usklađivanja";
 "sync_error" = "Došlo je do greške tokom usklađivanja u Oblaku";
 "sync_cant_fetch" = "Verzija baze podataka ili zakrpe koje se drže na Oblaku novija je nego ona koju podržava ova aplikacija.";

--- a/AndBible/sr.lproj/Localizable.strings
+++ b/AndBible/sr.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Планови читања и њихови статуси";
 "bookmarks_contents" = "Обележивачи, Ознаке и Радне Свеске";
 "workspaces_contents" = "Радне површи и Прозори";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категорије усклађивања";
 "sync_error" = "Дошло је до грешке током усклађивања у Облаку";
 "sync_cant_fetch" = "Верзија базе података или закрпе које се држе на Облаку новија је него она коју подржава ова апликација.";

--- a/AndBible/sv.lproj/Localizable.strings
+++ b/AndBible/sv.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Läsningsplaner och deras förlopp";
 "bookmarks_contents" = "Bokmärken, etiketter och studieblock";
 "workspaces_contents" = "Arbetsytor och fönster";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorier för synkronisering";
 "sync_error" = "Ett fel uppstod i molnsynkroniseringen";
 "sync_cant_fetch" = "Den molnlagrade databas- eller patch-filens version är högre än den som stöds av denna app.";

--- a/AndBible/ta.lproj/Localizable.strings
+++ b/AndBible/ta.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "வாசிப்பு திட்டங்களும் அதன் நிலைகளும்";
 "bookmarks_contents" = "புக்மார்க்குகள், லேபிள்கள் மற்றும் ஸ்டடி பேடுகள்.";
 "workspaces_contents" = "பணியிடங்கள் மற்றும் சாரளங்கள்";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "ஒத்திசைவு வகைகள்";
 "sync_error" = "மேக சேமிப்பகத்துடன் ஒத்திசைவில் பிழை ஏற்பட்டது";
 "sync_cant_fetch" = "மேக சேமிப்பகத்தில் உள்ள தரவு தளம் அல்லது ஒட்டு கோப்பு இந்த செயலியால் பயன்படுத்தக்கூடிய பதிப்பினை விட முந்தியது ஆகும்.";

--- a/AndBible/te.lproj/Localizable.strings
+++ b/AndBible/te.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "పఠన ప్రణాళికలు మరియు వాటి స్థితిగతులు";
 "bookmarks_contents" = "బుక్‌మార్క్‌లు, లేబుల్‌లు మరియు స్టడీ ప్యాడ్‌లు";
 "workspaces_contents" = "కార్యస్థలాలు మరియు విండోస్";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "సమకాలీకరణ వర్గాలు";
 "sync_error" = "క్లౌడ్ సింక్రొనైజేషన్‌లో లోపం సంభవించింది";
 "sync_cant_fetch" = "క్లౌడ్‌లో నిల్వ చేయబడిన డేటాబేస్ లేదా ప్యాచ్ ఫైల్ వెర్షన్ ఈ యాప్ ద్వారా సపోర్ట్ చేసే దాని కంటే ఎక్కువగా ఉంది.";

--- a/AndBible/tr.lproj/Localizable.strings
+++ b/AndBible/tr.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Okuma planları ve durumları";
 "bookmarks_contents" = "Yer İmleri, Etiketler ve Çalışma Pedleri";
 "workspaces_contents" = "Çalışma Alanları ve Pencereler";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Senkronizasyon kategorileri";
 "sync_error" = "Bulut senkronizasyonunda hata oluştu";
 "sync_cant_fetch" = "Bulutta depolanan veritabanı veya yama dosyasının sürümü, bu uygulama tarafından desteklenenden daha yüksektir.";

--- a/AndBible/uk.lproj/Localizable.strings
+++ b/AndBible/uk.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Плани читання та їх статуси";
 "bookmarks_contents" = "Закладки, мітки та блокноти для навчання";
 "workspaces_contents" = "Робочі області та вікна";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категорії синхронізації";
 "sync_error" = "Сталася помилка синхронізації з хмарою";
 "sync_cant_fetch" = "Версія бази даних або файлу виправлення, що зберігається в хмарі, є вищою за ту, що підтримується цією програмою.";

--- a/AndBible/uz.lproj/Localizable.strings
+++ b/AndBible/uz.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/AndBible/yue.lproj/Localizable.strings
+++ b/AndBible/yue.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "讀經計劃及其狀態";
 "bookmarks_contents" = "書籤、標籤及研習筆記";
 "workspaces_contents" = "工作區及視窗";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步類別";
 "sync_error" = "雲端同步時發生錯誤";
 "sync_cant_fetch" = "雲端上資料庫或修補文件版本，高於此程式的支援。";

--- a/AndBible/zh-Hans.lproj/Localizable.strings
+++ b/AndBible/zh-Hans.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "读经计划和相应状态";
 "bookmarks_contents" = "书签、标签、研经笔记";
 "workspaces_contents" = "工作空间与窗口";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步类别";
 "sync_error" = "云同步发生报错";
 "sync_cant_fetch" = "云端的数据库或补丁文件版本，高于软件支持的版本。";

--- a/AndBible/zh-Hant.lproj/Localizable.strings
+++ b/AndBible/zh-Hant.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "reading_plans_content" = "讀經計劃及其狀態";
 "bookmarks_contents" = "書籤、標籤及研習筆記";
 "workspaces_contents" = "工作區及視窗";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步類別";
 "sync_error" = "雲端同步時發生錯誤";
 "sync_cant_fetch" = "雲端上資料庫或修補文件版本，高於此程式的支援。";

--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -1,0 +1,602 @@
+// RemoteSyncMyDocumentRestoreTests.swift -- Android My Documents initial-backup restore tests
+
+import XCTest
+import SQLite3
+import SwiftData
+@testable import BibleCore
+
+private let myDocumentRestoreSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
+    func testRemoteSyncMyDocumentRestoreReplacesLocalGraphAndPreservesAIContext() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let store = MyDocumentStore(modelContext: modelContext)
+        modelContext.insert(MyDocument(name: "Legacy", initials: "LEGACY"))
+        try modelContext.save()
+
+        let documentID = UUID(uuidString: "a1000000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a1000000-0000-0000-0000-000000000011")!
+        let promptID = UUID(uuidString: "a1000000-0000-0000-0000-000000000021")!
+        let createdAt = Date(timeIntervalSince1970: 1_735_689_600)
+        let updatedAt = Date(timeIntervalSince1970: 1_735_689_660)
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: [
+                .init(
+                    id: documentID,
+                    name: "Android Document",
+                    documentDescription: "Imported",
+                    initials: "MYDOC",
+                    orderNumber: 2,
+                    createdAt: createdAt,
+                    updatedAt: updatedAt,
+                    sourcePromptId: nil
+                )
+            ],
+            pages: [
+                .init(
+                    id: pageID,
+                    documentId: documentID,
+                    title: "Intro",
+                    pageKey: "intro",
+                    contentType: .markdown,
+                    orderNumber: 1,
+                    createdAt: createdAt,
+                    updatedAt: updatedAt,
+                    sourcePromptId: promptID,
+                    languageCode: "en"
+                )
+            ],
+            pageContents: [
+                .init(pageId: pageID, content: "Restored **markdown**")
+            ],
+            aiPageCacheEntries: [
+                .init(
+                    pageId: pageID,
+                    sourcePromptId: promptID,
+                    sourceContext: #"{"osisRef":"Gen.1"}"#,
+                    kjvOrdinalStart: 1,
+                    kjvOrdinalEnd: 31,
+                    contextHash: "ctx-hash",
+                    usedWriteTools: true,
+                    sourceModelName: "gpt-test",
+                    sourceBookInitials: "KJV",
+                    sourceBookKey: "Gen.1"
+                )
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = RemoteSyncMyDocumentRestoreService()
+        let snapshot = try service.readSnapshot(from: databaseURL)
+        let report = try service.replaceLocalMyDocuments(from: snapshot, modelContext: modelContext)
+
+        XCTAssertEqual(
+            report,
+            .init(
+                restoredDocumentCount: 1,
+                restoredPageCount: 1,
+                restoredContentCount: 1,
+                restoredAIPageCacheEntryCount: 1
+            )
+        )
+        XCTAssertNil(store.document(initials: "LEGACY"))
+
+        let payload = try XCTUnwrap(store.rawContentPayload(bookInitials: "MYDOC", pageKey: "intro"))
+        XCTAssertEqual(payload.pageId, pageID.uuidString)
+        XCTAssertEqual(payload.contentType, "MARKDOWN")
+        XCTAssertEqual(payload.content, "Restored **markdown**")
+        XCTAssertEqual(payload.title, "Intro")
+        XCTAssertEqual(payload.sourcePromptId, promptID.uuidString)
+
+        let actionContext = try XCTUnwrap(store.aiPageActionContext(pageId: pageID))
+        XCTAssertEqual(actionContext.documentId, documentID)
+        XCTAssertEqual(actionContext.sourcePromptId, promptID)
+        XCTAssertEqual(actionContext.sourceContext, #"{"osisRef":"Gen.1"}"#)
+        XCTAssertEqual(actionContext.kjvOrdinalStart, 1)
+        XCTAssertEqual(actionContext.kjvOrdinalEnd, 31)
+        XCTAssertEqual(actionContext.contextHash, "ctx-hash")
+        XCTAssertTrue(actionContext.usedWriteTools)
+        XCTAssertEqual(actionContext.sourceModelName, "gpt-test")
+        XCTAssertEqual(actionContext.sourceBookInitials, "KJV")
+        XCTAssertEqual(actionContext.sourceBookKey, "Gen.1")
+
+        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
+        XCTAssertEqual(documents.map(\.id), [documentID])
+        XCTAssertEqual(documents[0].createdAt, createdAt)
+        XCTAssertEqual(documents[0].updatedAt, updatedAt)
+    }
+
+    func testRemoteSyncMyDocumentRestoreRejectsOrphansWithoutMutation() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let existingDocument = MyDocument(name: "Existing", initials: "EXISTING")
+        modelContext.insert(existingDocument)
+        try modelContext.save()
+
+        let orphanPageID = UUID(uuidString: "b1000000-0000-0000-0000-000000000011")!
+        let missingDocumentID = UUID(uuidString: "b1000000-0000-0000-0000-000000000099")!
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: [],
+            pages: [
+                .init(
+                    id: orphanPageID,
+                    documentId: missingDocumentID,
+                    title: "Orphan",
+                    pageKey: "orphan",
+                    contentType: .markdown
+                )
+            ],
+            pageContents: [],
+            aiPageCacheEntries: []
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = RemoteSyncMyDocumentRestoreService()
+        let snapshot = try service.readSnapshot(from: databaseURL)
+        XCTAssertThrowsError(
+            try service.replaceLocalMyDocuments(from: snapshot, modelContext: modelContext)
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncMyDocumentRestoreError,
+                .orphanReferences([
+                    "MyDocumentPage.id=\(orphanPageID.uuidString) missing MyDocument"
+                ])
+            )
+        }
+
+        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
+        XCTAssertEqual(documents.map(\.initials), ["EXISTING"])
+    }
+
+    func testRemoteSyncMyDocumentRestoreRejectsMalformedContentType() throws {
+        let documentID = UUID(uuidString: "d1000000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "d1000000-0000-0000-0000-000000000011")!
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: [
+                .init(id: documentID, name: "Malformed", initials: "BAD")
+            ],
+            pages: [
+                .init(
+                    id: pageID,
+                    documentId: documentID,
+                    title: "Malformed Page",
+                    pageKey: "bad",
+                    contentTypeRawValue: "PDF"
+                )
+            ],
+            pageContents: [],
+            aiPageCacheEntries: []
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = RemoteSyncMyDocumentRestoreService()
+        XCTAssertThrowsError(try service.readSnapshot(from: databaseURL)) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncMyDocumentRestoreError,
+                .invalidColumnValue(table: "MyDocumentPage", column: "contentType")
+            )
+        }
+    }
+
+    func testRemoteSyncInitialBackupRestoreDispatchesMyDocumentBackups() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let dispatcher = RemoteSyncInitialBackupRestoreService()
+        let documentID = UUID(uuidString: "c1000000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "c1000000-0000-0000-0000-000000000011")!
+        let promptID = UUID(uuidString: "c1000000-0000-0000-0000-000000000021")!
+        let logEntry = RemoteSyncLogEntry(
+            tableName: "MyDocument",
+            entityID1: .blob(uuidBlob(documentID)),
+            entityID2: .text(""),
+            type: .upsert,
+            lastUpdated: 1_735_689_600_000,
+            sourceDevice: "pixel"
+        )
+        let patchStatus = RemoteSyncPatchStatus(
+            sourceDevice: "pixel",
+            patchNumber: 3,
+            sizeBytes: 2_048,
+            appliedDate: 1_735_689_650_000
+        )
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: [
+                .init(id: documentID, name: "Dispatch", initials: "DISP")
+            ],
+            pages: [
+                .init(
+                    id: pageID,
+                    documentId: documentID,
+                    title: "Dispatch Page",
+                    pageKey: "dispatch",
+                    contentType: .html,
+                    sourcePromptId: promptID
+                )
+            ],
+            pageContents: [
+                .init(pageId: pageID, content: "<p>Dispatch</p>")
+            ],
+            aiPageCacheEntries: [
+                .init(pageId: pageID, sourcePromptId: promptID)
+            ],
+            logEntries: [logEntry],
+            syncStatuses: [patchStatus]
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let report = try dispatcher.restoreInitialBackup(
+            RemoteSyncStagedInitialBackup(
+                remoteFile: RemoteSyncFile(
+                    id: "/org.andbible.ios-sync-mydocuments/initial.sqlite3.gz",
+                    name: "initial.sqlite3.gz",
+                    size: 4_096,
+                    timestamp: 1_735_689_600_000,
+                    parentID: "/org.andbible.ios-sync-mydocuments",
+                    mimeType: "application/gzip"
+                ),
+                databaseFileURL: databaseURL,
+                schemaVersion: 4
+            ),
+            category: .myDocuments,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(
+            report,
+            .myDocuments(
+                .init(
+                    restoredDocumentCount: 1,
+                    restoredPageCount: 1,
+                    restoredContentCount: 1,
+                    restoredAIPageCacheEntryCount: 1
+                )
+            )
+        )
+
+        let store = MyDocumentStore(modelContext: modelContext)
+        XCTAssertEqual(
+            store.rawContentPayload(bookInitials: "DISP", pageKey: "dispatch")?.content,
+            "<p>Dispatch</p>"
+        )
+        XCTAssertEqual(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .myDocuments),
+            [logEntry]
+        )
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments),
+            [patchStatus]
+        )
+    }
+
+    private func makeModelContainer() throws -> ModelContainer {
+        let schema = Schema([
+            MyDocument.self,
+            MyDocumentPage.self,
+            MyDocumentPageContent.self,
+            AiPageCacheEntry.self,
+            Setting.self,
+        ])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    private func makeAndroidMyDocumentsDatabase(
+        documents: [AndroidMyDocumentRow],
+        pages: [AndroidMyDocumentPageRow],
+        pageContents: [AndroidMyDocumentPageContentRow],
+        aiPageCacheEntries: [AndroidAiPageCacheEntryRow],
+        logEntries: [RemoteSyncLogEntry] = [],
+        syncStatuses: [RemoteSyncPatchStatus] = [],
+        schemaVersion: Int = RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+    ) throws -> URL {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("android-mydocuments-\(UUID().uuidString).sqlite3")
+
+        var db: OpaquePointer?
+        guard sqlite3_open(databaseURL.path, &db) == SQLITE_OK, let db else {
+            XCTFail("Failed to open temporary Android My Documents database")
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+        defer { XCTAssertEqual(sqlite3_close(db), SQLITE_OK) }
+
+        let schemaSQL = """
+        PRAGMA user_version = \(schemaVersion);
+        CREATE TABLE MyDocument (
+            id BLOB NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            initials TEXT NOT NULL,
+            orderNumber INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            updatedAt INTEGER NOT NULL,
+            sourcePromptId BLOB
+        );
+        CREATE TABLE MyDocumentPage (
+            id BLOB NOT NULL PRIMARY KEY,
+            documentId BLOB NOT NULL,
+            title TEXT NOT NULL,
+            pageKey TEXT NOT NULL,
+            contentType TEXT NOT NULL,
+            orderNumber INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            updatedAt INTEGER NOT NULL,
+            sourcePromptId BLOB,
+            languageCode TEXT
+        );
+        CREATE TABLE MyDocumentPageContent (
+            pageId BLOB NOT NULL PRIMARY KEY,
+            content TEXT NOT NULL
+        );
+        CREATE TABLE AiPageCacheEntry (
+            pageId BLOB NOT NULL PRIMARY KEY,
+            sourcePromptId BLOB NOT NULL,
+            sourceContext TEXT,
+            kjvOrdinalStart INTEGER,
+            kjvOrdinalEnd INTEGER,
+            contextHash TEXT,
+            usedWriteTools INTEGER NOT NULL,
+            sourceModelName TEXT,
+            sourceBookInitials TEXT,
+            sourceBookKey TEXT
+        );
+        CREATE TABLE LogEntry (
+            tableName TEXT NOT NULL,
+            entityId1 BLOB NOT NULL,
+            entityId2 BLOB NOT NULL DEFAULT '',
+            type TEXT NOT NULL,
+            lastUpdated INTEGER NOT NULL,
+            sourceDevice TEXT NOT NULL
+        );
+        CREATE TABLE SyncStatus (
+            sourceDevice TEXT NOT NULL,
+            patchNumber INTEGER NOT NULL,
+            sizeBytes INTEGER NOT NULL,
+            appliedDate INTEGER NOT NULL,
+            PRIMARY KEY(sourceDevice, patchNumber)
+        );
+        """
+        XCTAssertEqual(sqlite3_exec(db, schemaSQL, nil, nil, nil), SQLITE_OK, String(cString: sqlite3_errmsg(db)))
+
+        for document in documents {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO MyDocument (id, name, description, initials, orderNumber, createdAt, updatedAt, sourcePromptId) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            bindUUIDBlob(document.id, to: statement, index: 1)
+            sqlite3_bind_text(statement, 2, document.name, -1, myDocumentRestoreSQLiteTransient)
+            bindOptionalText(document.documentDescription, to: statement, index: 3)
+            sqlite3_bind_text(statement, 4, document.initials, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_int(statement, 5, Int32(document.orderNumber))
+            bindDate(document.createdAt, to: statement, index: 6)
+            bindDate(document.updatedAt, to: statement, index: 7)
+            bindOptionalUUIDBlob(document.sourcePromptId, to: statement, index: 8)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        for page in pages {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO MyDocumentPage (id, documentId, title, pageKey, contentType, orderNumber, createdAt, updatedAt, sourcePromptId, languageCode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            bindUUIDBlob(page.id, to: statement, index: 1)
+            bindUUIDBlob(page.documentId, to: statement, index: 2)
+            sqlite3_bind_text(statement, 3, page.title, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_text(statement, 4, page.pageKey, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_text(statement, 5, page.contentTypeRawValue ?? page.contentType.rawValue, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_int(statement, 6, Int32(page.orderNumber))
+            bindDate(page.createdAt, to: statement, index: 7)
+            bindDate(page.updatedAt, to: statement, index: 8)
+            bindOptionalUUIDBlob(page.sourcePromptId, to: statement, index: 9)
+            bindOptionalText(page.languageCode, to: statement, index: 10)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        for content in pageContents {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO MyDocumentPageContent (pageId, content) VALUES (?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            bindUUIDBlob(content.pageId, to: statement, index: 1)
+            sqlite3_bind_text(statement, 2, content.content, -1, myDocumentRestoreSQLiteTransient)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        for cacheEntry in aiPageCacheEntries {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO AiPageCacheEntry (pageId, sourcePromptId, sourceContext, kjvOrdinalStart, kjvOrdinalEnd, contextHash, usedWriteTools, sourceModelName, sourceBookInitials, sourceBookKey) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            bindUUIDBlob(cacheEntry.pageId, to: statement, index: 1)
+            bindUUIDBlob(cacheEntry.sourcePromptId, to: statement, index: 2)
+            bindOptionalText(cacheEntry.sourceContext, to: statement, index: 3)
+            bindOptionalInt(cacheEntry.kjvOrdinalStart, to: statement, index: 4)
+            bindOptionalInt(cacheEntry.kjvOrdinalEnd, to: statement, index: 5)
+            bindOptionalText(cacheEntry.contextHash, to: statement, index: 6)
+            sqlite3_bind_int(statement, 7, cacheEntry.usedWriteTools ? 1 : 0)
+            bindOptionalText(cacheEntry.sourceModelName, to: statement, index: 8)
+            bindOptionalText(cacheEntry.sourceBookInitials, to: statement, index: 9)
+            bindOptionalText(cacheEntry.sourceBookKey, to: statement, index: 10)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        for logEntry in logEntries {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice) VALUES (?, ?, ?, ?, ?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            sqlite3_bind_text(statement, 1, logEntry.tableName, -1, myDocumentRestoreSQLiteTransient)
+            bindSQLiteValue(logEntry.entityID1, to: statement, index: 2)
+            bindSQLiteValue(logEntry.entityID2, to: statement, index: 3)
+            sqlite3_bind_text(statement, 4, logEntry.type.rawValue, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_int64(statement, 5, logEntry.lastUpdated)
+            sqlite3_bind_text(statement, 6, logEntry.sourceDevice, -1, myDocumentRestoreSQLiteTransient)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        for syncStatus in syncStatuses {
+            var statement: OpaquePointer?
+            XCTAssertEqual(
+                sqlite3_prepare_v2(
+                    db,
+                    "INSERT INTO SyncStatus (sourceDevice, patchNumber, sizeBytes, appliedDate) VALUES (?, ?, ?, ?)",
+                    -1,
+                    &statement,
+                    nil
+                ),
+                SQLITE_OK
+            )
+            sqlite3_bind_text(statement, 1, syncStatus.sourceDevice, -1, myDocumentRestoreSQLiteTransient)
+            sqlite3_bind_int64(statement, 2, syncStatus.patchNumber)
+            sqlite3_bind_int64(statement, 3, syncStatus.sizeBytes)
+            sqlite3_bind_int64(statement, 4, syncStatus.appliedDate)
+            XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+            sqlite3_finalize(statement)
+        }
+
+        return databaseURL
+    }
+
+    private struct AndroidMyDocumentRow {
+        let id: UUID
+        let name: String
+        var documentDescription: String? = nil
+        let initials: String
+        var orderNumber: Int = 0
+        var createdAt: Date = Date(timeIntervalSince1970: 1_735_689_600)
+        var updatedAt: Date = Date(timeIntervalSince1970: 1_735_689_600)
+        var sourcePromptId: UUID? = nil
+    }
+
+    private struct AndroidMyDocumentPageRow {
+        let id: UUID
+        let documentId: UUID
+        let title: String
+        let pageKey: String
+        var contentType: MyDocumentContentType = .markdown
+        var contentTypeRawValue: String? = nil
+        var orderNumber: Int = 0
+        var createdAt: Date = Date(timeIntervalSince1970: 1_735_689_600)
+        var updatedAt: Date = Date(timeIntervalSince1970: 1_735_689_600)
+        var sourcePromptId: UUID? = nil
+        var languageCode: String? = nil
+    }
+
+    private struct AndroidMyDocumentPageContentRow {
+        let pageId: UUID
+        let content: String
+    }
+
+    private struct AndroidAiPageCacheEntryRow {
+        let pageId: UUID
+        let sourcePromptId: UUID
+        var sourceContext: String? = nil
+        var kjvOrdinalStart: Int? = nil
+        var kjvOrdinalEnd: Int? = nil
+        var contextHash: String? = nil
+        var usedWriteTools: Bool = false
+        var sourceModelName: String? = nil
+        var sourceBookInitials: String? = nil
+        var sourceBookKey: String? = nil
+    }
+
+    private func bindUUIDBlob(_ value: UUID, to statement: OpaquePointer?, index: Int32) {
+        let blob = uuidBlob(value)
+        _ = blob.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(statement, index, bytes.baseAddress, Int32(blob.count), myDocumentRestoreSQLiteTransient)
+        }
+    }
+
+    private func bindOptionalUUIDBlob(_ value: UUID?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        bindUUIDBlob(value, to: statement, index: index)
+    }
+
+    private func bindSQLiteValue(_ value: RemoteSyncSQLiteValue, to statement: OpaquePointer?, index: Int32) {
+        switch value.kind {
+        case .null:
+            sqlite3_bind_null(statement, index)
+        case .integer:
+            sqlite3_bind_int64(statement, index, value.integerValue ?? 0)
+        case .real:
+            sqlite3_bind_double(statement, index, value.realValue ?? 0)
+        case .text:
+            sqlite3_bind_text(statement, index, value.textValue ?? "", -1, myDocumentRestoreSQLiteTransient)
+        case .blob:
+            let data = value.blobData ?? Data()
+            _ = data.withUnsafeBytes { bytes in
+                sqlite3_bind_blob(statement, index, bytes.baseAddress, Int32(data.count), myDocumentRestoreSQLiteTransient)
+            }
+        }
+    }
+
+    private func bindDate(_ value: Date, to statement: OpaquePointer?, index: Int32) {
+        sqlite3_bind_int64(statement, index, Int64(value.timeIntervalSince1970 * 1000.0))
+    }
+
+    private func bindOptionalText(_ value: String?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        sqlite3_bind_text(statement, index, value, -1, myDocumentRestoreSQLiteTransient)
+    }
+
+    private func bindOptionalInt(_ value: Int?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        sqlite3_bind_int(statement, index, Int32(value))
+    }
+
+    private func uuidBlob(_ value: UUID) -> Data {
+        var uuid = value.uuid
+        return withUnsafeBytes(of: &uuid) { Data($0) }
+    }
+}

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -3174,7 +3174,7 @@ final class AndBibleUITests: XCTestCase {
      * - Side effects:
      *   - reveals Search options when needed and taps the translation picker button
      * - Failure modes:
-     *   - fails when the translation picker affordance is not exposed by Search
+     *   - fails when the translation picker affordance does not open the picker
      */
     private func tapSearchTranslationPicker(
         in app: XCUIApplication,
@@ -3183,6 +3183,10 @@ final class AndBibleUITests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
 
         repeat {
+            if searchTranslationPickerIsOpen(in: app, timeout: 0.2) {
+                return
+            }
+
             dismissSearchFieldFocusIfNeeded(in: app)
             revealSearchControls(in: app)
             let searchScreen = unresolvedElement("searchScreen", in: app)
@@ -3198,13 +3202,31 @@ final class AndBibleUITests: XCTestCase {
                     && waitForElementToBecomeHittable($0, timeout: 0.5)
             }) {
                 picker.tap()
-                return
+                if searchTranslationPickerIsOpen(in: app, timeout: 2) {
+                    return
+                }
             }
 
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        XCTFail("Expected Search translation picker button to exist within \(timeout) seconds.")
+        XCTFail("Expected Search translation picker to open within \(timeout) seconds.")
+    }
+
+    /// Returns true once the Search translation picker sheet has exposed any stable child element.
+    private func searchTranslationPickerIsOpen(
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> Bool {
+        firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: timeout) != nil
+    }
+
+    /// Returns stable picker descendants that prove the Search translation picker sheet is open.
+    private func searchTranslationPickerOpenCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.buttons["searchTranslationDoneButton"].firstMatch,
+            app.navigationBars.buttons["searchTranslationDoneButton"].firstMatch,
+        ] + searchTranslationPickerListCandidates(in: app)
     }
 
     /**

--- a/Localizations/af.lproj/Localizable.strings
+++ b/Localizations/af.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Lees planne en hul statusse";
 "bookmarks_contents" = "Boekmerke, etikette en studieblokkies";
 "workspaces_contents" = "Werkspasies en Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sinchronisasie kategorieë";
 "sync_error" = "Fout het voorgekom in Clud sinchronisasie";
 "sync_cant_fetch" = "";

--- a/Localizations/ar.lproj/Localizable.strings
+++ b/Localizations/ar.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "فئات المزامنة";
 "sync_error" = "حدث خطأ في المزامنة السحابية";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/az.lproj/Localizable.strings
+++ b/Localizations/az.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/bg.lproj/Localizable.strings
+++ b/Localizations/bg.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/bn.lproj/Localizable.strings
+++ b/Localizations/bn.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "পরিকল্পনা এবং তাদের অবস্থা পড়া";
 "bookmarks_contents" = "বুকমার্ক, লেবেল এবং স্টাডি প্যাড";
 "workspaces_contents" = "ওয়ার্কস্পেস এবং উইন্ডোজ";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "সিঙ্ক্রোনাইজেশন বিভাগ";
 "sync_error" = "ক্লাউড সিঙ্ক্রোনাইজেশনে ত্রুটি ঘটেছে৷";
 "sync_cant_fetch" = "ক্লাউডে সংরক্ষিত ডাটাবেস বা প্যাচ ফাইলের সংস্করণ এই অ্যাপ দ্বারা সমর্থিত সংস্করণের চেয়ে বেশি।";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Plány čtení a jejich stav";
 "bookmarks_contents" = "Záložky, štítky a studijní složky";
 "workspaces_contents" = "Pracovní prochy a okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorie synchronizace";
 "sync_error" = "Nastala chyba při synchronizaci";
 "sync_cant_fetch" = "Verze databáze nebo souboru opravy uložená na síti je vyšší než verze podporovaná touto aplikací.";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Lesepläne und ihr Stand";
 "bookmarks_contents" = "Lesezeichen, Labels und Studienmappen";
 "workspaces_contents" = "Arbeitsumgebungen und Fenster";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronisationskategorien";
 "sync_error" = "Fehler bei der Synchronisation mit der Cloud";
 "sync_cant_fetch" = "Die in der Cloud gespeicherte Datenbankversion ist höher, als die Anwendung auf dem lokalen Gerät unterstützt.";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Σχέδια ανάγνωσης και η κατάσταση τους";
 "bookmarks_contents" = "Σελιδοδείκτες, Ετικέτες και Μπλοκ Μελέτης";
 "workspaces_contents" = "Χώροι εργασίας και Παράθυρα";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Κατηγορίες συγχρονισμού";
 "sync_error" = "Σφάλμα κατα τον συγχρονισμο cloud";
 "sync_cant_fetch" = "Η έκδοση της βάσης ή του αρχείου επιδιόρθωσης που βρίσκεται στο cloud είναι υψηλότερη της υποστηριζόμενης από αυτή την εφαρμογή";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -585,6 +585,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/eo.lproj/Localizable.strings
+++ b/Localizations/eo.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "legplanoj kun iliaj progresoj";
 "bookmarks_contents" = "legosignoj, etikedoj, notblokoj";
 "workspaces_contents" = "laborspacoj kaj fenestroj";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorioj de samtempigo";
 "sync_error" = "Eraro okazis dum samtempigi kun nubo";
 "sync_cant_fetch" = "La versio de datumbazo aŭ dosiero konservita en la nubo estas pli alta ol versio subtenata per tiu ĉi aplikaĵo.";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planes de lectura y sus estados";
 "bookmarks_contents" = "Marcadores, Etiquetas y Pizarras de Estudio";
 "workspaces_contents" = "Espacios de trabajo y Ventanas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorías de sincronización";
 "sync_error" = "Error ocurrido en la sincronización con la nube";
 "sync_cant_fetch" = "La versión de base de datos o archivo almacenado en la nube es más alta que la que soporta esta aplicación.";

--- a/Localizations/et.lproj/Localizable.strings
+++ b/Localizations/et.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Järjehoidjad, sildid ja õppemärkmikud";
 "workspaces_contents" = "Tööalad ja Aknad";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sünkroonimise kategooriad";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/fi.lproj/Localizable.strings
+++ b/Localizations/fi.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Lukusuunnitelmat ja niiden tila";
 "bookmarks_contents" = "Kirjanmerkit, kirjanmerkkiryhmät ja opintoalustat";
 "workspaces_contents" = "Työtilat ja ikkunat";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synkronoinnin kategoriat";
 "sync_error" = "Virhe tapahtui synkronoidessa pilvipalveluun";
 "sync_cant_fetch" = "Pilvipalvelussa olevan tietokannan tai patch-tiedoston versio on uudempi kuin se mitä tämä sovellus tukee.";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Les plans de lecture et leurs statuts";
 "bookmarks_contents" = "Marque-pages, étiquettes, et bloc-notes";
 "workspaces_contents" = "Espaces et fenêtres";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Catégories à synchroniser";
 "sync_error" = "Une erreur est survenue durant la synchronisation du Cloud";
 "sync_cant_fetch" = "La version de la base de données ou du fichier patch stockée dans le Nuage est supérieure à celle prise en charge par cette application.";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "סביבות עבודה וחלונות";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "קטגוריות לסנכרון";
 "sync_error" = "שגיאה בסנכרון לענן";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/hi.lproj/Localizable.strings
+++ b/Localizations/hi.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/hr.lproj/Localizable.strings
+++ b/Localizations/hr.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planovi čitanja i njihovi statusi";
 "bookmarks_contents" = "Straničnici, Oznake i Radne bilježnice";
 "workspaces_contents" = "Radne površine i Prozori";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije usklađivanja";
 "sync_error" = "Došlo je do pogreške tijekom usklađivanja u oblaku";
 "sync_cant_fetch" = "Verzija baze podataka ili zakrpe koje se drže na oblaku novija je nego ona koju podržava ova aplikacija.";

--- a/Localizations/hu.lproj/Localizable.strings
+++ b/Localizations/hu.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Olvasási tervek és állapotuk";
 "bookmarks_contents" = "Könyvjelzők, Címkék és Jegyzetlapok";
 "workspaces_contents" = "Munkaterületek és ablakok";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Összehangolási kategóriák";
 "sync_error" = "Hiba történt a felhővel való összehangolás közben";
 "sync_cant_fetch" = "A tárhelyen található adatbázis vagy frissítés verziója magasabb mint az alkalmazásé.";

--- a/Localizations/id.lproj/Localizable.strings
+++ b/Localizations/id.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/it.lproj/Localizable.strings
+++ b/Localizations/it.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Piani di lettura e loro stati";
 "bookmarks_contents" = "Segnalibri, Etichette e Appunti di Studio";
 "workspaces_contents" = "Spazi di Lavoro e Finestre";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorie di sincronizzazione";
 "sync_error" = "Errore nella sincronizzazione del Cloud";
 "sync_cant_fetch" = "La versione del database o del file patch memorizzato nel Cloud è superiore a quella supportata da questa app.";

--- a/Localizations/kk.lproj/Localizable.strings
+++ b/Localizations/kk.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Оқу жоспарлары және олардың күйлері";
 "bookmarks_contents" = "Бетбелгілер, белгілер және оқу тақталары";
 "workspaces_contents" = "Жұмыс кеңістігі және Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Синхрондау категориялары";
 "sync_error" = "Бұлтты синхрондауда қателік орын алды";
 "sync_cant_fetch" = "Бұлтта сақталған дерекқордың немесе патч файлының нұсқасы осы қолданба қолдайтын нұсқасынан жоғары.";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/lt.lproj/Localizable.strings
+++ b/Localizations/lt.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Skaitymo planai ir jų būsena";
 "bookmarks_contents" = "Žymės, etiketės ir bloknotai";
 "workspaces_contents" = "Darbo sritys ir langai";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Sinchronizavimo kategorijos";
 "sync_error" = "Įvyko klaida debesijos sinchronizavime";
 "sync_cant_fetch" = "Debesijoje saugomo duomenų bazės ar pataisos failo versija yra didesnė, nei palaiko ši programėlė.";

--- a/Localizations/ml.lproj/Localizable.strings
+++ b/Localizations/ml.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/my.lproj/Localizable.strings
+++ b/Localizations/my.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/nb.lproj/Localizable.strings
+++ b/Localizations/nb.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/nl.lproj/Localizable.strings
+++ b/Localizations/nl.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Leesplannen en hun statussen";
 "bookmarks_contents" = "Bladwijzers, Labels en Studiepaden";
 "workspaces_contents" = "Werkplek en Vensters";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronisatie categorieën";
 "sync_error" = "Er is een fout opgetreden bij de cloudsynchronisatie";
 "sync_cant_fetch" = "De Cloud-versie van de database of het patch bestand is hoger dan deze app ondersteund.";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "plany czytania wraz z postępami";
 "bookmarks_contents" = "zakładki, etykiety, bloczki notatek";
 "workspaces_contents" = "obszary robocze i okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorie synchronizacji";
 "sync_error" = "Wystąpił błąd podczas synchronizacji z chmurą.";
 "sync_cant_fetch" = "Wersja bazy danych lub pliku przechowywana w chmurze jest wyższa niż wersja wspierana przez tą aplikację.";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planos de leitura e seus status";
 "bookmarks_contents" = "Conteúdo dos favoritos";
 "workspaces_contents" = "Áreas de trabalho e Janelas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorias de sincronização";
 "sync_error" = "Ocorreu um erro de sincronização na Nuvem";
 "sync_cant_fetch" = "A versão do banco de dados ou arquivo de patch armazenado na nuvem é maior do que a suportada por este aplicativo.";

--- a/Localizations/pt.lproj/Localizable.strings
+++ b/Localizations/pt.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planos de leitura e seus status";
 "bookmarks_contents" = "Conteúdo dos favoritos";
 "workspaces_contents" = "Áreas de trabalho e Janelas";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorias de sincronização";
 "sync_error" = "Ocorreu um erro de sincronização na Nuvem";
 "sync_cant_fetch" = "A versão da base de dados ou do ficheiro de correção armazenado na Nuvem é superior à suportada por esta aplicação.";

--- a/Localizations/ro.lproj/Localizable.strings
+++ b/Localizations/ro.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planuri de lectură și starea acestora";
 "bookmarks_contents" = "Semne de carte, Etichete și Notițe de studiu";
 "workspaces_contents" = "Spații de studiu și Ferestre";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Categorii de sincronizare";
 "sync_error" = "A apărut o eroare în sincronizarea Cloud";
 "sync_cant_fetch" = "Versiunea bazei de date sau a fișierului stocat în Cloud este mai mare decît cea acceptată de această aplicație.";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Планы чтения и их статусы";
 "bookmarks_contents" = "Закладки, ярлыки и блокноты";
 "workspaces_contents" = "Рабочие области и окна";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категории синхронизации";
 "sync_error" = "Произошла ошибка при синхронизации с облаком.";
 "sync_cant_fetch" = "Версия базы данных или файла исправления, хранящегося в облаке, выше, чем версия, поддерживаемая этим приложением.";

--- a/Localizations/sk.lproj/Localizable.strings
+++ b/Localizations/sk.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Plány čítania a ich stavy";
 "bookmarks_contents" = "Záložky, Štítky a Študijné zložky";
 "workspaces_contents" = "Pracovné plochy a Okná";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronizačné kategórie";
 "sync_error" = "Vyskytla sa chyba pri synchronizácii s cloudom.";
 "sync_cant_fetch" = "Verzia databázy alebo súboru opravy uložená v cloude je vyššia ako verzia podporovaná touto aplikáciou.";

--- a/Localizations/sl.lproj/Localizable.strings
+++ b/Localizations/sl.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Načrti za branje in njihovo stanje";
 "bookmarks_contents" = "Zaznamki, oznake in študijske beležke";
 "workspaces_contents" = "Delovni prostori in okna";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije sinhronizacije";
 "sync_error" = "Pri sinhronizaciji v oblaku je prišlo do napake";
 "sync_cant_fetch" = "Različica podatkovne zbirke ali datoteke popravkov, shranjene v oblaku, je višja od različice, ki jo podpira ta aplikacija.";

--- a/Localizations/sr-Latn.lproj/Localizable.strings
+++ b/Localizations/sr-Latn.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Planovi čitanja i njihovi statusi";
 "bookmarks_contents" = "Obeleživači, Oznake i Radne Sveske";
 "workspaces_contents" = "Radne površi i Prozori";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorije usklađivanja";
 "sync_error" = "Došlo je do greške tokom usklađivanja u Oblaku";
 "sync_cant_fetch" = "Verzija baze podataka ili zakrpe koje se drže na Oblaku novija je nego ona koju podržava ova aplikacija.";

--- a/Localizations/sr.lproj/Localizable.strings
+++ b/Localizations/sr.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Планови читања и њихови статуси";
 "bookmarks_contents" = "Обележивачи, Ознаке и Радне Свеске";
 "workspaces_contents" = "Радне површи и Прозори";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категорије усклађивања";
 "sync_error" = "Дошло је до грешке током усклађивања у Облаку";
 "sync_cant_fetch" = "Верзија базе података или закрпе које се држе на Облаку новија је него она коју подржава ова апликација.";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Läsningsplaner och deras förlopp";
 "bookmarks_contents" = "Bokmärken, etiketter och studieblock";
 "workspaces_contents" = "Arbetsytor och fönster";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Kategorier för synkronisering";
 "sync_error" = "Ett fel uppstod i molnsynkroniseringen";
 "sync_cant_fetch" = "Den molnlagrade databas- eller patch-filens version är högre än den som stöds av denna app.";

--- a/Localizations/ta.lproj/Localizable.strings
+++ b/Localizations/ta.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "வாசிப்பு திட்டங்களும் அதன் நிலைகளும்";
 "bookmarks_contents" = "புக்மார்க்குகள், லேபிள்கள் மற்றும் ஸ்டடி பேடுகள்.";
 "workspaces_contents" = "பணியிடங்கள் மற்றும் சாரளங்கள்";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "ஒத்திசைவு வகைகள்";
 "sync_error" = "மேக சேமிப்பகத்துடன் ஒத்திசைவில் பிழை ஏற்பட்டது";
 "sync_cant_fetch" = "மேக சேமிப்பகத்தில் உள்ள தரவு தளம் அல்லது ஒட்டு கோப்பு இந்த செயலியால் பயன்படுத்தக்கூடிய பதிப்பினை விட முந்தியது ஆகும்.";

--- a/Localizations/te.lproj/Localizable.strings
+++ b/Localizations/te.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "పఠన ప్రణాళికలు మరియు వాటి స్థితిగతులు";
 "bookmarks_contents" = "బుక్‌మార్క్‌లు, లేబుల్‌లు మరియు స్టడీ ప్యాడ్‌లు";
 "workspaces_contents" = "కార్యస్థలాలు మరియు విండోస్";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "సమకాలీకరణ వర్గాలు";
 "sync_error" = "క్లౌడ్ సింక్రొనైజేషన్‌లో లోపం సంభవించింది";
 "sync_cant_fetch" = "క్లౌడ్‌లో నిల్వ చేయబడిన డేటాబేస్ లేదా ప్యాచ్ ఫైల్ వెర్షన్ ఈ యాప్ ద్వారా సపోర్ట్ చేసే దాని కంటే ఎక్కువగా ఉంది.";

--- a/Localizations/tr.lproj/Localizable.strings
+++ b/Localizations/tr.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Okuma planları ve durumları";
 "bookmarks_contents" = "Yer İmleri, Etiketler ve Çalışma Pedleri";
 "workspaces_contents" = "Çalışma Alanları ve Pencereler";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Senkronizasyon kategorileri";
 "sync_error" = "Bulut senkronizasyonunda hata oluştu";
 "sync_cant_fetch" = "Bulutta depolanan veritabanı veya yama dosyasının sürümü, bu uygulama tarafından desteklenenden daha yüksektir.";

--- a/Localizations/uk.lproj/Localizable.strings
+++ b/Localizations/uk.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Плани читання та їх статуси";
 "bookmarks_contents" = "Закладки, мітки та блокноти для навчання";
 "workspaces_contents" = "Робочі області та вікна";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Категорії синхронізації";
 "sync_error" = "Сталася помилка синхронізації з хмарою";
 "sync_cant_fetch" = "Версія бази даних або файлу виправлення, що зберігається в хмарі, є вищою за ту, що підтримується цією програмою.";

--- a/Localizations/uz.lproj/Localizable.strings
+++ b/Localizations/uz.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "Reading plans and their statuses";
 "bookmarks_contents" = "Bookmarks, Labels and Study Pads";
 "workspaces_contents" = "Workspaces and Windows";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "Synchronization categories";
 "sync_error" = "Error occurred in Cloud synchronization";
 "sync_cant_fetch" = "The version of database or patch file stored in Cloud is higher than the one supported by this app.";

--- a/Localizations/yue.lproj/Localizable.strings
+++ b/Localizations/yue.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "讀經計劃及其狀態";
 "bookmarks_contents" = "書籤、標籤及研習筆記";
 "workspaces_contents" = "工作區及視窗";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步類別";
 "sync_error" = "雲端同步時發生錯誤";
 "sync_cant_fetch" = "雲端上資料庫或修補文件版本，高於此程式的支援。";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "读经计划和相应状态";
 "bookmarks_contents" = "书签、标签、研经笔记";
 "workspaces_contents" = "工作空间与窗口";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步类别";
 "sync_error" = "云同步发生报错";
 "sync_cant_fetch" = "云端的数据库或补丁文件版本，高于软件支持的版本。";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "reading_plans_content" = "讀經計劃及其狀態";
 "bookmarks_contents" = "書籤、標籤及研習筆記";
 "workspaces_contents" = "工作區及視窗";
+"my_documents" = "My Documents";
+"my_documents_contents" = "My Documents and their pages";
 "synchronization_categories" = "同步類別";
 "sync_error" = "雲端同步時發生錯誤";
 "sync_cant_fetch" = "雲端上資料庫或修補文件版本，高於此程式的支援。";

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
@@ -427,7 +427,7 @@ public final class RemoteSyncBackgroundRefreshCoordinator {
             return false
         }
 
-        return RemoteSyncCategory.allCases.contains {
+        return RemoteSyncCategory.activeSyncCases.contains {
             remoteSettingsStore.isSyncEnabled(for: $0)
         }
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
@@ -18,6 +18,9 @@ public enum RemoteSyncInitialBackupRestoreReport: Sendable, Equatable {
 
     /// Successful restore report for the workspace sync category.
     case workspaces(RemoteSyncWorkspaceRestoreReport)
+
+    /// Successful restore report for the My Documents sync category.
+    case myDocuments(RemoteSyncMyDocumentRestoreReport)
 }
 
 /**
@@ -32,6 +35,7 @@ through one generic SQLite importer.
  - `RemoteSyncBookmarkRestoreService` restores staged Android `bookmarks.sqlite3` backups
  - `RemoteSyncReadingPlanRestoreService` restores staged Android `readingplans.sqlite3` backups
  - `RemoteSyncWorkspaceRestoreService` restores staged Android `workspaces.sqlite3` backups
+ - `RemoteSyncMyDocumentRestoreService` restores staged Android `mydocuments.sqlite3` backups
  - `RemoteSyncInitialBackupMetadataRestoreService` preserves staged Android `LogEntry` and
    `SyncStatus` rows needed for later patch replay
  - `RemoteSyncBookmarkSnapshotService` refreshes outbound bookmark fingerprint baselines after
@@ -62,6 +66,7 @@ public final class RemoteSyncInitialBackupRestoreService {
     private let bookmarkRestoreService: RemoteSyncBookmarkRestoreService
     private let readingPlanRestoreService: RemoteSyncReadingPlanRestoreService
     private let workspaceRestoreService: RemoteSyncWorkspaceRestoreService
+    private let myDocumentRestoreService: RemoteSyncMyDocumentRestoreService
     private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
     private let bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService
     private let workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService
@@ -74,6 +79,7 @@ public final class RemoteSyncInitialBackupRestoreService {
        - bookmarkRestoreService: Restore service used for the bookmark category.
        - readingPlanRestoreService: Restore service used for the reading-plan category.
        - workspaceRestoreService: Restore service used for the workspace category.
+       - myDocumentRestoreService: Restore service used for the My Documents category.
        - metadataRestoreService: Restore service used to preserve Android `LogEntry` and `SyncStatus`
          rows after content restore succeeds.
        - bookmarkSnapshotService: Snapshot service used to refresh outbound bookmark fingerprint
@@ -89,6 +95,7 @@ public final class RemoteSyncInitialBackupRestoreService {
         bookmarkRestoreService: RemoteSyncBookmarkRestoreService = RemoteSyncBookmarkRestoreService(),
         readingPlanRestoreService: RemoteSyncReadingPlanRestoreService = RemoteSyncReadingPlanRestoreService(),
         workspaceRestoreService: RemoteSyncWorkspaceRestoreService = RemoteSyncWorkspaceRestoreService(),
+        myDocumentRestoreService: RemoteSyncMyDocumentRestoreService = RemoteSyncMyDocumentRestoreService(),
         metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
         bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService = RemoteSyncBookmarkSnapshotService(),
         workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService = RemoteSyncWorkspaceSnapshotService(),
@@ -97,6 +104,7 @@ public final class RemoteSyncInitialBackupRestoreService {
         self.bookmarkRestoreService = bookmarkRestoreService
         self.readingPlanRestoreService = readingPlanRestoreService
         self.workspaceRestoreService = workspaceRestoreService
+        self.myDocumentRestoreService = myDocumentRestoreService
         self.metadataRestoreService = metadataRestoreService
         self.bookmarkSnapshotService = bookmarkSnapshotService
         self.workspaceSnapshotService = workspaceSnapshotService
@@ -156,6 +164,13 @@ public final class RemoteSyncInitialBackupRestoreService {
                 settingsStore: settingsStore
             )
             report = .workspaces(workspaceReport)
+        case .myDocuments:
+            let snapshot = try myDocumentRestoreService.readSnapshot(from: stagedBackup.databaseFileURL)
+            let myDocumentReport = try myDocumentRestoreService.replaceLocalMyDocuments(
+                from: snapshot,
+                modelContext: modelContext
+            )
+            report = .myDocuments(myDocumentReport)
         }
 
         _ = metadataRestoreService.replaceLocalMetadata(

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -18,6 +18,9 @@ public enum RemoteSyncInitialBackupUploadError: Error, Equatable {
 
     /// The temporary SQLite database could not be opened or written safely.
     case invalidSQLiteDatabase
+
+    /// The requested category does not yet have an initial-backup export pipeline.
+    case unsupportedCategory(RemoteSyncCategory)
 }
 
 /**
@@ -248,6 +251,8 @@ public final class RemoteSyncInitialBackupUploadService {
                 settingsStore: settingsStore,
                 schemaVersion: schemaVersion
             )
+        case .myDocuments:
+            throw RemoteSyncInitialBackupUploadError.unsupportedCategory(category)
         }
     }
 
@@ -317,6 +322,8 @@ public final class RemoteSyncInitialBackupUploadService {
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
+        case .myDocuments:
+            break
         }
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncLifecycleService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncLifecycleService.swift
@@ -483,12 +483,12 @@ public final class RemoteSyncLifecycleService {
      Returns the enabled remote-sync categories from local settings.
 
      - Parameter remoteSettingsStore: Local remote-sync settings store.
-     - Returns: Enabled categories in Android's declared `allCases` order.
+     - Returns: Enabled categories in the current broad-sync execution order.
      - Side Effects: Reads category toggle state from `RemoteSyncSettingsStore`.
      - Failure modes: Missing toggle values decode as disabled categories.
      */
     private func enabledCategories(using remoteSettingsStore: RemoteSyncSettingsStore) -> [RemoteSyncCategory] {
-        RemoteSyncCategory.allCases.filter { remoteSettingsStore.isSyncEnabled(for: $0) }
+        RemoteSyncCategory.activeSyncCases.filter { remoteSettingsStore.isSyncEnabled(for: $0) }
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
@@ -262,19 +262,20 @@ public final class RemoteSyncMyDocumentRestoreService {
             throw RemoteSyncMyDocumentRestoreError.orphanReferences(snapshot.orphanReferences)
         }
 
-        let existingCacheEntries = (try? modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())) ?? []
+        let existingCacheEntries = try modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())
+        let existingContents = try modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())
+        let existingPages = try modelContext.fetch(FetchDescriptor<MyDocumentPage>())
+        let existingDocuments = try modelContext.fetch(FetchDescriptor<MyDocument>())
+
         for cacheEntry in existingCacheEntries {
             modelContext.delete(cacheEntry)
         }
-        let existingContents = (try? modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())) ?? []
         for content in existingContents {
             modelContext.delete(content)
         }
-        let existingPages = (try? modelContext.fetch(FetchDescriptor<MyDocumentPage>())) ?? []
         for page in existingPages {
             modelContext.delete(page)
         }
-        let existingDocuments = (try? modelContext.fetch(FetchDescriptor<MyDocument>())) ?? []
         for document in existingDocuments {
             modelContext.delete(document)
         }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
@@ -1,0 +1,648 @@
+// RemoteSyncMyDocumentRestoreService.swift -- My Documents initial-backup restore from Android sync databases
+
+import Foundation
+import SQLite3
+import SwiftData
+
+private let remoteSyncMyDocumentSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/**
+ Errors raised while reading or restoring Android My Documents sync databases.
+ */
+public enum RemoteSyncMyDocumentRestoreError: Error, Equatable {
+    /// The staged file could not be opened as a readable SQLite database.
+    case invalidSQLiteDatabase
+
+    /// The staged database requires a newer Android schema than iOS currently supports.
+    case unsupportedSchemaVersion(Int)
+
+    /// The staged database does not contain one of the required Android My Documents tables.
+    case missingTable(String)
+
+    /// One Android UUID-like blob could not be converted into an iOS `UUID`.
+    case invalidIdentifierBlob(table: String, column: String)
+
+    /// One required staged column was missing or contained an unusable value.
+    case invalidColumnValue(table: String, column: String)
+
+    /// One or more staged rows referenced missing parent records.
+    case orphanReferences([String])
+}
+
+/**
+ One Android `MyDocument` row from a staged sync backup.
+ */
+public struct RemoteSyncAndroidMyDocument: Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public let documentDescription: String?
+    public let initials: String
+    public let orderNumber: Int
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let sourcePromptId: UUID?
+
+    public init(
+        id: UUID,
+        name: String,
+        documentDescription: String?,
+        initials: String,
+        orderNumber: Int,
+        createdAt: Date,
+        updatedAt: Date,
+        sourcePromptId: UUID?
+    ) {
+        self.id = id
+        self.name = name
+        self.documentDescription = documentDescription
+        self.initials = initials
+        self.orderNumber = orderNumber
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.sourcePromptId = sourcePromptId
+    }
+}
+
+/**
+ One Android `MyDocumentPage` row from a staged sync backup.
+ */
+public struct RemoteSyncAndroidMyDocumentPage: Sendable, Equatable {
+    public let id: UUID
+    public let documentId: UUID
+    public let title: String
+    public let pageKey: String
+    public let contentType: MyDocumentContentType
+    public let orderNumber: Int
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let sourcePromptId: UUID?
+    public let languageCode: String?
+
+    public init(
+        id: UUID,
+        documentId: UUID,
+        title: String,
+        pageKey: String,
+        contentType: MyDocumentContentType,
+        orderNumber: Int,
+        createdAt: Date,
+        updatedAt: Date,
+        sourcePromptId: UUID?,
+        languageCode: String?
+    ) {
+        self.id = id
+        self.documentId = documentId
+        self.title = title
+        self.pageKey = pageKey
+        self.contentType = contentType
+        self.orderNumber = orderNumber
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.sourcePromptId = sourcePromptId
+        self.languageCode = languageCode
+    }
+}
+
+/**
+ One Android `MyDocumentPageContent` row from a staged sync backup.
+ */
+public struct RemoteSyncAndroidMyDocumentPageContent: Sendable, Equatable {
+    public let pageId: UUID
+    public let content: String
+
+    public init(pageId: UUID, content: String) {
+        self.pageId = pageId
+        self.content = content
+    }
+}
+
+/**
+ One Android `AiPageCacheEntry` row from a staged sync backup.
+ */
+public struct RemoteSyncAndroidAiPageCacheEntry: Sendable, Equatable {
+    public let pageId: UUID
+    public let sourcePromptId: UUID
+    public let sourceContext: String?
+    public let kjvOrdinalStart: Int?
+    public let kjvOrdinalEnd: Int?
+    public let contextHash: String?
+    public let usedWriteTools: Bool
+    public let sourceModelName: String?
+    public let sourceBookInitials: String?
+    public let sourceBookKey: String?
+
+    public init(
+        pageId: UUID,
+        sourcePromptId: UUID,
+        sourceContext: String?,
+        kjvOrdinalStart: Int?,
+        kjvOrdinalEnd: Int?,
+        contextHash: String?,
+        usedWriteTools: Bool,
+        sourceModelName: String?,
+        sourceBookInitials: String?,
+        sourceBookKey: String?
+    ) {
+        self.pageId = pageId
+        self.sourcePromptId = sourcePromptId
+        self.sourceContext = sourceContext
+        self.kjvOrdinalStart = kjvOrdinalStart
+        self.kjvOrdinalEnd = kjvOrdinalEnd
+        self.contextHash = contextHash
+        self.usedWriteTools = usedWriteTools
+        self.sourceModelName = sourceModelName
+        self.sourceBookInitials = sourceBookInitials
+        self.sourceBookKey = sourceBookKey
+    }
+}
+
+/**
+ Read-only snapshot of one staged Android My Documents sync database.
+ */
+public struct RemoteSyncAndroidMyDocumentSnapshot: Sendable, Equatable {
+    public let documents: [RemoteSyncAndroidMyDocument]
+    public let pages: [RemoteSyncAndroidMyDocumentPage]
+    public let pageContents: [RemoteSyncAndroidMyDocumentPageContent]
+    public let aiPageCacheEntries: [RemoteSyncAndroidAiPageCacheEntry]
+    public let orphanReferences: [String]
+
+    public init(
+        documents: [RemoteSyncAndroidMyDocument],
+        pages: [RemoteSyncAndroidMyDocumentPage],
+        pageContents: [RemoteSyncAndroidMyDocumentPageContent],
+        aiPageCacheEntries: [RemoteSyncAndroidAiPageCacheEntry],
+        orphanReferences: [String] = []
+    ) {
+        self.documents = documents
+        self.pages = pages
+        self.pageContents = pageContents
+        self.aiPageCacheEntries = aiPageCacheEntries
+        self.orphanReferences = orphanReferences
+    }
+}
+
+/**
+ Summary of one successful Android My Documents restore.
+ */
+public struct RemoteSyncMyDocumentRestoreReport: Sendable, Equatable {
+    public let restoredDocumentCount: Int
+    public let restoredPageCount: Int
+    public let restoredContentCount: Int
+    public let restoredAIPageCacheEntryCount: Int
+
+    public init(
+        restoredDocumentCount: Int,
+        restoredPageCount: Int,
+        restoredContentCount: Int,
+        restoredAIPageCacheEntryCount: Int
+    ) {
+        self.restoredDocumentCount = restoredDocumentCount
+        self.restoredPageCount = restoredPageCount
+        self.restoredContentCount = restoredContentCount
+        self.restoredAIPageCacheEntryCount = restoredAIPageCacheEntryCount
+    }
+}
+
+/**
+ Reads staged Android My Documents databases and restores them into iOS SwiftData.
+ */
+public final class RemoteSyncMyDocumentRestoreService {
+    public static let supportedAndroidSchemaVersion = 4
+
+    public init() {}
+
+    /**
+     Reads one staged Android `mydocuments.sqlite3` database into a typed snapshot.
+     */
+    public func readSnapshot(from databaseURL: URL) throws -> RemoteSyncAndroidMyDocumentSnapshot {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(db) }
+
+        let userVersion = try databaseUserVersion(db)
+        if userVersion > Self.supportedAndroidSchemaVersion {
+            throw RemoteSyncMyDocumentRestoreError.unsupportedSchemaVersion(userVersion)
+        }
+
+        try requireTable(named: "MyDocument", in: db)
+        try requireTable(named: "MyDocumentPage", in: db)
+        try requireTable(named: "MyDocumentPageContent", in: db)
+        try requireTable(named: "AiPageCacheEntry", in: db)
+
+        let documents = try fetchDocuments(from: db)
+        let pages = try fetchPages(from: db)
+        let pageContents = try fetchPageContents(from: db)
+        let aiPageCacheEntries = try fetchAIPageCacheEntries(from: db)
+        let orphanReferences = Self.orphanReferences(
+            documents: documents,
+            pages: pages,
+            pageContents: pageContents,
+            aiPageCacheEntries: aiPageCacheEntries
+        )
+
+        return RemoteSyncAndroidMyDocumentSnapshot(
+            documents: documents.sorted { $0.orderNumber == $1.orderNumber ? $0.name < $1.name : $0.orderNumber < $1.orderNumber },
+            pages: pages.sorted { $0.orderNumber == $1.orderNumber ? $0.title < $1.title : $0.orderNumber < $1.orderNumber },
+            pageContents: pageContents.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            aiPageCacheEntries: aiPageCacheEntries.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            orphanReferences: orphanReferences
+        )
+    }
+
+    /**
+     Replaces local iOS My Documents with the supplied staged Android snapshot.
+     */
+    public func replaceLocalMyDocuments(
+        from snapshot: RemoteSyncAndroidMyDocumentSnapshot,
+        modelContext: ModelContext
+    ) throws -> RemoteSyncMyDocumentRestoreReport {
+        if !snapshot.orphanReferences.isEmpty {
+            throw RemoteSyncMyDocumentRestoreError.orphanReferences(snapshot.orphanReferences)
+        }
+
+        let existingCacheEntries = (try? modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())) ?? []
+        for cacheEntry in existingCacheEntries {
+            modelContext.delete(cacheEntry)
+        }
+        let existingContents = (try? modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())) ?? []
+        for content in existingContents {
+            modelContext.delete(content)
+        }
+        let existingPages = (try? modelContext.fetch(FetchDescriptor<MyDocumentPage>())) ?? []
+        for page in existingPages {
+            modelContext.delete(page)
+        }
+        let existingDocuments = (try? modelContext.fetch(FetchDescriptor<MyDocument>())) ?? []
+        for document in existingDocuments {
+            modelContext.delete(document)
+        }
+
+        var documentsByID: [UUID: MyDocument] = [:]
+        var pagesByID: [UUID: MyDocumentPage] = [:]
+
+        for stagedDocument in snapshot.documents {
+            let document = MyDocument(
+                id: stagedDocument.id,
+                name: stagedDocument.name,
+                documentDescription: stagedDocument.documentDescription,
+                initials: stagedDocument.initials,
+                orderNumber: stagedDocument.orderNumber,
+                createdAt: stagedDocument.createdAt,
+                updatedAt: stagedDocument.updatedAt,
+                sourcePromptId: stagedDocument.sourcePromptId
+            )
+            document.pages = []
+            documentsByID[stagedDocument.id] = document
+            modelContext.insert(document)
+        }
+
+        for stagedPage in snapshot.pages {
+            let page = MyDocumentPage(
+                id: stagedPage.id,
+                title: stagedPage.title,
+                pageKey: stagedPage.pageKey,
+                contentType: stagedPage.contentType,
+                orderNumber: stagedPage.orderNumber,
+                createdAt: stagedPage.createdAt,
+                updatedAt: stagedPage.updatedAt,
+                sourcePromptId: stagedPage.sourcePromptId,
+                languageCode: stagedPage.languageCode
+            )
+            page.aiPageCacheEntries = []
+            if let document = documentsByID[stagedPage.documentId] {
+                page.document = document
+                document.pages?.append(page)
+            }
+            pagesByID[stagedPage.id] = page
+            modelContext.insert(page)
+        }
+
+        for stagedContent in snapshot.pageContents {
+            let content = MyDocumentPageContent(
+                pageId: stagedContent.pageId,
+                content: stagedContent.content
+            )
+            if let page = pagesByID[stagedContent.pageId] {
+                content.page = page
+                page.pageContent = content
+            }
+            modelContext.insert(content)
+        }
+
+        for stagedCacheEntry in snapshot.aiPageCacheEntries {
+            let cacheEntry = AiPageCacheEntry(
+                pageId: stagedCacheEntry.pageId,
+                sourcePromptId: stagedCacheEntry.sourcePromptId,
+                sourceContext: stagedCacheEntry.sourceContext,
+                kjvOrdinalStart: stagedCacheEntry.kjvOrdinalStart,
+                kjvOrdinalEnd: stagedCacheEntry.kjvOrdinalEnd,
+                contextHash: stagedCacheEntry.contextHash,
+                usedWriteTools: stagedCacheEntry.usedWriteTools,
+                sourceModelName: stagedCacheEntry.sourceModelName,
+                sourceBookInitials: stagedCacheEntry.sourceBookInitials,
+                sourceBookKey: stagedCacheEntry.sourceBookKey
+            )
+            if let page = pagesByID[stagedCacheEntry.pageId] {
+                cacheEntry.page = page
+                page.aiPageCacheEntries?.append(cacheEntry)
+            }
+            modelContext.insert(cacheEntry)
+        }
+
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+
+        return RemoteSyncMyDocumentRestoreReport(
+            restoredDocumentCount: snapshot.documents.count,
+            restoredPageCount: snapshot.pages.count,
+            restoredContentCount: snapshot.pageContents.count,
+            restoredAIPageCacheEntryCount: snapshot.aiPageCacheEntries.count
+        )
+    }
+
+    private static func orphanReferences(
+        documents: [RemoteSyncAndroidMyDocument],
+        pages: [RemoteSyncAndroidMyDocumentPage],
+        pageContents: [RemoteSyncAndroidMyDocumentPageContent],
+        aiPageCacheEntries: [RemoteSyncAndroidAiPageCacheEntry]
+    ) -> [String] {
+        let documentIDs = Set(documents.map(\.id))
+        let pageIDs = Set(pages.map(\.id))
+        var references: [String] = []
+
+        for page in pages where !documentIDs.contains(page.documentId) {
+            references.append("MyDocumentPage.id=\(page.id.uuidString) missing MyDocument")
+        }
+        for content in pageContents where !pageIDs.contains(content.pageId) {
+            references.append("MyDocumentPageContent.pageId=\(content.pageId.uuidString) missing MyDocumentPage")
+        }
+        for cacheEntry in aiPageCacheEntries where !pageIDs.contains(cacheEntry.pageId) {
+            references.append("AiPageCacheEntry.pageId=\(cacheEntry.pageId.uuidString) missing MyDocumentPage")
+        }
+        return references.sorted()
+    }
+
+    private func databaseUserVersion(_ db: OpaquePointer) throws -> Int {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &statement, nil) == SQLITE_OK,
+              let statement,
+              sqlite3_step(statement) == SQLITE_ROW else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+        return Int(sqlite3_column_int(statement, 0))
+    }
+
+    private func requireTable(named tableName: String, in db: OpaquePointer) throws {
+        let sql = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+
+        sqlite3_bind_text(statement, 1, tableName, -1, remoteSyncMyDocumentSQLiteTransient)
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw RemoteSyncMyDocumentRestoreError.missingTable(tableName)
+        }
+    }
+
+    private func fetchDocuments(from db: OpaquePointer) throws -> [RemoteSyncAndroidMyDocument] {
+        let table = "MyDocument"
+        let sql = """
+        SELECT id, name, description, initials, orderNumber, createdAt, updatedAt, sourcePromptId
+        FROM MyDocument
+        ORDER BY orderNumber, name
+        """
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+
+        var rows: [RemoteSyncAndroidMyDocument] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(
+                RemoteSyncAndroidMyDocument(
+                    id: try uuidFromBlob(statement: statement, column: 0, table: table, name: "id"),
+                    name: try requiredTextColumn(statement: statement, index: 1, table: table, name: "name"),
+                    documentDescription: optionalTextColumn(statement: statement, index: 2),
+                    initials: try requiredTextColumn(statement: statement, index: 3, table: table, name: "initials"),
+                    orderNumber: try requiredIntColumn(statement: statement, index: 4, table: table, name: "orderNumber"),
+                    createdAt: try requiredDateColumn(statement: statement, index: 5, table: table, name: "createdAt"),
+                    updatedAt: try requiredDateColumn(statement: statement, index: 6, table: table, name: "updatedAt"),
+                    sourcePromptId: try optionalUUIDFromBlob(statement: statement, column: 7, table: table, name: "sourcePromptId")
+                )
+            )
+        }
+        return rows
+    }
+
+    private func fetchPages(from db: OpaquePointer) throws -> [RemoteSyncAndroidMyDocumentPage] {
+        let table = "MyDocumentPage"
+        let sql = """
+        SELECT id, documentId, title, pageKey, contentType, orderNumber, createdAt, updatedAt, sourcePromptId, languageCode
+        FROM MyDocumentPage
+        ORDER BY documentId, orderNumber, title
+        """
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+
+        var rows: [RemoteSyncAndroidMyDocumentPage] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            let rawContentType = try requiredTextColumn(statement: statement, index: 4, table: table, name: "contentType")
+            guard let contentType = MyDocumentContentType(rawValue: rawContentType) else {
+                throw RemoteSyncMyDocumentRestoreError.invalidColumnValue(table: table, column: "contentType")
+            }
+            rows.append(
+                RemoteSyncAndroidMyDocumentPage(
+                    id: try uuidFromBlob(statement: statement, column: 0, table: table, name: "id"),
+                    documentId: try uuidFromBlob(statement: statement, column: 1, table: table, name: "documentId"),
+                    title: try requiredTextColumn(statement: statement, index: 2, table: table, name: "title"),
+                    pageKey: try requiredTextColumn(statement: statement, index: 3, table: table, name: "pageKey"),
+                    contentType: contentType,
+                    orderNumber: try requiredIntColumn(statement: statement, index: 5, table: table, name: "orderNumber"),
+                    createdAt: try requiredDateColumn(statement: statement, index: 6, table: table, name: "createdAt"),
+                    updatedAt: try requiredDateColumn(statement: statement, index: 7, table: table, name: "updatedAt"),
+                    sourcePromptId: try optionalUUIDFromBlob(statement: statement, column: 8, table: table, name: "sourcePromptId"),
+                    languageCode: optionalTextColumn(statement: statement, index: 9)
+                )
+            )
+        }
+        return rows
+    }
+
+    private func fetchPageContents(from db: OpaquePointer) throws -> [RemoteSyncAndroidMyDocumentPageContent] {
+        let table = "MyDocumentPageContent"
+        let sql = """
+        SELECT pageId, content
+        FROM MyDocumentPageContent
+        ORDER BY pageId
+        """
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+
+        var rows: [RemoteSyncAndroidMyDocumentPageContent] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(
+                RemoteSyncAndroidMyDocumentPageContent(
+                    pageId: try uuidFromBlob(statement: statement, column: 0, table: table, name: "pageId"),
+                    content: try requiredTextColumn(statement: statement, index: 1, table: table, name: "content")
+                )
+            )
+        }
+        return rows
+    }
+
+    private func fetchAIPageCacheEntries(from db: OpaquePointer) throws -> [RemoteSyncAndroidAiPageCacheEntry] {
+        let table = "AiPageCacheEntry"
+        let sql = """
+        SELECT pageId, sourcePromptId, sourceContext, kjvOrdinalStart, kjvOrdinalEnd, contextHash,
+               usedWriteTools, sourceModelName, sourceBookInitials, sourceBookKey
+        FROM AiPageCacheEntry
+        ORDER BY pageId
+        """
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+        }
+
+        var rows: [RemoteSyncAndroidAiPageCacheEntry] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            rows.append(
+                RemoteSyncAndroidAiPageCacheEntry(
+                    pageId: try uuidFromBlob(statement: statement, column: 0, table: table, name: "pageId"),
+                    sourcePromptId: try uuidFromBlob(statement: statement, column: 1, table: table, name: "sourcePromptId"),
+                    sourceContext: optionalTextColumn(statement: statement, index: 2),
+                    kjvOrdinalStart: optionalIntColumn(statement: statement, index: 3),
+                    kjvOrdinalEnd: optionalIntColumn(statement: statement, index: 4),
+                    contextHash: optionalTextColumn(statement: statement, index: 5),
+                    usedWriteTools: try requiredBoolColumn(statement: statement, index: 6, table: table, name: "usedWriteTools"),
+                    sourceModelName: optionalTextColumn(statement: statement, index: 7),
+                    sourceBookInitials: optionalTextColumn(statement: statement, index: 8),
+                    sourceBookKey: optionalTextColumn(statement: statement, index: 9)
+                )
+            )
+        }
+        return rows
+    }
+
+    private func uuidFromBlob(statement: OpaquePointer?, column: Int32, table: String, name: String) throws -> UUID {
+        guard
+            let bytes = sqlite3_column_blob(statement, column),
+            sqlite3_column_bytes(statement, column) == 16
+        else {
+            throw RemoteSyncMyDocumentRestoreError.invalidIdentifierBlob(table: table, column: name)
+        }
+
+        let data = Data(bytes: bytes, count: 16)
+        let hex = data.map { String(format: "%02x", $0) }.joined()
+        let part1 = String(hex[hex.startIndex..<hex.index(hex.startIndex, offsetBy: 8)])
+        let part2Start = hex.index(hex.startIndex, offsetBy: 8)
+        let part2End = hex.index(part2Start, offsetBy: 4)
+        let part2 = String(hex[part2Start..<part2End])
+        let part3End = hex.index(part2End, offsetBy: 4)
+        let part3 = String(hex[part2End..<part3End])
+        let part4End = hex.index(part3End, offsetBy: 4)
+        let part4 = String(hex[part3End..<part4End])
+        let part5 = String(hex[part4End..<hex.endIndex])
+        let uuidString = "\(part1)-\(part2)-\(part3)-\(part4)-\(part5)"
+
+        guard let uuid = UUID(uuidString: uuidString) else {
+            throw RemoteSyncMyDocumentRestoreError.invalidIdentifierBlob(table: table, column: name)
+        }
+        return uuid
+    }
+
+    private func optionalUUIDFromBlob(statement: OpaquePointer?, column: Int32, table: String, name: String) throws -> UUID? {
+        if sqlite3_column_type(statement, column) == SQLITE_NULL {
+            return nil
+        }
+        return try uuidFromBlob(statement: statement, column: column, table: table, name: name)
+    }
+
+    private func requiredTextColumn(
+        statement: OpaquePointer?,
+        index: Int32,
+        table: String,
+        name: String
+    ) throws -> String {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let raw = sqlite3_column_text(statement, index) else {
+            throw RemoteSyncMyDocumentRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return String(cString: raw)
+    }
+
+    private func optionalTextColumn(statement: OpaquePointer?, index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let raw = sqlite3_column_text(statement, index) else {
+            return nil
+        }
+        return String(cString: raw)
+    }
+
+    private func optionalIntColumn(statement: OpaquePointer?, index: Int32) -> Int? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else {
+            return nil
+        }
+        return Int(sqlite3_column_int(statement, index))
+    }
+
+    private func requiredIntColumn(
+        statement: OpaquePointer?,
+        index: Int32,
+        table: String,
+        name: String
+    ) throws -> Int {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else {
+            throw RemoteSyncMyDocumentRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return Int(sqlite3_column_int(statement, index))
+    }
+
+    private func requiredInt64Column(
+        statement: OpaquePointer?,
+        index: Int32,
+        table: String,
+        name: String
+    ) throws -> Int64 {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else {
+            throw RemoteSyncMyDocumentRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return sqlite3_column_int64(statement, index)
+    }
+
+    private func requiredBoolColumn(
+        statement: OpaquePointer?,
+        index: Int32,
+        table: String,
+        name: String
+    ) throws -> Bool {
+        try requiredIntColumn(statement: statement, index: index, table: table, name: name) != 0
+    }
+
+    private func requiredDateColumn(
+        statement: OpaquePointer?,
+        index: Int32,
+        table: String,
+        name: String
+    ) throws -> Date {
+        let milliseconds = try requiredInt64Column(statement: statement, index: index, table: table, name: name)
+        return Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000.0)
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
@@ -23,8 +23,8 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
     /// My Documents document/page/content data.
     case myDocuments = "mydocuments"
 
-    /// Categories currently exposed through the iOS sync UI and lifecycle sweep.
-    public static var allCases: [RemoteSyncCategory] {
+    /// Categories currently ready for the broad iOS sync UI and lifecycle sweep.
+    public static var activeSyncCases: [RemoteSyncCategory] {
         [.bookmarks, .workspaces, .readingPlans]
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
@@ -5,10 +5,10 @@ import Foundation
 /**
  Identifies the logical data categories Android syncs as separate patch streams.
 
- Android's `SyncableDatabaseDefinition` uses three independent categories: bookmarks, workspaces,
- and reading plans. The iOS remote-sync implementation preserves that separation so remote folder
- naming, bootstrap state, and patch progress can be tracked per category instead of collapsing all
- user data into one opaque sync stream.
+ Android's `SyncableDatabaseDefinition` uses independent categories for bookmarks, workspaces,
+ reading plans, and My Documents. The iOS remote-sync implementation preserves that separation so
+ remote folder naming, bootstrap state, and patch progress can be tracked per category instead of
+ collapsing all user data into one opaque sync stream.
  */
 public enum RemoteSyncCategory: String, CaseIterable, Sendable {
     /// Bookmark, label, note, and StudyPad data.
@@ -19,6 +19,14 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
 
     /// Reading-plan definitions and completion progress.
     case readingPlans = "readingplans"
+
+    /// My Documents document/page/content data.
+    case myDocuments = "mydocuments"
+
+    /// Categories currently exposed through the iOS sync UI and lifecycle sweep.
+    public static var allCases: [RemoteSyncCategory] {
+        [.bookmarks, .workspaces, .readingPlans]
+    }
 
     /**
      Builds the Android-style remote sync folder name for this category.

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -13,6 +13,9 @@ import SwiftData
 public enum RemoteSyncSynchronizationError: Error, Equatable {
     /// A remotely adopted sync folder did not contain the required Android initial-backup archive.
     case missingInitialBackup(RemoteSyncCategory)
+
+    /// The requested category does not yet support this synchronization phase.
+    case unsupportedCategory(RemoteSyncCategory)
 }
 
 /**
@@ -676,6 +679,8 @@ public final class RemoteSyncSynchronizationService {
                     settingsStore: settingsStore
                 )
             )
+        case .myDocuments:
+            throw RemoteSyncSynchronizationError.unsupportedCategory(category)
         }
     }
 
@@ -729,6 +734,8 @@ public final class RemoteSyncSynchronizationService {
             ) {
                 return .workspaces(report)
             }
+            return nil
+        case .myDocuments:
             return nil
         }
     }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -523,7 +523,7 @@ public struct SyncSettingsView: View {
      Shared Android-style remote category toggle list used by supported remote backends.
      */
     private var remoteCategoryList: some View {
-        ForEach(RemoteSyncCategory.allCases, id: \.self) { category in
+        ForEach(RemoteSyncCategory.activeSyncCases, id: \.self) { category in
             let categoryBinding = remoteCategoryBinding(for: category)
             VStack(alignment: .leading, spacing: 8) {
                 HStack(alignment: .top, spacing: 12) {
@@ -667,7 +667,7 @@ public struct SyncSettingsView: View {
      - Failure modes: This helper cannot fail.
      */
     private var syncSettingsAccessibilityValue: String {
-        let enabledCategories = RemoteSyncCategory.allCases
+        let enabledCategories = RemoteSyncCategory.activeSyncCases
             .filter(isRemoteCategoryEnabled)
             .map(\.rawValue)
             .sorted()
@@ -910,7 +910,7 @@ public struct SyncSettingsView: View {
             password = "ui-test"
             folderPath = ""
             remoteCategoryEnabled = Dictionary(
-                uniqueKeysWithValues: RemoteSyncCategory.allCases.map { category in
+                uniqueKeysWithValues: RemoteSyncCategory.activeSyncCases.map { category in
                     (category, false)
                 }
             )
@@ -927,7 +927,7 @@ public struct SyncSettingsView: View {
         }
         password = remoteSettingsStore.webDAVPassword() ?? ""
         remoteCategoryEnabled = Dictionary(
-            uniqueKeysWithValues: RemoteSyncCategory.allCases.map { category in
+            uniqueKeysWithValues: RemoteSyncCategory.activeSyncCases.map { category in
                 (category, remoteSettingsStore.isSyncEnabled(for: category))
             }
         )

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -1258,6 +1258,8 @@ public struct SyncSettingsView: View {
             return String(localized: "help_workspaces_title")
         case .readingPlans:
             return String(localized: "reading_plans_plural")
+        case .myDocuments:
+            return String(localized: "my_documents")
         }
     }
 
@@ -1277,6 +1279,8 @@ public struct SyncSettingsView: View {
             return String(localized: "workspaces_contents")
         case .readingPlans:
             return String(localized: "reading_plans_content")
+        case .myDocuments:
+            return String(localized: "my_documents_contents")
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Settings/UITestRemoteSyncAdapter.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/UITestRemoteSyncAdapter.swift
@@ -44,7 +44,7 @@ actor UITestRemoteSyncAdapter: RemoteSyncAdapting {
         guard parentIDs == nil,
               mimeType == nil,
               let name,
-              RemoteSyncCategory.allCases.contains(where: {
+              RemoteSyncCategory.activeSyncCases.contains(where: {
                   $0.syncFolderName(bundleIdentifier: bundleIdentifier) == name
               }) else {
             return []


### PR DESCRIPTION
## Summary
Adds Android mydocuments initial-backup restore support for the iOS My Documents model.

## Scope
- Restores Android mydocuments.sqlite3 document, page, page content, and AI cache rows into SwiftData.
- Preserves Android identifiers, timestamps, content types, AI context, and category sync metadata.
- Keeps the mydocuments category hidden from broad settings and lifecycle sync sweeps until later parity work enables patch replay and upload.
- Adds Xcode unit coverage and project wiring for the new restore path.

## Contract references
- Issue #105: [Parity P3] Implement mydocuments initial-backup restore.
- Android sync category: mydocuments.
- Existing iOS My Documents SwiftData graph and remote initial-backup dispatcher contracts.

## Change details
- Added RemoteSyncMyDocumentRestoreService for staged Android SQLite reads, validation, orphan detection, and local graph replacement.
- Added the mydocuments category case for dispatcher routing while excluding it from RemoteSyncCategory.allCases so current UI and lifecycle loops remain unchanged.
- Added unsupported-category guards for initial upload and synchronization phases that are intentionally handled by follow-up work.
- Added RemoteSyncMyDocumentRestoreTests for restore fidelity, malformed content types, orphan rows, AI cache rows, metadata restore, and dispatcher routing.

## Validation evidence
- xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .derivedData -resultBundlePath .artifacts/RemoteSyncMyDocumentRestoreTests-3.xcresult CODE_SIGNING_ALLOWED=NO test -only-testing:AndBibleTests/RemoteSyncMyDocumentRestoreTests
- swift build --product UITestFixtureTool
- git diff --cached --check
- GitNexus staged impact analysis: low risk, no affected indexed processes.

## Risks/follow-ups
- My Documents patch replay and outbound upload remain follow-up work and are intentionally unsupported in this PR.
- The category remains hidden from general sync toggles and lifecycle sweeps until the full category is ready.

## Issue closure reference
Closes #105