### PR TITLE
feat(mydocuments): replay remote patch archives

### DIFF
--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -1201,6 +1201,88 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
 
         XCTAssertEqual(report.appliedLogEntryCount, 1)
         XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "TXTID")?.name, "Text Remote")
+        XCTAssertEqual(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .myDocuments),
+            [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 2_000,
+                    sourceDevice: "pixel"
+                )
+            ]
+        )
+    }
+
+    func testRemoteSyncMyDocumentPatchReplaySkipsOlderBlobPatchAgainstTextUUIDBaseline() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a8280000-0000-0000-0000-000000000001")!
+
+        modelContext.insert(MyDocument(id: documentID, name: "Text Baseline Local", initials: "TXTBLOB"))
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [
+                RemoteSyncLogEntry(
+                    tableName: "MyDocument",
+                    entityID1: .text(documentID.uuidString),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 5_000,
+                    sourceDevice: "iphone"
+                )
+            ],
+            for: .myDocuments
+        )
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 6,
+            timestamp: 8_800,
+            documents: [
+                .init(id: documentID, name: "Older Blob Remote", initials: "TXTBLOB")
+            ],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "pixel"
+                )
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        let report = try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+            [stagedArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedLogEntryCount, 0)
+        XCTAssertEqual(report.skippedLogEntryCount, 1)
+        XCTAssertEqual(
+            MyDocumentStore(modelContext: modelContext).document(initials: "TXTBLOB")?.name,
+            "Text Baseline Local"
+        )
+        XCTAssertEqual(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .myDocuments),
+            [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 5_000,
+                    sourceDevice: "iphone"
+                )
+            ]
+        )
     }
 
     func testRemoteSyncSynchronizationServiceReplaysRemoteMyDocumentPatch() async throws {

--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -681,6 +681,670 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         XCTAssertEqual(RemoteSyncStateStore(settingsStore: settingsStore).progressState(for: .myDocuments).lastPatchWritten, 2_400)
     }
 
