### PR TITLE
fix(reader): route multi-reference links through Vue documents

### DIFF
--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -2007,6 +2007,70 @@ final class AndBibleTests: XCTestCase {
     }
 
     @MainActor
+    func testMultiReferenceLinkEmitsVueMultiDocumentInsteadOfCrossReferenceSheet() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        var showedCrossReferences = false
+        controller.onShowCrossReferences = { _ in showedCrossReferences = true }
+
+        controller.bridge(bridge, openExternalLink: "multi://?osis=Gen.1.1&osis=Exod.2.1&v11n=KJVA")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        XCTAssertFalse(showedCrossReferences)
+        let addDocumentsScript = try XCTUnwrap(
+            recordedScripts().first(where: { $0.contains("emit('add_documents'") })
+        )
+        XCTAssertTrue(
+            addDocumentsScript.contains(#""type":"multi""#),
+            "Expected multi:// to render a Vue MultiDocument. Script: \(addDocumentsScript)"
+        )
+        XCTAssertTrue(addDocumentsScript.contains(#""bookCategory":"BIBLE""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.1""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Exod.2.1""#))
+    }
+
+    @MainActor
+    func testMultiReferenceOsisLinkEmitsVueMultiDocumentInsteadOfCrossReferenceSheet() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        var showedCrossReferences = false
+        controller.onShowCrossReferences = { _ in showedCrossReferences = true }
+
+        controller.bridge(bridge, openExternalLink: "osis://?osis=Gen.1.1,Exod.2.1&v11n=KJVA")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        XCTAssertFalse(showedCrossReferences)
+        let addDocumentsScript = try XCTUnwrap(
+            recordedScripts().first(where: { $0.contains("emit('add_documents'") })
+        )
+        XCTAssertTrue(
+            addDocumentsScript.contains(#""type":"multi""#),
+            "Expected multi-reference osis:// to render a Vue MultiDocument. Script: \(addDocumentsScript)"
+        )
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.1""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Exod.2.1""#))
+    }
+
+    @MainActor
+    func testSingleOsisReferenceStillNavigatesWithoutMultiDocument() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let controller = BibleReaderController(bridge: bridge)
+        var showedCrossReferences = false
+        controller.onShowCrossReferences = { _ in showedCrossReferences = true }
+
+        controller.bridge(bridge, openExternalLink: "osis://?osis=Exod.2.1&v11n=KJVA")
+
+        XCTAssertFalse(showedCrossReferences)
+        XCTAssertEqual(controller.currentBook, "Exodus")
+        XCTAssertEqual(controller.currentChapter, 2)
+        XCTAssertFalse(recordedScripts().contains { $0.contains(#""type":"multi""#) })
+    }
+
+    @MainActor
     func testReaderConfigPayloadIncludesDisplaySettingsAndActiveWindowState() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()
         let container = try makeWorkspaceModelContainer()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -406,16 +406,20 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Callback for opening search with a Strong's number (from "Find all occurrences" links).
     var onShowStrongsSearch: ((String) -> Void)?
 
-    /// Legacy callback for native cross-reference sheets.
-    ///
-    /// Multi-reference Bible links intentionally bypass this callback and render Vue
-    /// `MultiDocument` payloads so iOS follows Android's shared document pipeline.
+    /**
+     Legacy callback for native cross-reference sheets.
+
+     Multi-reference Bible links intentionally bypass this callback and render Vue
+     `MultiDocument` payloads so iOS follows Android's shared document pipeline.
+     */
     var onShowCrossReferences: (([CrossReference]) -> Void)?
 
-    /// Callback for opening a transient multi-reference Vue document in the Android-style links window.
-    ///
-    /// The string parameter is a serialized `MultiDocument` payload. The owning pane decides whether
-    /// to route it into a dedicated links window or render it in the current controller.
+    /**
+     Callback for opening a transient multi-reference Vue document in the Android-style links window.
+
+     The string parameter is a serialized `MultiDocument` payload. The owning pane decides whether
+     to route it into a dedicated links window or render it in the current controller.
+     */
     var onOpenMultiReferenceDocumentInLinksWindow: ((String) -> Void)?
 
     /// Callback for presenting compare view (book, chapter, moduleName, startVerse?, endVerse?).

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -4322,7 +4322,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        - module: Active Bible module to read from. A missing module yields a fallback fragment.
      - Returns: A `<div>` containing one `<verse>` element with the same approximate ordinal scheme
        used by chapter rendering.
-     - Side effects: when `module` is present, changes its current SWORD key to the requested verse.
+     - Side effects: when `module` is present, temporarily moves its SWORD key cursor inside one
+       serialized inspection call and restores the previous cursor before returning.
      - Failure modes: if the module cannot resolve the exact verse or returns empty raw OSIS, the
        fragment contains an escaped display label rather than throwing.
      */
@@ -4332,12 +4333,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         let rawText: String
 
         if let module {
-            module.setKey("=\(osisRef)")
-            if let key = module.currentVerseKeyChildren(),
+            let inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious("=\(osisRef)")
+            if let key = inspection.verseKey,
                key.osisBookName == ref.osisId,
                key.chapter == ref.chapter,
                key.verse == ref.verse {
-                rawText = module.rawEntry().trimmingCharacters(in: .whitespacesAndNewlines)
+                rawText = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
             } else {
                 rawText = ""
             }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -406,8 +406,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Callback for opening search with a Strong's number (from "Find all occurrences" links).
     var onShowStrongsSearch: ((String) -> Void)?
 
-    /// Callback for showing cross-reference results (list of parsed references with verse text).
+    /// Legacy callback for native cross-reference sheets.
+    ///
+    /// Multi-reference Bible links intentionally bypass this callback and render Vue
+    /// `MultiDocument` payloads so iOS follows Android's shared document pipeline.
     var onShowCrossReferences: (([CrossReference]) -> Void)?
+
+    /// Callback for opening a transient multi-reference Vue document in the Android-style links window.
+    ///
+    /// The string parameter is a serialized `MultiDocument` payload. The owning pane decides whether
+    /// to route it into a dedicated links window or render it in the current controller.
+    var onOpenMultiReferenceDocumentInLinksWindow: ((String) -> Void)?
 
     /// Callback for presenting compare view (book, chapter, moduleName, startVerse?, endVerse?).
     var onCompareVerses: ((String, Int, String, Int?, Int?) -> Void)?
@@ -932,6 +941,48 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         default:
             loadCurrentChapter()
         }
+    }
+
+    /**
+     Displays a transient Vue `MultiDocument` made from Bible reference fragments.
+
+     - Parameter documentJSON: Serialized multi-document payload produced by
+       `buildBibleMultiReferenceDocumentJSON(refs:)`.
+     - Side effects: clears the current Vue document, emits labels, emits the supplied document and
+       setup payload, resets selection state, updates the rendered-content accessibility token, and
+       reapplies the reader background. It intentionally does not persist PageManager category or
+       location state because Android treats multi-reference documents as link results, not the
+       owning Bible position.
+     - Failure modes: assumes the payload is already valid JSON; invalid payloads are forwarded to
+       the Vue bridge after the transient reader state is prepared, so caller-owned builders should
+       validate or serialize before invoking this method.
+     */
+    func loadMultiReferenceDocument(_ documentJSON: String) {
+        showingMyNotes = false
+        showingStudyPad = false
+        activeStudyPadLabelId = nil
+        activeStudyPadLabelName = nil
+        editingInWebView = false
+        hasActiveSelection = false
+        selectedText = ""
+        currentCategory = .bible
+
+        bridge.emit(event: "clear_document")
+        sendLabelsToVueJS()
+        bridge.emit(event: "add_documents", data: documentJSON)
+        bridge.emit(event: "setup_content", data: """
+        {"jumpToOrdinal":null,"jumpToAnchor":null,"jumpToId":null,"topOffset":0,"bottomOffset":0}
+        """)
+        setRenderedContentState(
+            category: .bible,
+            moduleName: activeModuleName,
+            book: "Multi",
+            key: "multi"
+        )
+        emitActiveState()
+
+        bridge.clearSelection()
+        applyNightModeBackground()
     }
 
     /// Load commentary text for the current chapter using the active commentary module.
@@ -4207,6 +4258,93 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         return "{\"id\":\"\(id)\",\"type\":\"multi\",\"osisFragments\":[\(osisFragmentsJSON.joined(separator: ","))],\"compare\":false\(contentTypeField)\(stateField)}"
     }
 
+    /**
+     Builds the Vue `MultiDocument` payload Android uses for multi-reference Bible links.
+
+     - Parameter refs: Parsed OSIS references in the order supplied by `multi://` or a
+       multi-reference `osis://` link. Empty input produces no document.
+     - Returns: Serialized JSON for a transient multi-document, or `nil` if there are no references
+       or JSON serialization fails.
+     - Side effects: reads the active SWORD Bible module and moves its key cursor while extracting
+       verse OSIS. Missing module content is represented by a fallback verse label so the link still
+       opens a document instead of falling back to the native cross-reference sheet.
+     - Note: The payload intentionally omits `contentType`; Vue routes non-Strong's `type: "multi"`
+       documents to `MultiDocument`, matching Android's `FakeBookFactory.multiDocument` path.
+     */
+    private func buildBibleMultiReferenceDocumentJSON(refs: [OsisRef]) -> String? {
+        guard !refs.isEmpty else { return nil }
+
+        let moduleName = activeModuleName
+        let fragments: [[String: Any]] = refs.map { ref in
+            let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+            let ordinal = BibleChapterDocumentBuilder.ordinal(chapter: ref.chapter, verse: ref.verse)
+            return [
+                "xml": buildBibleMultiReferenceXML(ref: ref, module: activeModule),
+                "key": "\(moduleName)--\(osisRef)",
+                "keyName": ref.displayName,
+                "v11n": "KJVA",
+                "bookCategory": DocumentCategory.bible.rawValue,
+                "bookInitials": moduleName,
+                "bookAbbreviation": ref.osisId,
+                "osisRef": osisRef,
+                "isNewTestament": isNewTestament(ref.book),
+                "features": [String: Any](),
+                "ordinalRange": [ordinal, ordinal],
+                "language": "en",
+                "direction": "ltr",
+            ]
+        }
+
+        let document: [String: Any] = [
+            "id": "multi-\(UUID().uuidString)",
+            "type": "multi",
+            "osisFragments": fragments,
+            "compare": false,
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            logger.error("Failed to serialize multi-reference document JSON")
+            return nil
+        }
+        return json
+    }
+
+    /**
+     Reads one Bible verse as an OSIS fragment suitable for Vue `MultiDocument`.
+
+     - Parameters:
+       - ref: Parsed Bible reference to render.
+       - module: Active Bible module to read from. A missing module yields a fallback fragment.
+     - Returns: A `<div>` containing one `<verse>` element with the same approximate ordinal scheme
+       used by chapter rendering.
+     - Side effects: when `module` is present, changes its current SWORD key to the requested verse.
+     - Failure modes: if the module cannot resolve the exact verse or returns empty raw OSIS, the
+       fragment contains an escaped display label rather than throwing.
+     */
+    private func buildBibleMultiReferenceXML(ref: OsisRef, module: SwordModule?) -> String {
+        let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+        let ordinal = BibleChapterDocumentBuilder.ordinal(chapter: ref.chapter, verse: ref.verse)
+        let rawText: String
+
+        if let module {
+            module.setKey("=\(osisRef)")
+            if let key = module.currentVerseKeyChildren(),
+               key.osisBookName == ref.osisId,
+               key.chapter == ref.chapter,
+               key.verse == ref.verse {
+                rawText = module.rawEntry().trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                rawText = ""
+            }
+        } else {
+            rawText = ""
+        }
+
+        let body = rawText.isEmpty ? escapeXML(ref.displayName) : rawText
+        return "<div><verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(body) </verse></div>"
+    }
+
     /// Escape special XML characters in text content.
     private func escapeXML(_ text: String) -> String {
         text.replacingOccurrences(of: "&", with: "&amp;")
@@ -4777,8 +4915,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             }
         } else if !refs.isEmpty {
             // Multiple references in one osis param (e.g. "Matt.1.1-Matt.1.3")
-            let crossRefs = lookupCrossReferences(refs)
-            onShowCrossReferences?(crossRefs)
+            openMultiReferenceDocument(refs: refs)
         }
     }
 
