### PR TITLE
feat(sync): upload mydocuments initial backups

### DIFF
--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -1,5 +1,6 @@
 // RemoteSyncMyDocumentRestoreTests.swift -- Android My Documents initial-backup restore tests
 
+import CLibSword
 import XCTest
 import SQLite3
 import SwiftData
@@ -269,6 +270,415 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
             RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments),
             [patchStatus]
         )
+
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob(documentID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPage",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+    }
+
+    func testRemoteSyncMyDocumentSnapshotFiltersOrphansAndRefreshesBaseline() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "f1000000-0000-0000-0000-000000000001")!
+        let validPageID = UUID(uuidString: "f1000000-0000-0000-0000-000000000011")!
+        let orphanPageID = UUID(uuidString: "f1000000-0000-0000-0000-000000000012")!
+        let missingPageID = UUID(uuidString: "f1000000-0000-0000-0000-000000000013")!
+        let promptID = UUID(uuidString: "f1000000-0000-0000-0000-000000000021")!
+        let duplicatePromptID = UUID(uuidString: "f1000000-0000-0000-0000-000000000022")!
+        let selectedCacheEntryID = UUID(uuidString: "f1000000-0000-0000-0000-000000000031")!
+        let duplicateCacheEntryID = UUID(uuidString: "f1000000-0000-0000-0000-000000000032")!
+        let staleDocumentID = UUID(uuidString: "f1000000-0000-0000-0000-000000000099")!
+
+        let document = MyDocument(
+            id: documentID,
+            name: "Snapshot",
+            initials: "SNAP"
+        )
+        let validPage = MyDocumentPage(
+            id: validPageID,
+            title: "Valid",
+            pageKey: "valid"
+        )
+        let validContent = MyDocumentPageContent(pageId: validPageID, content: "Valid content")
+        let validCacheEntry = AiPageCacheEntry(
+            id: selectedCacheEntryID,
+            pageId: validPageID,
+            sourcePromptId: promptID,
+            contextHash: "valid"
+        )
+        let duplicateCacheEntry = AiPageCacheEntry(
+            id: duplicateCacheEntryID,
+            pageId: validPageID,
+            sourcePromptId: duplicatePromptID,
+            contextHash: "duplicate"
+        )
+        document.pages = [validPage]
+        validPage.document = document
+        validPage.pageContent = validContent
+        validContent.page = validPage
+        validPage.aiPageCacheEntries = [validCacheEntry, duplicateCacheEntry]
+        validCacheEntry.page = validPage
+        duplicateCacheEntry.page = validPage
+
+        let orphanPage = MyDocumentPage(
+            id: orphanPageID,
+            title: "Orphan",
+            pageKey: "orphan"
+        )
+        let orphanContent = MyDocumentPageContent(pageId: orphanPageID, content: "Orphan content")
+        let orphanCacheEntry = AiPageCacheEntry(
+            pageId: orphanPageID,
+            sourcePromptId: promptID,
+            contextHash: "orphan"
+        )
+        orphanPage.pageContent = orphanContent
+        orphanContent.page = orphanPage
+        orphanPage.aiPageCacheEntries = [orphanCacheEntry]
+        orphanCacheEntry.page = orphanPage
+
+        let missingPageContent = MyDocumentPageContent(pageId: missingPageID, content: "Missing content")
+        let missingPageCacheEntry = AiPageCacheEntry(
+            pageId: missingPageID,
+            sourcePromptId: promptID,
+            contextHash: "missing"
+        )
+
+        modelContext.insert(document)
+        modelContext.insert(validPage)
+        modelContext.insert(validContent)
+        modelContext.insert(validCacheEntry)
+        modelContext.insert(duplicateCacheEntry)
+        modelContext.insert(orphanPage)
+        modelContext.insert(orphanContent)
+        modelContext.insert(orphanCacheEntry)
+        modelContext.insert(missingPageContent)
+        modelContext.insert(missingPageCacheEntry)
+        try modelContext.save()
+
+        let service = RemoteSyncMyDocumentSnapshotService()
+        let snapshot = service.snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(Set(snapshot.documentRowsByKey.values.map(\.id)), [documentID])
+        XCTAssertEqual(Set(snapshot.pageRowsByKey.values.map(\.id)), [validPageID])
+        XCTAssertEqual(Set(snapshot.pageContentRowsByKey.values.map(\.pageId)), [validPageID])
+        XCTAssertEqual(Set(snapshot.aiPageCacheEntryRowsByKey.values.map(\.pageId)), [validPageID])
+        XCTAssertEqual(snapshot.aiPageCacheEntryRowsByKey.values.first?.contextHash, "valid")
+        XCTAssertEqual(snapshot.fingerprintsByKey.count, 4)
+
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        fingerprintStore.setFingerprint(
+            "stale",
+            for: .myDocuments,
+            tableName: "MyDocument",
+            entityID1: .blob(uuidBlob(staleDocumentID)),
+            entityID2: .text("")
+        )
+
+        service.refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob(staleDocumentID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob(documentID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPage",
+                entityID1: .blob(uuidBlob(validPageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(uuidBlob(validPageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(uuidBlob(validPageID)),
+                entityID2: .text("")
+            )
+        )
+    }
+
+    func testRemoteSyncInitialBackupUploadWritesMyDocumentDatabaseAndResetsBaseline() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "e1000000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "e1000000-0000-0000-0000-000000000011")!
+        let documentPromptID = UUID(uuidString: "e1000000-0000-0000-0000-000000000021")!
+        let pagePromptID = UUID(uuidString: "e1000000-0000-0000-0000-000000000022")!
+        let createdAt = Date(timeIntervalSince1970: 1_735_689_600)
+        let updatedAt = Date(timeIntervalSince1970: 1_735_689_660)
+        let document = MyDocument(
+            id: documentID,
+            name: "iOS Document",
+            documentDescription: "Exported from iOS",
+            initials: "IOSDOC",
+            orderNumber: 4,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            sourcePromptId: documentPromptID
+        )
+        let page = MyDocumentPage(
+            id: pageID,
+            title: "Intro",
+            pageKey: "intro",
+            contentType: .html,
+            orderNumber: 2,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            sourcePromptId: pagePromptID,
+            languageCode: "en"
+        )
+        let content = MyDocumentPageContent(pageId: pageID, content: "<p>Exported</p>")
+        let cacheEntry = AiPageCacheEntry(
+            pageId: pageID,
+            sourcePromptId: pagePromptID,
+            sourceContext: #"{"osisRef":"John.3.16"}"#,
+            kjvOrdinalStart: 26_136,
+            kjvOrdinalEnd: 26_136,
+            contextHash: "ios-context",
+            usedWriteTools: true,
+            sourceModelName: "gpt-test",
+            sourceBookInitials: "KJV",
+            sourceBookKey: "John.3.16"
+        )
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        page.aiPageCacheEntries = [cacheEntry]
+        cacheEntry.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        modelContext.insert(cacheEntry)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).addEntry(
+            RemoteSyncLogEntry(
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob(documentID)),
+                entityID2: .text(""),
+                type: .upsert,
+                lastUpdated: 1_735_689_600_000,
+                sourceDevice: "android"
+            ),
+            for: .myDocuments
+        )
+
+        let syncFolderID = "/org.andbible.ios-sync-mydocuments"
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(syncFolderID)/initial.sqlite3.gz",
+                name: "initial.sqlite3.gz",
+                size: 0,
+                timestamp: 2_000,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncInitialBackupUploadService(
+            adapter: adapter,
+            deviceIdentifier: "ios-device",
+            nowProvider: { 1_900 }
+        )
+
+        let report = try await service.uploadInitialBackup(
+            for: .myDocuments,
+            bootstrapState: RemoteSyncBootstrapState(syncFolderID: syncFolderID),
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        )
+
+        XCTAssertEqual(report.category, .myDocuments)
+        XCTAssertTrue(RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .myDocuments).isEmpty)
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments),
+            [
+                RemoteSyncPatchStatus(
+                    sourceDevice: "ios-device",
+                    patchNumber: 0,
+                    sizeBytes: report.uploadedFile.size,
+                    appliedDate: 2_000
+                )
+            ]
+        )
+        XCTAssertEqual(RemoteSyncStateStore(settingsStore: settingsStore).progressState(for: .myDocuments).lastPatchWritten, 1_900)
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob(documentID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPage",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+        XCTAssertNotNil(
+            fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(uuidBlob(pageID)),
+                entityID2: .text("")
+            )
+        )
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedFile = try XCTUnwrap(uploadedFiles.first)
+        XCTAssertEqual(uploadedFile.name, "initial.sqlite3.gz")
+        XCTAssertEqual(uploadedFile.parentID, syncFolderID)
+        XCTAssertEqual(uploadedFile.contentType, NextCloudSyncAdapter.gzipMimeType)
+        let databaseURL = try writeUploadedMyDocumentDatabase(uploadedFile.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        XCTAssertEqual(try sqliteUserVersion(at: databaseURL), RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion)
+        XCTAssertEqual(try sqliteRoomIdentityHash(at: databaseURL), "3f0946602099d896c8d47129233c1794")
+        XCTAssertNil(try sqliteColumnDefault(tableName: "LogEntry", columnName: "entityId2", databaseURL: databaseURL))
+        let snapshot = try RemoteSyncMyDocumentRestoreService().readSnapshot(from: databaseURL)
+        XCTAssertEqual(snapshot.documents.count, 1)
+        XCTAssertEqual(snapshot.documents[0].id, documentID)
+        XCTAssertEqual(snapshot.documents[0].documentDescription, "Exported from iOS")
+        XCTAssertEqual(snapshot.pages.count, 1)
+        XCTAssertEqual(snapshot.pages[0].contentType, .html)
+        XCTAssertEqual(snapshot.pageContents, [.init(pageId: pageID, content: "<p>Exported</p>")])
+        XCTAssertEqual(snapshot.aiPageCacheEntries.count, 1)
+        XCTAssertEqual(snapshot.aiPageCacheEntries[0].sourceBookKey, "John.3.16")
+
+        let secondContainer = try makeModelContainer()
+        let secondModelContext = ModelContext(secondContainer)
+        let restoreReport = try RemoteSyncMyDocumentRestoreService().replaceLocalMyDocuments(
+            from: snapshot,
+            modelContext: secondModelContext
+        )
+        XCTAssertEqual(restoreReport.restoredDocumentCount, 1)
+        XCTAssertEqual(
+            MyDocumentStore(modelContext: secondModelContext).rawContentPayload(bookInitials: "IOSDOC", pageKey: "intro")?.content,
+            "<p>Exported</p>"
+        )
+    }
+
+    func testRemoteSyncInitialBackupUploadWritesDeterministicEmptyMyDocumentDatabase() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let syncFolderID = "/org.andbible.ios-sync-mydocuments-empty"
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(syncFolderID)/initial.sqlite3.gz",
+                name: "initial.sqlite3.gz",
+                size: 0,
+                timestamp: 2_500,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncInitialBackupUploadService(
+            adapter: adapter,
+            deviceIdentifier: "ios-device",
+            nowProvider: { 2_400 }
+        )
+
+        _ = try await service.uploadInitialBackup(
+            for: .myDocuments,
+            bootstrapState: RemoteSyncBootstrapState(syncFolderID: syncFolderID),
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        )
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedFile = try XCTUnwrap(uploadedFiles.first)
+        let databaseURL = try writeUploadedMyDocumentDatabase(uploadedFile.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        let snapshot = try RemoteSyncMyDocumentRestoreService().readSnapshot(from: databaseURL)
+
+        XCTAssertTrue(snapshot.documents.isEmpty)
+        XCTAssertTrue(snapshot.pages.isEmpty)
+        XCTAssertTrue(snapshot.pageContents.isEmpty)
+        XCTAssertTrue(snapshot.aiPageCacheEntries.isEmpty)
+        XCTAssertEqual(try sqliteCount(tableName: "MyDocument", databaseURL: databaseURL), 0)
+        XCTAssertEqual(try sqliteCount(tableName: "AiPageCacheEntry", databaseURL: databaseURL), 0)
+        XCTAssertTrue(
+            settingsStore.entries(
+                withPrefix: RemoteSyncRowFingerprintStore(settingsStore: settingsStore).prefix(for: .myDocuments)
+            ).isEmpty
+        )
+        XCTAssertEqual(RemoteSyncStateStore(settingsStore: settingsStore).progressState(for: .myDocuments).lastPatchWritten, 2_400)
     }
 
     private func makeModelContainer() throws -> ModelContainer {
@@ -599,4 +1009,200 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         var uuid = value.uuid
         return withUnsafeBytes(of: &uuid) { Data($0) }
     }