+    func testRemoteSyncMyDocumentPatchReplayAppliesUpdatesDeletesAndSparseRows() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+
+        let documentID = UUID(uuidString: "a8100000-0000-0000-0000-000000000001")!
+        let existingPageID = UUID(uuidString: "a8100000-0000-0000-0000-000000000011")!
+        let existingPromptID = UUID(uuidString: "a8100000-0000-0000-0000-000000000021")!
+        let remotePromptID = UUID(uuidString: "a8100000-0000-0000-0000-000000000022")!
+        let newDocumentID = UUID(uuidString: "a8100000-0000-0000-0000-000000000002")!
+        let newPageID = UUID(uuidString: "a8100000-0000-0000-0000-000000000012")!
+        let deletedDocumentID = UUID(uuidString: "a8100000-0000-0000-0000-000000000003")!
+        let deletedPageID = UUID(uuidString: "a8100000-0000-0000-0000-000000000013")!
+        let orphanPageID = UUID(uuidString: "a8100000-0000-0000-0000-000000000014")!
+        let missingDocumentID = UUID(uuidString: "a8100000-0000-0000-0000-000000000099")!
+        let createdAt = Date(timeIntervalSince1970: 1_735_689_600)
+        let remoteUpdatedAt = Date(timeIntervalSince1970: 1_735_689_900)
+
+        let existingDocument = MyDocument(
+            id: documentID,
+            name: "Local",
+            initials: "LOC",
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+        let existingPage = MyDocumentPage(
+            id: existingPageID,
+            title: "Local Page",
+            pageKey: "local",
+            sourcePromptId: existingPromptID
+        )
+        let existingContent = MyDocumentPageContent(pageId: existingPageID, content: "Local content")
+        let existingCacheEntry = AiPageCacheEntry(
+            pageId: existingPageID,
+            sourcePromptId: existingPromptID,
+            contextHash: "local-cache"
+        )
+        existingDocument.pages = [existingPage]
+        existingPage.document = existingDocument
+        existingPage.pageContent = existingContent
+        existingContent.page = existingPage
+        existingPage.aiPageCacheEntries = [existingCacheEntry]
+        existingCacheEntry.page = existingPage
+
+        let deletedDocument = MyDocument(id: deletedDocumentID, name: "Deleted", initials: "DEL")
+        let deletedPage = MyDocumentPage(id: deletedPageID, title: "Deleted Page", pageKey: "deleted")
+        let deletedContent = MyDocumentPageContent(pageId: deletedPageID, content: "Delete me")
+        deletedDocument.pages = [deletedPage]
+        deletedPage.document = deletedDocument
+        deletedPage.pageContent = deletedContent
+        deletedContent.page = deletedPage
+
+        modelContext.insert(existingDocument)
+        modelContext.insert(existingPage)
+        modelContext.insert(existingContent)
+        modelContext.insert(existingCacheEntry)
+        modelContext.insert(deletedDocument)
+        modelContext.insert(deletedPage)
+        modelContext.insert(deletedContent)
+        try modelContext.save()
+
+        logEntryStore.replaceEntries(
+            myDocumentLogEntries(
+                documentIDs: [documentID, deletedDocumentID],
+                pageIDs: [existingPageID, deletedPageID],
+                timestamp: 1_000,
+                sourceDevice: "iphone"
+            ),
+            for: .myDocuments
+        )
+
+        let patchLogEntries: [RemoteSyncLogEntry] = [
+            myDocumentLogEntry(tableName: "MyDocument", rowID: documentID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocument", rowID: newDocumentID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocumentPage", rowID: newPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocumentPage", rowID: orphanPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocumentPageContent", rowID: existingPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocumentPageContent", rowID: newPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocumentPageContent", rowID: orphanPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "AiPageCacheEntry", rowID: existingPageID, type: .upsert),
+            myDocumentLogEntry(tableName: "MyDocument", rowID: deletedDocumentID, type: .delete),
+        ]
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 1,
+            timestamp: 7_000,
+            documents: [
+                .init(
+                    id: documentID,
+                    name: "Remote Updated",
+                    documentDescription: "Remote metadata",
+                    initials: "LOC",
+                    orderNumber: 4,
+                    createdAt: createdAt,
+                    updatedAt: remoteUpdatedAt
+                ),
+                .init(
+                    id: newDocumentID,
+                    name: "Remote New",
+                    initials: "NEW",
+                    orderNumber: 5,
+                    createdAt: createdAt,
+                    updatedAt: remoteUpdatedAt
+                ),
+            ],
+            pages: [
+                .init(
+                    id: newPageID,
+                    documentId: newDocumentID,
+                    title: "New Page",
+                    pageKey: "new",
+                    contentType: .html,
+                    orderNumber: 1,
+                    createdAt: createdAt,
+                    updatedAt: remoteUpdatedAt
+                ),
+                .init(
+                    id: orphanPageID,
+                    documentId: missingDocumentID,
+                    title: "Orphan Page",
+                    pageKey: "orphan",
+                    contentType: .markdown,
+                    orderNumber: 2,
+                    createdAt: createdAt,
+                    updatedAt: remoteUpdatedAt
+                )
+            ],
+            pageContents: [
+                .init(pageId: existingPageID, content: "Remote content only"),
+                .init(pageId: newPageID, content: "<p>Remote new</p>"),
+                .init(pageId: orphanPageID, content: "Orphan content"),
+            ],
+            aiPageCacheEntries: [
+                .init(
+                    pageId: existingPageID,
+                    sourcePromptId: remotePromptID,
+                    contextHash: "remote-cache",
+                    sourceBookKey: "Gen.1"
+                )
+            ],
+            logEntries: patchLogEntries
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        let report = try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+            [stagedArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedPatchCount, 1)
+        XCTAssertEqual(report.appliedLogEntryCount, 9)
+        XCTAssertEqual(report.skippedLogEntryCount, 0)
+        XCTAssertEqual(
+            report.restoreReport,
+            .init(
+                restoredDocumentCount: 2,
+                restoredPageCount: 2,
+                restoredContentCount: 2,
+                restoredAIPageCacheEntryCount: 1
+            )
+        )
+
+        let store = MyDocumentStore(modelContext: modelContext)
+        XCTAssertEqual(store.document(initials: "LOC")?.name, "Remote Updated")
+        XCTAssertEqual(
+            store.rawContentPayload(bookInitials: "LOC", pageKey: "local")?.content,
+            "Remote content only"
+        )
+        XCTAssertEqual(
+            store.rawContentPayload(bookInitials: "NEW", pageKey: "new")?.content,
+            "<p>Remote new</p>"
+        )
+        XCTAssertNil(store.document(initials: "DEL"))
+        XCTAssertNil(store.page(pageId: deletedPageID))
+        XCTAssertNil(store.page(pageId: orphanPageID))
+        XCTAssertEqual(
+            store.aiPageActionContext(pageId: existingPageID)?.contextHash,
+            "remote-cache"
+        )
+
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments),
+            [
+                RemoteSyncPatchStatus(
+                    sourceDevice: "pixel",
+                    patchNumber: 1,
+                    sizeBytes: stagedArchive.patch.file.size,
+                    appliedDate: 7_000
+                )
+            ]
+        )
+        XCTAssertTrue(
+            logEntryStore.entries(for: .myDocuments).contains(
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: deletedDocumentID,
+                    type: .delete
+                )
+            )
+        )
+    }
+
+    func testRemoteSyncMyDocumentPatchReplaySkipsOlderRowsAndRecordsPatchStatus() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let documentID = UUID(uuidString: "a8200000-0000-0000-0000-000000000001")!
+
+        modelContext.insert(MyDocument(id: documentID, name: "Local Newer", initials: "SKIP"))
+        try modelContext.save()
+
+        let localLogEntry = myDocumentLogEntry(
+            tableName: "MyDocument",
+            rowID: documentID,
+            type: .upsert,
+            timestamp: 5_000,
+            sourceDevice: "iphone"
+        )
+        logEntryStore.replaceEntries([localLogEntry], for: .myDocuments)
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 2,
+            timestamp: 8_000,
+            documents: [
+                .init(id: documentID, name: "Remote Older", initials: "SKIP")
+            ],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "pixel"
+                )
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        let report = try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+            [stagedArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedPatchCount, 1)
+        XCTAssertEqual(report.appliedLogEntryCount, 0)
+        XCTAssertEqual(report.skippedLogEntryCount, 1)
+        XCTAssertEqual(report.restoreReport.restoredDocumentCount, 1)
+        XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "SKIP")?.name, "Local Newer")
+        XCTAssertEqual(logEntryStore.entries(for: .myDocuments), [localLogEntry])
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).status(
+                for: .myDocuments,
+                sourceDevice: "pixel",
+                patchNumber: 2
+            ),
+            RemoteSyncPatchStatus(
+                sourceDevice: "pixel",
+                patchNumber: 2,
+                sizeBytes: stagedArchive.patch.file.size,
+                appliedDate: 8_000
+            )
+        )
+    }
+
+    func testRemoteSyncMyDocumentPatchReplayAppliesMultipleArchivesInOrder() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a8240000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a8240000-0000-0000-0000-000000000011")!
+
+        let document = MyDocument(id: documentID, name: "Batch Local", initials: "BATCH")
+        let page = MyDocumentPage(id: pageID, title: "Batch Page", pageKey: "batch")
+        let content = MyDocumentPageContent(pageId: pageID, content: "Before batch")
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+                myDocumentLogEntry(
+                    tableName: "MyDocumentPage",
+                    rowID: pageID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+                myDocumentLogEntry(
+                    tableName: "MyDocumentPageContent",
+                    rowID: pageID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+            ],
+            for: .myDocuments
+        )
+
+        let firstArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 1,
+            timestamp: 8_100,
+            documents: [
+                .init(id: documentID, name: "Batch Remote", initials: "BATCH")
+            ],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(tableName: "MyDocument", rowID: documentID, type: .upsert, timestamp: 2_000)
+            ]
+        )
+        let secondArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 2,
+            timestamp: 8_200,
+            documents: [],
+            pages: [],
+            pageContents: [
+                .init(pageId: pageID, content: "After batch")
+            ],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(tableName: "MyDocumentPageContent", rowID: pageID, type: .upsert, timestamp: 3_000)
+            ]
+        )
+        defer {
+            try? FileManager.default.removeItem(at: firstArchive.archiveFileURL)
+            try? FileManager.default.removeItem(at: secondArchive.archiveFileURL)
+        }
+
+        let report = try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+            [firstArchive, secondArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedPatchCount, 2)
+        XCTAssertEqual(report.appliedLogEntryCount, 2)
+        XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "BATCH")?.name, "Batch Remote")
+        XCTAssertEqual(
+            MyDocumentStore(modelContext: modelContext).rawContentPayload(bookInitials: "BATCH", pageKey: "batch")?.content,
+            "After batch"
+        )
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments),
+            [
+                RemoteSyncPatchStatus(
+                    sourceDevice: "pixel",
+                    patchNumber: 1,
+                    sizeBytes: firstArchive.patch.file.size,
+                    appliedDate: 8_100
+                ),
+                RemoteSyncPatchStatus(
+                    sourceDevice: "pixel",
+                    patchNumber: 2,
+                    sizeBytes: secondArchive.patch.file.size,
+                    appliedDate: 8_200
+                ),
+            ]
+        )
+    }
+
+    func testRemoteSyncMyDocumentPatchReplayRejectsMissingUpsertRowWithoutMutation() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a8250000-0000-0000-0000-000000000001")!
+        let missingDocumentID = UUID(uuidString: "a8250000-0000-0000-0000-000000000002")!
+
+        modelContext.insert(MyDocument(id: documentID, name: "Existing", initials: "MISS"))
+        try modelContext.save()
+
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 3,
+            timestamp: 8_500,
+            documents: [],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(tableName: "MyDocument", rowID: missingDocumentID, type: .upsert)
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        XCTAssertThrowsError(
+            try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+                [stagedArchive],
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncMyDocumentPatchApplyError,
+                .missingPatchRow(table: "MyDocument", id: missingDocumentID)
+            )
+        }
+        XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "MISS")?.name, "Existing")
+        XCTAssertTrue(RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments).isEmpty)
+    }
+
+    func testRemoteSyncMyDocumentPatchReplayRejectsInvalidLogEntryIdentifierWithoutMutation() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a8260000-0000-0000-0000-000000000001")!
+
+        modelContext.insert(MyDocument(id: documentID, name: "Existing", initials: "BADID"))
+        try modelContext.save()
+
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 4,
+            timestamp: 8_600,
+            documents: [],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                RemoteSyncLogEntry(
+                    tableName: "MyDocument",
+                    entityID1: .text("not-a-uuid"),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 2_000,
+                    sourceDevice: "pixel"
+                )
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        XCTAssertThrowsError(
+            try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+                [stagedArchive],
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncMyDocumentPatchApplyError,
+                .invalidLogEntryIdentifier(table: "MyDocument", field: "entityId1")
+            )
+        }
+        XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "BADID")?.name, "Existing")
+        XCTAssertTrue(RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .myDocuments).isEmpty)
+    }
+
+    func testRemoteSyncMyDocumentPatchReplayAcceptsTextUUIDIdentifiers() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let documentID = UUID(uuidString: "a8270000-0000-0000-0000-000000000001")!
+
+        modelContext.insert(MyDocument(id: documentID, name: "Text Local", initials: "TXTID"))
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                )
+            ],
+            for: .myDocuments
+        )
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 5,
+            timestamp: 8_700,
+            documents: [
+                .init(id: documentID, name: "Text Remote", initials: "TXTID")
+            ],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: [],
+            logEntries: [
+                RemoteSyncLogEntry(
+                    tableName: "MyDocument",
+                    entityID1: .text(documentID.uuidString),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 2_000,
+                    sourceDevice: "pixel"
+                )
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        let report = try RemoteSyncMyDocumentPatchApplyService().applyPatchArchives(
+            [stagedArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedLogEntryCount, 1)
+        XCTAssertEqual(MyDocumentStore(modelContext: modelContext).document(initials: "TXTID")?.name, "Text Remote")
+    }
+
+    func testRemoteSyncSynchronizationServiceReplaysRemoteMyDocumentPatch() async throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let syncFolderID = "/org.andbible.ios-sync-mydocuments"
+        let localDeviceFolderID = "\(syncFolderID)/ios-device"
+        let remoteDeviceFolderID = "\(syncFolderID)/pixel"
+
+        stateStore.setBootstrapState(
+            RemoteSyncBootstrapState(
+                syncFolderID: syncFolderID,
+                deviceFolderID: localDeviceFolderID,
+                secretFileName: "device-known-ios-device-secret"
+            ),
+            for: .myDocuments
+        )
+
+        let documentID = UUID(uuidString: "a8300000-0000-0000-0000-000000000001")!
+        let pageID = UUID(uuidString: "a8300000-0000-0000-0000-000000000011")!
+        let document = MyDocument(id: documentID, name: "Sync Replay", initials: "REPLAY")
+        let page = MyDocumentPage(id: pageID, title: "Replay Page", pageKey: "replay")
+        let content = MyDocumentPageContent(pageId: pageID, content: "Before replay")
+        document.pages = [page]
+        page.document = document
+        page.pageContent = content
+        content.page = page
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        try modelContext.save()
+
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [
+                myDocumentLogEntry(
+                    tableName: "MyDocument",
+                    rowID: documentID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+                myDocumentLogEntry(
+                    tableName: "MyDocumentPage",
+                    rowID: pageID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+                myDocumentLogEntry(
+                    tableName: "MyDocumentPageContent",
+                    rowID: pageID,
+                    type: .upsert,
+                    timestamp: 1_000,
+                    sourceDevice: "iphone"
+                ),
+            ],
+            for: .myDocuments
+        )
+
+        let stagedArchive = try makeStagedMyDocumentPatchArchive(
+            sourceDevice: "pixel",
+            patchNumber: 1,
+            timestamp: 7_500,
+            documents: [],
+            pages: [],
+            pageContents: [
+                .init(pageId: pageID, content: "After replay")
+            ],
+            aiPageCacheEntries: [],
+            logEntries: [
+                myDocumentLogEntry(tableName: "MyDocumentPageContent", rowID: pageID, type: .upsert)
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+        let archiveData = try Data(contentsOf: stagedArchive.archiveFileURL)
+        let remoteDeviceFolder = RemoteSyncFile(
+            id: remoteDeviceFolderID,
+            name: "pixel",
+            size: 0,
+            timestamp: 7_400,
+            parentID: syncFolderID,
+            mimeType: NextCloudSyncAdapter.folderMimeType
+        )
+        let remotePatchFile = RemoteSyncFile(
+            id: "\(remoteDeviceFolderID)/1.4.sqlite3.gz",
+            name: "1.4.sqlite3.gz",
+            size: Int64(archiveData.count),
+            timestamp: 7_500,
+            parentID: remoteDeviceFolderID,
+            mimeType: NextCloudSyncAdapter.gzipMimeType
+        )
+        let adapter = MyDocumentMockRemoteSyncAdapter()
+        await adapter.setKnownResponse(
+            true,
+            forSyncFolderID: syncFolderID,
+            secretFileName: "device-known-ios-device-secret"
+        )
+        await adapter.setListedFiles([remoteDeviceFolder], forParentID: syncFolderID)
+        await adapter.setListedFiles([remotePatchFile], forParentID: remoteDeviceFolderID)
+        await adapter.setDownloadData(archiveData, forID: remotePatchFile.id)
+        let service = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-device",
+            nowProvider: { 7_600 }
+        )
+
+        let outcome = try await service.synchronize(
+            .myDocuments,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            currentSchemaVersion: RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        )
+
+        guard case .synchronized(let report) = outcome else {
+            return XCTFail("Expected synchronized outcome")
+        }
+        XCTAssertEqual(report.category, .myDocuments)
+        XCTAssertEqual(report.discoveredPatchCount, 1)
+        XCTAssertNil(report.patchUploadReport)
+        XCTAssertEqual(report.lastPatchWritten, nil)
+        XCTAssertEqual(report.lastSynchronized, 7_600)
+        guard case .myDocuments(let replayReport)? = report.patchReplayReport else {
+            return XCTFail("Expected My Documents replay report")
+        }
+        XCTAssertEqual(replayReport.appliedPatchCount, 1)
+        XCTAssertEqual(replayReport.appliedLogEntryCount, 1)
+        XCTAssertEqual(replayReport.skippedLogEntryCount, 0)
+        XCTAssertEqual(
+            MyDocumentStore(modelContext: modelContext).rawContentPayload(bookInitials: "REPLAY", pageKey: "replay")?.content,
+            "After replay"
+        )
+        XCTAssertEqual(
+            RemoteSyncPatchStatusStore(settingsStore: settingsStore).status(
+                for: .myDocuments,
+                sourceDevice: "pixel",
+                patchNumber: 1
+            )?.appliedDate,
+            7_500
+        )
+    }
+
     func testRemoteSyncMyDocumentPatchUploadWritesAndUploadsSparsePatch() async throws {
         let container = try makeModelContainer()
         let modelContext = ModelContext(container)
@@ -1198,7 +1862,8 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         let outcome = try await service.synchronize(
             .myDocuments,
             modelContext: modelContext,
-            settingsStore: settingsStore
+            settingsStore: settingsStore,
+            currentSchemaVersion: RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
         )
 
         guard case .synchronized(let report) = outcome else {
@@ -1247,6 +1912,49 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         ])
         let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    private func makeStagedMyDocumentPatchArchive(
+        sourceDevice: String,
+        patchNumber: Int64,
+        timestamp: Int64,
+        documents: [AndroidMyDocumentRow],
+        pages: [AndroidMyDocumentPageRow],
+        pageContents: [AndroidMyDocumentPageContentRow],
+        aiPageCacheEntries: [AndroidAiPageCacheEntryRow],
+        logEntries: [RemoteSyncLogEntry]
+    ) throws -> RemoteSyncStagedPatchArchive {
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: documents,
+            pages: pages,
+            pageContents: pageContents,
+            aiPageCacheEntries: aiPageCacheEntries,
+            logEntries: logEntries
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let archiveData = try RemoteSyncArchiveStagingService.gzip(Data(contentsOf: databaseURL))
+        let archiveURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("android-mydocuments-patch-\(UUID().uuidString).sqlite3.gz")
+        try archiveData.write(to: archiveURL, options: .atomic)
+
+        let parentID = "/org.andbible.ios-sync-mydocuments/\(sourceDevice)"
+        return RemoteSyncStagedPatchArchive(
+            patch: RemoteSyncDiscoveredPatch(
+                sourceDevice: sourceDevice,
+                patchNumber: patchNumber,
+                schemaVersion: RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion,
+                file: RemoteSyncFile(
+                    id: "\(parentID)/\(patchNumber).\(RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion).sqlite3.gz",
+                    name: "\(patchNumber).\(RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion).sqlite3.gz",
+                    size: Int64(archiveData.count),
+                    timestamp: timestamp,
+                    parentID: parentID,
+                    mimeType: NextCloudSyncAdapter.gzipMimeType
+                )
+            ),
+            archiveFileURL: archiveURL
+        )
     }
 
     private func makeAndroidMyDocumentsDatabase(
@@ -1561,6 +2269,23 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
         sqlite3_bind_int(statement, index, Int32(value))
     }
 
+    private func myDocumentLogEntry(
+        tableName: String,
+        rowID: UUID,
+        type: RemoteSyncLogEntryType,
+        timestamp: Int64 = 2_000,
+        sourceDevice: String = "pixel"
+    ) -> RemoteSyncLogEntry {
+        RemoteSyncLogEntry(
+            tableName: tableName,
+            entityID1: .blob(uuidBlob(rowID)),
+            entityID2: .text(""),
+            type: type,
+            lastUpdated: timestamp,
+            sourceDevice: sourceDevice
+        )
+    }
+
     private func myDocumentLogEntries(
         documentIDs: [UUID],
         pageIDs: [UUID],
@@ -1615,6 +2340,8 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
 private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
     private var uploadResults: [RemoteSyncFile] = []
     private var knownResponses: [String: Bool] = [:]
+    private var listedFilesByParentID: [String: [RemoteSyncFile]] = [:]
+    private var downloadDataByID: [String: Data] = [:]
     private var uploadedFiles: [MyDocumentMockUploadedFile] = []
 
     func enqueueUploadResult(_ result: RemoteSyncFile) {
@@ -1623,6 +2350,14 @@ private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
 
     func setKnownResponse(_ value: Bool, forSyncFolderID syncFolderID: String, secretFileName: String) {
         knownResponses["\(syncFolderID)|\(secretFileName)"] = value
+    }
+
+    func setListedFiles(_ files: [RemoteSyncFile], forParentID parentID: String) {
+        listedFilesByParentID[parentID] = files
+    }
+
+    func setDownloadData(_ data: Data, forID id: String) {
+        downloadDataByID[id] = data
     }
 
     func uploadedFilesSnapshot() -> [MyDocumentMockUploadedFile] {
@@ -1635,7 +2370,28 @@ private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
         mimeType: String?,
         modifiedAtLeast: Date?
     ) async throws -> [RemoteSyncFile] {
-        []
+        let files: [RemoteSyncFile]
+        if let parentIDs {
+            files = parentIDs.flatMap { listedFilesByParentID[$0, default: []] }
+        } else {
+            files = listedFilesByParentID.values.flatMap { $0 }
+        }
+
+        return files.filter { file in
+            if let name, file.name != name {
+                return false
+            }
+            if let mimeType, file.mimeType != mimeType {
+                return false
+            }
+            if let modifiedAtLeast {
+                let modifiedDate = Date(timeIntervalSince1970: TimeInterval(file.timestamp) / 1000.0)
+                if modifiedDate < modifiedAtLeast {
+                    return false
+                }
+            }
+            return true
+        }
     }
 
     func createNewFolder(name: String, parentID: String?) async throws -> RemoteSyncFile {
@@ -1650,7 +2406,7 @@ private actor MyDocumentMockRemoteSyncAdapter: RemoteSyncAdapting {
     }
 
     func download(id: String) async throws -> Data {
-        Data()
+        downloadDataByID[id] ?? Data()
     }
 
     func upload(

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -6366,6 +6366,7 @@ final class AndBibleUITests: XCTestCase {
      *   - taps the real add-window control in the reader tab bar
      *   - waits for the new tab pill to appear, become active, and export the matching
      *     `readerRenderedContentState` window order before returning
+     *   - retries the add tap once when the expected new tab never materializes
      * - Failure modes:
      *   - fails if the add control or the expected tab does not appear
      *   - fails if the new tab appears but never becomes the active rendered window
@@ -6377,28 +6378,41 @@ final class AndBibleUITests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        tapElementReliably(
-            requireElement("windowTabAddButton", in: app, timeout: timeout, file: file, line: line),
-            timeout: timeout,
-            file: file,
-            line: line
-        )
-
         let identifier = "windowTabButton::\(order)"
-        let tabButton = requireElement(identifier, in: app, timeout: timeout, file: file, line: line)
+        var sawExpectedTab = false
+        var lastTabValue = "nil"
+        var lastRenderedState = "nil"
 
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            let tabValue = tabButton.value as? String ?? ""
-            let renderedState = readerRenderedContentStateValue(in: app) ?? ""
-            if tabValue.contains("state=active") && renderedState.contains("windowOrder=\(order)") {
-                return
+        for attempt in 1...2 {
+            tapElementReliably(
+                requireElement("windowTabAddButton", in: app, timeout: timeout, file: file, line: line),
+                timeout: timeout,
+                file: file,
+                line: line
+            )
+
+            let deadline = Date().addingTimeInterval(timeout)
+            repeat {
+                if let tabButton = resolvedElement(identifier, in: app) {
+                    sawExpectedTab = true
+                    lastTabValue = tabButton.value.map { "\($0)" } ?? "nil"
+                    lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+                    if lastTabValue.contains("state=active") && lastRenderedState.contains("windowOrder=\(order)") {
+                        return
+                    }
+                } else {
+                    lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            } while Date() < deadline
+
+            if sawExpectedTab || attempt == 2 {
+                break
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
 
-        let lastTabValue = tabButton.value.map { "\($0)" } ?? "nil"
-        let lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+
         XCTFail(
             "Expected added window tab \(order) to become the active rendered window within \(timeout) seconds; last tab value was '\(lastTabValue)' and last reader state was '\(lastRenderedState)'.",
             file: file,

--- a/AndBibleUITests/AndBibleUITests.swift
+++ b/AndBibleUITests/AndBibleUITests.swift
@@ -495,7 +495,7 @@ final class AndBibleUITests: XCTestCase {
 
         _ = openWorkspaceCreatePrompt(in: app, timeout: 10)
         let workspaceNameField = requireWorkspaceNamePromptField(in: app, timeout: 10)
-        focusResolvedPromptTextEntryElement(workspaceNameField, timeout: 10)
+        focusResolvedPromptTextEntryElement(workspaceNameField, in: app, timeout: 10)
         app.typeText(createdName)
         tapElementReliably(requireElement("workspaceNamePromptConfirmButton", in: app, timeout: 10), timeout: 10)
 
@@ -1455,7 +1455,7 @@ final class AndBibleUITests: XCTestCase {
         tapElementReliably(requireElement("labelManagerAddButton", in: app, timeout: 10), timeout: 10)
         waitForLabelManagerState(containing: "showNewLabel=true", in: app, timeout: 10)
         let newLabelNameField = requireLabelManagerNewLabelField(in: app, timeout: 10)
-        focusResolvedPromptTextEntryElement(newLabelNameField, timeout: 10)
+        focusResolvedPromptTextEntryElement(newLabelNameField, in: app, timeout: 10)
         app.typeText(originalName)
         tapElementReliably(requireLabelManagerCreateButton(in: app, timeout: 10), timeout: 10)
         waitForLabelManagerState(containing: labelManagerRowStateToken(originalName), in: app, timeout: 10)
@@ -9068,7 +9068,7 @@ final class AndBibleUITests: XCTestCase {
     private func createFreshLabelFromAssignment(in app: XCUIApplication) {
         presentLabelCreationPrompt(in: app, timeout: 10)
         let nameField = requireLabelManagerNewLabelField(in: app, timeout: 10)
-        focusResolvedPromptTextEntryElement(nameField, timeout: 10)
+        focusResolvedPromptTextEntryElement(nameField, in: app, timeout: 10)
         app.typeText("UI Test Fresh")
         tapElementReliably(requireLabelManagerCreateButton(in: app, timeout: 10), timeout: 10)
     }
@@ -9996,32 +9996,32 @@ final class AndBibleUITests: XCTestCase {
      Focuses a prompt-owned text-entry control without polling `isHittable`.
 
      SwiftUI alert text fields can occasionally stall XCTest while resolving frame-based taps even
-     after the prompt-specific resolver has found the field. Use XCTest's native tap only when the
-     field is already hittable, then reserve the coordinate path as a fallback.
+     after the prompt-specific resolver has found the field. Prefer the alert's automatic keyboard
+     focus first, then tap the modal surface instead of the resolved field so XCTest does not rebuild
+     a slow text-field snapshot.
      */
     private func focusResolvedPromptTextEntryElement(
         _ element: XCUIElement,
+        in app: XCUIApplication,
         preferTrailingEdge: Bool = false,
         timeout: TimeInterval = 10,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        if waitForElementKeyboardFocus(element, timeout: 1) {
+            return
+        }
+
         let deadline = Date().addingTimeInterval(timeout)
         let tapOffset = CGVector(dx: preferTrailingEdge ? 0.92 : 0.5, dy: 0.5)
 
         repeat {
-            let frame = element.frame
-            if elementFrameIsUsable(frame) && element.isHittable {
-                element.tap()
-                if waitForElementKeyboardFocus(element, timeout: 0.75) {
-                    return
-                }
-            }
-            if elementFrameIsUsable(frame) {
-                element.coordinate(withNormalizedOffset: tapOffset).tap()
-                if waitForElementKeyboardFocus(element, timeout: 0.75) {
-                    return
-                }
+            let coordinate = resolvedModalPrompt(in: app, timeout: 0.2)?
+                .coordinate(withNormalizedOffset: tapOffset)
+                ?? app.coordinate(withNormalizedOffset: tapOffset)
+            coordinate.tap()
+            if waitForElementKeyboardFocus(element, timeout: 0.75) {
+                return
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchApplyService.swift
@@ -278,12 +278,7 @@ public final class RemoteSyncMyDocumentPatchApplyService {
         let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
 
         var snapshot = try currentSnapshot(from: modelContext, settingsStore: settingsStore)
-        var logEntriesByKey = Dictionary(
-            logEntryStore.entries(for: .myDocuments).map {
-                (logEntryStore.key(for: .myDocuments, entry: $0), $0)
-            },
-            uniquingKeysWith: { _, replacement in replacement }
-        )
+        var logEntriesByKey = seededLogEntriesByKey(logEntryStore: logEntryStore)
 
         var appliedPatchStatuses: [RemoteSyncPatchStatus] = []
         var appliedLogEntryCount = 0
@@ -301,7 +296,8 @@ public final class RemoteSyncMyDocumentPatchApplyService {
                 let metadataSnapshot = try metadataRestoreService.readSnapshot(from: patchDatabaseURL)
                 let patchSnapshot = try restoreService.readSnapshot(from: patchDatabaseURL)
                 let patchLogEntries = metadataSnapshot.logEntries.filter { Self.supportedTableNames.contains($0.tableName) }
-                let filteredLogEntries = patchLogEntries.filter { entry in
+                let canonicalPatchLogEntries = try patchLogEntries.map(canonicalLogEntry)
+                let filteredLogEntries = canonicalPatchLogEntries.filter { entry in
                     let key = logEntryStore.key(for: .myDocuments, entry: entry)
                     guard let localEntry = logEntriesByKey[key] else {
                         return true
@@ -377,6 +373,36 @@ public final class RemoteSyncMyDocumentPatchApplyService {
             skippedLogEntryCount: skippedLogEntryCount,
             restoreReport: restoreReport
         )
+    }
+
+    /**
+     Builds the replay conflict map from locally persisted My Documents log metadata.
+
+     My Documents tables use UUID primary keys and Android writes an empty secondary identifier for
+     these single-key tables. Older imports can still preserve UUID identifiers as SQLite text. This
+     seed step canonicalizes supported My Documents rows to blob UUID identifiers before conflict
+     comparison so text/blob representations of the same row share one baseline key.
+
+     - Parameter logEntryStore: Local metadata store to read.
+     - Returns: Canonicalized local log entries keyed by the same store key used for persistence.
+     - Side effects: reads local settings-backed log entries.
+     - Failure modes: Malformed local supported-table identifiers are retained under their raw key
+       rather than failing replay.
+     */
+    private func seededLogEntriesByKey(logEntryStore: RemoteSyncLogEntryStore) -> [String: RemoteSyncLogEntry] {
+        var entriesByKey: [String: RemoteSyncLogEntry] = [:]
+        for entry in logEntryStore.entries(for: .myDocuments) {
+            let keyedEntry = (try? canonicalLogEntry(entry)) ?? entry
+            let key = logEntryStore.key(for: .myDocuments, entry: keyedEntry)
+            guard let existingEntry = entriesByKey[key] else {
+                entriesByKey[key] = keyedEntry
+                continue
+            }
+            if Self.logEntrySort(existingEntry, keyedEntry) {
+                entriesByKey[key] = keyedEntry
+            }
+        }
+        return entriesByKey
     }
 
     /**
@@ -617,25 +643,56 @@ public final class RemoteSyncMyDocumentPatchApplyService {
         var didMutate = false
 
         for entry in upserts {
-            let rowID = try uuid(from: entry.entityID1, tableName: tableName, field: "entityId1")
+            let canonicalEntry = try canonicalLogEntry(entry)
+            let rowID = try uuid(from: canonicalEntry.entityID1, tableName: tableName, field: "entityId1")
             guard let row = patchRows[rowID] else {
                 throw RemoteSyncMyDocumentPatchApplyError.missingPatchRow(table: tableName, id: rowID)
             }
             upsert(row)
             didMutate = true
-            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: entry)] = entry
+            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: canonicalEntry)] = canonicalEntry
         }
 
         for entry in deletes {
-            let rowID = try uuid(from: entry.entityID1, tableName: tableName, field: "entityId1")
+            let canonicalEntry = try canonicalLogEntry(entry)
+            let rowID = try uuid(from: canonicalEntry.entityID1, tableName: tableName, field: "entityId1")
             delete(rowID)
             didMutate = true
-            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: entry)] = entry
+            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: canonicalEntry)] = canonicalEntry
         }
 
         if didMutate {
             afterMutation()
         }
+    }
+
+    /**
+     Canonicalizes one My Documents log-entry identifier for conflict checks and local persistence.
+
+     Android My Documents patch rows are keyed by UUID `entityId1` values. SQLite can preserve those
+     UUIDs as either 16-byte blobs or text strings depending on the writer, but iOS snapshot/upload
+     paths always use blob UUIDs. Canonical replay metadata prevents text/blob duplicates for the
+     same logical row.
+
+     - Parameter entry: Supported My Documents log entry to canonicalize.
+     - Returns: Log entry with blob UUID `entityID1` and empty-string `entityID2`.
+     - Side effects: none.
+     - Failure modes: Throws `RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier` when
+       `entityID1` cannot be decoded as a UUID.
+     */
+    private func canonicalLogEntry(_ entry: RemoteSyncLogEntry) throws -> RemoteSyncLogEntry {
+        guard Self.supportedTableNames.contains(entry.tableName) else {
+            return entry
+        }
+        let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName, field: "entityId1")
+        return RemoteSyncLogEntry(
+            tableName: entry.tableName,
+            entityID1: .blob(RemoteSyncMyDocumentSnapshotService.uuidBlob(rowID)),
+            entityID2: RemoteSyncMyDocumentSnapshotService.emptySecondaryEntityID,
+            type: entry.type,
+            lastUpdated: entry.lastUpdated,
+            sourceDevice: entry.sourceDevice
+        )
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentPatchApplyService.swift
@@ -1,0 +1,811 @@
+// RemoteSyncMyDocumentPatchApplyService.swift -- Incremental Android patch replay for My Documents
+
+import CLibSword
+import Foundation
+import SwiftData
+
+/**
+ Errors raised while replaying Android My Documents patch archives against the local SwiftData graph.
+ */
+public enum RemoteSyncMyDocumentPatchApplyError: Error, Equatable {
+    /// One Android `LogEntry` identifier could not be converted into the expected UUID row key.
+    case invalidLogEntryIdentifier(table: String, field: String)
+
+    /// One `UPSERT` log entry referenced a row that was not present in the staged patch database.
+    case missingPatchRow(table: String, id: UUID)
+}
+
+/**
+ Summary of one successful My Documents patch replay batch.
+ */
+public struct RemoteSyncMyDocumentPatchApplyReport: Sendable, Equatable {
+    /// Number of patch archives successfully evaluated and recorded in patch status, including all-skipped archives.
+    public let appliedPatchCount: Int
+
+    /// Number of remote `LogEntry` rows accepted into local metadata, including rows later pruned by foreign-key cleanup.
+    public let appliedLogEntryCount: Int
+
+    /// Number of remote `LogEntry` rows skipped because a local row was newer or equal.
+    public let skippedLogEntryCount: Int
+
+    /// Final My Documents restore summary produced by the centralized rewrite path.
+    public let restoreReport: RemoteSyncMyDocumentRestoreReport
+
+    /**
+     Creates one replay summary after a batch has been evaluated.
+
+     - Parameters:
+       - appliedPatchCount: Number of patch archives successfully evaluated and recorded in patch status, including archives whose log entries were all skipped.
+       - appliedLogEntryCount: Number of newer remote log entries accepted into local metadata. Rows removed by foreign-key cleanup still count here because Android records their log-entry watermarks.
+       - skippedLogEntryCount: Number of remote log entries ignored because local metadata was newer or equal.
+       - restoreReport: Final My Documents row counts after replay normalization.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        appliedPatchCount: Int,
+        appliedLogEntryCount: Int,
+        skippedLogEntryCount: Int,
+        restoreReport: RemoteSyncMyDocumentRestoreReport
+    ) {
+        self.appliedPatchCount = appliedPatchCount
+        self.appliedLogEntryCount = appliedLogEntryCount
+        self.skippedLogEntryCount = skippedLogEntryCount
+        self.restoreReport = restoreReport
+    }
+}
+
+/**
+ Replays Android My Documents patch archives into the local SwiftData My Documents graph.
+
+ Android applies `mydocuments` patches by attaching each sparse SQLite archive, replaying newer
+ `LogEntry` rows in Android table order, pruning foreign-key violations per table, and recording
+ patch status after successful application. This service mirrors that contract without mutating
+ SwiftData until the full batch has been evaluated:
+
+ - current local rows are projected into an Android-shaped mutable working snapshot
+ - each archive contributes only log entries whose `lastUpdated` value is newer than local metadata
+ - accepted `UPSERT` and `DELETE` rows mutate the working snapshot in Android's table order
+ - orphan pages, page content, and AI cache rows are pruned before the final snapshot is written
+ - the final snapshot is committed through `RemoteSyncMyDocumentRestoreService`
+
+ Data dependencies:
+ - `RemoteSyncInitialBackupMetadataRestoreService` reads staged Android `LogEntry` rows
+ - `RemoteSyncMyDocumentRestoreService` decodes sparse patch tables and performs the final rewrite
+ - `RemoteSyncMyDocumentSnapshotService` projects the current local graph and refreshes fingerprints
+ - `RemoteSyncLogEntryStore` and `RemoteSyncPatchStatusStore` preserve Android sync metadata
+
+ Side effects:
+ - reads staged gzip patch archives from disk and writes temporary extracted SQLite files
+ - reads the current local My Documents graph from SwiftData
+ - rewrites local My Documents SwiftData rows when at least one remote log entry is accepted
+ - replaces category-scoped local `LogEntry` metadata and appends applied patch statuses
+ - refreshes My Documents fingerprint baselines after replay evaluation
+
+ Failure modes:
+ - throws `RemoteSyncArchiveStagingError.decompressionFailed` when a staged gzip archive is invalid
+ - rethrows metadata or snapshot decode errors from staged SQLite readers
+ - throws `RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier` for malformed row keys
+ - throws `RemoteSyncMyDocumentPatchApplyError.missingPatchRow` for an accepted upsert without data
+ - rethrows SwiftData restore failures from `RemoteSyncMyDocumentRestoreService`
+
+ Concurrency:
+ - this type is not `Sendable`; callers must use it on the execution context that owns the supplied
+   `ModelContext` and `SettingsStore`
+ */
+public final class RemoteSyncMyDocumentPatchApplyService {
+    /**
+     Mutable Android-shaped row set used to evaluate a full patch batch before touching SwiftData.
+
+     The dictionaries are keyed by Android primary identifiers rather than SwiftData object identity
+     so sparse content/cache updates can be applied without requiring full parent rows in the same
+     patch archive.
+     */
+    private struct WorkingSnapshot {
+        var documentsByID: [UUID: RemoteSyncAndroidMyDocument]
+        var pagesByID: [UUID: RemoteSyncAndroidMyDocumentPage]
+        var pageContentsByPageID: [UUID: RemoteSyncAndroidMyDocumentPageContent]
+        var aiPageCacheEntriesByPageID: [UUID: RemoteSyncAndroidAiPageCacheEntry]
+
+        /**
+         Removes one document and every child row currently present in the working snapshot.
+
+         - Parameter id: Android `MyDocument.id` value to remove.
+         - Side effects: mutates all working row dictionaries that contain descendants.
+         - Failure modes: This helper cannot fail.
+         */
+        mutating func removeDocument(id: UUID) {
+            documentsByID.removeValue(forKey: id)
+            let removedPageIDs = pagesByID.values
+                .filter { $0.documentId == id }
+                .map(\.id)
+            for pageID in removedPageIDs {
+                removePage(id: pageID)
+            }
+        }
+
+        /**
+         Removes one page and detached child rows keyed by that page identifier.
+
+         - Parameter id: Android `MyDocumentPage.id` value to remove.
+         - Side effects: mutates page, page-content, and AI-cache working dictionaries.
+         - Failure modes: This helper cannot fail.
+         */
+        mutating func removePage(id: UUID) {
+            pagesByID.removeValue(forKey: id)
+            pageContentsByPageID.removeValue(forKey: id)
+            aiPageCacheEntriesByPageID.removeValue(forKey: id)
+        }
+
+        /**
+         Drops rows that would violate Android My Documents foreign-key relationships.
+
+         Android runs `pragma_foreign_key_check` after each table is replayed. This in-memory
+         equivalent removes pages whose parent document is absent, then removes detached
+         page-content and AI-cache rows whose page is absent.
+
+         - Side effects: mutates working dictionaries by deleting invalid child rows.
+         - Failure modes: This helper cannot fail.
+         */
+        mutating func pruneForeignKeyViolations() {
+            let validDocumentIDs = Set(documentsByID.keys)
+            let invalidPageIDs = pagesByID.values
+                .filter { !validDocumentIDs.contains($0.documentId) }
+                .map(\.id)
+            for pageID in invalidPageIDs {
+                removePage(id: pageID)
+            }
+
+            let validPageIDs = Set(pagesByID.keys)
+            let invalidPageContentIDs = pageContentsByPageID.keys.filter { !validPageIDs.contains($0) }
+            for pageID in invalidPageContentIDs {
+                pageContentsByPageID.removeValue(forKey: pageID)
+            }
+            let invalidAiCacheIDs = aiPageCacheEntriesByPageID.keys.filter { !validPageIDs.contains($0) }
+            for pageID in invalidAiCacheIDs {
+                aiPageCacheEntriesByPageID.removeValue(forKey: pageID)
+            }
+        }
+
+        /**
+         Converts the mutable working row dictionaries into a deterministic restore snapshot.
+
+         - Returns: Android-shaped snapshot suitable for `RemoteSyncMyDocumentRestoreService`.
+         - Side effects: none.
+         - Failure modes: This helper cannot fail.
+         */
+        func materializedSnapshot() -> RemoteSyncAndroidMyDocumentSnapshot {
+            RemoteSyncAndroidMyDocumentSnapshot(
+                documents: documentsByID.values.sorted(by: Self.documentSort),
+                pages: pagesByID.values.sorted(by: Self.pageSort),
+                pageContents: pageContentsByPageID.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+                aiPageCacheEntries: aiPageCacheEntriesByPageID.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString }
+            )
+        }
+
+        private static func documentSort(
+            _ lhs: RemoteSyncAndroidMyDocument,
+            _ rhs: RemoteSyncAndroidMyDocument
+        ) -> Bool {
+            if lhs.orderNumber == rhs.orderNumber {
+                if lhs.name == rhs.name {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.name < rhs.name
+            }
+            return lhs.orderNumber < rhs.orderNumber
+        }
+
+        private static func pageSort(
+            _ lhs: RemoteSyncAndroidMyDocumentPage,
+            _ rhs: RemoteSyncAndroidMyDocumentPage
+        ) -> Bool {
+            if lhs.documentId == rhs.documentId {
+                if lhs.orderNumber == rhs.orderNumber {
+                    if lhs.title == rhs.title {
+                        return lhs.id.uuidString < rhs.id.uuidString
+                    }
+                    return lhs.title < rhs.title
+                }
+                return lhs.orderNumber < rhs.orderNumber
+            }
+            return lhs.documentId.uuidString < rhs.documentId.uuidString
+        }
+    }
+
+    private static let supportedTableNames: Set<String> = [
+        "MyDocument",
+        "MyDocumentPage",
+        "MyDocumentPageContent",
+        "AiPageCacheEntry",
+    ]
+
+    private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
+    private let restoreService: RemoteSyncMyDocumentRestoreService
+    private let snapshotService: RemoteSyncMyDocumentSnapshotService
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+
+    /**
+     Creates a My Documents patch replay service with injectable readers and scratch storage.
+
+     - Parameters:
+       - metadataRestoreService: Reader for Android `LogEntry` and `SyncStatus` tables in staged patches.
+       - restoreService: Reader and final SwiftData writer for Android-shaped My Documents rows.
+       - snapshotService: Projector for current local rows and outbound fingerprint refresh.
+       - fileManager: File manager used for temporary extracted SQLite files.
+       - temporaryDirectory: Scratch directory override. Defaults to the process temporary directory.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
+        restoreService: RemoteSyncMyDocumentRestoreService = RemoteSyncMyDocumentRestoreService(),
+        snapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil
+    ) {
+        self.metadataRestoreService = metadataRestoreService
+        self.restoreService = restoreService
+        self.snapshotService = snapshotService
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+    }
+
+    /**
+     Applies one ordered batch of staged Android My Documents patch archives.
+
+     - Parameters:
+       - stagedArchives: Already downloaded gzip patch archives sorted in application order.
+       - modelContext: SwiftData context that owns the local My Documents graph.
+       - settingsStore: Local settings store backing Android sync metadata and fingerprints.
+     - Returns: Patch replay counts and the final normalized My Documents row counts.
+     - Side effects:
+       - reads and extracts staged patch archives into temporary SQLite files
+       - may rewrite the local My Documents graph through the centralized restore service when
+         at least one log entry is accepted
+       - updates local `LogEntry`, patch-status, and fingerprint stores for `.myDocuments`
+     - Failure modes:
+       - throws archive decompression, staged metadata decode, row identifier, missing-row, and
+         SwiftData restore errors from the lower-level helpers
+     */
+    public func applyPatchArchives(
+        _ stagedArchives: [RemoteSyncStagedPatchArchive],
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncMyDocumentPatchApplyReport {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+
+        var snapshot = try currentSnapshot(from: modelContext, settingsStore: settingsStore)
+        var logEntriesByKey = Dictionary(
+            logEntryStore.entries(for: .myDocuments).map {
+                (logEntryStore.key(for: .myDocuments, entry: $0), $0)
+            },
+            uniquingKeysWith: { _, replacement in replacement }
+        )
+
+        var appliedPatchStatuses: [RemoteSyncPatchStatus] = []
+        var appliedLogEntryCount = 0
+        var skippedLogEntryCount = 0
+
+        for stagedArchive in stagedArchives {
+            try {
+                let patchDatabaseURL = temporaryDatabaseURL(prefix: "remote-sync-mydocuments-patch-", suffix: ".sqlite3")
+                defer { try? fileManager.removeItem(at: patchDatabaseURL) }
+
+                let archiveData = try Data(contentsOf: stagedArchive.archiveFileURL)
+                let databaseData = try Self.gunzip(archiveData)
+                try databaseData.write(to: patchDatabaseURL, options: .atomic)
+
+                let metadataSnapshot = try metadataRestoreService.readSnapshot(from: patchDatabaseURL)
+                let patchSnapshot = try restoreService.readSnapshot(from: patchDatabaseURL)
+                let patchLogEntries = metadataSnapshot.logEntries.filter { Self.supportedTableNames.contains($0.tableName) }
+                let filteredLogEntries = patchLogEntries.filter { entry in
+                    let key = logEntryStore.key(for: .myDocuments, entry: entry)
+                    guard let localEntry = logEntriesByKey[key] else {
+                        return true
+                    }
+                    return entry.lastUpdated > localEntry.lastUpdated
+                }
+
+                skippedLogEntryCount += patchLogEntries.count - filteredLogEntries.count
+                try applyDocumentOperations(
+                    logEntries: filteredLogEntries.filter { $0.tableName == "MyDocument" },
+                    patchSnapshot: patchSnapshot,
+                    snapshot: &snapshot,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applyPageOperations(
+                    logEntries: filteredLogEntries.filter { $0.tableName == "MyDocumentPage" },
+                    patchSnapshot: patchSnapshot,
+                    snapshot: &snapshot,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applyPageContentOperations(
+                    logEntries: filteredLogEntries.filter { $0.tableName == "MyDocumentPageContent" },
+                    patchSnapshot: patchSnapshot,
+                    snapshot: &snapshot,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applyAiPageCacheOperations(
+                    logEntries: filteredLogEntries.filter { $0.tableName == "AiPageCacheEntry" },
+                    patchSnapshot: patchSnapshot,
+                    snapshot: &snapshot,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+
+                appliedLogEntryCount += filteredLogEntries.count
+                appliedPatchStatuses.append(
+                    RemoteSyncPatchStatus(
+                        sourceDevice: stagedArchive.patch.sourceDevice,
+                        patchNumber: stagedArchive.patch.patchNumber,
+                        sizeBytes: stagedArchive.patch.file.size,
+                        appliedDate: stagedArchive.patch.file.timestamp
+                    )
+                )
+            }()
+        }
+
+        let materializedSnapshot = snapshot.materializedSnapshot()
+        let restoreReport: RemoteSyncMyDocumentRestoreReport
+        if appliedLogEntryCount > 0 {
+            restoreReport = try restoreService.replaceLocalMyDocuments(
+                from: materializedSnapshot,
+                modelContext: modelContext
+            )
+        } else {
+            restoreReport = Self.restoreReport(from: materializedSnapshot)
+        }
+        logEntryStore.replaceEntries(
+            logEntriesByKey.values.sorted(by: Self.logEntrySort),
+            for: .myDocuments
+        )
+        patchStatusStore.addStatuses(appliedPatchStatuses, for: .myDocuments)
+        snapshotService.refreshBaselineFingerprints(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        return RemoteSyncMyDocumentPatchApplyReport(
+            appliedPatchCount: appliedPatchStatuses.count,
+            appliedLogEntryCount: appliedLogEntryCount,
+            skippedLogEntryCount: skippedLogEntryCount,
+            restoreReport: restoreReport
+        )
+    }
+
+    /**
+     Projects the current SwiftData graph into the mutable working representation used by replay.
+
+     - Parameters:
+       - modelContext: SwiftData context to read.
+       - settingsStore: Settings store needed by the snapshot service for Android sync keys.
+     - Returns: Working snapshot seeded with the current local My Documents rows.
+     - Side effects: reads SwiftData through `RemoteSyncMyDocumentSnapshotService`.
+     - Failure modes: Rethrows SwiftData fetch failures so replay never treats an unreadable local graph as empty.
+     */
+    private func currentSnapshot(
+        from modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> WorkingSnapshot {
+        let currentSnapshot = try snapshotService.snapshotCurrentStateThrowing(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        return WorkingSnapshot(
+            documentsByID: Dictionary(
+                currentSnapshot.documentRowsByKey.values.map { ($0.id, $0) },
+                uniquingKeysWith: { _, replacement in replacement }
+            ),
+            pagesByID: Dictionary(
+                currentSnapshot.pageRowsByKey.values.map { ($0.id, $0) },
+                uniquingKeysWith: { _, replacement in replacement }
+            ),
+            pageContentsByPageID: Dictionary(
+                currentSnapshot.pageContentRowsByKey.values.map { ($0.pageId, $0) },
+                uniquingKeysWith: { _, replacement in replacement }
+            ),
+            aiPageCacheEntriesByPageID: Dictionary(
+                currentSnapshot.aiPageCacheEntryRowsByKey.values.map { ($0.pageId, $0) },
+                uniquingKeysWith: { _, replacement in replacement }
+            )
+        )
+    }
+
+    /**
+     Applies accepted `MyDocument` operations from one patch archive.
+
+     - Parameters:
+       - logEntries: Newer Android log entries for the `MyDocument` table.
+       - patchSnapshot: Sparse patch data decoded from the staged SQLite database.
+       - snapshot: Mutable working snapshot to update.
+       - logEntriesByKey: Local metadata map updated for every accepted operation.
+       - logEntryStore: Store used to compute Android-compatible log keys.
+     - Side effects: mutates `snapshot` and `logEntriesByKey`.
+     - Failure modes: Throws when an accepted upsert log row has no corresponding document row.
+     */
+    private func applyDocumentOperations(
+        logEntries: [RemoteSyncLogEntry],
+        patchSnapshot: RemoteSyncAndroidMyDocumentSnapshot,
+        snapshot: inout WorkingSnapshot,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let patchRows = Dictionary(
+            patchSnapshot.documents.map { ($0.id, $0) },
+            uniquingKeysWith: { _, replacement in replacement }
+        )
+        try applySingleIDOperations(
+            logEntries: logEntries,
+            tableName: "MyDocument",
+            patchRows: patchRows,
+            upsert: { row in
+                snapshot.documentsByID[row.id] = row
+            },
+            delete: { id in
+                snapshot.removeDocument(id: id)
+            },
+            afterMutation: {
+                snapshot.pruneForeignKeyViolations()
+            },
+            logEntriesByKey: &logEntriesByKey,
+            logEntryStore: logEntryStore
+        )
+    }
+
+    /**
+     Applies accepted `MyDocumentPage` operations from one patch archive.
+
+     - Parameters:
+       - logEntries: Newer Android log entries for the `MyDocumentPage` table.
+       - patchSnapshot: Sparse patch data decoded from the staged SQLite database.
+       - snapshot: Mutable working snapshot to update.
+       - logEntriesByKey: Local metadata map updated for every accepted operation.
+       - logEntryStore: Store used to compute Android-compatible log keys.
+     - Side effects: mutates `snapshot` and `logEntriesByKey`.
+     - Failure modes: Throws when an accepted upsert log row has no corresponding page row.
+     */
+    private func applyPageOperations(
+        logEntries: [RemoteSyncLogEntry],
+        patchSnapshot: RemoteSyncAndroidMyDocumentSnapshot,
+        snapshot: inout WorkingSnapshot,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let patchRows = Dictionary(
+            patchSnapshot.pages.map { ($0.id, $0) },
+            uniquingKeysWith: { _, replacement in replacement }
+        )
+        try applySingleIDOperations(
+            logEntries: logEntries,
+            tableName: "MyDocumentPage",
+            patchRows: patchRows,
+            upsert: { row in
+                snapshot.pagesByID[row.id] = row
+            },
+            delete: { id in
+                snapshot.removePage(id: id)
+            },
+            afterMutation: {
+                snapshot.pruneForeignKeyViolations()
+            },
+            logEntriesByKey: &logEntriesByKey,
+            logEntryStore: logEntryStore
+        )
+    }
+
+    /**
+     Applies accepted `MyDocumentPageContent` operations from one patch archive.
+
+     - Parameters:
+       - logEntries: Newer Android log entries for the `MyDocumentPageContent` table.
+       - patchSnapshot: Sparse patch data decoded from the staged SQLite database.
+       - snapshot: Mutable working snapshot to update.
+       - logEntriesByKey: Local metadata map updated for every accepted operation.
+       - logEntryStore: Store used to compute Android-compatible log keys.
+     - Side effects: mutates `snapshot` and `logEntriesByKey`.
+     - Failure modes: Throws when an accepted upsert log row has no corresponding content row.
+     */
+    private func applyPageContentOperations(
+        logEntries: [RemoteSyncLogEntry],
+        patchSnapshot: RemoteSyncAndroidMyDocumentSnapshot,
+        snapshot: inout WorkingSnapshot,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let patchRows = Dictionary(
+            patchSnapshot.pageContents.map { ($0.pageId, $0) },
+            uniquingKeysWith: { _, replacement in replacement }
+        )
+        try applySingleIDOperations(
+            logEntries: logEntries,
+            tableName: "MyDocumentPageContent",
+            patchRows: patchRows,
+            upsert: { row in
+                snapshot.pageContentsByPageID[row.pageId] = row
+            },
+            delete: { id in
+                snapshot.pageContentsByPageID.removeValue(forKey: id)
+            },
+            afterMutation: {
+                snapshot.pruneForeignKeyViolations()
+            },
+            logEntriesByKey: &logEntriesByKey,
+            logEntryStore: logEntryStore
+        )
+    }
+
+    /**
+     Applies accepted `AiPageCacheEntry` operations from one patch archive.
+
+     - Parameters:
+       - logEntries: Newer Android log entries for the `AiPageCacheEntry` table.
+       - patchSnapshot: Sparse patch data decoded from the staged SQLite database.
+       - snapshot: Mutable working snapshot to update.
+       - logEntriesByKey: Local metadata map updated for every accepted operation.
+       - logEntryStore: Store used to compute Android-compatible log keys.
+     - Side effects: mutates `snapshot` and `logEntriesByKey`.
+     - Failure modes: Throws when an accepted upsert log row has no corresponding AI-cache row.
+     */
+    private func applyAiPageCacheOperations(
+        logEntries: [RemoteSyncLogEntry],
+        patchSnapshot: RemoteSyncAndroidMyDocumentSnapshot,
+        snapshot: inout WorkingSnapshot,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let patchRows = Dictionary(
+            patchSnapshot.aiPageCacheEntries.map { ($0.pageId, $0) },
+            uniquingKeysWith: { _, replacement in replacement }
+        )
+        try applySingleIDOperations(
+            logEntries: logEntries,
+            tableName: "AiPageCacheEntry",
+            patchRows: patchRows,
+            upsert: { row in
+                snapshot.aiPageCacheEntriesByPageID[row.pageId] = row
+            },
+            delete: { id in
+                snapshot.aiPageCacheEntriesByPageID.removeValue(forKey: id)
+            },
+            afterMutation: {
+                snapshot.pruneForeignKeyViolations()
+            },
+            logEntriesByKey: &logEntriesByKey,
+            logEntryStore: logEntryStore
+        )
+    }
+
+    /**
+     Applies single-UUID `UPSERT` and `DELETE` log rows for one Android My Documents table.
+
+     Android's table replay first upserts newer rows, processes deletes, and normalizes foreign-key
+     violations for that table. This helper preserves the same final table state and records
+     accepted log entries in the local metadata map.
+
+     - Parameters:
+       - logEntries: Newer log entries for one table.
+       - tableName: Android table name used in errors and log keys.
+       - patchRows: Sparse patch rows keyed by the same UUID stored in `entityId1`.
+       - upsert: Closure that inserts or replaces one working row.
+       - delete: Closure that removes one working row.
+       - afterMutation: Closure that normalizes foreign-key state after the table has been replayed.
+       - logEntriesByKey: Local metadata map updated for accepted log entries.
+       - logEntryStore: Store used to compute Android-compatible log keys.
+     - Side effects: mutates caller-owned working rows through the supplied closures.
+     - Failure modes:
+       - throws `RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier` for malformed keys
+       - throws `RemoteSyncMyDocumentPatchApplyError.missingPatchRow` for accepted upserts without data
+     */
+    private func applySingleIDOperations<Row>(
+        logEntries: [RemoteSyncLogEntry],
+        tableName: String,
+        patchRows: [UUID: Row],
+        upsert: (Row) -> Void,
+        delete: (UUID) -> Void,
+        afterMutation: () -> Void,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let upserts = logEntries.filter { $0.type == .upsert }.sorted(by: Self.logEntrySort)
+        let deletes = logEntries.filter { $0.type == .delete }.sorted(by: Self.logEntrySort)
+        var didMutate = false
+
+        for entry in upserts {
+            let rowID = try uuid(from: entry.entityID1, tableName: tableName, field: "entityId1")
+            guard let row = patchRows[rowID] else {
+                throw RemoteSyncMyDocumentPatchApplyError.missingPatchRow(table: tableName, id: rowID)
+            }
+            upsert(row)
+            didMutate = true
+            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: entry)] = entry
+        }
+
+        for entry in deletes {
+            let rowID = try uuid(from: entry.entityID1, tableName: tableName, field: "entityId1")
+            delete(rowID)
+            didMutate = true
+            logEntriesByKey[logEntryStore.key(for: .myDocuments, entry: entry)] = entry
+        }
+
+        if didMutate {
+            afterMutation()
+        }
+    }
+
+    /**
+     Converts an Android `LogEntry` identifier value into the UUID used by My Documents tables.
+
+     - Parameters:
+       - value: SQLite value from `LogEntry.entityId1`.
+       - tableName: Android table name used for diagnostics.
+       - field: Android field name used for diagnostics.
+     - Returns: UUID decoded from a 16-byte blob or UUID string.
+     - Side effects: none.
+     - Failure modes: Throws `RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier` when
+       the value cannot be decoded as a UUID.
+     */
+    private func uuid(from value: RemoteSyncSQLiteValue, tableName: String, field: String) throws -> UUID {
+        switch value.kind {
+        case .blob:
+            guard let data = value.blobData,
+                  let uuid = uuid(from: data) else {
+                throw RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier(table: tableName, field: field)
+            }
+            return uuid
+        case .text:
+            guard let textValue = value.textValue,
+                  let uuid = UUID(uuidString: textValue) else {
+                throw RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier(table: tableName, field: field)
+            }
+            return uuid
+        default:
+            throw RemoteSyncMyDocumentPatchApplyError.invalidLogEntryIdentifier(table: tableName, field: field)
+        }
+    }
+
+    /**
+     Converts Android's raw 16-byte UUID blob into Swift's UUID value.
+
+     - Parameter data: SQLite blob payload expected to contain exactly 16 UUID bytes.
+     - Returns: Decoded UUID, or `nil` when the blob has an invalid length.
+     - Side effects: none.
+     - Failure modes: This helper cannot throw.
+     */
+    private func uuid(from data: Data) -> UUID? {
+        guard data.count == 16 else {
+            return nil
+        }
+        return data.withUnsafeBytes { bytes -> UUID? in
+            guard bytes.count == 16 else { return nil }
+            let tuple = (
+                bytes[0], bytes[1], bytes[2], bytes[3],
+                bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[8], bytes[9], bytes[10], bytes[11],
+                bytes[12], bytes[13], bytes[14], bytes[15]
+            )
+            return UUID(uuid: tuple)
+        }
+    }
+
+    /**
+     Builds a unique temporary SQLite filename beneath the configured scratch directory.
+
+     - Parameters:
+       - prefix: Filename prefix used to identify the staging purpose.
+       - suffix: Filename suffix, including extension.
+     - Returns: Nonexistent candidate URL for temporary replay work.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func temporaryDatabaseURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    /**
+     Extracts one gzip payload using the shared CLibSword compression bridge.
+
+     - Parameter data: Gzip-compressed patch archive bytes.
+     - Returns: Decompressed SQLite database bytes.
+     - Side effects: allocates and frees native memory through the compression bridge.
+     - Failure modes: Throws `RemoteSyncArchiveStagingError.decompressionFailed` for invalid gzip data.
+     */
+    private static func gunzip(_ data: Data) throws -> Data {
+        try data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+            guard let baseAddress = ptr.baseAddress else {
+                throw RemoteSyncArchiveStagingError.decompressionFailed
+            }
+
+            var outputLength: UInt = 0
+            guard let output = gunzip_data(
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                UInt(data.count),
+                &outputLength
+            ) else {
+                throw RemoteSyncArchiveStagingError.decompressionFailed
+            }
+
+            defer { gunzip_free(output) }
+            return Data(bytes: output, count: Int(outputLength))
+        }
+    }
+
+    /**
+     Builds a restore-count report from an already-normalized in-memory snapshot.
+
+     This is used for all-skipped patch batches so the service can record patch status without
+     destructively rewriting SwiftData for a no-op replay.
+
+     - Parameter snapshot: Materialized working snapshot after replay evaluation.
+     - Returns: Row counts matching the restore report shape.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func restoreReport(
+        from snapshot: RemoteSyncAndroidMyDocumentSnapshot
+    ) -> RemoteSyncMyDocumentRestoreReport {
+        RemoteSyncMyDocumentRestoreReport(
+            restoredDocumentCount: snapshot.documents.count,
+            restoredPageCount: snapshot.pages.count,
+            restoredContentCount: snapshot.pageContents.count,
+            restoredAIPageCacheEntryCount: snapshot.aiPageCacheEntries.count
+        )
+    }
+
+    /**
+     Provides deterministic ordering for Android log-entry metadata persistence.
+
+     - Parameters:
+       - lhs: First log entry.
+       - rhs: Second log entry.
+     - Returns: `true` when `lhs` should be stored before `rhs`.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.lastUpdated != rhs.lastUpdated {
+            return lhs.lastUpdated < rhs.lastUpdated
+        }
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.type != rhs.type {
+            return lhs.type.rawValue < rhs.type.rawValue
+        }
+        if lhs.sourceDevice != rhs.sourceDevice {
+            return lhs.sourceDevice < rhs.sourceDevice
+        }
+        if lhs.entityID1 != rhs.entityID1 {
+            return sortKey(for: lhs.entityID1) < sortKey(for: rhs.entityID1)
+        }
+        return sortKey(for: lhs.entityID2) < sortKey(for: rhs.entityID2)
+    }
+
+    /**
+     Converts one SQLite value into a stable string for tie-breaking log-entry sort order.
+
+     - Parameter value: SQLite value to canonicalize.
+     - Returns: Sortable representation including the SQLite storage kind.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func sortKey(for value: RemoteSyncSQLiteValue) -> String {
+        switch value.kind {
+        case .null:
+            return "null"
+        case .integer:
+            return "integer:\(value.integerValue ?? 0)"
+        case .real:
+            return "real:\(value.realValue?.bitPattern ?? 0)"
+        case .text:
+            return "text:\(value.textValue ?? "")"
+        case .blob:
+            return "blob:\(value.blobBase64Value ?? "")"
+        }
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentSnapshotService.swift
@@ -73,7 +73,6 @@ public final class RemoteSyncMyDocumentSnapshotService {
         modelContext: ModelContext,
         settingsStore: SettingsStore
     ) -> RemoteSyncMyDocumentCurrentSnapshot {
-        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
         let documents = ((try? modelContext.fetch(FetchDescriptor<MyDocument>())) ?? [])
             .sorted(by: Self.documentSort)
         let pages = ((try? modelContext.fetch(FetchDescriptor<MyDocumentPage>())) ?? [])
@@ -83,6 +82,71 @@ public final class RemoteSyncMyDocumentSnapshotService {
         let aiPageCacheEntries = ((try? modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())) ?? [])
             .sorted(by: Self.aiPageCacheEntrySort)
 
+        return buildSnapshot(
+            documents: documents,
+            pages: pages,
+            pageContents: pageContents,
+            aiPageCacheEntries: aiPageCacheEntries,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Projects the current local My Documents graph into Android-shaped rows while preserving fetch failures.
+
+     Patch replay uses this throwing variant because treating a failed local fetch as an empty graph
+     could make an accepted remote patch replace local My Documents with only sparse patch rows.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns the local My Documents graph.
+       - settingsStore: Local settings store used to build Android-compatible log keys.
+     - Returns: Android-shaped current-state snapshot for replay.
+     - Side effects: reads My Documents SwiftData rows.
+     - Failure modes: Rethrows SwiftData fetch failures from `ModelContext`.
+     */
+    public func snapshotCurrentStateThrowing(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncMyDocumentCurrentSnapshot {
+        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
+            .sorted(by: Self.documentSort)
+        let pages = try modelContext.fetch(FetchDescriptor<MyDocumentPage>())
+            .sorted(by: Self.pageSort)
+        let pageContents = try modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())
+            .sorted { $0.pageId.uuidString < $1.pageId.uuidString }
+        let aiPageCacheEntries = try modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())
+            .sorted(by: Self.aiPageCacheEntrySort)
+
+        return buildSnapshot(
+            documents: documents,
+            pages: pages,
+            pageContents: pageContents,
+            aiPageCacheEntries: aiPageCacheEntries,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Builds the Android-shaped snapshot maps from already fetched and sorted SwiftData rows.
+
+     - Parameters:
+       - documents: Local document rows sorted for deterministic output.
+       - pages: Local page rows sorted for deterministic output.
+       - pageContents: Local content rows sorted for deterministic output.
+       - aiPageCacheEntries: Local AI-cache rows sorted for deterministic output.
+       - settingsStore: Local settings store used to derive Android sync keys.
+     - Returns: Current-state snapshot with Android-shaped rows and fingerprints.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func buildSnapshot(
+        documents: [MyDocument],
+        pages: [MyDocumentPage],
+        pageContents: [MyDocumentPageContent],
+        aiPageCacheEntries: [AiPageCacheEntry],
+        settingsStore: SettingsStore
+    ) -> RemoteSyncMyDocumentCurrentSnapshot {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
         let documentIDs = Set(documents.map(\.id))
         var pageIDs: Set<UUID> = []
         var emittedAIPageCachePageIDs: Set<UUID> = []

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -34,6 +34,9 @@ public enum RemoteSyncCategoryPatchReplayReport: Sendable, Equatable {
 
     /// Reading-plan-category patch replay summary.
     case readingPlans(RemoteSyncReadingPlanPatchApplyReport)
+
+    /// My Documents-category patch replay summary.
+    case myDocuments(RemoteSyncMyDocumentPatchApplyReport)
 }
 
 /**
@@ -171,6 +174,7 @@ public enum RemoteSyncSynchronizationOutcome: Sendable, Equatable {
  - `RemoteSyncBookmarkPatchUploadService` exports and uploads outbound sparse bookmark patches
  - `RemoteSyncWorkspacePatchUploadService` exports and uploads outbound sparse workspace patches
  - `RemoteSyncReadingPlanPatchUploadService` exports and uploads outbound sparse reading-plan patches
+ - `RemoteSyncMyDocumentPatchApplyService` replays inbound sparse My Documents patches
  - `RemoteSyncMyDocumentPatchUploadService` exports and uploads outbound sparse My Documents patches
  - `RemoteSyncStateStore` persists Android-aligned bootstrap and progress metadata locally
  - `RemoteSyncPatchStatusStore` records patch zero after remote initial-backup adoption, matching Android
@@ -206,6 +210,7 @@ public final class RemoteSyncSynchronizationService {
     private let bookmarkPatchUploadService: RemoteSyncBookmarkPatchUploadService
     private let workspacePatchApplyService: RemoteSyncWorkspacePatchApplyService
     private let workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService
+    private let myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService
     private let myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService
     private let fileManager: FileManager
     private let temporaryDirectory: URL?
@@ -226,6 +231,7 @@ public final class RemoteSyncSynchronizationService {
        - bookmarkPatchUploadService: Bookmark outbound patch upload service.
        - workspacePatchApplyService: Workspace patch replay service.
        - workspacePatchUploadService: Workspace outbound patch upload service.
+       - myDocumentPatchApplyService: My Documents patch replay service.
        - myDocumentPatchUploadService: My Documents outbound patch upload service.
        - fileManager: File manager used for staging cleanup.
        - temporaryDirectory: Optional staging directory override.
@@ -245,6 +251,7 @@ public final class RemoteSyncSynchronizationService {
         bookmarkPatchUploadService: RemoteSyncBookmarkPatchUploadService? = nil,
         workspacePatchApplyService: RemoteSyncWorkspacePatchApplyService = RemoteSyncWorkspacePatchApplyService(),
         workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService? = nil,
+        myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService = RemoteSyncMyDocumentPatchApplyService(),
         myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL? = nil,
@@ -280,6 +287,7 @@ public final class RemoteSyncSynchronizationService {
                 adapter: adapter,
                 nowProvider: nowProvider
             )
+        self.myDocumentPatchApplyService = myDocumentPatchApplyService
         self.myDocumentPatchUploadService = myDocumentPatchUploadService
             ?? RemoteSyncMyDocumentPatchUploadService(
                 adapter: adapter,
@@ -692,7 +700,13 @@ public final class RemoteSyncSynchronizationService {
                 )
             )
         case .myDocuments:
-            throw RemoteSyncSynchronizationError.unsupportedCategory(category)
+            return .myDocuments(
+                try myDocumentPatchApplyService.applyPatchArchives(
+                    stagedArchives,
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                )
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Implements Android-compatible My Documents inbound patch replay for #108.
- Wires `mydocuments` patch archives into synchronization so newer remote changes mutate local SwiftData state instead of returning an unsupported-category error.

## Scope
- Adds `RemoteSyncMyDocumentPatchApplyService` for Android-shaped SQLite patch archives.
- Adds a throwing My Documents snapshot path used by replay only.
- Extends My Documents restore tests and the sync mock adapter to cover patch discovery, download, replay, status writes, baseline refresh, and text/blob UUID `LogEntry` canonicalization.

## Contract References
- Follows Android My Documents patch table order from `SyncUtilities.kt`: `MyDocument`, `MyDocumentPage`, `MyDocumentPageContent`, `AiPageCacheEntry`.
- Uses Android's strict newer-than `LogEntry.lastUpdated` conflict rule.
- Records patch status for evaluated archives, including all-skipped patches, so the same patch is not replayed repeatedly.
- Canonicalizes My Documents replay metadata to blob UUID `entityID1` values plus empty `entityID2`, matching iOS snapshot/upload keys while still accepting Android text UUID patch identifiers.
- Commit and PR formatting follow `../commit-message-standard.md`.

## Change Details
- Replays UPSERT and DELETE rows for documents, pages, page content, and AI cache entries.
- Preserves sparse content-only edits without requiring a full page row in the patch archive.
- Cascades document/page deletes in memory and prunes foreign-key orphans after table mutations.
- Records accepted patch log-entry watermarks, refreshes My Documents baseline fingerprints after replay, and avoids destructive SwiftData rewrites when no log entries are accepted.
- Surfaces snapshot fetch failures through the replay path instead of treating a failed SwiftData fetch as an empty local graph.
- Normalizes local and incoming My Documents `LogEntry` identifiers so text and blob encodings of the same UUID share one conflict baseline.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleTests/RemoteSyncMyDocumentRestoreTests -derivedDataPath .derivedData-codex-108` passed: 21 tests, 0 failures.
- `git diff --check` passed.
- `python3 scripts/check_repo_standards.py docblocks --all-files` passed.
- `python3 scripts/check_repo_standards.py commits --rev-range HEAD~1..HEAD` passed after amending the commit body.
- GitNexus `detect_changes` on staged changes completed with low risk for the latest review-feedback update.
- Gemini, Claude, and Copilot local reviews completed; non-blocking feedback was addressed or evaluated against Android `SyncUtilities.kt`.
- `swift test --filter RemoteSyncMyDocumentRestoreTests` was attempted but is blocked locally by the existing SwiftPM `SwordKitTests`/`XCTest` target layout.

## Risks / Follow-Ups
- Ready-state synchronization is in the blast radius because `.myDocuments` now participates in `applyPendingPatches`.
- Existing upload/fingerprint snapshot callers keep their non-throwing behavior; only patch replay uses the throwing current-state snapshot.
- The replay service rewrites local My Documents rows when at least one remote log entry is accepted, matching the existing restore-service pattern.

## Issue Closure
Closes #108