@@ -4799,8 +4936,27 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         if allRefs.count == 1, let ref = allRefs.first {
             navigateTo(book: ref.book, chapter: ref.chapter)
         } else {
-            let crossRefs = lookupCrossReferences(allRefs)
-            onShowCrossReferences?(crossRefs)
+            openMultiReferenceDocument(refs: allRefs)
+        }
+    }
+
+    /**
+     Opens parsed multi-reference results through the shared Vue document pipeline.
+
+     - Parameter refs: Non-empty parsed references collected from one `osis://` range/list or a
+       `multi://` Open All link.
+     - Side effects: builds a transient multi-document from the active Bible module, then either
+       hands it to the owner for links-window routing or renders it in this controller.
+     - Failure modes: returns without side effects when JSON construction fails; single-reference
+       navigation is handled by callers before this method is reached.
+     */
+    private func openMultiReferenceDocument(refs: [OsisRef]) {
+        guard let documentJSON = buildBibleMultiReferenceDocumentJSON(refs: refs) else { return }
+
+        if let openInLinksWindow = onOpenMultiReferenceDocumentInLinksWindow {
+            openInLinksWindow(documentJSON)
+        } else {
+            loadMultiReferenceDocument(documentJSON)
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -495,7 +495,8 @@ struct BibleWindowPane: View {
         }
 
         // Links window support: single OSIS references open in a links window
-        ctrl.onOpenInLinksWindow = { [weak windowManager] book, chapter in
+        ctrl.onOpenInLinksWindow = { [weak ctrl, weak windowManager] book, chapter in
+            guard let ctrl else { return }
             let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
             guard useLinksWindow else {
                 ctrl.navigateTo(book: book, chapter: chapter)
@@ -513,7 +514,8 @@ struct BibleWindowPane: View {
             }
         }
 
-        ctrl.onOpenMultiReferenceDocumentInLinksWindow = { [weak windowManager] documentJSON in
+        ctrl.onOpenMultiReferenceDocumentInLinksWindow = { [weak ctrl, weak windowManager] documentJSON in
+            guard let ctrl else { return }
             let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
             guard useLinksWindow else {
                 ctrl.loadMultiReferenceDocument(documentJSON)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -463,16 +463,17 @@ struct BibleWindowPane: View {
         // Wire WindowManager reference for synchronized scrolling
         ctrl.windowManagerRef = windowManager
 
-        // Links window support: single OSIS references open in a links window
-        ctrl.onOpenInLinksWindow = { [weak windowManager] book, chapter in
-            let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
-            guard useLinksWindow else {
-                ctrl.navigateTo(book: book, chapter: chapter)
-                return
-            }
+        /**
+         Resolves the Android-style links target window for link results from this pane.
 
-            guard let wm = windowManager else { return }
-            // Find or create a links window for this source window
+         - Parameter wm: Window manager that owns the source window and controller registry.
+         - Returns: The existing or newly created links window, or `nil` when the manager cannot
+           create another window.
+         - Side effects: may create a window, mark it as the pinned links target, attach it to the
+           source window, unminimize an existing target, and refresh visible windows.
+         - Failure modes: returns `nil` when window creation is refused by the manager.
+         */
+        func prepareLinksWindow(using wm: WindowManager) -> Window? {
             let linksWindow: Window
             if let existingId = window.targetLinksWindowId,
                let existing = wm.allWindows.first(where: { $0.id == existingId }) {
@@ -487,13 +488,44 @@ struct BibleWindowPane: View {
                 window.targetLinksWindowId = newWindow.id
                 linksWindow = newWindow
             } else {
-                return
+                return nil
             }
             wm.refreshWindows()
+            return linksWindow
+        }
+
+        // Links window support: single OSIS references open in a links window
+        ctrl.onOpenInLinksWindow = { [weak windowManager] book, chapter in
+            let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
+            guard useLinksWindow else {
+                ctrl.navigateTo(book: book, chapter: chapter)
+                return
+            }
+
+            guard let wm = windowManager,
+                  let linksWindow = prepareLinksWindow(using: wm) else { return }
+
             // Navigate the links window's controller to the reference
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 if let ctrl = wm.controllers[linksWindow.id] as? BibleReaderController {
                     ctrl.navigateTo(book: book, chapter: chapter)
+                }
+            }
+        }
+
+        ctrl.onOpenMultiReferenceDocumentInLinksWindow = { [weak windowManager] documentJSON in
+            let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
+            guard useLinksWindow else {
+                ctrl.loadMultiReferenceDocument(documentJSON)
+                return
+            }
+
+            guard let wm = windowManager,
+                  let linksWindow = prepareLinksWindow(using: wm) else { return }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if let ctrl = wm.controllers[linksWindow.id] as? BibleReaderController {
+                    ctrl.loadMultiReferenceDocument(documentJSON)
                 }
             }
         }

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -94,39 +94,70 @@ public final class SwordModule: @unchecked Sendable {
     /// Get structured VerseKey data for the current position when the module uses VerseKey.
     public func currentVerseKeyChildren() -> VerseKeyChildren? {
         queue.sync {
-            guard let children = SWModule_getKeyChildren(handle) else { return nil }
-
-            var parts: [String] = []
-            var index = 0
-            while index < 11, let ptr = children[index] {
-                parts.append(String(cString: ptr))
-                index += 1
-            }
-
-            guard parts.count >= 11,
-                  let testament = Int(parts[0]),
-                  let book = Int(parts[1]),
-                  let chapter = Int(parts[2]),
-                  let verse = Int(parts[3]),
-                  let chapterMax = Int(parts[4]),
-                  let verseMax = Int(parts[5]) else {
-                return nil
-            }
-
-            return VerseKeyChildren(
-                testament: testament,
-                book: book,
-                chapter: chapter,
-                verse: verse,
-                chapterMax: chapterMax,
-                verseMax: verseMax,
-                bookName: parts[6],
-                osisRef: parts[7],
-                shortText: parts[8],
-                bookAbbreviation: parts[9],
-                osisBookName: parts[10]
-            )
+            Self.currentVerseKeyChildren(handle: handle)
         }
+    }
+
+    /**
+     Atomically inspects one verse key and restores the module's previous cursor.
+
+     - Parameter keyText: SWORD key text to inspect, such as `=Gen.1.1`.
+     - Returns: The resolved key text, structured VerseKey metadata when available, and raw OSIS
+       entry captured at the resolved key.
+     - Side effects: temporarily moves the SWORD module cursor inside one serialized queue block,
+       then restores the cursor that was active before the call returns.
+     - Failure modes: returns `nil` VerseKey metadata when the module is not positioned on a
+       VerseKey or SWORD cannot expose structured key children.
+     - Important: Use this instead of separate `setKey`, `currentVerseKeyChildren`, and `rawEntry`
+       calls when the key metadata and raw entry must describe the same module position.
+     */
+    public func inspectVerseKeyAndRawEntryRestoringPrevious(
+        _ keyText: String
+    ) -> (actualKey: String, verseKey: VerseKeyChildren?, rawEntry: String) {
+        queue.sync {
+            let previousKey = String(cString: SWModule_getKeyText(handle))
+            SWModule_setKeyText(handle, keyText)
+            let actualKey = String(cString: SWModule_getKeyText(handle))
+            let verseKey = Self.currentVerseKeyChildren(handle: handle)
+            let rawEntry = String(cString: SWModule_getRawEntry(handle))
+            SWModule_setKeyText(handle, previousKey)
+            return (actualKey, verseKey, rawEntry)
+        }
+    }
+
+    private static func currentVerseKeyChildren(handle: UnsafeMutableRawPointer) -> VerseKeyChildren? {
+        guard let children = SWModule_getKeyChildren(handle) else { return nil }
+
+        var parts: [String] = []
+        var index = 0
+        while index < 11, let ptr = children[index] {
+            parts.append(String(cString: ptr))
+            index += 1
+        }
+
+        guard parts.count >= 11,
+              let testament = Int(parts[0]),
+              let book = Int(parts[1]),
+              let chapter = Int(parts[2]),
+              let verse = Int(parts[3]),
+              let chapterMax = Int(parts[4]),
+              let verseMax = Int(parts[5]) else {
+            return nil
+        }
+
+        return VerseKeyChildren(
+            testament: testament,
+            book: book,
+            chapter: chapter,
+            verse: verse,
+            chapterMax: chapterMax,
+            verseMax: verseMax,
+            bookName: parts[6],
+            osisRef: parts[7],
+            shortText: parts[8],
+            bookAbbreviation: parts[9],
+            osisBookName: parts[10]
+        )
     }
 
     /**


### PR DESCRIPTION
Summary
- Routes iOS multi-reference Bible links through Vue MultiDocument instead of the native CrossReferenceView sheet.

Scope
- BibleReaderController link handling and transient multi-document JSON emission.
- BibleWindowPane links-window routing for multi-reference document payloads.
- AndBibleTests coverage for multi://, multi-reference osis://, and single-reference osis:// behavior.

Contract references
- Issue #124 acceptance criteria.
- Android parity path: LinkControl.openMulti, FakeBookFactory.multiDocument, and Vue MultiDocument rendering.

Change details
- multi:// links with multiple osis parameters now build Bible multi-document fragments and emit clear_document, add_documents, and setup_content.
- Multi-reference osis:// links now use the same Vue document path.
- Single OSIS references still navigate normally or use the links window according to current settings.
- CrossReferenceView remains available, but these multi-reference routes bypass it.

Validation evidence
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17 -derivedDataPath build/DerivedData-124 test -only-testing:AndBibleTests/AndBibleTests/testMultiReferenceLinkEmitsVueMultiDocumentInsteadOfCrossReferenceSheet -only-testing:AndBibleTests/AndBibleTests/testMultiReferenceOsisLinkEmitsVueMultiDocumentInsteadOfCrossReferenceSheet -only-testing:AndBibleTests/AndBibleTests/testSingleOsisReferenceStillNavigatesWithoutMultiDocument
- GitNexus impact analysis before edits and detect_changes on the staged diff.

Risks/follow-ups
- Risk is elevated because the changed code touches central reader bridge and pane routing.
- CrossReferenceView can be removed later after all remaining native callers are retired.

Issue closure
Closes #124