+}
+
+private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
+    private var uploadResults: [RemoteSyncFile] = []
+    private var uploadedFiles: [MyDocumentMockUploadedFile] = []
+
+    func enqueueUploadResult(_ result: RemoteSyncFile) {
+        uploadResults.append(result)
+    }
+
+    func uploadedFilesSnapshot() -> [MyDocumentMockUploadedFile] {
+        uploadedFiles
+    }
+
+    func listFiles(
+        parentIDs: [String]?,
+        name: String?,
+        mimeType: String?,
+        modifiedAtLeast: Date?
+    ) async throws -> [RemoteSyncFile] {
+        []
+    }
+
+    func createNewFolder(name: String, parentID: String?) async throws -> RemoteSyncFile {
+        RemoteSyncFile(
+            id: [parentID, name].compactMap { $0 }.joined(separator: "/"),
+            name: name,
+            size: 0,
+            timestamp: 0,
+            parentID: parentID ?? "/",
+            mimeType: NextCloudSyncAdapter.folderMimeType
+        )
+    }
+
+    func download(id: String) async throws -> Data {
+        Data()
+    }
+
+    func upload(
+        name: String,
+        fileURL: URL,
+        parentID: String,
+        contentType: String
+    ) async throws -> RemoteSyncFile {
+        let data = try Data(contentsOf: fileURL)
+        uploadedFiles.append(
+            MyDocumentMockUploadedFile(
+                name: name,
+                parentID: parentID,
+                contentType: contentType,
+                data: data
+            )
+        )
+        if !uploadResults.isEmpty {
+            let result = uploadResults.removeFirst()
+            return RemoteSyncFile(
+                id: result.id,
+                name: result.name,
+                size: Int64(data.count),
+                timestamp: result.timestamp,
+                parentID: result.parentID,
+                mimeType: result.mimeType
+            )
+        }
+        return RemoteSyncFile(
+            id: [parentID, name].joined(separator: "/"),
+            name: name,
+            size: Int64(data.count),
+            timestamp: 0,
+            parentID: parentID,
+            mimeType: contentType
+        )
+    }
+
+    func delete(id: String) async throws {}
+
+    func isSyncFolderKnown(syncFolderID: String, secretFileName: String) async throws -> Bool {
+        false
+    }
+
+    func makeSyncFolderKnown(syncFolderID: String, deviceIdentifier: String) async throws -> String {
+        "device-known-\(deviceIdentifier)-secret"
+    }
+}
+
+private struct MyDocumentMockUploadedFile: Equatable {
+    let name: String
+    let parentID: String
+    let contentType: String
+    let data: Data
+}
+
+private func writeUploadedMyDocumentDatabase(_ archiveData: Data) throws -> URL {
+    let databaseURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("uploaded-mydocuments-\(UUID().uuidString).sqlite3")
+    let databaseData = try myDocumentGunzipTestData(archiveData)
+    try databaseData.write(to: databaseURL, options: .atomic)
+    return databaseURL
+}
+
+private func myDocumentGunzipTestData(_ data: Data) throws -> Data {
+    try data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+        guard let baseAddress = ptr.baseAddress else {
+            throw RemoteSyncArchiveStagingError.decompressionFailed
+        }
+
+        var outputLength: UInt = 0
+        guard let output = gunzip_data(
+            baseAddress.assumingMemoryBound(to: UInt8.self),
+            UInt(data.count),
+            &outputLength
+        ) else {
+            throw RemoteSyncArchiveStagingError.decompressionFailed
+        }
+
+        defer { gunzip_free(output) }
+        return Data(bytes: output, count: Int(outputLength))
+    }
+}
+
+private func sqliteUserVersion(at databaseURL: URL) throws -> Int {
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &statement, nil) == SQLITE_OK,
+          sqlite3_step(statement) == SQLITE_ROW else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    return Int(sqlite3_column_int(statement, 0))
+}
+
+private func sqliteRoomIdentityHash(at databaseURL: URL) throws -> String {
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_prepare_v2(db, "SELECT identity_hash FROM room_master_table WHERE id = 42;", -1, &statement, nil) == SQLITE_OK,
+          sqlite3_step(statement) == SQLITE_ROW,
+          let value = sqlite3_column_text(statement, 0) else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    return String(cString: value)
+}
+
+private func sqliteColumnDefault(tableName: String, columnName: String, databaseURL: URL) throws -> String? {
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_prepare_v2(db, "PRAGMA table_info(\(tableName));", -1, &statement, nil) == SQLITE_OK else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+
+    while sqlite3_step(statement) == SQLITE_ROW {
+        guard let rawName = sqlite3_column_text(statement, 1) else {
+            continue
+        }
+        guard String(cString: rawName) == columnName else {
+            continue
+        }
+        guard sqlite3_column_type(statement, 4) != SQLITE_NULL,
+              let defaultValue = sqlite3_column_text(statement, 4) else {
+            return nil
+        }
+        return String(cString: defaultValue)
+    }
+    throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+}
+
+private func sqliteCount(tableName: String, databaseURL: URL) throws -> Int {
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(databaseURL.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+
+    var statement: OpaquePointer?
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM \(tableName)", -1, &statement, nil) == SQLITE_OK,
+          sqlite3_step(statement) == SQLITE_ROW else {
+        throw RemoteSyncMyDocumentRestoreError.invalidSQLiteDatabase
+    }
+    return Int(sqlite3_column_int(statement, 0))
 }

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -402,11 +402,7 @@ final class AndBibleUITests: XCTestCase {
         waitForReadingPlanListState(containing: builtInPlanToken, in: app, timeout: 10)
 
         let activePlan = requireElement("readingPlanActivePlanLink", in: app, timeout: 10)
-        activePlan.swipeLeft()
-        tapElementReliably(
-            requireElement(readingPlanDeleteButtonIdentifier(for: builtInPlanCode), in: app, timeout: 10),
-            timeout: 10
-        )
+        deleteReadingPlan(activePlan, planCode: builtInPlanCode, in: app, timeout: 10)
         waitForReadingPlanListState(containing: "active=0", in: app, timeout: 10)
         waitForReadingPlanListState(notContaining: builtInPlanToken, in: app, timeout: 10)
 
@@ -609,7 +605,6 @@ final class AndBibleUITests: XCTestCase {
         addWindowTab(expectingOrder: 1, in: app, timeout: 15)
         addWindowTab(expectingOrder: 2, in: app, timeout: 15)
 
-        tapWindowTab(2, in: app, timeout: 10)
         waitForReaderRenderedContentState(
             containing: "windowOrder=2;category=bible;module=KJV;book=Genesis;chapter=1",
             in: app,
@@ -1127,8 +1122,7 @@ final class AndBibleUITests: XCTestCase {
         _ = openHistory(in: app)
         let exodusRow = requireHistoryRow(containing: "Exodus 2", in: app, timeout: 10)
         _ = requireHistoryRow(containing: "Matthew 3", in: app, timeout: 10)
-        exodusRow.swipeLeft()
-        tapElementReliably(requireElement("historyDeleteButton::Exod_2_1", in: app, timeout: 10), timeout: 10)
+        deleteHistoryRow(exodusRow, keyToken: "Exod_2_1", in: app, timeout: 10)
         waitForHistoryState(containing: "count=1", in: app, timeout: 10)
         waitForHistoryState(notContaining: historyRowStateToken("Exod_2_1"), in: app, timeout: 10)
         waitForHistoryState(containing: historyRowStateToken("Matt_3_1"), in: app, timeout: 10)
@@ -4131,6 +4125,53 @@ final class AndBibleUITests: XCTestCase {
         "readingPlanDeleteButton::\(sanitizedReadingPlanStateToken(planCode))"
     }
 
+    /// Performs one Reading Plan row deletion through SwiftUI's swipe affordance.
+    private func deleteReadingPlan(
+        _ row: XCUIElement,
+        planCode: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) {
+        let rowToken = readingPlanStateToken(planCode)
+        let deleteIdentifier = readingPlanDeleteButtonIdentifier(for: planCode)
+
+        row.swipeLeft()
+        if waitForReadingPlanListStateToExclude(rowToken, in: app, timeout: 1) {
+            return
+        }
+
+        if !waitForResolvedElementAppearance(deleteIdentifier, in: app, timeout: 2) {
+            row.swipeLeft()
+        }
+        tapElementReliably(requireElement(deleteIdentifier, in: app, timeout: timeout), timeout: timeout)
+
+        if !waitForReadingPlanListStateToExclude(rowToken, in: app, timeout: 3),
+           let refreshedRow = resolvedElement("readingPlanActivePlanLink", in: app) {
+            refreshedRow.swipeLeft()
+            if waitForResolvedElementAppearance(deleteIdentifier, in: app, timeout: 2) {
+                tapElementReliably(requireElement(deleteIdentifier, in: app, timeout: timeout), timeout: timeout)
+            }
+        }
+    }
+
+    /// Returns true when the Reading Plans state drops one token before the timeout.
+    private func waitForReadingPlanListStateToExclude(
+        _ token: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let currentValue = resolvedReadingPlanListStateValue(in: app),
+               !currentValue.contains(token) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        return resolvedReadingPlanListStateValue(in: app)?.contains(token) == false
+    }
+
     /// Sanitizes one reading-plan code to match the production accessibility export.
     private func sanitizedReadingPlanStateToken(_ value: String) -> String {
         let mapped = value.unicodeScalars.map { scalar -> String in
@@ -4296,6 +4337,45 @@ final class AndBibleUITests: XCTestCase {
         timeout: TimeInterval = 10
     ) {
         waitForElementValue("historyScreen", toNotContain: token, in: app, timeout: timeout)
+    }
+
+    /// Performs one History row deletion through SwiftUI's swipe affordance.
+    private func deleteHistoryRow(
+        _ row: XCUIElement,
+        keyToken: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) {
+        let rowToken = historyRowStateToken(keyToken)
+        let deleteIdentifier = "historyDeleteButton::\(keyToken)"
+
+        row.swipeLeft()
+        if waitForHistoryStateToExclude(rowToken, in: app, timeout: 1) {
+            return
+        }
+
+        if !waitForResolvedElementAppearance(deleteIdentifier, in: app, timeout: 2) {
+            row.swipeLeft()
+        }
+        tapElementReliably(requireElement(deleteIdentifier, in: app, timeout: timeout), timeout: timeout)
+    }
+
+    /// Returns true when the History state drops one token before the timeout.
+    private func waitForHistoryStateToExclude(
+        _ token: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let currentValue = resolvedElementSemanticText("historyScreen", in: app),
+               !currentValue.contains(token) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        return resolvedElementSemanticText("historyScreen", in: app)?.contains(token) == false
     }
 
     /**
@@ -6083,15 +6163,15 @@ final class AndBibleUITests: XCTestCase {
 
     /// Reads the compact reader state export without walking drawer or overflow menu contents.
     private func readerRenderedContentStateValue(in app: XCUIApplication) -> String? {
-        if let headerValue = readerDocumentHeaderStateValue(in: app) {
-            return headerValue
-        }
         for stateElement in readerRenderedContentStateElements(in: app) {
             guard stateElement.exists,
                   let value = stateElement.value as? String else {
                 continue
             }
             return value
+        }
+        if let headerValue = readerDocumentHeaderStateValue(in: app) {
+            return headerValue
         }
         return nil
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
@@ -42,6 +42,8 @@ through one generic SQLite importer.
    successful bookmark restores
  - `RemoteSyncWorkspaceSnapshotService` refreshes outbound workspace fingerprint baselines after
    successful workspace restores
+ - `RemoteSyncMyDocumentSnapshotService` refreshes outbound My Documents fingerprint baselines
+   after successful My Documents restores
  - `SettingsStore` provides local-only persistence for fidelity-preserving side stores such as
   `RemoteSyncReadingPlanStatusStore`, `RemoteSyncBookmarkPlaybackSettingsStore`, and
   `RemoteSyncBookmarkLabelAliasStore`, `RemoteSyncWorkspaceFidelityStore`,
@@ -51,8 +53,8 @@ through one generic SQLite importer.
  - mutates live local SwiftData records for the supported category
  - may write local-only settings rows needed to preserve Android-only fidelity
  - replaces local Android sync metadata rows for the category after content restore succeeds
- - refreshes outbound bookmark, workspace, and reading-plan fingerprint baselines after successful
-   restores for those categories
+ - refreshes outbound bookmark, workspace, reading-plan, and My Documents fingerprint baselines
+   after successful restores for those categories
 
  Failure modes:
  - rethrows category-specific restore errors from the selected restore service
@@ -71,6 +73,7 @@ public final class RemoteSyncInitialBackupRestoreService {
     private let bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService
     private let workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService
     private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
+    private let myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService
 
     /**
      Creates a category-level initial-backup restore dispatcher.
@@ -88,6 +91,8 @@ public final class RemoteSyncInitialBackupRestoreService {
          baselines after successful workspace restores.
        - readingPlanSnapshotService: Snapshot service used to refresh outbound reading-plan
          fingerprint baselines after successful remote restores.
+       - myDocumentSnapshotService: Snapshot service used to refresh outbound My Documents
+         fingerprint baselines after successful remote restores.
      - Side effects: none.
      - Failure modes: This initializer cannot fail.
      */
@@ -99,7 +104,8 @@ public final class RemoteSyncInitialBackupRestoreService {
         metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
         bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService = RemoteSyncBookmarkSnapshotService(),
         workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService = RemoteSyncWorkspaceSnapshotService(),
-        readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService()
+        readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(),
+        myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService()
     ) {
         self.bookmarkRestoreService = bookmarkRestoreService
         self.readingPlanRestoreService = readingPlanRestoreService
@@ -109,6 +115,7 @@ public final class RemoteSyncInitialBackupRestoreService {
         self.bookmarkSnapshotService = bookmarkSnapshotService
         self.workspaceSnapshotService = workspaceSnapshotService
         self.readingPlanSnapshotService = readingPlanSnapshotService
+        self.myDocumentSnapshotService = myDocumentSnapshotService
     }
 
     /**
@@ -124,7 +131,7 @@ public final class RemoteSyncInitialBackupRestoreService {
        - mutates live SwiftData state for the supported category
        - may persist local-only helper state needed to preserve Android-only fidelity
        - replaces local Android sync metadata rows for the category after the content restore succeeds
-       - refreshes outbound bookmark, workspace, or reading-plan fingerprint baselines after successful restores
+       - refreshes outbound fingerprint baselines after successful restores
      - Failure modes:
        - rethrows category-specific snapshot and restore errors from the selected service
        - rethrows staged sync-metadata read errors when present Android metadata tables are malformed
@@ -190,6 +197,11 @@ public final class RemoteSyncInitialBackupRestoreService {
             )
         } else if category == .readingPlans {
             readingPlanSnapshotService.refreshBaselineFingerprints(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        } else if category == .myDocuments {
+            myDocumentSnapshotService.refreshBaselineFingerprints(
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -1001,17 +1001,24 @@ public final class RemoteSyncInitialBackupUploadService {
                 in: database
             )
 
-            for row in snapshot.documentRowsByKey.values.sorted(by: Self.myDocumentSort) {
-                try insertMyDocumentRow(row, in: database)
-            }
-            for row in snapshot.pageRowsByKey.values.sorted(by: Self.myDocumentPageSort) {
-                try insertMyDocumentPageRow(row, in: database)
-            }
-            for row in snapshot.pageContentRowsByKey.values.sorted(by: Self.myDocumentPageContentSort) {
-                try insertMyDocumentPageContentRow(row, in: database)
-            }
-            for row in snapshot.aiPageCacheEntryRowsByKey.values.sorted(by: Self.aiPageCacheEntrySort) {
-                try insertAiPageCacheEntryRow(row, in: database)
+            try execute("BEGIN IMMEDIATE TRANSACTION;", in: database)
+            do {
+                for row in snapshot.documentRowsByKey.values.sorted(by: Self.myDocumentSort) {
+                    try insertMyDocumentRow(row, in: database)
+                }
+                for row in snapshot.pageRowsByKey.values.sorted(by: Self.myDocumentPageSort) {
+                    try insertMyDocumentPageRow(row, in: database)
+                }
+                for row in snapshot.pageContentRowsByKey.values.sorted(by: Self.myDocumentPageContentSort) {
+                    try insertMyDocumentPageContentRow(row, in: database)
+                }
+                for row in snapshot.aiPageCacheEntryRowsByKey.values.sorted(by: Self.aiPageCacheEntrySort) {
+                    try insertAiPageCacheEntryRow(row, in: database)
+                }
+                try execute("COMMIT;", in: database)
+            } catch {
+                try? execute("ROLLBACK;", in: database)
+                throw error
             }
 
             return BuiltInitialBackup(databaseURL: databaseURL, workspaceHistoryAliases: [])

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -894,6 +894,9 @@ public final class RemoteSyncInitialBackupUploadService {
                 SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
                 nil
             ) == SQLITE_OK, let database else {
+                if let database {
+                    sqlite3_close(database)
+                }
                 throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
             }
             defer { sqlite3_close(database) }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -252,7 +252,11 @@ public final class RemoteSyncInitialBackupUploadService {
                 schemaVersion: schemaVersion
             )
         case .myDocuments:
-            throw RemoteSyncInitialBackupUploadError.unsupportedCategory(category)
+            return try buildMyDocumentInitialBackup(
+                modelContext: modelContext,
+                settingsStore: settingsStore,
+                schemaVersion: schemaVersion
+            )
         }
     }
 
@@ -323,7 +327,10 @@ public final class RemoteSyncInitialBackupUploadService {
                 settingsStore: settingsStore
             )
         case .myDocuments:
-            break
+            RemoteSyncMyDocumentSnapshotService().refreshBaselineFingerprints(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
         }
     }
 
@@ -854,6 +861,163 @@ public final class RemoteSyncInitialBackupUploadService {
         }
     }
 
+    /**
+     Builds one full Android My Documents database from the current local snapshot.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns the current My Documents graph.
+       - settingsStore: Local-only settings store that preserves sync bookkeeping.
+       - schemaVersion: SQLite user-version written into the exported database.
+     - Returns: Temporary SQLite database containing the current My Documents baseline.
+     - Side effects:
+       - reads My Documents rows from `modelContext`
+       - writes one temporary SQLite database beneath the configured temporary directory
+     - Failure modes:
+       - throws `RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase` when SQLite rejects schema creation or row insertion
+     */
+    private func buildMyDocumentInitialBackup(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int
+    ) throws -> BuiltInitialBackup {
+        let snapshotService = RemoteSyncMyDocumentSnapshotService()
+        let snapshot = snapshotService.snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let databaseURL = temporaryURL(prefix: "remote-sync-mydocuments-initial-", suffix: ".sqlite3")
+        do {
+            var database: OpaquePointer?
+            guard sqlite3_open_v2(
+                databaseURL.path,
+                &database,
+                SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                nil
+            ) == SQLITE_OK, let database else {
+                throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+            }
+            defer { sqlite3_close(database) }
+
+            try execute(
+                """
+                PRAGMA foreign_keys = ON;
+                PRAGMA user_version = \(schemaVersion);
+                CREATE TABLE MyDocument (
+                    id BLOB NOT NULL PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    description TEXT DEFAULT NULL,
+                    initials TEXT NOT NULL,
+                    orderNumber INTEGER NOT NULL,
+                    createdAt INTEGER NOT NULL,
+                    updatedAt INTEGER NOT NULL,
+                    sourcePromptId BLOB DEFAULT NULL
+                );
+                CREATE TABLE MyDocumentPage (
+                    id BLOB NOT NULL PRIMARY KEY,
+                    documentId BLOB NOT NULL,
+                    title TEXT NOT NULL,
+                    pageKey TEXT NOT NULL,
+                    contentType TEXT NOT NULL,
+                    orderNumber INTEGER NOT NULL,
+                    createdAt INTEGER NOT NULL,
+                    updatedAt INTEGER NOT NULL,
+                    sourcePromptId BLOB DEFAULT NULL,
+                    languageCode TEXT DEFAULT NULL,
+                    FOREIGN KEY(documentId) REFERENCES MyDocument(id) ON DELETE CASCADE
+                );
+                CREATE TABLE MyDocumentPageContent (
+                    pageId BLOB NOT NULL PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    FOREIGN KEY(pageId) REFERENCES MyDocumentPage(id) ON DELETE CASCADE
+                );
+                CREATE TABLE AiPageCacheEntry (
+                    pageId BLOB NOT NULL PRIMARY KEY,
+                    sourcePromptId BLOB NOT NULL,
+                    sourceContext TEXT DEFAULT NULL,
+                    kjvOrdinalStart INTEGER DEFAULT NULL,
+                    kjvOrdinalEnd INTEGER DEFAULT NULL,
+                    contextHash TEXT DEFAULT NULL,
+                    usedWriteTools INTEGER NOT NULL,
+                    sourceModelName TEXT DEFAULT NULL,
+                    sourceBookInitials TEXT DEFAULT NULL,
+                    sourceBookKey TEXT DEFAULT NULL,
+                    FOREIGN KEY(pageId) REFERENCES MyDocumentPage(id) ON DELETE CASCADE
+                );
+                CREATE TABLE LogEntry (
+                    tableName TEXT NOT NULL,
+                    entityId1 BLOB NOT NULL,
+                    entityId2 BLOB NOT NULL,
+                    type TEXT NOT NULL,
+                    lastUpdated INTEGER NOT NULL DEFAULT 0,
+                    sourceDevice TEXT NOT NULL,
+                    PRIMARY KEY(tableName, entityId1, entityId2)
+                );
+                CREATE TABLE SyncConfiguration (
+                    keyName TEXT NOT NULL,
+                    stringValue TEXT,
+                    longValue INTEGER,
+                    booleanValue INTEGER,
+                    PRIMARY KEY(keyName)
+                );
+                CREATE TABLE SyncStatus (
+                    sourceDevice TEXT NOT NULL,
+                    patchNumber INTEGER NOT NULL,
+                    sizeBytes INTEGER NOT NULL,
+                    appliedDate INTEGER NOT NULL,
+                    PRIMARY KEY(sourceDevice, patchNumber)
+                );
+                CREATE TABLE room_master_table (
+                    id INTEGER PRIMARY KEY,
+                    identity_hash TEXT
+                );
+                INSERT OR REPLACE INTO room_master_table (id, identity_hash)
+                    VALUES(42, '3f0946602099d896c8d47129233c1794');
+                CREATE UNIQUE INDEX index_MyDocument_initials ON MyDocument (initials);
+                CREATE INDEX index_MyDocumentPage_documentId ON MyDocumentPage (documentId);
+                CREATE UNIQUE INDEX index_MyDocumentPage_documentId_pageKey ON MyDocumentPage (documentId, pageKey);
+                CREATE INDEX index_AiPageCacheEntry_sourcePromptId_contextHash ON AiPageCacheEntry (sourcePromptId, contextHash);
+                CREATE INDEX index_AiPageCacheEntry_sourcePromptId_kjvOrdinalStart_kjvOrdinalEnd ON AiPageCacheEntry (sourcePromptId, kjvOrdinalStart, kjvOrdinalEnd);
+                CREATE INDEX index_AiPageCacheEntry_kjvOrdinalStart_kjvOrdinalEnd ON AiPageCacheEntry (kjvOrdinalStart, kjvOrdinalEnd);
+                CREATE INDEX index_AiPageCacheEntry_sourceBookInitials_sourceBookKey ON AiPageCacheEntry (sourceBookInitials, sourceBookKey);
+                CREATE INDEX index_LogEntry_lastUpdated ON LogEntry (lastUpdated);
+                CREATE INDEX index_LogEntry_sourceDevice ON LogEntry (sourceDevice);
+                CREATE VIEW MyDocumentPageWithContent AS
+                    SELECT p.*, c.content
+                    FROM MyDocumentPage p
+                    LEFT OUTER JOIN MyDocumentPageContent c ON p.id = c.pageId;
+                CREATE VIEW AiCachedPageWithContent AS
+                    SELECT c.pageId, c.sourcePromptId, c.sourceContext, c.kjvOrdinalStart,
+                           c.kjvOrdinalEnd, c.contextHash, c.usedWriteTools, c.sourceModelName,
+                           c.sourceBookInitials, c.sourceBookKey,
+                           p.title, p.pageKey, p.contentType, p.documentId,
+                           p.orderNumber, p.createdAt, p.updatedAt, p.languageCode, cnt.content
+                    FROM AiPageCacheEntry c
+                    INNER JOIN MyDocumentPage p ON c.pageId = p.id
+                    LEFT OUTER JOIN MyDocumentPageContent cnt ON p.id = cnt.pageId;
+                """,
+                in: database
+            )
+
+            for row in snapshot.documentRowsByKey.values.sorted(by: Self.myDocumentSort) {
+                try insertMyDocumentRow(row, in: database)
+            }
+            for row in snapshot.pageRowsByKey.values.sorted(by: Self.myDocumentPageSort) {
+                try insertMyDocumentPageRow(row, in: database)
+            }
+            for row in snapshot.pageContentRowsByKey.values.sorted(by: Self.myDocumentPageContentSort) {
+                try insertMyDocumentPageContentRow(row, in: database)
+            }
+            for row in snapshot.aiPageCacheEntryRowsByKey.values.sorted(by: Self.aiPageCacheEntrySort) {
+                try insertAiPageCacheEntryRow(row, in: database)
+            }
+
+            return BuiltInitialBackup(databaseURL: databaseURL, workspaceHistoryAliases: [])
+        } catch {
+            try? fileManager.removeItem(at: databaseURL)
+            throw error
+        }
+    }
+
     private struct ProjectedWorkspaceHistory {
         let rows: [RemoteSyncAndroidWorkspaceHistoryItem]
         let aliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias]
@@ -1131,6 +1295,55 @@ public final class RemoteSyncInitialBackupUploadService {
      */
     private static func pageManagerSort(_ lhs: RemoteSyncCurrentWorkspacePageManagerRow, _ rhs: RemoteSyncCurrentWorkspacePageManagerRow) -> Bool {
         lhs.windowID.uuidString < rhs.windowID.uuidString
+    }
+
+    /**
+     Sorts My Documents rows into a deterministic export order.
+     */
+    private static func myDocumentSort(_ lhs: RemoteSyncAndroidMyDocument, _ rhs: RemoteSyncAndroidMyDocument) -> Bool {
+        if lhs.orderNumber == rhs.orderNumber {
+            if lhs.name == rhs.name {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.name < rhs.name
+        }
+        return lhs.orderNumber < rhs.orderNumber
+    }
+
+    /**
+     Sorts My Document page rows into a deterministic export order.
+     */
+    private static func myDocumentPageSort(_ lhs: RemoteSyncAndroidMyDocumentPage, _ rhs: RemoteSyncAndroidMyDocumentPage) -> Bool {
+        if lhs.documentId == rhs.documentId {
+            if lhs.orderNumber == rhs.orderNumber {
+                if lhs.title == rhs.title {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.title < rhs.title
+            }
+            return lhs.orderNumber < rhs.orderNumber
+        }
+        return lhs.documentId.uuidString < rhs.documentId.uuidString
+    }
+
+    /**
+     Sorts My Document page-content rows into a deterministic export order.
+     */
+    private static func myDocumentPageContentSort(
+        _ lhs: RemoteSyncAndroidMyDocumentPageContent,
+        _ rhs: RemoteSyncAndroidMyDocumentPageContent
+    ) -> Bool {
+        lhs.pageId.uuidString < rhs.pageId.uuidString
+    }
+
+    /**
+     Sorts AI page-cache rows into a deterministic export order.
+     */
+    private static func aiPageCacheEntrySort(
+        _ lhs: RemoteSyncAndroidAiPageCacheEntry,
+        _ rhs: RemoteSyncAndroidAiPageCacheEntry
+    ) -> Bool {
+        lhs.pageId.uuidString < rhs.pageId.uuidString
     }
 
     /**
@@ -1586,6 +1799,106 @@ public final class RemoteSyncInitialBackupUploadService {
         bindOptionalInt(row.mapAnchorOrdinal, to: statement, index: index)
         index += 1
         try bindTextDisplaySettings(row.textDisplaySettings, to: statement, index: &index)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    /**
+     Inserts one Android `MyDocument` row into the open initial-backup database.
+     */
+    private func insertMyDocumentRow(_ row: RemoteSyncAndroidMyDocument, in database: OpaquePointer) throws {
+        let sql = "INSERT INTO MyDocument (id, name, description, initials, orderNumber, createdAt, updatedAt, sourcePromptId) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        bindText(row.name, to: statement, index: 2)
+        bindOptionalText(row.documentDescription, to: statement, index: 3)
+        bindText(row.initials, to: statement, index: 4)
+        sqlite3_bind_int(statement, 5, Int32(row.orderNumber))
+        sqlite3_bind_int64(statement, 6, Int64(row.createdAt.timeIntervalSince1970 * 1000.0))
+        sqlite3_bind_int64(statement, 7, Int64(row.updatedAt.timeIntervalSince1970 * 1000.0))
+        bindOptionalUUIDBlob(row.sourcePromptId, to: statement, index: 8)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    /**
+     Inserts one Android `MyDocumentPage` row into the open initial-backup database.
+     */
+    private func insertMyDocumentPageRow(_ row: RemoteSyncAndroidMyDocumentPage, in database: OpaquePointer) throws {
+        let sql = "INSERT INTO MyDocumentPage (id, documentId, title, pageKey, contentType, orderNumber, createdAt, updatedAt, sourcePromptId, languageCode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        bindUUIDBlob(row.documentId, to: statement, index: 2)
+        bindText(row.title, to: statement, index: 3)
+        bindText(row.pageKey, to: statement, index: 4)
+        bindText(row.contentType.rawValue, to: statement, index: 5)
+        sqlite3_bind_int(statement, 6, Int32(row.orderNumber))
+        sqlite3_bind_int64(statement, 7, Int64(row.createdAt.timeIntervalSince1970 * 1000.0))
+        sqlite3_bind_int64(statement, 8, Int64(row.updatedAt.timeIntervalSince1970 * 1000.0))
+        bindOptionalUUIDBlob(row.sourcePromptId, to: statement, index: 9)
+        bindOptionalText(row.languageCode, to: statement, index: 10)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    /**
+     Inserts one Android `MyDocumentPageContent` row into the open initial-backup database.
+     */
+    private func insertMyDocumentPageContentRow(
+        _ row: RemoteSyncAndroidMyDocumentPageContent,
+        in database: OpaquePointer
+    ) throws {
+        let sql = "INSERT INTO MyDocumentPageContent (pageId, content) VALUES (?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        bindUUIDBlob(row.pageId, to: statement, index: 1)
+        bindText(row.content, to: statement, index: 2)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    /**
+     Inserts one Android `AiPageCacheEntry` row into the open initial-backup database.
+     */
+    private func insertAiPageCacheEntryRow(
+        _ row: RemoteSyncAndroidAiPageCacheEntry,
+        in database: OpaquePointer
+    ) throws {
+        let sql = "INSERT INTO AiPageCacheEntry (pageId, sourcePromptId, sourceContext, kjvOrdinalStart, kjvOrdinalEnd, contextHash, usedWriteTools, sourceModelName, sourceBookInitials, sourceBookKey) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        bindUUIDBlob(row.pageId, to: statement, index: 1)
+        bindUUIDBlob(row.sourcePromptId, to: statement, index: 2)
+        bindOptionalText(row.sourceContext, to: statement, index: 3)
+        bindOptionalInt(row.kjvOrdinalStart, to: statement, index: 4)
+        bindOptionalInt(row.kjvOrdinalEnd, to: statement, index: 5)
+        bindOptionalText(row.contextHash, to: statement, index: 6)
+        bindBool(row.usedWriteTools, to: statement, index: 7)
+        bindOptionalText(row.sourceModelName, to: statement, index: 8)
+        bindOptionalText(row.sourceBookInitials, to: statement, index: 9)
+        bindOptionalText(row.sourceBookKey, to: statement, index: 10)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
         }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncLifecycleService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncLifecycleService.swift
@@ -43,7 +43,7 @@ public protocol RemoteSyncCategorySynchronizing: AnyObject {
      - Returns: Successful synchronization summary for the created remote folder.
      - Side Effects: Performs remote folder creation/deletion and may mutate local SwiftData.
      - Throws: Re-throws bootstrap, upload, or synchronization failures from the concrete service.
-     */
+    */
     func createRemoteFolderAndSynchronize(
         for category: RemoteSyncCategory,
         replacingRemoteFolderID: String?,
@@ -92,7 +92,7 @@ extension RemoteSyncSynchronizationService: RemoteSyncCategorySynchronizing {
             category,
             modelContext: modelContext,
             settingsStore: settingsStore,
-            currentSchemaVersion: 1
+            currentSchemaVersion: category.currentSchemaVersion
         )
     }
 
@@ -107,10 +107,10 @@ extension RemoteSyncSynchronizationService: RemoteSyncCategorySynchronizing {
      - Returns: Successful synchronization summary for the created remote folder.
      - Side Effects: Delegates to `RemoteSyncSynchronizationService.createRemoteFolderAndSynchronize`.
      - Failure modes: Re-throws bootstrap, upload, and synchronization failures from the underlying service.
-     */
+    */
     public func createRemoteFolderAndSynchronize(
         for category: RemoteSyncCategory,
-        replacingRemoteFolderID: String?,
+        replacingRemoteFolderID: String? = nil,
         modelContext: ModelContext,
         settingsStore: SettingsStore
     ) async throws -> RemoteSyncCategorySynchronizationReport {
@@ -119,7 +119,7 @@ extension RemoteSyncSynchronizationService: RemoteSyncCategorySynchronizing {
             replacingRemoteFolderID: replacingRemoteFolderID,
             modelContext: modelContext,
             settingsStore: settingsStore,
-            currentSchemaVersion: 1
+            currentSchemaVersion: category.currentSchemaVersion
         )
     }
 
@@ -146,7 +146,7 @@ extension RemoteSyncSynchronizationService: RemoteSyncCategorySynchronizing {
             remoteFolderID: remoteFolderID,
             modelContext: modelContext,
             settingsStore: settingsStore,
-            currentSchemaVersion: 1
+            currentSchemaVersion: category.currentSchemaVersion
         )
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
@@ -1,0 +1,367 @@
+// RemoteSyncMyDocumentSnapshotService.swift -- Android-shaped local My Documents snapshots for outbound sync
+
+import CryptoKit
+import Foundation
+import SwiftData
+
+/**
+ Snapshot of current local My Documents state expressed in Android row form.
+
+ The snapshot carries row maps keyed by Android's `(tableName, entityId1, entityId2)` sync identity
+ plus stable content fingerprints so later patch upload work can diff against the accepted
+ baseline without re-reading SwiftData.
+ */
+public struct RemoteSyncMyDocumentCurrentSnapshot: Sendable, Equatable {
+    /// Android-shaped current `MyDocument` rows keyed by Android composite key.
+    public let documentRowsByKey: [String: RemoteSyncAndroidMyDocument]
+
+    /// Android-shaped current `MyDocumentPage` rows keyed by Android composite key.
+    public let pageRowsByKey: [String: RemoteSyncAndroidMyDocumentPage]
+
+    /// Android-shaped current `MyDocumentPageContent` rows keyed by Android composite key.
+    public let pageContentRowsByKey: [String: RemoteSyncAndroidMyDocumentPageContent]
+
+    /// Android-shaped current `AiPageCacheEntry` rows keyed by Android composite key.
+    public let aiPageCacheEntryRowsByKey: [String: RemoteSyncAndroidAiPageCacheEntry]
+
+    /// Stable content fingerprints for every current row keyed by Android composite key.
+    public let fingerprintsByKey: [String: String]
+
+    public init(
+        documentRowsByKey: [String: RemoteSyncAndroidMyDocument],
+        pageRowsByKey: [String: RemoteSyncAndroidMyDocumentPage],
+        pageContentRowsByKey: [String: RemoteSyncAndroidMyDocumentPageContent],
+        aiPageCacheEntryRowsByKey: [String: RemoteSyncAndroidAiPageCacheEntry],
+        fingerprintsByKey: [String: String]
+    ) {
+        self.documentRowsByKey = documentRowsByKey
+        self.pageRowsByKey = pageRowsByKey
+        self.pageContentRowsByKey = pageContentRowsByKey
+        self.aiPageCacheEntryRowsByKey = aiPageCacheEntryRowsByKey
+        self.fingerprintsByKey = fingerprintsByKey
+    }
+}
+
+/**
+ Projects local My Documents SwiftData rows into Android My Documents sync rows.
+
+ Android defines My Documents as four sync targets in `SyncUtilities.kt`:
+ `MyDocument`, `MyDocumentPage`, `MyDocumentPageContent`, and `AiPageCacheEntry`. This service
+ mirrors those table identities and uses `pageId` for the detached content/cache targets so iOS
+ initial backups and future patches match Android's trigger contract.
+
+ Side effects:
+ - `snapshotCurrentState` reads `MyDocument`, `MyDocumentPage`, `MyDocumentPageContent`, and
+   `AiPageCacheEntry` rows from SwiftData
+ - `refreshBaselineFingerprints` rewrites the local fingerprint baseline for the My Documents
+   category
+
+ Failure modes:
+ - fetch failures from `ModelContext` are swallowed and treated as an empty snapshot, matching the
+   existing outbound snapshot services
+ */
+public final class RemoteSyncMyDocumentSnapshotService {
+    public init() {}
+
+    /**
+     Projects the current local My Documents graph into Android-shaped rows.
+     */
+    public func snapshotCurrentState(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) -> RemoteSyncMyDocumentCurrentSnapshot {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let documents = ((try? modelContext.fetch(FetchDescriptor<MyDocument>())) ?? [])
+            .sorted(by: Self.documentSort)
+        let pages = ((try? modelContext.fetch(FetchDescriptor<MyDocumentPage>())) ?? [])
+            .sorted(by: Self.pageSort)
+        let pageContents = ((try? modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())) ?? [])
+            .sorted { $0.pageId.uuidString < $1.pageId.uuidString }
+        let aiPageCacheEntries = ((try? modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())) ?? [])
+            .sorted(by: Self.aiPageCacheEntrySort)
+
+        let documentIDs = Set(documents.map(\.id))
+        var pageIDs: Set<UUID> = []
+        var emittedAIPageCachePageIDs: Set<UUID> = []
+        var documentRowsByKey: [String: RemoteSyncAndroidMyDocument] = [:]
+        var pageRowsByKey: [String: RemoteSyncAndroidMyDocumentPage] = [:]
+        var pageContentRowsByKey: [String: RemoteSyncAndroidMyDocumentPageContent] = [:]
+        var aiPageCacheEntryRowsByKey: [String: RemoteSyncAndroidAiPageCacheEntry] = [:]
+        var fingerprintsByKey: [String: String] = [:]
+
+        for document in documents {
+            let row = RemoteSyncAndroidMyDocument(
+                id: document.id,
+                name: document.name,
+                documentDescription: document.documentDescription,
+                initials: document.initials,
+                orderNumber: document.orderNumber,
+                createdAt: document.createdAt,
+                updatedAt: document.updatedAt,
+                sourcePromptId: document.sourcePromptId
+            )
+            let key = logEntryStore.key(
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(Self.uuidBlob(row.id)),
+                entityID2: .text("")
+            )
+            documentRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        for page in pages {
+            guard let documentID = page.document?.id, documentIDs.contains(documentID) else {
+                continue
+            }
+            let row = RemoteSyncAndroidMyDocumentPage(
+                id: page.id,
+                documentId: documentID,
+                title: page.title,
+                pageKey: page.pageKey,
+                contentType: page.contentType,
+                orderNumber: page.orderNumber,
+                createdAt: page.createdAt,
+                updatedAt: page.updatedAt,
+                sourcePromptId: page.sourcePromptId,
+                languageCode: page.languageCode
+            )
+            let key = logEntryStore.key(
+                for: .myDocuments,
+                tableName: "MyDocumentPage",
+                entityID1: .blob(Self.uuidBlob(row.id)),
+                entityID2: .text("")
+            )
+            pageIDs.insert(row.id)
+            pageRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        for pageContent in pageContents where pageIDs.contains(pageContent.pageId) {
+            let row = RemoteSyncAndroidMyDocumentPageContent(
+                pageId: pageContent.pageId,
+                content: pageContent.content
+            )
+            let key = logEntryStore.key(
+                for: .myDocuments,
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(Self.uuidBlob(row.pageId)),
+                entityID2: .text("")
+            )
+            pageContentRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        for cacheEntry in aiPageCacheEntries where pageIDs.contains(cacheEntry.pageId) {
+            guard emittedAIPageCachePageIDs.insert(cacheEntry.pageId).inserted else {
+                continue
+            }
+            let row = RemoteSyncAndroidAiPageCacheEntry(
+                pageId: cacheEntry.pageId,
+                sourcePromptId: cacheEntry.sourcePromptId,
+                sourceContext: cacheEntry.sourceContext,
+                kjvOrdinalStart: cacheEntry.kjvOrdinalStart,
+                kjvOrdinalEnd: cacheEntry.kjvOrdinalEnd,
+                contextHash: cacheEntry.contextHash,
+                usedWriteTools: cacheEntry.usedWriteTools,
+                sourceModelName: cacheEntry.sourceModelName,
+                sourceBookInitials: cacheEntry.sourceBookInitials,
+                sourceBookKey: cacheEntry.sourceBookKey
+            )
+            let key = logEntryStore.key(
+                for: .myDocuments,
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(Self.uuidBlob(row.pageId)),
+                entityID2: .text("")
+            )
+            aiPageCacheEntryRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        return RemoteSyncMyDocumentCurrentSnapshot(
+            documentRowsByKey: documentRowsByKey,
+            pageRowsByKey: pageRowsByKey,
+            pageContentRowsByKey: pageContentRowsByKey,
+            aiPageCacheEntryRowsByKey: aiPageCacheEntryRowsByKey,
+            fingerprintsByKey: fingerprintsByKey
+        )
+    }
+
+    /**
+     Replaces the stored fingerprint baseline with the current My Documents snapshot.
+     */
+    public func refreshBaselineFingerprints(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) {
+        let snapshot = snapshotCurrentState(modelContext: modelContext, settingsStore: settingsStore)
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        fingerprintStore.clearCategory(.myDocuments)
+
+        for (key, row) in snapshot.documentRowsByKey {
+            guard let fingerprint = snapshot.fingerprintsByKey[key] else {
+                continue
+            }
+            fingerprintStore.setFingerprint(
+                fingerprint,
+                for: .myDocuments,
+                tableName: "MyDocument",
+                entityID1: .blob(Self.uuidBlob(row.id)),
+                entityID2: .text("")
+            )
+        }
+
+        for (key, row) in snapshot.pageRowsByKey {
+            guard let fingerprint = snapshot.fingerprintsByKey[key] else {
+                continue
+            }
+            fingerprintStore.setFingerprint(
+                fingerprint,
+                for: .myDocuments,
+                tableName: "MyDocumentPage",
+                entityID1: .blob(Self.uuidBlob(row.id)),
+                entityID2: .text("")
+            )
+        }
+
+        for (key, row) in snapshot.pageContentRowsByKey {
+            guard let fingerprint = snapshot.fingerprintsByKey[key] else {
+                continue
+            }
+            fingerprintStore.setFingerprint(
+                fingerprint,
+                for: .myDocuments,
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(Self.uuidBlob(row.pageId)),
+                entityID2: .text("")
+            )
+        }
+
+        for (key, row) in snapshot.aiPageCacheEntryRowsByKey {
+            guard let fingerprint = snapshot.fingerprintsByKey[key] else {
+                continue
+            }
+            fingerprintStore.setFingerprint(
+                fingerprint,
+                for: .myDocuments,
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(Self.uuidBlob(row.pageId)),
+                entityID2: .text("")
+            )
+        }
+    }
+
+    /**
+     Converts one UUID into Android's raw 16-byte blob representation.
+     */
+    public static func uuidBlob(_ uuid: UUID) -> Data {
+        withUnsafeBytes(of: uuid.uuid) { Data($0) }
+    }
+
+    static func fingerprintHex(for value: RemoteSyncAndroidMyDocument) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                value.name,
+                value.documentDescription ?? "",
+                value.initials,
+                String(value.orderNumber),
+                canonicalDateMillis(value.createdAt),
+                canonicalDateMillis(value.updatedAt),
+                value.sourcePromptId?.uuidString.lowercased() ?? "",
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncAndroidMyDocumentPage) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                value.documentId.uuidString.lowercased(),
+                value.title,
+                value.pageKey,
+                value.contentType.rawValue,
+                String(value.orderNumber),
+                canonicalDateMillis(value.createdAt),
+                canonicalDateMillis(value.updatedAt),
+                value.sourcePromptId?.uuidString.lowercased() ?? "",
+                value.languageCode ?? "",
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncAndroidMyDocumentPageContent) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.pageId.uuidString.lowercased(),
+                value.content,
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncAndroidAiPageCacheEntry) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.pageId.uuidString.lowercased(),
+                value.sourcePromptId.uuidString.lowercased(),
+                value.sourceContext ?? "",
+                canonicalOptionalInt(value.kjvOrdinalStart),
+                canonicalOptionalInt(value.kjvOrdinalEnd),
+                value.contextHash ?? "",
+                canonicalBool(value.usedWriteTools),
+                value.sourceModelName ?? "",
+                value.sourceBookInitials ?? "",
+                value.sourceBookKey ?? "",
+            ].joined(separator: "|")
+        )
+    }
+
+    private static func documentSort(_ lhs: MyDocument, _ rhs: MyDocument) -> Bool {
+        if lhs.orderNumber == rhs.orderNumber {
+            if lhs.name == rhs.name {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.name < rhs.name
+        }
+        return lhs.orderNumber < rhs.orderNumber
+    }
+
+    private static func pageSort(_ lhs: MyDocumentPage, _ rhs: MyDocumentPage) -> Bool {
+        let lhsDocumentID = lhs.document?.id.uuidString ?? ""
+        let rhsDocumentID = rhs.document?.id.uuidString ?? ""
+        if lhsDocumentID == rhsDocumentID {
+            if lhs.orderNumber == rhs.orderNumber {
+                if lhs.title == rhs.title {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.title < rhs.title
+            }
+            return lhs.orderNumber < rhs.orderNumber
+        }
+        return lhsDocumentID < rhsDocumentID
+    }
+
+    private static func aiPageCacheEntrySort(_ lhs: AiPageCacheEntry, _ rhs: AiPageCacheEntry) -> Bool {
+        if lhs.pageId == rhs.pageId {
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+        return lhs.pageId.uuidString < rhs.pageId.uuidString
+    }
+
+    private static func canonicalDateMillis(_ value: Date) -> String {
+        String(Int64(value.timeIntervalSince1970 * 1000.0))
+    }
+
+    private static func canonicalOptionalInt(_ value: Int?) -> String {
+        value.map(String.init) ?? ""
+    }
+
+    private static func canonicalBool(_ value: Bool) -> String {
+        value ? "1" : "0"
+    }
+
+    private static func fingerprintHex(canonicalValue: String) -> String {
+        let digest = SHA256.hash(data: Data(canonicalValue.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
@@ -28,6 +28,16 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
         [.bookmarks, .workspaces, .readingPlans]
     }
 
+    /// Highest Android SQLite schema version iOS can currently read and write for this category.
+    public var currentSchemaVersion: Int {
+        switch self {
+        case .myDocuments:
+            RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        case .bookmarks, .workspaces, .readingPlans:
+            1
+        }
+    }
+
     /**
      Builds the Android-style remote sync folder name for this category.
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -303,7 +303,7 @@ public final class RemoteSyncSynchronizationService {
         _ category: RemoteSyncCategory,
         modelContext: ModelContext,
         settingsStore: SettingsStore,
-        currentSchemaVersion: Int = 1
+        currentSchemaVersion: Int
     ) async throws -> RemoteSyncSynchronizationOutcome {
         let bootstrapCoordinator = makeBootstrapCoordinator(settingsStore: settingsStore)
 
@@ -359,7 +359,7 @@ public final class RemoteSyncSynchronizationService {
         remoteFolderID: String,
         modelContext: ModelContext,
         settingsStore: SettingsStore,
-        currentSchemaVersion: Int = 1
+        currentSchemaVersion: Int
     ) async throws -> RemoteSyncCategorySynchronizationReport {
         let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
         let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
@@ -447,7 +447,7 @@ public final class RemoteSyncSynchronizationService {
         replacingRemoteFolderID: String? = nil,
         modelContext: ModelContext,
         settingsStore: SettingsStore,
-        currentSchemaVersion: Int = 1
+        currentSchemaVersion: Int
     ) async throws -> RemoteSyncCategorySynchronizationReport {
         let bootstrapCoordinator = makeBootstrapCoordinator(settingsStore: settingsStore)
 

--- a/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
@@ -109,10 +109,11 @@ public struct ReadingPlanListView: View {
                         .accessibilityIdentifier("readingPlanActivePlanLink")
                         .accessibilityLabel(plan.planName)
                         .accessibilityValue(plan.planCode)
-                        .swipeActions(edge: .trailing) {
-                            Button(String(localized: "delete"), role: .destructive) {
-                                modelContext.delete(plan)
-                                try? modelContext.save()
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                deletePlan(plan)
+                            } label: {
+                                SwiftUI.Label(String(localized: "delete"), systemImage: "trash")
                             }
                             .accessibilityIdentifier(readingPlanDeleteButtonIdentifier(for: plan))
                         }
@@ -124,10 +125,11 @@ public struct ReadingPlanListView: View {
                 Section(String(localized: "reading_plan_completed")) {
                     ForEach(completedPlans) { plan in
                         CompletedPlanRow(plan: plan)
-                            .swipeActions(edge: .trailing) {
-                                Button(String(localized: "delete"), role: .destructive) {
-                                    modelContext.delete(plan)
-                                    try? modelContext.save()
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    deletePlan(plan)
+                                } label: {
+                                    SwiftUI.Label(String(localized: "delete"), systemImage: "trash")
                                 }
                                 .accessibilityIdentifier(readingPlanDeleteButtonIdentifier(for: plan))
                             }
@@ -170,6 +172,14 @@ public struct ReadingPlanListView: View {
     /// Stable row-level delete button identifier for UI tests.
     private func readingPlanDeleteButtonIdentifier(for plan: ReadingPlan) -> String {
         "readingPlanDeleteButton::\(readingPlanAccessibilitySegment(plan.planCode))"
+    }
+
+    /// Deletes one persisted plan and lets the live query refresh the list sections.
+    private func deletePlan(_ plan: ReadingPlan) {
+        withAnimation {
+            modelContext.delete(plan)
+        }
+        try? modelContext.save()
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the My Documents initial-backup upload path so iOS can export Android-compatible `mydocuments.sqlite3` archives for issue #106.

## Scope
- Projects local SwiftData My Documents data into Android-shaped document, page, content, and AI cache rows.
- Builds Android schema v4 `mydocuments.sqlite3` initial backups with Room identity metadata, indexes, views, and sync metadata tables.
- Refreshes My Documents row-fingerprint baselines after initial upload and restore.
- Uses category-specific schema versions in remote sync lifecycle calls and removes the lower-level v1 default footgun.
- Adds populated, empty, restore-dispatch, and direct snapshot tests covering schema metadata, restore round trips, orphan filtering, and baseline fingerprints.

## Contract References
- Issue: #106
- Android source: `MyDocumentDatabase` schema v4 and `SyncUtilities.kt` My Documents sync table definitions.
- Commit/PR convention: `../commit-message-standard.md`

## Change Details
- Added `RemoteSyncMyDocumentSnapshotService` for Android sync keys and stable row fingerprints.
- Extended `RemoteSyncInitialBackupUploadService` to export `.myDocuments` instead of treating it as unsupported.
- Extended initial restore baseline refresh for My Documents.
- Added `RemoteSyncCategory.currentSchemaVersion` and routed lifecycle calls through it.
- Required explicit schema versions on lower-level `RemoteSyncSynchronizationService` entry points while preserving category-aware lifecycle wrappers.
- Added tests that inspect uploaded SQLite output, verify Room identity/schema details, restore the generated DB back into SwiftData, and assert fingerprint baselines for all My Documents sync tables.

## Validation Evidence
- `xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=73679934-67DF-45BE-AEAC-186E2396213C' -only-testing:AndBibleTests/RemoteSyncMyDocumentRestoreTests COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES test`
- `git diff --check`
- `git diff --cached --check`
- `npx gitnexus analyze --force --skip-agents-md`
- `npx gitnexus detect-changes --repo and-bible-ios --scope compare --base-ref origin/main`
- Claude CLI local review completed; low-severity coverage and schema-version findings were addressed.
- Gemini CLI local review completed with GitNexus MCP connected; result: No findings.

## Risks / Follow-ups
- My Documents patch upload remains a later parity slice; this PR prepares accepted baseline fingerprints for that work.
- Existing bookmark, workspace, and reading-plan initial backup paths are intended to remain behaviorally unchanged.

Closes #106
