### PR TITLE
fix(downloads): preserve download link target search

### DIFF
--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -169,6 +169,7 @@
    Downloads / Module Browser
    ======================================== */
 "module_browser" = "Module Browser";
+"doc_type_all" = "All types";
 "bibles" = "Bibles";
 "commentaries" = "Commentaries";
 "dictionaries" = "Dictionaries";

--- a/AndBibleTests/AndBibleTests.swift
+++ b/AndBibleTests/AndBibleTests.swift
@@ -586,6 +586,7 @@ final class AndBibleTests: XCTestCase {
             nightModeMode: Binding.constant("system"),
             readingProgressInitialTab: .reading,
             chapterReadHistoryTarget: nil,
+            downloadsInitialSearchText: "",
             onDismiss: {},
             onSettingsChanged: {}
         )
@@ -1911,6 +1912,38 @@ final class AndBibleTests: XCTestCase {
     }
 
     #if os(iOS)
+    func testDownloadLinkInitialsAreParsedForDownloadsSearch() {
+        XCTAssertEqual(
+            BibleReaderController.downloadSearchText(from: "download://?initials=KJV"),
+            "KJV"
+        )
+        XCTAssertEqual(
+            BibleReaderController.downloadSearchText(from: "download://?initials=StrongsHebrew%20"),
+            "StrongsHebrew"
+        )
+        XCTAssertNil(BibleReaderController.downloadSearchText(from: "download://"))
+        XCTAssertNil(BibleReaderController.downloadSearchText(from: "download://?initials="))
+    }
+
+    @MainActor
+    func testDownloadLinkRoutesInitialsToDownloadsPresentation() throws {
+        let bridge = BibleBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        var requestedSearchText: String?
+        controller.onRequestOpenDownloads = { requestedSearchText = $0 }
+
+        controller.bridge(bridge, openExternalLink: "download://?initials=KJV")
+
+        XCTAssertEqual(requestedSearchText, "KJV")
+
+        requestedSearchText = "stale"
+        controller.bridge(bridge, openExternalLink: "download://")
+
+        XCTAssertNil(requestedSearchText)
+    }
+
     func testBuildStrongsMultiDocJSONReturnsInstallFallbackWhenNoStrongsDictionaryIsInstalled() throws {
         let bridge = BibleBridge()
         let modulePath = try makeTemporaryBundledSwordPath()

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -156,6 +156,7 @@
    Downloads / Module Browser
    ======================================== */
 "module_browser" = "Module Browser";
+"doc_type_all" = "All types";
 "bibles" = "Bibles";
 "commentaries" = "Commentaries";
 "dictionaries" = "Dictionaries";

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
@@ -15,6 +15,10 @@ struct BibleReaderActiveSheetContent: View {
     @Binding var nightModeMode: String
     let readingProgressInitialTab: ReadingProgressTab
     let chapterReadHistoryTarget: ChapterReadHistoryTarget?
+
+    /// Initial Downloads search text supplied by Android-compatible `download://` links.
+    let downloadsInitialSearchText: String
+
     let onDismiss: () -> Void
     let onSettingsChanged: () -> Void
 
@@ -48,7 +52,7 @@ struct BibleReaderActiveSheetContent: View {
             }
         case .downloads:
             NavigationStack {
-                ModuleBrowserView()
+                ModuleBrowserView(initialSearchText: downloadsInitialSearchText)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button(String(localized: "done"), action: onDismiss)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -3256,7 +3256,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Callback for presenting action sheets (set by BibleReaderView)
     var onShareVerseText: ((String) -> Void)?
-    var onRequestOpenDownloads: (() -> Void)?
+
+    /**
+     Callback for presenting Downloads with an optional Android-compatible search seed.
+
+     The optional string mirrors Android `DownloadActivity`'s `"search"` extra: `nil` opens
+     Downloads normally, while a non-empty module initials value pre-populates the browser search.
+     */
+    var onRequestOpenDownloads: ((String?) -> Void)?
     var onOpenExternalURL: ((URL) -> Void)?
 
     /// Whether there's an active text selection in the WebView.
@@ -3974,7 +3981,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
         // Handle Downloads links surfaced in web-rendered help/error content.
         if link.hasPrefix("download://") {
-            onRequestOpenDownloads?()
+            onRequestOpenDownloads?(Self.downloadSearchText(from: link))
             return
         }
         // Handle My Notes links surfaced in bookmark metadata.
@@ -4026,6 +4033,26 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
         guard let url = URL(string: link) else { return }
         openPlatformURL(url)
+    }
+
+    /**
+     Extracts the module-initials search seed from an Android-compatible Downloads pseudo-link.
+
+     - Parameter link: A `download://` link emitted by rendered document content, optionally with
+       an `initials` query item such as `download://?initials=KJV`.
+     - Returns: The decoded, trimmed `initials` value when present and non-empty; otherwise `nil`.
+
+     The method is deterministic and performs no I/O. Malformed or non-download links return
+     `nil`, which keeps the caller on the standard unfiltered Downloads presentation path.
+     */
+    static func downloadSearchText(from link: String) -> String? {
+        guard link.hasPrefix("download://"),
+              let components = URLComponents(string: link),
+              let value = components.queryItems?.first(where: { $0.name == "initials" })?.value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func handleErrorReportLink() {
@@ -5840,7 +5867,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Requests that the owning SwiftUI view present the downloads/install UI.
      */
     public func bridgeDidRequestOpenDownloads(_ bridge: BibleBridge) {
-        onRequestOpenDownloads?()
+        onRequestOpenDownloads?(nil)
     }
 
     // MARK: - BibleBridgeDelegate — Dialogs

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -174,6 +174,9 @@ public struct BibleReaderView: View {
     /// Presents the current top-level reader sheet driven by the overflow menu and shortcuts.
     @State private var activeReaderSheet: ReaderSheet?
 
+    /// Initial search applied when Downloads is opened from an Android-compatible download link.
+    @State private var downloadsInitialSearchText = ""
+
     /// Initial tab requested by the Android-compatible reading-progress bridge.
     @State private var readingProgressInitialTab: ReadingProgressTab = .reading
 
@@ -621,6 +624,7 @@ public struct BibleReaderView: View {
                 nightModeMode: $nightModeMode,
                 readingProgressInitialTab: readingProgressInitialTab,
                 chapterReadHistoryTarget: chapterReadHistoryTarget,
+                downloadsInitialSearchText: downloadsInitialSearchText,
                 onDismiss: dismissReaderSheet,
                 onSettingsChanged: applyGlobalDisplaySettingsChange
             )
@@ -655,6 +659,7 @@ public struct BibleReaderView: View {
                 reloadBehaviorPreferences()
             }
             if oldValue == .downloads, newValue == nil {
+                downloadsInitialSearchText = ""
                 for (_, ctrl) in windowManager.controllers {
                     (ctrl as? BibleReaderController)?.refreshInstalledModules()
                 }
@@ -722,7 +727,7 @@ public struct BibleReaderView: View {
                 onNavigatePrevious: { navigatePreviousIfReaderCanHostNavigate(focusedController) },
                 onNavigateNext: { navigateNextIfReaderCanHostNavigate(focusedController) },
                 onCloseClientModal: { _ = closeFocusedWebModalIfNeeded() },
-                onOpenDownloads: { presentReaderSheet(.downloads, from: windowManager.activeWindow?.id) },
+                onOpenDownloads: { presentDownloads(from: windowManager.activeWindow?.id) },
                 onOpenSettings: { presentReaderSheet(.settings, from: windowManager.activeWindow?.id) }
             )
         }
@@ -736,8 +741,33 @@ public struct BibleReaderView: View {
         activeReaderSheet = sheet
     }
 
+    /**
+     Presents Downloads and seeds its free-text search from an Android `download://` target.
+
+     - Parameters:
+       - windowId: Pane whose controller should own the sheet context. When `nil`, the focused pane
+         is used.
+       - initialSearchText: Optional module initials from the link query. Empty and whitespace-only
+         values are normalized away so normal Downloads entry points remain unfiltered.
+
+     Side effects:
+     - captures the pane presentation target
+     - updates `downloadsInitialSearchText`
+     - presents the `.downloads` reader sheet
+
+     Failure modes:
+     - invalid search text is normalized to an empty string and opens the standard Downloads view
+     */
+    private func presentDownloads(from windowId: UUID? = nil, initialSearchText: String? = nil) {
+        downloadsInitialSearchText = normalizedDownloadsSearchText(initialSearchText)
+        presentReaderSheet(.downloads, from: windowId)
+    }
+
     /// Closes the currently active top-level reader sheet.
     private func dismissReaderSheet() {
+        if activeReaderSheet == .downloads {
+            downloadsInitialSearchText = ""
+        }
         activeReaderSheet = nil
         chapterReadHistoryTarget = nil
     }
@@ -745,6 +775,36 @@ public struct BibleReaderView: View {
     /// Presents a follow-up top-level sheet after another flow already captured the pane target.
     private func presentReaderSheetPreservingPane(_ sheet: ReaderSheet) {
         activeReaderSheet = sheet
+    }
+
+    /**
+     Presents Downloads after a pane-scoped flow has already captured the owning pane.
+
+     - Parameter initialSearchText: Optional module initials from an Android-compatible link.
+     Side effects mirror `presentDownloads(from:initialSearchText:)` without changing the captured
+     pane target.
+
+     Failure modes:
+     - invalid search text is normalized to an empty string and opens the standard Downloads view
+     */
+    private func presentDownloadsPreservingPane(initialSearchText: String? = nil) {
+        downloadsInitialSearchText = normalizedDownloadsSearchText(initialSearchText)
+        presentReaderSheetPreservingPane(.downloads)
+    }
+
+    /**
+     Normalizes an optional Downloads search seed for storage in SwiftUI state.
+
+     - Parameter searchText: Optional module initials from Android-compatible routing.
+     - Returns: A trimmed search string, or an empty string when no target should be applied.
+
+     The helper is deterministic and performs no side effects.
+
+     Failure modes:
+     - `nil` or whitespace-only input returns an empty string
+     */
+    private func normalizedDownloadsSearchText(_ searchText: String?) -> String {
+        searchText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
     /// Presents the book chooser for the pane that initiated the navigation.
@@ -814,7 +874,7 @@ public struct BibleReaderView: View {
                 controller: panePresentationController,
                 category: pickerCategory,
                 onDismiss: dismissReaderModal,
-                onOpenDownloads: { presentReaderSheetPreservingPane(.downloads) },
+                onOpenDownloads: { presentDownloadsPreservingPane() },
                 onOpenDictionaryBrowser: { presentReaderModalPreservingPane(.dictionaryBrowser) },
                 onOpenGeneralBookBrowser: { presentReaderModalPreservingPane(.generalBookBrowser) },
                 onOpenMapBrowser: { presentReaderModalPreservingPane(.mapBrowser) }
@@ -1092,7 +1152,7 @@ public struct BibleReaderView: View {
             case .workspaces:
                 presentReaderSheet(.workspaces, from: windowManager.activeWindow?.id)
             case .downloads:
-                presentReaderSheet(.downloads, from: windowManager.activeWindow?.id)
+                presentDownloads(from: windowManager.activeWindow?.id)
             case .epubLibrary:
                 presentReaderModal(.epubLibrary, from: windowManager.activeWindow?.id)
             case .epubBrowser:
@@ -1134,7 +1194,7 @@ public struct BibleReaderView: View {
 
     /** Opens Downloads from the reader shell. */
     private func openDownloadsFromReaderAction() {
-        presentReaderSheet(.downloads, from: windowManager.activeWindow?.id)
+        presentDownloads(from: windowManager.activeWindow?.id)
     }
 
     /** Opens About from the reader shell. */
@@ -1162,7 +1222,9 @@ public struct BibleReaderView: View {
             onShowSearch: { presentSearch(from: window.id) },
             onShowBookmarks: { presentReaderSheet(.bookmarks, from: window.id) },
             onShowSettings: { presentReaderSheet(.settings, from: window.id) },
-            onShowDownloads: { presentReaderSheet(.downloads, from: window.id) },
+            onShowDownloads: { initialSearchText in
+                presentDownloads(from: window.id, initialSearchText: initialSearchText)
+            },
             onShowHistory: { presentReaderSheet(.history, from: window.id) },
             onShowCompare: {
                 (windowManager.controllers[window.id] as? BibleReaderController)?.loadCompareDocument()
@@ -1542,7 +1604,7 @@ public struct BibleReaderView: View {
             }
         case .downloads:
             dismissReaderNavigationDrawerAndPerform {
-                presentReaderSheet(.downloads, from: windowManager.activeWindow?.id)
+                presentDownloads(from: windowManager.activeWindow?.id)
             }
         case .importExport:
             dismissReaderNavigationDrawerAndPerform { presentReaderModal(.importExport) }
@@ -1669,7 +1731,7 @@ public struct BibleReaderView: View {
             case .dictionary:
                 let modules = controller.installedDictionaryModules
                 if modules.isEmpty {
-                    presentReaderSheetPreservingPane(.downloads)
+                    presentDownloadsPreservingPane()
                 } else if modules.count == 1 {
                     controller.switchDictionaryModule(to: modules[0].name)
                     controller.switchCategory(to: .dictionary)
@@ -1681,7 +1743,7 @@ public struct BibleReaderView: View {
             case .generalBook:
                 let modules = controller.installedGeneralBookModules
                 if modules.isEmpty {
-                    presentReaderSheetPreservingPane(.downloads)
+                    presentDownloadsPreservingPane()
                 } else if modules.count == 1 {
                     controller.switchGeneralBookModule(to: modules[0].name)
                     controller.switchCategory(to: .generalBook)
@@ -1693,7 +1755,7 @@ public struct BibleReaderView: View {
             case .map:
                 let modules = controller.installedMapModules
                 if modules.isEmpty {
-                    presentReaderSheetPreservingPane(.downloads)
+                    presentDownloadsPreservingPane()
                 } else if modules.count == 1 {
                     controller.switchMapModule(to: modules[0].name)
                     controller.switchCategory(to: .map)
@@ -1711,7 +1773,7 @@ public struct BibleReaderView: View {
                         presentReaderModalPreservingPane(.epubLibrary)
                     }
                 } else {
-                    presentReaderSheetPreservingPane(.downloads)
+                    presentDownloadsPreservingPane()
                 }
             }
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -98,8 +98,8 @@ struct BibleWindowPane: View {
     /// Requests the parent reader to present settings UI.
     var onShowSettings: (() -> Void)?
 
-    /// Requests the parent reader to present download/module-management UI.
-    var onShowDownloads: (() -> Void)?
+    /// Requests the parent reader to present download/module-management UI with optional search.
+    var onShowDownloads: ((String?) -> Void)?
 
     /// Requests the parent reader to present navigation history UI.
     var onShowHistory: (() -> Void)?
@@ -401,7 +401,7 @@ struct BibleWindowPane: View {
         ctrl.myDocumentStore = MyDocumentStore(modelContext: modelContext)
 
         ctrl.onShareVerseText = { text in onShareText?(text) }
-        ctrl.onRequestOpenDownloads = { onShowDownloads?() }
+        ctrl.onRequestOpenDownloads = { initialSearchText in onShowDownloads?(initialSearchText) }
         ctrl.onShowStrongsSearch = { strongsNum in onSearchForStrongs?(strongsNum) }
         ctrl.onShowCrossReferences = { refs in onShowCrossReferences?(refs) }
         ctrl.onShowReadingProgress = { tab in onShowReadingProgress?(tab) }

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -27,8 +27,8 @@ import SwordKit
    `SwordManager`, and refreshes the installed-module list shown in the UI
  */
 public struct ModuleBrowserView: View {
-    /// Selected remote/local module category segment.
-    @State private var selectedCategory: ModuleCategory = .bible
+    /// Selected remote/local module category segment, or `nil` for Android's "All types" filter.
+    @State private var selectedCategory: ModuleCategory? = .bible
 
     /// Selected language filter, or an empty string when all languages should be shown.
     @State private var selectedLanguage: String = ""
@@ -64,11 +64,26 @@ public struct ModuleBrowserView: View {
     @State private var refreshProgress: String?
 
     /**
-     Creates the module browser with empty local state.
+     Creates the module browser with optional Android-compatible search state.
 
-     - Note: The view resolves installed modules and repository data lazily in `onAppear`.
+     - Parameter initialSearchText: Optional module initials that should pre-populate search.
+       Empty or whitespace-only values are normalized to an empty query. A non-empty value starts
+       on Android's "All types" category so Bibles, commentaries, dictionaries, and books can all
+       satisfy a module-initials link.
+
+     Side effects:
+     - initializes local SwiftUI state only; repository and installed-module data are still loaded
+       lazily in `onAppear`
+
+     Failure modes:
+     - invalid or unknown initials simply behave as a free-text all-types search with no matching
+       rows until catalog data contains that module
      */
-    public init() {}
+    public init(initialSearchText: String = "") {
+        let normalizedSearchText = initialSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        _selectedCategory = State(initialValue: normalizedSearchText.isEmpty ? .bible : nil)
+        _searchText = State(initialValue: normalizedSearchText)
+    }
 
     // MARK: - Computed Properties
 
@@ -79,10 +94,10 @@ public struct ModuleBrowserView: View {
      */
     private var availableLanguages: [String] {
         var langs = Set<String>()
-        for m in availableModules where m.category == selectedCategory {
+        for m in availableModules where matchesSelectedCategory(m.category) {
             langs.insert(m.language)
         }
-        for m in installedModules where m.category == selectedCategory {
+        for m in installedModules where matchesSelectedCategory(m.category) {
             langs.insert(m.language)
         }
         return langs.sorted { a, b in
@@ -109,7 +124,7 @@ public struct ModuleBrowserView: View {
 
     /// Installed modules filtered by category, language, and search text.
     private var filteredInstalledModules: [ModuleInfo] {
-        var modules = installedModules.filter { $0.category == selectedCategory }
+        var modules = installedModules.filter { matchesSelectedCategory($0.category) }
         if !selectedLanguage.isEmpty {
             modules = modules.filter { $0.language == selectedLanguage }
         }
@@ -125,7 +140,7 @@ public struct ModuleBrowserView: View {
 
     /// Available (remote) modules filtered by category, language, and search text.
     private var filteredAvailableModules: [RemoteModuleInfo] {
-        var modules = availableModules.filter { $0.category == selectedCategory }
+        var modules = availableModules.filter { matchesSelectedCategory($0.category) }
         if !selectedLanguage.isEmpty {
             modules = modules.filter { $0.language == selectedLanguage }
         }
@@ -151,10 +166,12 @@ public struct ModuleBrowserView: View {
             // Category picker
             Section {
                 Picker("Category", selection: $selectedCategory) {
-                    Text(String(localized: "bibles")).tag(ModuleCategory.bible)
-                    Text(String(localized: "commentaries")).tag(ModuleCategory.commentary)
-                    Text(String(localized: "dictionaries")).tag(ModuleCategory.dictionary)
-                    Text(String(localized: "category_books")).tag(ModuleCategory.generalBook)
+                    Text(String(localized: "doc_type_all", defaultValue: "All types"))
+                        .tag(Optional<ModuleCategory>.none)
+                    Text(String(localized: "bibles")).tag(Optional(ModuleCategory.bible))
+                    Text(String(localized: "commentaries")).tag(Optional(ModuleCategory.commentary))
+                    Text(String(localized: "dictionaries")).tag(Optional(ModuleCategory.dictionary))
+                    Text(String(localized: "category_books")).tag(Optional(ModuleCategory.generalBook))
                 }
                 .pickerStyle(.segmented)
                 .onChange(of: selectedCategory) {
@@ -262,6 +279,22 @@ public struct ModuleBrowserView: View {
     }
 
     // MARK: - Row Views
+
+    /**
+     Tests whether a module category is visible under the current Android-parity type filter.
+
+     - Parameter category: Module category from installed or remote catalog metadata.
+     - Returns: `true` when the selected filter is "All types" or matches the supplied category.
+
+     The helper is deterministic and performs no side effects. It exists so installed, available,
+     and language filters all interpret the optional category state identically.
+
+     Failure modes:
+     - none; unknown future categories only match an identical selected enum value
+     */
+    private func matchesSelectedCategory(_ category: ModuleCategory) -> Bool {
+        selectedCategory.map { $0 == category } ?? true
+    }
 
     /**
      Builds one row for a locally installed module with removal controls.


### PR DESCRIPTION
## Summary

Preserves Android-compatible download link targets on iOS by carrying download:// initials into Downloads and applying the target as an initial module search.

## Scope

- Parse and route download:// initials from reader web content.
- Preserve pane-scoped Downloads presentation while carrying optional search text.
- Seed Downloads search for routed links and use Android All types filtering for those routed searches.
- Add focused unit coverage and the English All types localization key.

## Contract References

- Issue: #118
- Parent parity stream: #117
- Commit standard: ../commit-message-standard.md
- Android reference: BibleView forwards initials to DownloadActivity search; DocumentSelectionBase applies search with All types selected.

## Change Details

- BibleReaderController now extracts trimmed initials from download:// query parameters and passes them through the Downloads callback.
- BibleWindowPane and BibleReaderView now preserve optional download search state through the sheet presentation path.
- BibleReaderActiveSheetContent passes the search seed into ModuleBrowserView.
- ModuleBrowserView keeps normal opens on the existing Bible default, but routed non-empty searches select All types so dictionaries, commentaries, Bibles, and books can all match.
- Tests cover initials parsing, routed presentation, and the existing settings sheet initializer path.

## Validation Evidence

- git diff --check
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination platform=iOS Simulator,id=98C37D62-54A5-4C52-846B-B0801AEAD2CB -derivedDataPath /private/tmp/andbible-dd-118 -only-testing:AndBibleTests/AndBibleTests/testDownloadLinkInitialsAreParsedForDownloadsSearch -only-testing:AndBibleTests/AndBibleTests/testDownloadLinkRoutesInitialsToDownloadsPresentation -only-testing:AndBibleTests/AndBibleTests/testBibleReaderActiveSheetContentBuildsSettingsSheet
- xcodebuild build -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination platform=iOS Simulator,id=98C37D62-54A5-4C52-846B-B0801AEAD2CB -derivedDataPath /private/tmp/andbible-dd-118
- Reinstalled and launched org.andbible.ios on the existing booted simulator without erasing app data.
- GitNexus staged detect_changes reported HIGH risk due central reader wiring; affected flows were the expected pane/controller initialization and pane presentation paths.

## Risks / Follow-ups

- Risk is concentrated in reader sheet presentation wiring and downloader filtering.
- Broader downloader UI parity remains out of scope for #118 and stays tracked under #117.
- No documented platform deviation is needed for this behavior because iOS can match Android here.

## Issue Closure

Closes #118
