### PR TITLE
feat(sync): upload My Documents patches

### DIFF
--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -681,6 +681,562 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         XCTAssertEqual(RemoteSyncStateStore(settingsStore: settingsStore).progressState(for: .myDocuments).lastPatchWritten, 2_400)
     }
 
+    func testRemoteSyncMyDocumentPatchUploadWritesAndUploadsSparsePatch() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+        let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let snapshotService = RemoteSyncMyDocumentSnapshotService()
+        let metadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService()
+        let restoreService = RemoteSyncMyDocumentRestoreService()
+
+        let existingDocumentID = UUID(uuidString: "a7100000-0000-0000-0000-000000000001")!
+        let existingPageID = UUID(uuidString: "a7100000-0000-0000-0000-000000000011")!
+        let existingPromptID = UUID(uuidString: "a7100000-0000-0000-0000-000000000021")!
+        let newDocumentID = UUID(uuidString: "a7100000-0000-0000-0000-000000000002")!
+        let newPageID = UUID(uuidString: "a7100000-0000-0000-0000-000000000012")!
+        let newPromptID = UUID(uuidString: "a7100000-0000-0000-0000-000000000022")!
+        let createdAt = Date(timeIntervalSince1970: 1_735_689_600)
+        let updatedAt = Date(timeIntervalSince1970: 1_735_689_660)
+
+        let existingDocument = MyDocument(
+            id: existingDocumentID,
+            name: "Existing",
+            initials: "EXIST",
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+        let existingPage = MyDocumentPage(
+            id: existingPageID,
+            title: "Existing Page",
+            pageKey: "existing",
+            contentType: .markdown,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            sourcePromptId: existingPromptID,
+            languageCode: "en"
+        )
+        let existingContent = MyDocumentPageContent(pageId: existingPageID, content: "Original content")
+        let existingCacheEntry = AiPageCacheEntry(
+            pageId: existingPageID,
+            sourcePromptId: existingPromptID,
+            contextHash: "old-context",
+            sourceBookKey: "John.1"
+        )
+        existingDocument.pages = [existingPage]
+        existingPage.document = existingDocument
+        existingPage.pageContent = existingContent
+        existingContent.page = existingPage
+        existingPage.aiPageCacheEntries = [existingCacheEntry]
+        existingCacheEntry.page = existingPage
+        modelContext.insert(existingDocument)
+        modelContext.insert(existingPage)
+        modelContext.insert(existingContent)
+        modelContext.insert(existingCacheEntry)
+        try modelContext.save()
+
+        logEntryStore.replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [existingDocumentID],
+                pageIDs: [existingPageID],
+                timestamp: 1_000,
+                sourceDevice: "pixel"
+            ),
+            for: .myDocuments
+        )
+        snapshotService.refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        existingContent.content = "Edited content only"
+        existingCacheEntry.contextHash = "updated-context"
+        let newDocument = MyDocument(
+            id: newDocumentID,
+            name: "New",
+            documentDescription: "Created locally",
+            initials: "NEWDOC",
+            orderNumber: 1,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+        let newPage = MyDocumentPage(
+            id: newPageID,
+            title: "New Page",
+            pageKey: "new",
+            contentType: .html,
+            orderNumber: 1,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            sourcePromptId: newPromptID,
+            languageCode: "en"
+        )
+        let newContent = MyDocumentPageContent(pageId: newPageID, content: "<p>New</p>")
+        let newCacheEntry = AiPageCacheEntry(
+            pageId: newPageID,
+            sourcePromptId: newPromptID,
+            sourceContext: #"{"osisRef":"Rom.8"}"#,
+            kjvOrdinalStart: 28_000,
+            kjvOrdinalEnd: 28_001,
+            contextHash: "new-context",
+            usedWriteTools: true,
+            sourceModelName: "gpt-test",
+            sourceBookInitials: "KJV",
+            sourceBookKey: "Rom.8"
+        )
+        newDocument.pages = [newPage]
+        newPage.document = newDocument
+        newPage.pageContent = newContent
+        newContent.page = newPage
+        newPage.aiPageCacheEntries = [newCacheEntry]
+        newCacheEntry.page = newPage
+        modelContext.insert(newDocument)
+        modelContext.insert(newPage)
+        modelContext.insert(newContent)
+        modelContext.insert(newCacheEntry)
+        try modelContext.save()
+
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "/org.andbible.ios-sync-mydocuments/ios-device/1.4.sqlite3.gz",
+                name: "1.4.sqlite3.gz",
+                size: 0,
+                timestamp: 3_000,
+                parentID: "/org.andbible.ios-sync-mydocuments/ios-device",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncMyDocumentPatchUploadService(
+            adapter: adapter,
+            nowProvider: { 3_000 }
+        )
+
+        let report = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/org.andbible.ios-sync-mydocuments/ios-device"),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let unwrappedReport = try XCTUnwrap(report)
+        XCTAssertEqual(unwrappedReport.patchNumber, 1)
+        XCTAssertEqual(unwrappedReport.upsertedDocumentCount, 1)
+        XCTAssertEqual(unwrappedReport.upsertedPageCount, 1)
+        XCTAssertEqual(unwrappedReport.upsertedPageContentCount, 2)
+        XCTAssertEqual(unwrappedReport.upsertedAiPageCacheEntryCount, 2)
+        XCTAssertEqual(unwrappedReport.deletedRowCount, 0)
+        XCTAssertEqual(unwrappedReport.logEntryCount, 6)
+        XCTAssertEqual(unwrappedReport.lastUpdated, 3_000)
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedFile = try XCTUnwrap(uploadedFiles.first)
+        XCTAssertEqual(uploadedFile.name, "1.4.sqlite3.gz")
+        XCTAssertEqual(uploadedFile.parentID, "/org.andbible.ios-sync-mydocuments/ios-device")
+        XCTAssertEqual(uploadedFile.contentType, NextCloudSyncAdapter.gzipMimeType)
+        let databaseURL = try writeUploadedMyDocumentDatabase(uploadedFile.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        XCTAssertEqual(try sqliteUserVersion(at: databaseURL), RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion)
+        XCTAssertEqual(try sqliteRoomIdentityHash(at: databaseURL), "3f0946602099d896c8d47129233c1794")
+        let metadataSnapshot = try metadataRestoreService.readSnapshot(from: databaseURL)
+        XCTAssertEqual(metadataSnapshot.logEntries.map(\.type), Array(repeating: .upsert, count: 6))
+        XCTAssertEqual(Set(metadataSnapshot.logEntries.map(\.sourceDevice)), ["ios-device"])
+        XCTAssertEqual(
+            metadataSnapshot.logEntries.map(\.entityID2),
+            Array(repeating: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID, count: 6)
+        )
+        XCTAssertEqual(
+            Set(metadataSnapshot.logEntries.map(\.tableName)),
+            ["AiPageCacheEntry", "MyDocument", "MyDocumentPage", "MyDocumentPageContent"]
+        )
+
+        let patchSnapshot = try restoreService.readSnapshot(from: databaseURL)
+        XCTAssertEqual(patchSnapshot.documents.map(\.id), [newDocumentID])
+        XCTAssertEqual(patchSnapshot.pages.map(\.id), [newPageID])
+        XCTAssertEqual(
+            patchSnapshot.pageContents.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            [
+                .init(pageId: existingPageID, content: "Edited content only"),
+                .init(pageId: newPageID, content: "<p>New</p>"),
+            ]
+        )
+        XCTAssertEqual(Set(patchSnapshot.aiPageCacheEntries.map(\.pageId)), [existingPageID, newPageID])
+        XCTAssertEqual(patchSnapshot.aiPageCacheEntries.first(where: { $0.pageId == newPageID })?.sourceBookKey, "Rom.8")
+
+        XCTAssertEqual(
+            patchStatusStore.statuses(for: .myDocuments),
+            [
+                RemoteSyncPatchStatus(
+                    sourceDevice: "ios-device",
+                    patchNumber: 1,
+                    sizeBytes: unwrappedReport.uploadedFile.size,
+                    appliedDate: 3_000
+                )
+            ]
+        )
+        XCTAssertEqual(stateStore.progressState(for: .myDocuments).lastPatchWritten, 3_000)
+        XCTAssertEqual(logEntryStore.entries(for: .myDocuments).count, 8)
+
+        let currentSnapshot = snapshotService.snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let existingContentKey = logEntryStore.key(
+            for: .myDocuments,
+            tableName: "MyDocumentPageContent",
+            entityID1: .blob(uuidBlob(existingPageID)),
+            entityID2: .text("")
+        )
+        XCTAssertEqual(
+            RemoteSyncRowFingerprintStore(settingsStore: settingsStore).fingerprint(
+                forLogKey: existingContentKey,
+                category: .myDocuments
+            ),
+            currentSnapshot.fingerprintsByKey[existingContentKey]
+        )
+    }
+
+    func testRemoteSyncMyDocumentPatchUploadReturnsNilWhenStateMatchesBaseline() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a7200000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a7200000-0000-0000-0000-000000000011")!
+        let promptID = UUID(uuidString: "a7200000-0000-0000-0000-000000000021")!
+
+        let document = MyDocument(id: documentID, name: "Idle", initials: "IDLE")
+        let page = MyDocumentPage(id: pageID, title: "Idle Page", pageKey: "idle", sourcePromptId: promptID)
+        let content = MyDocumentPageContent(pageId: pageID, content: "Unchanged")
+        let cacheEntry = AiPageCacheEntry(pageId: pageID, sourcePromptId: promptID, contextHash: "unchanged")
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        page.aiPageCacheEntries = [cacheEntry]
+        cacheEntry.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        modelContext.insert(cacheEntry)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [documentID],
+                pageIDs: [pageID],
+                timestamp: 1_000,
+                sourceDevice: "pixel"
+            ),
+            for: .myDocuments
+        )
+        RemoteSyncMyDocumentSnapshotService().refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        let service = RemoteSyncMyDocumentPatchUploadService(
+            adapter: adapter,
+            nowProvider: { 4_000 }
+        )
+
+        let report = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/org.andbible.ios-sync-mydocuments/ios-device"),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertNil(report)
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        XCTAssertTrue(uploadedFiles.isEmpty)
+    }
+
+    func testRemoteSyncMyDocumentPatchUploadUploadsRowsWithMissingFingerprintBaseline() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a7250000-0000-0000-0000-000000000001")!
+        let document = MyDocument(id: documentID, name: "Migrated", initials: "MIG")
+        modelContext.insert(document)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [documentID],
+                pageIDs: [],
+                timestamp: 1_000,
+                sourceDevice: "pixel"
+            ),
+            for: .myDocuments
+        )
+
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "/org.andbible.ios-sync-mydocuments/ios-device/1.4.sqlite3.gz",
+                name: "1.4.sqlite3.gz",
+                size: 0,
+                timestamp: 4_500,
+                parentID: "/org.andbible.ios-sync-mydocuments/ios-device",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncMyDocumentPatchUploadService(
+            adapter: adapter,
+            nowProvider: { 4_500 }
+        )
+
+        let report = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/org.andbible.ios-sync-mydocuments/ios-device"),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let unwrappedReport = try XCTUnwrap(report)
+        XCTAssertEqual(unwrappedReport.upsertedDocumentCount, 1)
+        XCTAssertEqual(unwrappedReport.logEntryCount, 1)
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedFile = try XCTUnwrap(uploadedFiles.first)
+        let databaseURL = try writeUploadedMyDocumentDatabase(uploadedFile.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        let patchSnapshot = try RemoteSyncMyDocumentRestoreService().readSnapshot(from: databaseURL)
+        XCTAssertEqual(patchSnapshot.documents.map(\.id), [documentID])
+    }
+
+    func testRemoteSyncMyDocumentPatchUploadRejectsMissingDeviceFolder() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let service = RemoteSyncMyDocumentPatchUploadService(
+            adapter: MyDocumentMockRemoteSyncAdapter(),
+            nowProvider: { 4_750 }
+        )
+
+        do {
+            _ = try await service.uploadPendingPatch(
+                bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "   "),
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            XCTFail("Expected missing device folder error")
+        } catch {
+            XCTAssertEqual(error as? RemoteSyncMyDocumentPatchUploadError, .missingDeviceFolderID)
+        }
+    }
+
+    func testRemoteSyncMyDocumentPatchUploadDetectsDeletesAfterBaselineRefresh() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let metadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService()
+        let documentID = UUID(uuidString: "a7300000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a7300000-0000-0000-0000-000000000011")!
+        let promptID = UUID(uuidString: "a7300000-0000-0000-0000-000000000021")!
+
+        let document = MyDocument(id: documentID, name: "Delete", initials: "DEL")
+        let page = MyDocumentPage(id: pageID, title: "Delete Page", pageKey: "delete", sourcePromptId: promptID)
+        let content = MyDocumentPageContent(pageId: pageID, content: "Delete me")
+        let cacheEntry = AiPageCacheEntry(pageId: pageID, sourcePromptId: promptID, contextHash: "delete")
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        page.aiPageCacheEntries = [cacheEntry]
+        cacheEntry.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        modelContext.insert(cacheEntry)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [documentID],
+                pageIDs: [pageID],
+                timestamp: 1_000,
+                sourceDevice: "pixel"
+            ),
+            for: .myDocuments
+        )
+        RemoteSyncMyDocumentSnapshotService().refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        modelContext.delete(document)
+        try modelContext.save()
+
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "/org.andbible.ios-sync-mydocuments/ios-device/1.4.sqlite3.gz",
+                name: "1.4.sqlite3.gz",
+                size: 0,
+                timestamp: 5_000,
+                parentID: "/org.andbible.ios-sync-mydocuments/ios-device",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncMyDocumentPatchUploadService(
+            adapter: adapter,
+            nowProvider: { 5_000 }
+        )
+
+        let report = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/org.andbible.ios-sync-mydocuments/ios-device"),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let unwrappedReport = try XCTUnwrap(report)
+        XCTAssertEqual(unwrappedReport.upsertedDocumentCount, 0)
+        XCTAssertEqual(unwrappedReport.upsertedPageCount, 0)
+        XCTAssertEqual(unwrappedReport.upsertedPageContentCount, 0)
+        XCTAssertEqual(unwrappedReport.upsertedAiPageCacheEntryCount, 0)
+        XCTAssertEqual(unwrappedReport.deletedRowCount, 4)
+        XCTAssertEqual(unwrappedReport.logEntryCount, 4)
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedFile = try XCTUnwrap(uploadedFiles.first)
+        let databaseURL = try writeUploadedMyDocumentDatabase(uploadedFile.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let metadataSnapshot = try metadataRestoreService.readSnapshot(from: databaseURL)
+        XCTAssertEqual(metadataSnapshot.logEntries.map(\.type), Array(repeating: .delete, count: 4))
+        XCTAssertEqual(
+            Set(metadataSnapshot.logEntries.map(\.tableName)),
+            ["AiPageCacheEntry", "MyDocument", "MyDocumentPage", "MyDocumentPageContent"]
+        )
+        XCTAssertEqual(try sqliteCount(tableName: "MyDocument", databaseURL: databaseURL), 0)
+        XCTAssertEqual(try sqliteCount(tableName: "MyDocumentPageContent", databaseURL: databaseURL), 0)
+        XCTAssertEqual(try sqliteCount(tableName: "AiPageCacheEntry", databaseURL: databaseURL), 0)
+    }
+
+    func testRemoteSyncSynchronizationServiceUploadsLocalMyDocumentChangesWhenNoRemotePatchesExist() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let snapshotService = RemoteSyncMyDocumentSnapshotService()
+        let syncFolderID = "/org.andbible.ios-sync-mydocuments"
+        let deviceFolderID = "/org.andbible.ios-sync-mydocuments/ios-device"
+
+        stateStore.setBootstrapState(
+            RemoteSyncBootstrapState(
+                syncFolderID: syncFolderID,
+                deviceFolderID: deviceFolderID,
+                secretFileName: "device-known-ios-device-secret"
+            ),
+            for: .myDocuments
+        )
+
+        let documentID = UUID(uuidString: "a7400000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a7400000-0000-0000-0000-000000000011")!
+        let promptID = UUID(uuidString: "a7400000-0000-0000-0000-000000000021")!
+        let document = MyDocument(id: documentID, name: "Sync", initials: "SYNC")
+        let page = MyDocumentPage(id: pageID, title: "Sync Page", pageKey: "sync", sourcePromptId: promptID)
+        let content = MyDocumentPageContent(pageId: pageID, content: "Sync")
+        let cacheEntry = AiPageCacheEntry(pageId: pageID, sourcePromptId: promptID)
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        page.aiPageCacheEntries = [cacheEntry]
+        cacheEntry.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        modelContext.insert(cacheEntry)
+        try modelContext.save()
+
+        logEntryStore.replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [documentID],
+                pageIDs: [pageID],
+                timestamp: 1_000,
+                sourceDevice: "pixel"
+            ),
+            for: .myDocuments
+        )
+        snapshotService.refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        document.name = "Sync Updated"
+        try modelContext.save()
+
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.setKnownResponse(
+            true,
+            forSyncFolderID: syncFolderID,
+            secretFileName: "device-known-ios-device-secret"
+        )
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(deviceFolderID)/1.4.sqlite3.gz",
+                name: "1.4.sqlite3.gz",
+                size: 0,
+                timestamp: 6_000,
+                parentID: deviceFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+
+        let service = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-device",
+            nowProvider: { 6_000 }
+        )
+
+        let outcome = try await service.synchronize(
+            .myDocuments,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        guard case .synchronized(let report) = outcome else {
+            return XCTFail("Expected synchronized outcome")
+        }
+        XCTAssertEqual(report.category, .myDocuments)
+        XCTAssertNil(report.initialRestoreReport)
+        XCTAssertNil(report.patchReplayReport)
+        XCTAssertEqual(report.discoveredPatchCount, 0)
+        XCTAssertEqual(report.lastPatchWritten, 6_000)
+        XCTAssertEqual(report.lastSynchronized, 6_000)
+
+        guard case .myDocuments(let uploadReport)? = report.patchUploadReport else {
+            return XCTFail("Expected My Documents patch upload report")
+        }
+        XCTAssertEqual(uploadReport.patchNumber, 1)
+        XCTAssertEqual(uploadReport.upsertedDocumentCount, 1)
+        XCTAssertEqual(uploadReport.upsertedPageCount, 0)
+        XCTAssertEqual(uploadReport.upsertedPageContentCount, 0)
+        XCTAssertEqual(uploadReport.upsertedAiPageCacheEntryCount, 0)
+        XCTAssertEqual(uploadReport.deletedRowCount, 0)
+        XCTAssertEqual(uploadReport.logEntryCount, 1)
+        XCTAssertEqual(uploadReport.lastUpdated, 6_000)
+        XCTAssertEqual(uploadReport.uploadedFile.name, "1.4.sqlite3.gz")
+        XCTAssertEqual(uploadReport.uploadedFile.parentID, deviceFolderID)
+        XCTAssertEqual(
+            patchStatusStore.statuses(for: .myDocuments),
+            [
+                RemoteSyncPatchStatus(
+                    sourceDevice: "ios-device",
+                    patchNumber: 1,
+                    sizeBytes: uploadReport.uploadedFile.size,
+                    appliedDate: 6_000
+                )
+            ]
+        )
+    }
+
     private func makeModelContainer() throws -> ModelContainer {
         let schema = Schema([
             MyDocument.self,
@@ -1005,6 +1561,51 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         sqlite3_bind_int(statement, index, Int32(value))
     }
 
+    private func myDocumentLogEntries(
+        documentIDs: [UUID],
+        pageIDs: [UUID],
+        timestamp: Int64,
+        sourceDevice: String
+    ) -> [RemoteSyncLogEntry] {
+        documentIDs.map {
+            RemoteSyncLogEntry(
+                tableName: "MyDocument",
+                entityID1: .blob(uuidBlob($0)),
+                entityID2: .text(""),
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+        } + pageIDs.flatMap {
+            [
+                RemoteSyncLogEntry(
+                    tableName: "MyDocumentPage",
+                    entityID1: .blob(uuidBlob($0)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: timestamp,
+                    sourceDevice: sourceDevice
+                ),
+                RemoteSyncLogEntry(
+                    tableName: "MyDocumentPageContent",
+                    entityID1: .blob(uuidBlob($0)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: timestamp,
+                    sourceDevice: sourceDevice
+                ),
+                RemoteSyncLogEntry(
+                    tableName: "AiPageCacheEntry",
+                    entityID1: .blob(uuidBlob($0)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: timestamp,
+                    sourceDevice: sourceDevice
+                ),
+            ]
+        }
+    }
+
     private func uuidBlob(_ value: UUID) -> Data {
         var uuid = value.uuid
         return withUnsafeBytes(of: &uuid) { Data($0) }
@@ -1013,10 +1614,15 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
 
 private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
     private var uploadResults: [RemoteSyncFile] = []
+    private var knownResponses: [String: Bool] = [:]
     private var uploadedFiles: [MyDocumentMockUploadedFile] = []
 
     func enqueueUploadResult(_ result: RemoteSyncFile) {
         uploadResults.append(result)
+    }
+
+    func setKnownResponse(_ value: Bool, forSyncFolderID syncFolderID: String, secretFileName: String) {
+        knownResponses["\(syncFolderID)|\(secretFileName)"] = value
     }
 
     func uploadedFilesSnapshot() -> [MyDocumentMockUploadedFile] {
@@ -1086,7 +1692,7 @@ private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
     func delete(id: String) async throws {}
 
     func isSyncFolderKnown(syncFolderID: String, secretFileName: String) async throws -> Bool {
-        false
+        knownResponses["\(syncFolderID)|\(secretFileName)"] ?? false
     }
 
     func makeSyncFolderKnown(syncFolderID: String, deviceIdentifier: String) async throws -> String {

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchUploadService.swift
@@ -1,0 +1,836 @@
+// RemoteSyncMyDocumentPatchUploadService.swift -- Android-shaped outbound My Documents patch creation and upload
+
+import Foundation
+import SQLite3
+import SwiftData
+
+private let remoteSyncMyDocumentPatchUploadSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/**
+ Errors raised while exporting and uploading an outbound Android My Documents patch.
+ */
+public enum RemoteSyncMyDocumentPatchUploadError: Error, Equatable {
+    /// The category is not ready for upload because no remote device folder identifier is known locally.
+    case missingDeviceFolderID
+
+    /// The generated temporary SQLite patch database could not be opened for writing.
+    case invalidSQLiteDatabase
+}
+
+/**
+ Summary of one successful outbound My Documents patch upload.
+ */
+public struct RemoteSyncMyDocumentPatchUploadReport: Sendable, Equatable {
+    /// Remote file metadata returned by the backend after upload succeeded.
+    public let uploadedFile: RemoteSyncFile
+
+    /// Monotonic patch number assigned within the current device folder.
+    public let patchNumber: Int64
+
+    /// Number of `MyDocument` rows written into the patch database.
+    public let upsertedDocumentCount: Int
+
+    /// Number of `MyDocumentPage` rows written into the patch database.
+    public let upsertedPageCount: Int
+
+    /// Number of `MyDocumentPageContent` rows written into the patch database.
+    public let upsertedPageContentCount: Int
+
+    /// Number of `AiPageCacheEntry` rows written into the patch database.
+    public let upsertedAiPageCacheEntryCount: Int
+
+    /// Number of `DELETE` log entries emitted for rows removed locally.
+    public let deletedRowCount: Int
+
+    /// Total number of Android `LogEntry` rows written into the patch database.
+    public let logEntryCount: Int
+
+    /// Millisecond timestamp recorded as `lastUpdated` for the emitted Android log entries.
+    public let lastUpdated: Int64
+
+    /**
+     Creates one outbound My Documents patch-upload summary.
+     */
+    public init(
+        uploadedFile: RemoteSyncFile,
+        patchNumber: Int64,
+        upsertedDocumentCount: Int,
+        upsertedPageCount: Int,
+        upsertedPageContentCount: Int,
+        upsertedAiPageCacheEntryCount: Int,
+        deletedRowCount: Int,
+        logEntryCount: Int,
+        lastUpdated: Int64
+    ) {
+        self.uploadedFile = uploadedFile
+        self.patchNumber = patchNumber
+        self.upsertedDocumentCount = upsertedDocumentCount
+        self.upsertedPageCount = upsertedPageCount
+        self.upsertedPageContentCount = upsertedPageContentCount
+        self.upsertedAiPageCacheEntryCount = upsertedAiPageCacheEntryCount
+        self.deletedRowCount = deletedRowCount
+        self.logEntryCount = logEntryCount
+        self.lastUpdated = lastUpdated
+    }
+}
+
+/**
+ Creates Android-shaped sparse My Documents patch databases and uploads them to the active backend.
+ */
+public final class RemoteSyncMyDocumentPatchUploadService {
+    private struct ChangeSet {
+        let documentRowsByKey: [String: RemoteSyncAndroidMyDocument]
+        let pageRowsByKey: [String: RemoteSyncAndroidMyDocumentPage]
+        let pageContentRowsByKey: [String: RemoteSyncAndroidMyDocumentPageContent]
+        let aiPageCacheEntryRowsByKey: [String: RemoteSyncAndroidAiPageCacheEntry]
+        let logEntries: [RemoteSyncLogEntry]
+        let updatedEntriesByKey: [String: RemoteSyncLogEntry]
+
+        var deletedRowCount: Int {
+            logEntries.filter { $0.type == .delete }.count
+        }
+    }
+
+    private static let supportedTableNames: Set<String> = [
+        "MyDocument",
+        "MyDocumentPage",
+        "MyDocumentPageContent",
+        "AiPageCacheEntry",
+    ]
+
+    private let adapter: any RemoteSyncAdapting
+    private let snapshotService: RemoteSyncMyDocumentSnapshotService
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+    private let nowProvider: () -> Int64
+
+    /**
+     Creates a My Documents patch upload service for one remote backend.
+     */
+    public init(
+        adapter: any RemoteSyncAdapting,
+        snapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil,
+        nowProvider: @escaping () -> Int64 = {
+            Int64(Date().timeIntervalSince1970 * 1000.0)
+        }
+    ) {
+        self.adapter = adapter
+        self.snapshotService = snapshotService
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        self.nowProvider = nowProvider
+    }
+
+    /**
+     Builds and uploads the next sparse My Documents patch when local state differs from the baseline.
+     */
+    public func uploadPendingPatch(
+        bootstrapState: RemoteSyncBootstrapState,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+    ) async throws -> RemoteSyncMyDocumentPatchUploadReport? {
+        guard let deviceFolderID = bootstrapState.deviceFolderID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !deviceFolderID.isEmpty else {
+            throw RemoteSyncMyDocumentPatchUploadError.missingDeviceFolderID
+        }
+
+        let sourceDevice = Self.sourceDeviceName(from: deviceFolderID)
+        let timestamp = nowProvider()
+        let snapshot = snapshotService.snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+        let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        let existingEntriesByKey = Dictionary(
+            uniqueKeysWithValues: logEntryStore.entries(for: .myDocuments).map {
+                (logEntryStore.key(for: .myDocuments, entry: $0), $0)
+            }
+        )
+
+        let hadMissingFingerprintBaseline = existingEntriesByKey.contains { key, entry in
+            guard Self.supportedTableNames.contains(entry.tableName),
+                  entry.type != .delete,
+                  currentRowExists(forKey: key, in: snapshot) else {
+                return false
+            }
+            return fingerprintStore.fingerprint(
+                for: .myDocuments,
+                tableName: entry.tableName,
+                entityID1: entry.entityID1,
+                entityID2: entry.entityID2
+            ) == nil
+        }
+
+        let changeSet = buildChangeSet(
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+
+        if changeSet.logEntries.isEmpty {
+            if hadMissingFingerprintBaseline {
+                snapshotService.refreshBaselineFingerprints(
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                )
+            }
+            return nil
+        }
+
+        let patchNumber = (patchStatusStore.lastPatchNumber(
+            for: .myDocuments,
+            sourceDevice: sourceDevice
+        ) ?? 0) + 1
+        let patchFileName = "\(patchNumber).\(schemaVersion).sqlite3.gz"
+
+        let databaseURL = temporaryURL(prefix: "remote-sync-mydocuments-upload-", suffix: ".sqlite3")
+        let archiveURL = temporaryURL(prefix: "remote-sync-mydocuments-upload-", suffix: ".sqlite3.gz")
+        defer {
+            try? fileManager.removeItem(at: databaseURL)
+            try? fileManager.removeItem(at: archiveURL)
+        }
+
+        try writePatchDatabase(
+            at: databaseURL,
+            schemaVersion: schemaVersion,
+            changeSet: changeSet
+        )
+        let archiveData = try RemoteSyncArchiveStagingService.gzip(Data(contentsOf: databaseURL))
+        try archiveData.write(to: archiveURL, options: .atomic)
+
+        let uploadedFile = try await adapter.upload(
+            name: patchFileName,
+            fileURL: archiveURL,
+            parentID: deviceFolderID,
+            contentType: NextCloudSyncAdapter.gzipMimeType
+        )
+
+        logEntryStore.replaceEntries(
+            changeSet.updatedEntriesByKey.values.sorted(by: Self.logEntrySort),
+            for: .myDocuments
+        )
+        patchStatusStore.addStatus(
+            RemoteSyncPatchStatus(
+                sourceDevice: sourceDevice,
+                patchNumber: patchNumber,
+                sizeBytes: uploadedFile.size,
+                appliedDate: timestamp
+            ),
+            for: .myDocuments
+        )
+        var progressState = stateStore.progressState(for: .myDocuments)
+        progressState.lastPatchWritten = timestamp
+        stateStore.setProgressState(progressState, for: .myDocuments)
+        snapshotService.refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        return RemoteSyncMyDocumentPatchUploadReport(
+            uploadedFile: uploadedFile,
+            patchNumber: patchNumber,
+            upsertedDocumentCount: changeSet.documentRowsByKey.count,
+            upsertedPageCount: changeSet.pageRowsByKey.count,
+            upsertedPageContentCount: changeSet.pageContentRowsByKey.count,
+            upsertedAiPageCacheEntryCount: changeSet.aiPageCacheEntryRowsByKey.count,
+            deletedRowCount: changeSet.deletedRowCount,
+            logEntryCount: changeSet.logEntries.count,
+            lastUpdated: timestamp
+        )
+    }
+
+    private func buildChangeSet(
+        snapshot: RemoteSyncMyDocumentCurrentSnapshot,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore,
+        timestamp: Int64,
+        sourceDevice: String
+    ) -> ChangeSet {
+        var documentRowsByKey: [String: RemoteSyncAndroidMyDocument] = [:]
+        var pageRowsByKey: [String: RemoteSyncAndroidMyDocumentPage] = [:]
+        var pageContentRowsByKey: [String: RemoteSyncAndroidMyDocumentPageContent] = [:]
+        var aiPageCacheEntryRowsByKey: [String: RemoteSyncAndroidAiPageCacheEntry] = [:]
+        var logEntries: [RemoteSyncLogEntry] = []
+        var updatedEntriesByKey = existingEntriesByKey
+
+        for (key, row) in snapshot.documentRowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard shouldUploadCurrentRow(
+                key: key,
+                currentFingerprint: snapshot.fingerprintsByKey[key],
+                existingEntriesByKey: existingEntriesByKey,
+                fingerprintStore: fingerprintStore
+            ) else {
+                continue
+            }
+            let entry = RemoteSyncLogEntry(
+                tableName: "MyDocument",
+                entityID1: .blob(RemoteSyncMyDocumentSnapshotService.uuidBlob(row.id)),
+                entityID2: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID,
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            documentRowsByKey[key] = row
+            logEntries.append(entry)
+            updatedEntriesByKey[key] = entry
+        }
+
+        for (key, row) in snapshot.pageRowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard shouldUploadCurrentRow(
+                key: key,
+                currentFingerprint: snapshot.fingerprintsByKey[key],
+                existingEntriesByKey: existingEntriesByKey,
+                fingerprintStore: fingerprintStore
+            ) else {
+                continue
+            }
+            let entry = RemoteSyncLogEntry(
+                tableName: "MyDocumentPage",
+                entityID1: .blob(RemoteSyncMyDocumentSnapshotService.uuidBlob(row.id)),
+                entityID2: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID,
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            pageRowsByKey[key] = row
+            logEntries.append(entry)
+            updatedEntriesByKey[key] = entry
+        }
+
+        for (key, row) in snapshot.pageContentRowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard shouldUploadCurrentRow(
+                key: key,
+                currentFingerprint: snapshot.fingerprintsByKey[key],
+                existingEntriesByKey: existingEntriesByKey,
+                fingerprintStore: fingerprintStore
+            ) else {
+                continue
+            }
+            let entry = RemoteSyncLogEntry(
+                tableName: "MyDocumentPageContent",
+                entityID1: .blob(RemoteSyncMyDocumentSnapshotService.uuidBlob(row.pageId)),
+                entityID2: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID,
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            pageContentRowsByKey[key] = row
+            logEntries.append(entry)
+            updatedEntriesByKey[key] = entry
+        }
+
+        for (key, row) in snapshot.aiPageCacheEntryRowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard shouldUploadCurrentRow(
+                key: key,
+                currentFingerprint: snapshot.fingerprintsByKey[key],
+                existingEntriesByKey: existingEntriesByKey,
+                fingerprintStore: fingerprintStore
+            ) else {
+                continue
+            }
+            let entry = RemoteSyncLogEntry(
+                tableName: "AiPageCacheEntry",
+                entityID1: .blob(RemoteSyncMyDocumentSnapshotService.uuidBlob(row.pageId)),
+                entityID2: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID,
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            aiPageCacheEntryRowsByKey[key] = row
+            logEntries.append(entry)
+            updatedEntriesByKey[key] = entry
+        }
+
+        for (key, entry) in existingEntriesByKey.sorted(by: { $0.key < $1.key }) {
+            guard Self.supportedTableNames.contains(entry.tableName), entry.type != .delete else {
+                continue
+            }
+            guard !currentRowExists(forKey: key, in: snapshot) else {
+                continue
+            }
+            let deleteEntry = RemoteSyncLogEntry(
+                tableName: entry.tableName,
+                entityID1: entry.entityID1,
+                entityID2: entry.entityID2,
+                type: .delete,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            logEntries.append(deleteEntry)
+            updatedEntriesByKey[key] = deleteEntry
+        }
+
+        return ChangeSet(
+            documentRowsByKey: documentRowsByKey,
+            pageRowsByKey: pageRowsByKey,
+            pageContentRowsByKey: pageContentRowsByKey,
+            aiPageCacheEntryRowsByKey: aiPageCacheEntryRowsByKey,
+            logEntries: logEntries.sorted(by: Self.logEntrySort),
+            updatedEntriesByKey: updatedEntriesByKey
+        )
+    }
+
+    private func shouldUploadCurrentRow(
+        key: String,
+        currentFingerprint: String?,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore
+    ) -> Bool {
+        guard let currentFingerprint else {
+            return false
+        }
+
+        guard let existingEntry = existingEntriesByKey[key] else {
+            if let existingFingerprint = fingerprintStore.fingerprint(
+                forLogKey: key,
+                category: .myDocuments
+            ) {
+                return existingFingerprint != currentFingerprint
+            }
+            return true
+        }
+
+        guard Self.supportedTableNames.contains(existingEntry.tableName) else {
+            return false
+        }
+
+        if existingEntry.type == .delete {
+            return true
+        }
+
+        let existingFingerprint = fingerprintStore.fingerprint(
+            for: .myDocuments,
+            tableName: existingEntry.tableName,
+            entityID1: existingEntry.entityID1,
+            entityID2: existingEntry.entityID2
+        )
+        guard let existingFingerprint else {
+            return true
+        }
+        return existingFingerprint != currentFingerprint
+    }
+
+    private func currentRowExists(forKey key: String, in snapshot: RemoteSyncMyDocumentCurrentSnapshot) -> Bool {
+        snapshot.documentRowsByKey[key] != nil
+            || snapshot.pageRowsByKey[key] != nil
+            || snapshot.pageContentRowsByKey[key] != nil
+            || snapshot.aiPageCacheEntryRowsByKey[key] != nil
+    }
+
+    private func writePatchDatabase(
+        at url: URL,
+        schemaVersion: Int,
+        changeSet: ChangeSet
+    ) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &database,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+            nil
+        ) == SQLITE_OK, let database else {
+            if let database {
+                sqlite3_close(database)
+            }
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(database) }
+
+        try execute(
+            """
+            PRAGMA user_version = \(schemaVersion);
+            CREATE TABLE MyDocument (
+                id BLOB NOT NULL PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT DEFAULT NULL,
+                initials TEXT NOT NULL,
+                orderNumber INTEGER NOT NULL,
+                createdAt INTEGER NOT NULL,
+                updatedAt INTEGER NOT NULL,
+                sourcePromptId BLOB DEFAULT NULL
+            );
+            CREATE TABLE MyDocumentPage (
+                id BLOB NOT NULL PRIMARY KEY,
+                documentId BLOB NOT NULL,
+                title TEXT NOT NULL,
+                pageKey TEXT NOT NULL,
+                contentType TEXT NOT NULL,
+                orderNumber INTEGER NOT NULL,
+                createdAt INTEGER NOT NULL,
+                updatedAt INTEGER NOT NULL,
+                sourcePromptId BLOB DEFAULT NULL,
+                languageCode TEXT DEFAULT NULL,
+                FOREIGN KEY(documentId) REFERENCES MyDocument(id) ON DELETE CASCADE
+            );
+            CREATE TABLE MyDocumentPageContent (
+                pageId BLOB NOT NULL PRIMARY KEY,
+                content TEXT NOT NULL,
+                FOREIGN KEY(pageId) REFERENCES MyDocumentPage(id) ON DELETE CASCADE
+            );
+            CREATE TABLE AiPageCacheEntry (
+                pageId BLOB NOT NULL PRIMARY KEY,
+                sourcePromptId BLOB NOT NULL,
+                sourceContext TEXT DEFAULT NULL,
+                kjvOrdinalStart INTEGER DEFAULT NULL,
+                kjvOrdinalEnd INTEGER DEFAULT NULL,
+                contextHash TEXT DEFAULT NULL,
+                usedWriteTools INTEGER NOT NULL,
+                sourceModelName TEXT DEFAULT NULL,
+                sourceBookInitials TEXT DEFAULT NULL,
+                sourceBookKey TEXT DEFAULT NULL,
+                FOREIGN KEY(pageId) REFERENCES MyDocumentPage(id) ON DELETE CASCADE
+            );
+            CREATE TABLE LogEntry (
+                tableName TEXT NOT NULL,
+                entityId1 BLOB NOT NULL,
+                entityId2 BLOB NOT NULL,
+                type TEXT NOT NULL,
+                lastUpdated INTEGER NOT NULL,
+                sourceDevice TEXT NOT NULL,
+                PRIMARY KEY(tableName, entityId1, entityId2)
+            );
+            CREATE TABLE SyncConfiguration (
+                keyName TEXT NOT NULL,
+                stringValue TEXT,
+                longValue INTEGER,
+                booleanValue INTEGER,
+                PRIMARY KEY(keyName)
+            );
+            CREATE TABLE SyncStatus (
+                sourceDevice TEXT NOT NULL,
+                patchNumber INTEGER NOT NULL,
+                sizeBytes INTEGER NOT NULL,
+                appliedDate INTEGER NOT NULL,
+                PRIMARY KEY(sourceDevice, patchNumber)
+            );
+            CREATE TABLE room_master_table (
+                id INTEGER PRIMARY KEY,
+                identity_hash TEXT
+            );
+            INSERT OR REPLACE INTO room_master_table (id, identity_hash)
+                VALUES(42, '3f0946602099d896c8d47129233c1794');
+            CREATE UNIQUE INDEX index_MyDocument_initials ON MyDocument (initials);
+            CREATE INDEX index_MyDocumentPage_documentId ON MyDocumentPage (documentId);
+            CREATE UNIQUE INDEX index_MyDocumentPage_documentId_pageKey ON MyDocumentPage (documentId, pageKey);
+            CREATE INDEX index_AiPageCacheEntry_sourcePromptId_contextHash ON AiPageCacheEntry (sourcePromptId, contextHash);
+            CREATE INDEX index_AiPageCacheEntry_sourcePromptId_kjvOrdinalStart_kjvOrdinalEnd ON AiPageCacheEntry (sourcePromptId, kjvOrdinalStart, kjvOrdinalEnd);
+            CREATE INDEX index_AiPageCacheEntry_kjvOrdinalStart_kjvOrdinalEnd ON AiPageCacheEntry (kjvOrdinalStart, kjvOrdinalEnd);
+            CREATE INDEX index_AiPageCacheEntry_sourceBookInitials_sourceBookKey ON AiPageCacheEntry (sourceBookInitials, sourceBookKey);
+            CREATE INDEX index_LogEntry_lastUpdated ON LogEntry (lastUpdated);
+            CREATE INDEX index_LogEntry_sourceDevice ON LogEntry (sourceDevice);
+            CREATE VIEW MyDocumentPageWithContent AS
+                SELECT p.*, c.content
+                FROM MyDocumentPage p
+                LEFT OUTER JOIN MyDocumentPageContent c ON p.id = c.pageId;
+            CREATE VIEW AiCachedPageWithContent AS
+                SELECT c.pageId, c.sourcePromptId, c.sourceContext, c.kjvOrdinalStart,
+                       c.kjvOrdinalEnd, c.contextHash, c.usedWriteTools, c.sourceModelName,
+                       c.sourceBookInitials, c.sourceBookKey,
+                       p.title, p.pageKey, p.contentType, p.documentId,
+                       p.orderNumber, p.createdAt, p.updatedAt, p.languageCode, cnt.content
+                FROM AiPageCacheEntry c
+                INNER JOIN MyDocumentPage p ON c.pageId = p.id
+                LEFT OUTER JOIN MyDocumentPageContent cnt ON p.id = cnt.pageId;
+            """,
+            in: database
+        )
+
+        try execute("BEGIN IMMEDIATE TRANSACTION;", in: database)
+        do {
+            for row in changeSet.documentRowsByKey.values.sorted(by: Self.myDocumentSort) {
+                try insertMyDocumentRow(row, in: database)
+            }
+            for row in changeSet.pageRowsByKey.values.sorted(by: Self.myDocumentPageSort) {
+                try insertMyDocumentPageRow(row, in: database)
+            }
+            for row in changeSet.pageContentRowsByKey.values.sorted(by: Self.myDocumentPageContentSort) {
+                try insertMyDocumentPageContentRow(row, in: database)
+            }
+            for row in changeSet.aiPageCacheEntryRowsByKey.values.sorted(by: Self.aiPageCacheEntrySort) {
+                try insertAiPageCacheEntryRow(row, in: database)
+            }
+            for entry in changeSet.logEntries {
+                try insertLogEntry(entry, in: database)
+            }
+            try execute("COMMIT;", in: database)
+        } catch {
+            try? execute("ROLLBACK;", in: database)
+            throw error
+        }
+    }
+
+    private func insertMyDocumentRow(_ row: RemoteSyncAndroidMyDocument, in database: OpaquePointer) throws {
+        let sql = "INSERT INTO MyDocument (id, name, description, initials, orderNumber, createdAt, updatedAt, sourcePromptId) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        Self.bindUUIDBlob(row.id, to: statement, index: 1)
+        Self.bindText(row.name, to: statement, index: 2)
+        Self.bindOptionalText(row.documentDescription, to: statement, index: 3)
+        Self.bindText(row.initials, to: statement, index: 4)
+        sqlite3_bind_int(statement, 5, Int32(row.orderNumber))
+        sqlite3_bind_int64(statement, 6, Int64(row.createdAt.timeIntervalSince1970 * 1000.0))
+        sqlite3_bind_int64(statement, 7, Int64(row.updatedAt.timeIntervalSince1970 * 1000.0))
+        Self.bindOptionalUUIDBlob(row.sourcePromptId, to: statement, index: 8)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func insertMyDocumentPageRow(_ row: RemoteSyncAndroidMyDocumentPage, in database: OpaquePointer) throws {
+        let sql = "INSERT INTO MyDocumentPage (id, documentId, title, pageKey, contentType, orderNumber, createdAt, updatedAt, sourcePromptId, languageCode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        Self.bindUUIDBlob(row.id, to: statement, index: 1)
+        Self.bindUUIDBlob(row.documentId, to: statement, index: 2)
+        Self.bindText(row.title, to: statement, index: 3)
+        Self.bindText(row.pageKey, to: statement, index: 4)
+        Self.bindText(row.contentType.rawValue, to: statement, index: 5)
+        sqlite3_bind_int(statement, 6, Int32(row.orderNumber))
+        sqlite3_bind_int64(statement, 7, Int64(row.createdAt.timeIntervalSince1970 * 1000.0))
+        sqlite3_bind_int64(statement, 8, Int64(row.updatedAt.timeIntervalSince1970 * 1000.0))
+        Self.bindOptionalUUIDBlob(row.sourcePromptId, to: statement, index: 9)
+        Self.bindOptionalText(row.languageCode, to: statement, index: 10)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func insertMyDocumentPageContentRow(
+        _ row: RemoteSyncAndroidMyDocumentPageContent,
+        in database: OpaquePointer
+    ) throws {
+        let sql = "INSERT INTO MyDocumentPageContent (pageId, content) VALUES (?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        Self.bindUUIDBlob(row.pageId, to: statement, index: 1)
+        Self.bindText(row.content, to: statement, index: 2)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func insertAiPageCacheEntryRow(
+        _ row: RemoteSyncAndroidAiPageCacheEntry,
+        in database: OpaquePointer
+    ) throws {
+        let sql = "INSERT INTO AiPageCacheEntry (pageId, sourcePromptId, sourceContext, kjvOrdinalStart, kjvOrdinalEnd, contextHash, usedWriteTools, sourceModelName, sourceBookInitials, sourceBookKey) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        Self.bindUUIDBlob(row.pageId, to: statement, index: 1)
+        Self.bindUUIDBlob(row.sourcePromptId, to: statement, index: 2)
+        Self.bindOptionalText(row.sourceContext, to: statement, index: 3)
+        Self.bindOptionalInt(row.kjvOrdinalStart, to: statement, index: 4)
+        Self.bindOptionalInt(row.kjvOrdinalEnd, to: statement, index: 5)
+        Self.bindOptionalText(row.contextHash, to: statement, index: 6)
+        Self.bindBool(row.usedWriteTools, to: statement, index: 7)
+        Self.bindOptionalText(row.sourceModelName, to: statement, index: 8)
+        Self.bindOptionalText(row.sourceBookInitials, to: statement, index: 9)
+        Self.bindOptionalText(row.sourceBookKey, to: statement, index: 10)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func insertLogEntry(_ entry: RemoteSyncLogEntry, in database: OpaquePointer) throws {
+        let sql = "INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice) VALUES (?, ?, ?, ?, ?, ?)"
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        Self.bindText(entry.tableName, to: statement, index: 1)
+        Self.bindSQLiteValue(entry.entityID1, to: statement, index: 2)
+        Self.bindSQLiteValue(entry.entityID2, to: statement, index: 3)
+        Self.bindText(entry.type.rawValue, to: statement, index: 4)
+        sqlite3_bind_int64(statement, 5, entry.lastUpdated)
+        Self.bindText(entry.sourceDevice, to: statement, index: 6)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func execute(_ sql: String, in database: OpaquePointer) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncMyDocumentPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func temporaryURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    private static func sourceDeviceName(from deviceFolderID: String) -> String {
+        let trimmed = deviceFolderID.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmed.split(separator: "/").last.map(String.init) ?? deviceFolderID
+    }
+
+    private static func bindText(_ value: String, to statement: OpaquePointer?, index: Int32) {
+        sqlite3_bind_text(statement, index, value, -1, remoteSyncMyDocumentPatchUploadSQLiteTransient)
+    }
+
+    private static func bindOptionalText(_ value: String?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        bindText(value, to: statement, index: index)
+    }
+
+    private static func bindBool(_ value: Bool, to statement: OpaquePointer?, index: Int32) {
+        sqlite3_bind_int(statement, index, value ? 1 : 0)
+    }
+
+    private static func bindOptionalInt(_ value: Int?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        sqlite3_bind_int64(statement, index, Int64(value))
+    }
+
+    private static func bindUUIDBlob(_ value: UUID, to statement: OpaquePointer?, index: Int32) {
+        let blob = RemoteSyncMyDocumentSnapshotService.uuidBlob(value)
+        _ = blob.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(
+                statement,
+                index,
+                bytes.baseAddress,
+                Int32(blob.count),
+                remoteSyncMyDocumentPatchUploadSQLiteTransient
+            )
+        }
+    }
+
+    private static func bindOptionalUUIDBlob(_ value: UUID?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        bindUUIDBlob(value, to: statement, index: index)
+    }
+
+    private static func bindSQLiteValue(
+        _ value: RemoteSyncSQLiteValue,
+        to statement: OpaquePointer?,
+        index: Int32
+    ) {
+        switch value.kind {
+        case .null:
+            sqlite3_bind_null(statement, index)
+        case .integer:
+            sqlite3_bind_int64(statement, index, value.integerValue ?? 0)
+        case .real:
+            sqlite3_bind_double(statement, index, value.realValue ?? 0)
+        case .text:
+            sqlite3_bind_text(statement, index, value.textValue ?? "", -1, remoteSyncMyDocumentPatchUploadSQLiteTransient)
+        case .blob:
+            let data = value.blobData ?? Data()
+            _ = data.withUnsafeBytes { bytes in
+                sqlite3_bind_blob(
+                    statement,
+                    index,
+                    bytes.baseAddress,
+                    Int32(data.count),
+                    remoteSyncMyDocumentPatchUploadSQLiteTransient
+                )
+            }
+        }
+    }
+
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.lastUpdated != rhs.lastUpdated {
+            return lhs.lastUpdated < rhs.lastUpdated
+        }
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.type != rhs.type {
+            return lhs.type.rawValue < rhs.type.rawValue
+        }
+        if lhs.sourceDevice != rhs.sourceDevice {
+            return lhs.sourceDevice < rhs.sourceDevice
+        }
+        if lhs.entityID1 != rhs.entityID1 {
+            return sortKey(for: lhs.entityID1) < sortKey(for: rhs.entityID1)
+        }
+        return sortKey(for: lhs.entityID2) < sortKey(for: rhs.entityID2)
+    }
+
+    private static func sortKey(for value: RemoteSyncSQLiteValue) -> String {
+        switch value.kind {
+        case .null:
+            return "null"
+        case .integer:
+            return "integer:\(value.integerValue ?? 0)"
+        case .real:
+            return "real:\(value.realValue?.bitPattern ?? 0)"
+        case .text:
+            return "text:\(value.textValue ?? "")"
+        case .blob:
+            return "blob:\(value.blobBase64Value ?? "")"
+        }
+    }
+
+    private static func myDocumentSort(_ lhs: RemoteSyncAndroidMyDocument, _ rhs: RemoteSyncAndroidMyDocument) -> Bool {
+        if lhs.orderNumber == rhs.orderNumber {
+            if lhs.name == rhs.name {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.name < rhs.name
+        }
+        return lhs.orderNumber < rhs.orderNumber
+    }
+
+    private static func myDocumentPageSort(_ lhs: RemoteSyncAndroidMyDocumentPage, _ rhs: RemoteSyncAndroidMyDocumentPage) -> Bool {
+        if lhs.documentId == rhs.documentId {
+            if lhs.orderNumber == rhs.orderNumber {
+                if lhs.title == rhs.title {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.title < rhs.title
+            }
+            return lhs.orderNumber < rhs.orderNumber
+        }
+        return lhs.documentId.uuidString < rhs.documentId.uuidString
+    }
+
+    private static func myDocumentPageContentSort(
+        _ lhs: RemoteSyncAndroidMyDocumentPageContent,
+        _ rhs: RemoteSyncAndroidMyDocumentPageContent
+    ) -> Bool {
+        lhs.pageId.uuidString < rhs.pageId.uuidString
+    }
+
+    private static func aiPageCacheEntrySort(
+        _ lhs: RemoteSyncAndroidAiPageCacheEntry,
+        _ rhs: RemoteSyncAndroidAiPageCacheEntry
+    ) -> Bool {
+        lhs.pageId.uuidString < rhs.pageId.uuidString
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
@@ -61,6 +61,9 @@ public struct RemoteSyncMyDocumentCurrentSnapshot: Sendable, Equatable {
    existing outbound snapshot services
  */
 public final class RemoteSyncMyDocumentSnapshotService {
+    // Android sync triggers write the SQL literal '' for entityId2 on single-key tables.
+    static let emptySecondaryEntityID = RemoteSyncSQLiteValue.text("")
+
     public init() {}
 
     /**
@@ -104,7 +107,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocument",
                 entityID1: .blob(Self.uuidBlob(row.id)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
             documentRowsByKey[key] = row
             fingerprintsByKey[key] = Self.fingerprintHex(for: row)
@@ -130,7 +133,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocumentPage",
                 entityID1: .blob(Self.uuidBlob(row.id)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
             pageIDs.insert(row.id)
             pageRowsByKey[key] = row
@@ -146,7 +149,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocumentPageContent",
                 entityID1: .blob(Self.uuidBlob(row.pageId)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
             pageContentRowsByKey[key] = row
             fingerprintsByKey[key] = Self.fingerprintHex(for: row)
@@ -172,7 +175,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "AiPageCacheEntry",
                 entityID1: .blob(Self.uuidBlob(row.pageId)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
             aiPageCacheEntryRowsByKey[key] = row
             fingerprintsByKey[key] = Self.fingerprintHex(for: row)
@@ -207,7 +210,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocument",
                 entityID1: .blob(Self.uuidBlob(row.id)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
         }
 
@@ -220,7 +223,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocumentPage",
                 entityID1: .blob(Self.uuidBlob(row.id)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
         }
 
@@ -233,7 +236,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "MyDocumentPageContent",
                 entityID1: .blob(Self.uuidBlob(row.pageId)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
         }
 
@@ -246,7 +249,7 @@ public final class RemoteSyncMyDocumentSnapshotService {
                 for: .myDocuments,
                 tableName: "AiPageCacheEntry",
                 entityID1: .blob(Self.uuidBlob(row.pageId)),
-                entityID2: .text("")
+                entityID2: Self.emptySecondaryEntityID
             )
         }
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -39,8 +39,8 @@ public enum RemoteSyncCategoryPatchReplayReport: Sendable, Equatable {
 /**
  Category-specific outbound patch upload summary returned after one synchronization run.
 
- The coordinator preserves each category's native upload report because bookmark, workspace, and
- reading-plan sync expose different counters and fidelity details.
+ The coordinator preserves each category's native upload report because each sync stream exposes
+ different counters and fidelity details.
  */
 public enum RemoteSyncCategoryPatchUploadReport: Sendable, Equatable {
     /// Bookmark-category outbound patch upload summary.
@@ -51,6 +51,9 @@ public enum RemoteSyncCategoryPatchUploadReport: Sendable, Equatable {
 
     /// Reading-plan-category outbound patch upload summary.
     case readingPlans(RemoteSyncReadingPlanPatchUploadReport)
+
+    /// My Documents-category outbound patch upload summary.
+    case myDocuments(RemoteSyncMyDocumentPatchUploadReport)
 }
 
 /**
@@ -168,6 +171,7 @@ public enum RemoteSyncSynchronizationOutcome: Sendable, Equatable {
  - `RemoteSyncBookmarkPatchUploadService` exports and uploads outbound sparse bookmark patches
  - `RemoteSyncWorkspacePatchUploadService` exports and uploads outbound sparse workspace patches
  - `RemoteSyncReadingPlanPatchUploadService` exports and uploads outbound sparse reading-plan patches
+ - `RemoteSyncMyDocumentPatchUploadService` exports and uploads outbound sparse My Documents patches
  - `RemoteSyncStateStore` persists Android-aligned bootstrap and progress metadata locally
  - `RemoteSyncPatchStatusStore` records patch zero after remote initial-backup adoption, matching Android
 
@@ -176,7 +180,7 @@ public enum RemoteSyncSynchronizationOutcome: Sendable, Equatable {
  - may restore a full staged initial backup into local SwiftData
  - may export and upload a full staged initial backup from local SwiftData into a fresh remote folder
  - may replay staged remote patches into local SwiftData and local-only fidelity stores
- - may upload one outbound sparse bookmark, workspace, or reading-plan patch and rewrite local baseline metadata after success
+ - may upload one outbound sparse bookmark, workspace, reading-plan, or My Documents patch and rewrite local baseline metadata after success
  - persists bootstrap, patch-status, and progress metadata through `SettingsStore`
  - creates and removes temporary staged archive files beneath the configured temporary directory
 
@@ -202,6 +206,7 @@ public final class RemoteSyncSynchronizationService {
     private let bookmarkPatchUploadService: RemoteSyncBookmarkPatchUploadService
     private let workspacePatchApplyService: RemoteSyncWorkspacePatchApplyService
     private let workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService
+    private let myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService
     private let fileManager: FileManager
     private let temporaryDirectory: URL?
     private let nowProvider: () -> Int64
@@ -221,6 +226,7 @@ public final class RemoteSyncSynchronizationService {
        - bookmarkPatchUploadService: Bookmark outbound patch upload service.
        - workspacePatchApplyService: Workspace patch replay service.
        - workspacePatchUploadService: Workspace outbound patch upload service.
+       - myDocumentPatchUploadService: My Documents outbound patch upload service.
        - fileManager: File manager used for staging cleanup.
        - temporaryDirectory: Optional staging directory override.
        - nowProvider: Millisecond clock used for Android-aligned sync progress timestamps.
@@ -239,6 +245,7 @@ public final class RemoteSyncSynchronizationService {
         bookmarkPatchUploadService: RemoteSyncBookmarkPatchUploadService? = nil,
         workspacePatchApplyService: RemoteSyncWorkspacePatchApplyService = RemoteSyncWorkspacePatchApplyService(),
         workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService? = nil,
+        myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL? = nil,
         nowProvider: @escaping () -> Int64 = {
@@ -270,6 +277,11 @@ public final class RemoteSyncSynchronizationService {
         self.workspacePatchApplyService = workspacePatchApplyService
         self.workspacePatchUploadService = workspacePatchUploadService
             ?? RemoteSyncWorkspacePatchUploadService(
+                adapter: adapter,
+                nowProvider: nowProvider
+            )
+        self.myDocumentPatchUploadService = myDocumentPatchUploadService
+            ?? RemoteSyncMyDocumentPatchUploadService(
                 adapter: adapter,
                 nowProvider: nowProvider
             )
@@ -687,8 +699,8 @@ public final class RemoteSyncSynchronizationService {
     /**
      Uploads one outbound sparse patch when the category already has a local export pipeline.
 
-     Bookmark and reading-plan uploads are currently supported. Workspace upload remains follow-up
-     work, so that category intentionally returns `nil` here even when local state has diverged.
+     Categories without an outbound exporter intentionally return `nil` here even when local state
+     has diverged.
 
      - Parameters:
        - category: Logical sync category whose outbound exporter should run.
@@ -736,6 +748,13 @@ public final class RemoteSyncSynchronizationService {
             }
             return nil
         case .myDocuments:
+            if let report = try await myDocumentPatchUploadService.uploadPendingPatch(
+                bootstrapState: bootstrapState,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            ) {
+                return .myDocuments(report)
+            }
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Implements outbound sparse patch upload for My Documents sync.
- Writes Android-shaped SQLite patch archives, gzips them, uploads them to the current device folder, and records accepted local sync metadata after upload.
- Adds Room metadata, SyncConfiguration, SyncStatus, and Android schema views so generated patches match the Android MyDocumentDatabase v4 shape.

## Scope
- Adds My Documents patch upload service in BibleCore.
- Wires My Documents into RemoteSyncSynchronizationService outbound upload reports.
- Extends RemoteSyncMyDocumentRestoreTests for sparse patch archives, no-op detection, missing fingerprint baselines, missing device-folder rejection, delete detection, and synchronization-service upload.

## Contract References
- Follows ../commit-message-standard.md PR description contract.
- Android parity checked against ../and-bible/app/src/main/java/net/bible/service/cloudsync/SyncUtilities.kt.
- Room schema checked against ../and-bible/app/schemas/net.bible.android.database.mydocument.MyDocumentDatabase/4.json.

## Change Details
- Builds current My Documents snapshots from MyDocument, MyDocumentPage, MyDocumentPageContent, and AiPageCacheEntry rows.
- Diffs current rows against preserved Android LogEntry metadata and row fingerprint baselines.
- Emits UPSERT and DELETE LogEntry rows into a sparse SQLite patch database using Android-compatible table names and identifiers.
- Uploads patches as N.4.sqlite3.gz files and updates patch status, lastPatchWritten, and row fingerprint baselines after success.
- Keeps inbound My Documents patch replay unchanged.

## Validation Evidence
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17 -only-testing:AndBibleTests/RemoteSyncMyDocumentRestoreTests
- Gemini CLI final review: No actionable findings.
- Claude CLI review: findings triaged; Android schema and missing-baseline items addressed or confirmed against Android source.
- GitNexus impact: CRITICAL class-level blast radius acknowledged for RemoteSyncMyDocumentSnapshotService before the parity clarification.
- GitNexus staged detect_changes: medium risk, affecting expected My Documents snapshot and initial-backup flows.
- Issue state verified: #107 is OPEN.

## Risks / Follow-ups
- This implements outbound My Documents patch upload only; inbound My Documents patch replay remains unsupported and unchanged.
- The upload metadata persistence follows the existing nonthrowing SettingsStore pattern used by the bookmark, workspace, and reading-plan patch upload services.

## Issue Closure
Closes #107