### PR TITLE
docs(settings): re-audit Android preference contract

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -18,11 +18,11 @@ env:
   UI_TEST_TIMINGS_FILE: scripts/ui_test_timings.json
 
 jobs:
-  classify-changes:
-    name: Classify Changes
+  repo-standards:
+    name: Repo Standards
     runs-on: ubuntu-latest
     outputs:
-      docs_only: ${{ steps.classify.outputs.docs_only }}
+      required_checks_only: ${{ steps.classify.outputs.required_checks_only }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,33 +55,24 @@ jobs:
             mapfile -t changed_files < <(git diff --name-only "${base}" "${head}")
           fi
 
-          docs_only=true
+          required_checks_only=true
           if [[ "${#changed_files[@]}" -eq 0 ]]; then
-            docs_only=false
+            required_checks_only=false
           fi
 
           for path in "${changed_files[@]}"; do
             echo "changed: ${path}"
             case "${path}" in
-              docs/*|*.md)
+              docs/*|*.md|.github/workflows/ios-ci.yml)
                 ;;
               *)
-                docs_only=false
+                required_checks_only=false
                 ;;
             esac
           done
 
-          echo "docs_only=${docs_only}"
-          echo "docs_only=${docs_only}" >> "${GITHUB_OUTPUT}"
-
-  repo-standards:
-    name: Repo Standards
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+          echo "required_checks_only=${required_checks_only}"
+          echo "required_checks_only=${required_checks_only}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -136,18 +127,13 @@ jobs:
     name: BibleView JS
     runs-on: ubuntu-latest
     needs:
-      - classify-changes
+      - repo-standards
+    if: needs.repo-standards.outputs.required_checks_only != 'true'
     steps:
-      - name: Docs-only pass
-        if: needs.classify-changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change set; BibleView JS checks are not required."
-
       - name: Checkout
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -155,25 +141,22 @@ jobs:
           cache-dependency-path: bibleview-js/package-lock.json
 
       - name: Install frontend dependencies
-        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm ci
 
       - name: Run frontend tests
-        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm run test:ci
 
       - name: Build frontend debug bundle
-        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm run build-debug
 
   ui-shard-plan:
     name: Plan UI Test Shards
     runs-on: ubuntu-latest
+    if: needs.repo-standards.outputs.required_checks_only != 'true'
     needs:
-      - classify-changes
       - repo-standards
       - localization-guardrails
     outputs:
@@ -201,29 +184,23 @@ jobs:
 
   ios-ui-foundation:
     name: Prepare UI Test Foundation
-    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    runs-on: macos-15
+    if: needs.repo-standards.outputs.required_checks_only != 'true'
     needs:
-      - classify-changes
       - repo-standards
       - localization-guardrails
     timeout-minutes: 60
     steps:
-      - name: Docs-only pass
-        if: needs.classify-changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change set; UI test foundation preparation is not required."
-
       - name: Checkout
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore libsword build cache
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -235,11 +212,11 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-hosttool-
 
       - name: Show Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure libsword build prerequisites
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -249,7 +226,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "1"
@@ -262,7 +239,7 @@ jobs:
 
       - name: Upload prepared libsword XCFramework
         id: upload_libsword_xcframework
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -272,7 +249,7 @@ jobs:
           retention-days: 1
 
       - name: Retry upload prepared libsword XCFramework
-        if: needs.classify-changes.outputs.docs_only != 'true' && steps.upload_libsword_xcframework.outcome == 'failure'
+        if: needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_libsword_xcframework.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: libsword-hosttool-xcframework
@@ -283,9 +260,8 @@ jobs:
 
   ios-simulator-unit-tests:
     name: Unit Tests (Simulator)
-    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    runs-on: ${{ needs.repo-standards.outputs.required_checks_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
     needs:
-      - classify-changes
       - repo-standards
       - localization-guardrails
     timeout-minutes: 60
@@ -297,22 +273,22 @@ jobs:
         -skip-testing:AndBibleUITests
         -skip-testing:AndBibleTests/AndBibleTests/testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks
     steps:
-      - name: Docs-only pass
-        if: needs.classify-changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change set; simulator unit tests are not required."
+      - name: Required-checks-only pass
+        if: needs.repo-standards.outputs.required_checks_only == 'true'
+        run: echo "Required-checks-only change set; simulator unit tests are not required."
 
       - name: Checkout
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore SwiftPM and build caches
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -324,7 +300,7 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-spm-
 
       - name: Restore libsword build cache
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -336,11 +312,11 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-
 
       - name: Show Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure iOS simulator runtime is available
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
             echo "An iOS simulator runtime is already installed."
@@ -350,7 +326,7 @@ jobs:
           fi
 
       - name: Ensure libsword build prerequisites
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -360,7 +336,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "0"
@@ -373,7 +349,7 @@ jobs:
 
       - name: Resolve iOS simulator destination
         id: simulator
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: >-
           python3 -u scripts/resolve_ios_simulator_destination.py
           --project AndBible.xcodeproj
@@ -382,14 +358,14 @@ jobs:
           --device-name-prefix "AndBible CI Unit"
 
       - name: Boot selected simulator
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: >-
           python3 -u scripts/wait_for_simulator_boot.py
           --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
           --timeout-seconds 300
 
       - name: Build for testing
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           mkdir -p .artifacts
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -403,7 +379,7 @@ jobs:
             --action build-for-testing
 
       - name: Run selected simulator tests without rebuilding
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         timeout-minutes: 10
         run: |
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -418,7 +394,7 @@ jobs:
 
       - name: Upload xcodebuild test result bundle
         id: upload_unit_xcresult
-        if: always() && needs.classify-changes.outputs.docs_only != 'true'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -429,7 +405,7 @@ jobs:
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
-        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.upload_unit_xcresult.outcome == 'failure'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_unit_xcresult.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: andbible-xcresult-${{ github.run_id }}-unit
@@ -440,14 +416,15 @@ jobs:
           overwrite: true
 
       - name: Delete dedicated simulator
-        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
 
   ios-simulator-ui-tests:
     name: ${{ matrix.job_name }}
-    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    runs-on: macos-15
+    if: needs.repo-standards.outputs.required_checks_only != 'true'
     needs:
-      - classify-changes
+      - repo-standards
       - ui-shard-plan
       - ios-ui-foundation
     strategy:
@@ -460,22 +437,16 @@ jobs:
       TEST_XCRESULT_BUNDLE_PATH: ${{ matrix.test_xcresult_bundle_path }}
       TEST_SELECTION_ARGS: ${{ matrix.test_selection_args }}
     steps:
-      - name: Docs-only pass
-        if: needs.classify-changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change set; simulator UI shard is not required."
-
       - name: Checkout
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore SwiftPM and build caches
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -487,7 +458,7 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-spm-
 
       - name: Restore libsword build cache
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -499,18 +470,18 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-hosttool-
 
       - name: Download prepared libsword XCFramework
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         uses: actions/download-artifact@v5
         with:
           name: libsword-hosttool-xcframework
           path: libsword
 
       - name: Show Xcode version
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure iOS simulator runtime is available
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
             echo "An iOS simulator runtime is already installed."
@@ -520,7 +491,7 @@ jobs:
           fi
 
       - name: Ensure libsword build prerequisites
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -530,7 +501,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "1"
@@ -543,7 +514,7 @@ jobs:
 
       - name: Resolve iOS simulator destination
         id: simulator
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: >-
           python3 scripts/resolve_ios_simulator_destination.py
           --project AndBible.xcodeproj
@@ -552,14 +523,14 @@ jobs:
           --device-name-prefix "AndBible CI UI"
 
       - name: Boot selected simulator
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: >-
           python3 scripts/wait_for_simulator_boot.py
           --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
           --timeout-seconds 300
 
       - name: Build for testing
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: |
           mkdir -p .artifacts
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -573,11 +544,11 @@ jobs:
             --action build-for-testing
 
       - name: Build host-side UI fixture tool
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         run: swift build --package-path . --product UITestFixtureTool
 
       - name: Run selected simulator tests without rebuilding
-        if: needs.classify-changes.outputs.docs_only != 'true'
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
         env:
           UITEST_FIXTURE_TOOL_PATH: ${{ github.workspace }}/.build/debug/UITestFixtureTool
           UITEST_BUNDLE_ID: org.andbible.ios
@@ -595,7 +566,7 @@ jobs:
 
       - name: Upload xcodebuild test result bundle
         id: upload_ui_xcresult
-        if: always() && needs.classify-changes.outputs.docs_only != 'true'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -606,7 +577,7 @@ jobs:
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
-        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.upload_ui_xcresult.outcome == 'failure'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_ui_xcresult.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: andbible-xcresult-${{ github.run_id }}-${{ matrix.artifact_suffix }}
@@ -617,5 +588,5 @@ jobs:
           overwrite: true
 
       - name: Delete dedicated simulator
-        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -2,15 +2,9 @@ name: iOS CI
 
 on:
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
   push:
     branches:
       - main
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
 
 concurrency:
   group: ios-ci-${{ github.event.pull_request.number || github.ref }}
@@ -24,6 +18,62 @@ env:
   UI_TEST_TIMINGS_FILE: scripts/ui_test_timings.json
 
 jobs:
+  classify-changes:
+    name: Classify Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify change set
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            base="${PR_BASE_SHA}"
+            head="${PR_HEAD_SHA}"
+          else
+            base="${PUSH_BEFORE_SHA}"
+            head="${CURRENT_SHA}"
+          fi
+
+          if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+            mapfile -t changed_files < <(git diff-tree --no-commit-id --name-only -r "${head}")
+          else
+            mapfile -t changed_files < <(git diff --name-only "${base}" "${head}")
+          fi
+
+          docs_only=true
+          if [[ "${#changed_files[@]}" -eq 0 ]]; then
+            docs_only=false
+          fi
+
+          for path in "${changed_files[@]}"; do
+            echo "changed: ${path}"
+            case "${path}" in
+              docs/*|*.md)
+                ;;
+              *)
+                docs_only=false
+                ;;
+            esac
+          done
+
+          echo "docs_only=${docs_only}"
+          echo "docs_only=${docs_only}" >> "${GITHUB_OUTPUT}"
+
   repo-standards:
     name: Repo Standards
     runs-on: ubuntu-latest
@@ -85,11 +135,19 @@ jobs:
   bibleview-js:
     name: BibleView JS
     runs-on: ubuntu-latest
+    needs:
+      - classify-changes
     steps:
+      - name: Docs-only pass
+        if: needs.classify-changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change set; BibleView JS checks are not required."
+
       - name: Checkout
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Setup Node.js
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -97,14 +155,17 @@ jobs:
           cache-dependency-path: bibleview-js/package-lock.json
 
       - name: Install frontend dependencies
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm ci
 
       - name: Run frontend tests
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm run test:ci
 
       - name: Build frontend debug bundle
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: bibleview-js
         run: npm run build-debug
 
@@ -112,6 +173,7 @@ jobs:
     name: Plan UI Test Shards
     runs-on: ubuntu-latest
     needs:
+      - classify-changes
       - repo-standards
       - localization-guardrails
     outputs:
@@ -139,21 +201,29 @@ jobs:
 
   ios-ui-foundation:
     name: Prepare UI Test Foundation
-    runs-on: macos-15
+    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
     needs:
+      - classify-changes
       - repo-standards
       - localization-guardrails
     timeout-minutes: 60
     steps:
+      - name: Docs-only pass
+        if: needs.classify-changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change set; UI test foundation preparation is not required."
+
       - name: Checkout
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore libsword build cache
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -165,9 +235,11 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-hosttool-
 
       - name: Show Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure libsword build prerequisites
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -177,6 +249,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "1"
@@ -189,6 +262,7 @@ jobs:
 
       - name: Upload prepared libsword XCFramework
         id: upload_libsword_xcframework
+        if: needs.classify-changes.outputs.docs_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -198,7 +272,7 @@ jobs:
           retention-days: 1
 
       - name: Retry upload prepared libsword XCFramework
-        if: steps.upload_libsword_xcframework.outcome == 'failure'
+        if: needs.classify-changes.outputs.docs_only != 'true' && steps.upload_libsword_xcframework.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: libsword-hosttool-xcframework
@@ -209,8 +283,9 @@ jobs:
 
   ios-simulator-unit-tests:
     name: Unit Tests (Simulator)
-    runs-on: macos-15
+    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
     needs:
+      - classify-changes
       - repo-standards
       - localization-guardrails
     timeout-minutes: 60
@@ -222,15 +297,22 @@ jobs:
         -skip-testing:AndBibleUITests
         -skip-testing:AndBibleTests/AndBibleTests/testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks
     steps:
+      - name: Docs-only pass
+        if: needs.classify-changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change set; simulator unit tests are not required."
+
       - name: Checkout
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore SwiftPM and build caches
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -242,6 +324,7 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-spm-
 
       - name: Restore libsword build cache
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -253,9 +336,11 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-
 
       - name: Show Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure iOS simulator runtime is available
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
             echo "An iOS simulator runtime is already installed."
@@ -265,6 +350,7 @@ jobs:
           fi
 
       - name: Ensure libsword build prerequisites
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -274,6 +360,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "0"
@@ -286,6 +373,7 @@ jobs:
 
       - name: Resolve iOS simulator destination
         id: simulator
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: >-
           python3 -u scripts/resolve_ios_simulator_destination.py
           --project AndBible.xcodeproj
@@ -294,12 +382,14 @@ jobs:
           --device-name-prefix "AndBible CI Unit"
 
       - name: Boot selected simulator
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: >-
           python3 -u scripts/wait_for_simulator_boot.py
           --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
           --timeout-seconds 300
 
       - name: Build for testing
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           mkdir -p .artifacts
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -313,6 +403,7 @@ jobs:
             --action build-for-testing
 
       - name: Run selected simulator tests without rebuilding
+        if: needs.classify-changes.outputs.docs_only != 'true'
         timeout-minutes: 10
         run: |
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -327,7 +418,7 @@ jobs:
 
       - name: Upload xcodebuild test result bundle
         id: upload_unit_xcresult
-        if: always()
+        if: always() && needs.classify-changes.outputs.docs_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -338,7 +429,7 @@ jobs:
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
-        if: always() && steps.upload_unit_xcresult.outcome == 'failure'
+        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.upload_unit_xcresult.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: andbible-xcresult-${{ github.run_id }}-unit
@@ -349,13 +440,14 @@ jobs:
           overwrite: true
 
       - name: Delete dedicated simulator
-        if: always() && steps.simulator.outputs.simulator_created == 'true'
+        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
 
   ios-simulator-ui-tests:
     name: ${{ matrix.job_name }}
-    runs-on: macos-15
+    runs-on: ${{ needs.classify-changes.outputs.docs_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
     needs:
+      - classify-changes
       - ui-shard-plan
       - ios-ui-foundation
     strategy:
@@ -368,15 +460,22 @@ jobs:
       TEST_XCRESULT_BUNDLE_PATH: ${{ matrix.test_xcresult_bundle_path }}
       TEST_SELECTION_ARGS: ${{ matrix.test_selection_args }}
     steps:
+      - name: Docs-only pass
+        if: needs.classify-changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change set; simulator UI shard is not required."
+
       - name: Checkout
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/checkout@v6
 
       - name: Select Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Restore SwiftPM and build caches
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -388,6 +487,7 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-spm-
 
       - name: Restore libsword build cache
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -399,15 +499,18 @@ jobs:
             ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-hosttool-
 
       - name: Download prepared libsword XCFramework
+        if: needs.classify-changes.outputs.docs_only != 'true'
         uses: actions/download-artifact@v5
         with:
           name: libsword-hosttool-xcframework
           path: libsword
 
       - name: Show Xcode version
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: xcodebuild -version
 
       - name: Ensure iOS simulator runtime is available
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
             echo "An iOS simulator runtime is already installed."
@@ -417,6 +520,7 @@ jobs:
           fi
 
       - name: Ensure libsword build prerequisites
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           if ! command -v cmake >/dev/null 2>&1; then
             brew install cmake
@@ -426,6 +530,7 @@ jobs:
           fi
 
       - name: Build libsword XCFramework
+        if: needs.classify-changes.outputs.docs_only != 'true'
         working-directory: libsword
         env:
           INCLUDE_MACOS_SLICE: "1"
@@ -438,6 +543,7 @@ jobs:
 
       - name: Resolve iOS simulator destination
         id: simulator
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: >-
           python3 scripts/resolve_ios_simulator_destination.py
           --project AndBible.xcodeproj
@@ -446,12 +552,14 @@ jobs:
           --device-name-prefix "AndBible CI UI"
 
       - name: Boot selected simulator
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: >-
           python3 scripts/wait_for_simulator_boot.py
           --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
           --timeout-seconds 300
 
       - name: Build for testing
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: |
           mkdir -p .artifacts
           python3 -u scripts/run_xcodebuild_with_test_selection.py \
@@ -465,9 +573,11 @@ jobs:
             --action build-for-testing
 
       - name: Build host-side UI fixture tool
+        if: needs.classify-changes.outputs.docs_only != 'true'
         run: swift build --package-path . --product UITestFixtureTool
 
       - name: Run selected simulator tests without rebuilding
+        if: needs.classify-changes.outputs.docs_only != 'true'
         env:
           UITEST_FIXTURE_TOOL_PATH: ${{ github.workspace }}/.build/debug/UITestFixtureTool
           UITEST_BUNDLE_ID: org.andbible.ios
@@ -485,7 +595,7 @@ jobs:
 
       - name: Upload xcodebuild test result bundle
         id: upload_ui_xcresult
-        if: always()
+        if: always() && needs.classify-changes.outputs.docs_only != 'true'
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -496,7 +606,7 @@ jobs:
           retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
-        if: always() && steps.upload_ui_xcresult.outcome == 'failure'
+        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.upload_ui_xcresult.outcome == 'failure'
         uses: actions/upload-artifact@v6
         with:
           name: andbible-xcresult-${{ github.run_id }}-${{ matrix.artifact_suffix }}
@@ -507,5 +617,5 @@ jobs:
           overwrite: true
 
       - name: Delete dedicated simulator
-        if: always() && steps.simulator.outputs.simulator_created == 'true'
+        if: always() && needs.classify-changes.outputs.docs_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"

--- a/docs/parity/settings/contract.md
+++ b/docs/parity/settings/contract.md
@@ -1,91 +1,136 @@
 # Android Settings Contract (Source Of Truth)
 
-This file captures the explicit Android contract to match on iOS.
+Last audited: 2026-05-31 for #154.
 
-Primary sources:
-- Settings schema: `and-bible/app/src/main/res/xml/settings.xml:25-253`
-- Labels/summaries: `and-bible/app/src/main/res/values/strings.xml`
-- Option arrays: `and-bible/app/src/main/res/values/arrays.xml`
-- Runtime rules/visibility: `and-bible/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt:219-357`
-- Runtime behavior consumers: callsites listed below per key.
+This file records the Android Application preferences contract and the current iOS
+disposition for each Android preference row. It intentionally separates two layers:
+
+- Android source inventory: every actionable preference row in
+  `and-bible/app/src/main/res/xml/settings.xml`.
+- iOS implementation registry: `AppPreferenceRegistry`, which only contains durable
+  iOS parity settings and action rows that iOS currently implements.
+
+The two counts are not expected to be equal. Android currently exposes 41 actionable
+preference rows. iOS currently registers 35 of them in `AppPreferenceRegistry`; every
+Android row outside that registry must have an explicit disposition below.
+
+Primary Android sources:
+- Settings schema: `and-bible/app/src/main/res/xml/settings.xml:23-293`
+- Runtime setup/reset/visibility: `and-bible/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt:134-385`
+- Reader config values: `and-bible/app/src/main/java/net/bible/service/common/CommonUtils.kt:452-459`
+- Reader config payload: `and-bible/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt:1508-1538`
+- Shared Vue reader config: `and-bible/app/bibleview-js/src/composables/config.ts`
+
+Primary iOS sources:
+- Registry: `Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift`
+- Settings UI: `Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift`
+- Reader config payload: `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
+- Shared Vue reader config: `bibleview-js/src/composables/config.ts`
+
+## Inventory Rules
+
+- `bible_display_pref` is the Android `PreferenceScreen` container key and is not an
+  actionable application preference.
+- `dictionaries_category` is a category container key. It is documented as category
+  metadata, not as a user preference.
+- `global_text_display_settings`, `sync_settings_shortcut`,
+  `ai_settings_shortcut`, and `reading_progress_settings_shortcut` are action rows,
+  not durable preference values. They should not be added to `AppPreferenceRegistry`
+  unless iOS intentionally models them as registry-backed actions.
+- `eink_mode` is an Android e-ink feature switch and is intentionally not registered
+  on iOS unless iOS gains equivalent e-ink behavior.
+- `notes_content_type` is a real Android preference and is tracked separately by #163
+  because it depends on note-editor Markdown parity, not e-ink behavior.
+- `locale_pref` is registry-backed, but the option list is not currently complete
+  against Android `arrays.xml`; that drift is tracked by #164.
 
 ## Category Titles
 
 | Category | String key | English text | Reference |
 |---|---|---|---|
-| Dictionaries | `prefs_dictionaries_cat` | Dictionaries | `strings.xml:234` |
-| Application behavior | `prefs_behavior_customization_cat` | Application behavior | `strings.xml:195` |
-| Look & feel | `prefs_display_customization_cat` | Look & feel | `strings.xml:194` |
-| Settings for the persecuted | `prefs_persecution_cat` | Settings for the persecuted | `strings.xml:1147` |
-| Advanced settings | `prefs_advanced_settings_cat` | Advanced settings | `strings.xml:193` |
+| Dictionaries | `prefs_dictionaries_cat` | Dictionaries | `strings.xml:277` |
+| Application behavior | `prefs_behavior_customization_cat` | Application behavior | `strings.xml:227` |
+| Look & feel | `prefs_display_customization_cat` | Look & feel | `strings.xml:226` |
+| E-ink settings | `prefs_eink_settings_cat` | E-ink settings | `strings.xml:120` |
+| Settings for the persecuted | `prefs_persecution_cat` | Settings for the persecuted | `strings.xml:1166` |
+| Features | `prefs_features_cat` | Features | `strings.xml:225` |
+| Advanced settings | `prefs_advanced_settings_cat` | Advanced settings | `strings.xml:224` |
 
-## Per-Key Contract
+## Android Preference Inventory And iOS Disposition
 
-| Key | Type | Default (from XML/runtime) | Label / Summary (en) | Runtime behavior reference |
-|---|---|---|---|---|
-| `strongs_greek_dictionary` | `MultiSelectListPreference` | Runtime default = all available entries (`SettingsActivity.kt:183-196`) | `choose_strongs_greek_dictionary_title` / `choose_strongs_greek_dictionary_summary` (`strings.xml:235-236`) | `SwordDocumentFacade.kt:94` |
-| `strongs_hebrew_dictionary` | `MultiSelectListPreference` | Runtime default = all available entries (`SettingsActivity.kt:183-196`) | `choose_strongs_hebrew_dictionary_title` / `choose_strongs_hebrew_dictionary_summary` (`strings.xml:237-238`) | `SwordDocumentFacade.kt:96` |
-| `robinson_greek_morphology` | `MultiSelectListPreference` | Runtime default = all available entries (`SettingsActivity.kt:183-196`) | `choose_strongs_greek_morphology_title` / `choose_strongs_greek_morphology_summary` (`strings.xml:239-240`) | `SwordDocumentFacade.kt:92` |
-| `disabled_word_lookup_dictionaries` | `InverseMultiSelectListPreference` | No XML default; inverse logic means empty disabled set | `choose_word_lookup_dictionary_title` / `choose_word_lookup_dictionary_summary` (`strings.xml:241-242`) | `SwordDocumentFacade.kt:100` |
-| `navigate_to_verse_pref` | `SwitchPreferenceCompat` | `false` (`settings.xml:55`) | `prefs_navigate_to_verse_title` / `prefs_navigate_to_verse_summary` (`strings.xml:164-165`) | `GridChoosePassageBook.kt:134`, `GridChoosePassageChapter.kt:81` |
-| `open_links_in_special_window_pref` | `SwitchPreferenceCompat` | `true` (`settings.xml:62`) | `prefs_open_links_in_special_window_title` / `prefs_open_links_in_special_window_summary` (`strings.xml:166-167`) | `LinkControl.kt:401-402`, `BibleView.kt:1261` |
-| `screen_keep_on_pref` | `SwitchPreferenceCompat` | `false` (`settings.xml:67`) | `prefs_screen_keep_on_title` / `prefs_screen_keep_on_summary` (`strings.xml:169-170`) | `ActivityBase.kt:453` |
-| `double_tap_to_fullscreen` | `SwitchPreferenceCompat` | `true` (`settings.xml:73`) | `prefs_double_tap_to_fullscreen_title` / `prefs_double_tap_to_fullscreen_summary` (`strings.xml:1062-1063`) | `BibleGestureListener.kt:156` |
-| `auto_fullscreen_pref` | `SwitchPreferenceCompat` | `false` (`settings.xml:79`) | `auto_fullscreen` / `auto_fullscreen_summary` (`strings.xml:183`, `190`) | `BibleGestureListener.kt:43` |
-| `toolbar_button_actions` | `ListPreference` | Runtime fallback to `default` when blank (`SettingsActivity.kt:262-265`) | `prefs_toolbar_button_action_title` / `prefs_toolbar_button_action_summary` (`strings.xml:151-152`) | `MainBibleActivity.kt:1055` |
-| `disable_two_step_bookmarking` | `SwitchPreferenceCompat` | `false` (`settings.xml:91`) | `prefs_disable_two_step_bookmarking_title` / `prefs_disable_two_step_bookmarking_summary` (`strings.xml:1060-1061`) | `BibleView.kt:566` |
-| `bible_view_swipe_mode` | `ListPreference` | `CHAPTER` (`settings.xml:100`) | `prefs_bible_view_swipe_mode_title` / `prefs_bible_view_swipe_mode_summary` (`strings.xml:1311-1312`) | `CommonUtils.kt:440` |
-| `volume_keys_scroll` | `SwitchPreferenceCompat` | `true` (`settings.xml:104`) | `prefs_volume_keys_scroll_title` / `prefs_volume_keys_scroll_summary` (`strings.xml:1316-1317`) | `MainBibleActivity.kt:1856` |
-| `night_mode_pref3` | `ListPreference` | XML default `manual` (`settings.xml:113`), runtime entry-set/default adjusted (`SettingsActivity.kt:225-234`) | `prefs_night_mode_title` / `prefs_night_mode_summary` (`strings.xml:157-158`) | `ScreenSettings.kt:62-64` |
-| `locale_pref` | `ListPreference` | `""` (`settings.xml:124`) | `prefs_interface_locale_title` / `prefs_interface_locale_summary` (`strings.xml:171-172`) | `CommonUtils.kt:457`, `LocaleHelper.kt:31` |
-| `monochrome_mode` | `SwitchPreferenceCompat` | `false` (`settings.xml:128`) | `prefs_e_ink_mode_title` / `prefs_eink_mode_summary` (`strings.xml:106-107`) | `CommonUtils.kt:435` |
-| `disable_animations` | `SwitchPreferenceCompat` | `false` (`settings.xml:134`) | `prefs_disable_animations_title` / `prefs_disable_animations_summary` (`strings.xml:109-110`) | `CommonUtils.kt:436` |
-| `disable_click_to_edit` | `SwitchPreferenceCompat` | `false` (`settings.xml:141`) | `prefs_disable_click_to_edit_title` / `prefs_disable_click_to_edit_summary` (`strings.xml:112-113`) | consumed via JS appSettings payload (Android bridge path) |
-| `font_size_multiplier` | `SeekBarPreference` | `100` (`settings.xml:147`), min `10`, max `500` (`settings.xml:148-149`) | `pref_font_size_multiplier_title` (`strings.xml:1307`) | `CommonUtils.kt:438-439` |
-| `full_screen_hide_buttons_pref` | `SwitchPreferenceCompat` | `true` (`settings.xml:156`) | `full_screen_hide_buttons_pref_title` / `full_screen_hide_buttons_pref_summary` (`strings.xml:231-232`) | `SplitBibleArea.kt:319` |
-| `hide_window_buttons` | `SwitchPreferenceCompat` | `false` (`settings.xml:162`) | `hide_window_buttons_title` / `hide_window_buttons_summary` (`strings.xml:226-227`) | `SplitBibleArea.kt:316` |
-| `hide_bible_reference_overlay` | `SwitchPreferenceCompat` | `false` (`settings.xml:168`) | `hide_bible_reference_overlay_title` / `hide_bible_reference_overlay_summary` (`strings.xml:228-229`) | `SplitBibleArea.kt:624` |
-| `show_active_window_indicator` | `SwitchPreferenceCompat` | `true` (`settings.xml:174`) | `active_window_indicator_title` / `active_window_indicator_summary` (`strings.xml:952-953`) | `BibleView.kt:1379` |
-| `disable_bible_bookmark_modal_buttons` | `InverseMultiSelectListPreference` | No XML default | `prefs_in_window_bible_bookmark_modal_buttons_title` / `prefs_in_window_bookmark_modal_buttons_description` (`strings.xml:1284`, `1286`) | `BibleView.kt:1397` |
-| `disable_gen_bookmark_modal_buttons` | `InverseMultiSelectListPreference` | No XML default | `prefs_in_window_gen_bookmark_modal_buttons_title` / `prefs_in_window_bookmark_modal_buttons_description` (`strings.xml:1285`, `1286`) | `BibleView.kt:1400` |
-| `discrete_help` | `Preference` | N/A | `prefs_persecuted_help` / `prefs_persecuted_summary` (`strings.xml:1157`, `1159`) | click behavior dialog `SettingsActivity.kt:291-319` |
-| `discrete_mode` | `SwitchPreferenceCompat` | `false` (`settings.xml:202`) | `prefs_discrete_mode` / `prefs_discrete_mode_desc` (`strings.xml:1148-1149`) | icon/name switch `CommonUtils.kt:1529-1563`, `MainBibleActivity.kt:1937` |
-| `show_calculator` | `SwitchPreferenceCompat` | `false` (`settings.xml:207`) | `prefs_show_calculator` (title), summary set dynamically from `calculator_par*` (`SettingsActivity.kt:285-289`) | startup calculator gate `CommonUtils.kt:1583`, `StartupActivity.kt:386-401` |
-| `calculator_pin` | `EditTextPreference` | `1234` (`settings.xml:213`) | `prefs_calculator_pin` / `prefs_calculator_pin_desc` (`strings.xml:1151-1152`) | calculator unlock `CalculatorActivity.kt:263-270` |
-| `experimental_features` | `MultiSelectListPreference` | `@null` (`settings.xml:223`) | `prefs_experimental_features_title` / `prefs_experimental_features_summary` (`strings.xml:946-947`) | `CommonUtils.kt:443` |
-| `enable_bluetooth_pref` | `SwitchPreferenceCompat` | `true` (`settings.xml:230`) | `prefs_enable_bluetooth_title` / `prefs_enable_bluetooth_summary` (`strings.xml:256-257`) | `MediaButtonHandler.kt:56`, `89`, `132` |
-| `request_sdcard_permission_pref` | `SwitchPreferenceCompat` | `false` (`settings.xml:234`) | `prefs_request_sdcard_permission_title` / `prefs_request_sdcard_permission_summary` (`strings.xml:175-176`) | `MainBibleActivity.kt:2077`, `DocumentControl.kt:167` |
-| `show_errorbox` | `SwitchPreferenceCompat` | `false` (`settings.xml:238`) | `prefs_show_error_box_title` / `prefs_show_error_box_summary` (`strings.xml:950-951`) | `BibleView.kt:1387` |
-| `open_links` | `Preference` | `false` (`settings.xml:244`) | `open_bible_links_title` / `open_bible_links_summary` (`strings.xml:1209-1210`) | click opens OS App-links settings `SettingsActivity.kt:334-349` |
-| `crash_app` | `Preference` | N/A | `crash_app` / `crash_app_summary` (`strings.xml`, same file) | click behavior only in beta `SettingsActivity.kt:321-333` |
-
-## Android Runtime Visibility / Dynamic Rules
-
-| Rule | Reference |
-|---|---|
-| `night_mode_pref3` entries and defaults are adjusted by `autoModeAvailable` | `SettingsActivity.kt:225-234` |
-| `show_errorbox` visible only in beta builds | `SettingsActivity.kt:235-236` |
-| dictionaries category hidden if no dictionary modules available | `SettingsActivity.kt:237-247` |
-| `font_size_multiplier` summary shows current multiplier string | `SettingsActivity.kt:249-260` |
-| `request_sdcard_permission_pref` hidden on Android Q+ | `SettingsActivity.kt:267-270` |
-| `calculator_pin` editor forced numeric input | `SettingsActivity.kt:272-274` |
-| `discrete_mode` and `show_calculator` hidden in discrete flavor | `SettingsActivity.kt:276-284` |
-| `show_calculator` summary built from calculator paragraphs | `SettingsActivity.kt:285-289` |
-| `discrete_help` dialog content differs by build flavor | `SettingsActivity.kt:291-307` |
-| `crash_app` visible only in beta | `SettingsActivity.kt:321-333` |
-| `open_links` visible only on API >= S; otherwise hidden | `SettingsActivity.kt:334-349` |
+| Key | Android source / behavior | iOS disposition |
+|---|---|---|
+| `strongs_greek_dictionary` | XML `settings.xml:28-32`; dictionary rows/defaults are populated at `SettingsActivity.kt:245-254`. | Registry-backed pass. |
+| `strongs_hebrew_dictionary` | XML `settings.xml:33-37`; dictionary rows/defaults are populated at `SettingsActivity.kt:245-254`. | Registry-backed pass. |
+| `robinson_greek_morphology` | XML `settings.xml:38-42`; dictionary rows/defaults are populated at `SettingsActivity.kt:245-254`. | Registry-backed pass. |
+| `disabled_word_lookup_dictionaries` | XML `settings.xml:43-47`; inverse dictionary row is populated at `SettingsActivity.kt:251-254`. | Registry-backed pass. |
+| `navigate_to_verse_pref` | XML `settings.xml:52-57`; default `false`. | Registry-backed pass. |
+| `open_links_in_special_window_pref` | XML `settings.xml:58-62`; default `true`. | Registry-backed pass. |
+| `screen_keep_on_pref` | XML `settings.xml:63-68`; default `false`. | Registry-backed pass. |
+| `double_tap_to_fullscreen` | XML `settings.xml:69-74`; default `true`. | Registry-backed pass. |
+| `auto_fullscreen_pref` | XML `settings.xml:75-80`; default `false`. | Registry-backed pass. |
+| `toolbar_button_actions` | XML `settings.xml:81-86`; blank values are normalized to `default` at `SettingsActivity.kt:270-273`. | Registry-backed adapted pass. |
+| `disable_two_step_bookmarking` | XML `settings.xml:88-93`; default `false`. | Registry-backed pass. |
+| `bible_view_swipe_mode` | XML `settings.xml:94-100`; default `CHAPTER`. | Registry-backed adapted pass. |
+| `volume_keys_scroll` | XML `settings.xml:101-106`; Android handles hardware volume-key scrolling. | Registry-backed documented divergence: iOS keeps persistence/UI for sync continuity but cannot intercept volume buttons for app actions. |
+| `night_mode_pref3` | XML `settings.xml:107-113`; runtime entries/default are replaced at `SettingsActivity.kt:233-242`. | Registry-backed adapted pass. |
+| `global_text_display_settings` | XML `settings.xml:118-122`; action starts global `TextDisplaySettingsActivity` at `SettingsActivity.kt:299-308`. | Outside registry, adapted on iOS. Global display settings use `SettingsStore.globalTextDisplaySettingsKey`; Settings links live in `SettingsView.lookAndFeelSection`. |
+| `locale_pref` | XML `settings.xml:124-130`; option arrays are `arrays.xml:121-230`. | Registry-backed partial. iOS persists/applies locale overrides, but its option list is stale against Android arrays; tracked by #164. |
+| `disable_click_to_edit` | XML `settings.xml:131-137`; Android emits `disableClickToEdit` into `appSettings`. | Registry-backed pass. |
+| `notes_content_type` | XML `settings.xml:138-145`; default `HTML`; values `HTML`/`MARKDOWN` at `arrays.xml:264-271`; Android emits `notesContentType` at `BibleView.kt:1537`. | Missing on iOS; tracked by #163. Not e-ink related. |
+| `font_size_multiplier` | XML `settings.xml:146-153`; default `100`, min `10`, max `500`; summary updates at `SettingsActivity.kt:255-268`. | Registry-backed pass. |
+| `full_screen_hide_buttons_pref` | XML `settings.xml:154-159`; effective default `true`. | Registry-backed pass. |
+| `hide_window_buttons` | XML `settings.xml:160-165`; default `false`. | Registry-backed pass. |
+| `hide_bible_reference_overlay` | XML `settings.xml:166-171`; default `false`. | Registry-backed pass. |
+| `show_active_window_indicator` | XML `settings.xml:172-177`; default `true`. | Registry-backed pass. |
+| `disable_bible_bookmark_modal_buttons` | XML `settings.xml:178-184`; Android inverse multi-select action IDs from `arrays.xml:231-250`. | Registry-backed pass. |
+| `disable_gen_bookmark_modal_buttons` | XML `settings.xml:185-191`; Android inverse multi-select action IDs from `arrays.xml:251-262`. | Registry-backed pass. |
+| `monochrome_mode` | XML `settings.xml:195-200`; Android runtime default is `isOnyxDevice` at `CommonUtils.kt:452`. | Registry-backed adapted pass. iOS default remains `false` because iOS has no Onyx-device default path. |
+| `eink_mode` | XML `settings.xml:201-206`; Android emits `einkMode` at `BibleView.kt:1531`; Vue uses it for scroll helper lines/page buttons at `BibleView.vue:74-83`. | Documented divergence. Do not implement as dead iOS UI; see `dispositions.md`. |
+| `disable_animations` | XML `settings.xml:207-212`; Android runtime default is `isOnyxDevice` at `CommonUtils.kt:454`. | Registry-backed adapted pass. iOS default remains `false` because iOS has no Onyx-device default path. |
+| `discrete_help` | XML `settings.xml:216-221`; click behavior is `SettingsActivity.kt:325-353`. | Registry-backed adapted action. |
+| `discrete_mode` | XML `settings.xml:222-227`; hidden in discrete flavor at `SettingsActivity.kt:310-314`. | Registry-backed adapted pass. |
+| `show_calculator` | XML `settings.xml:228-232`; hidden/summary adjusted at `SettingsActivity.kt:315-324`. | Registry-backed pass. |
+| `calculator_pin` | XML `settings.xml:233-238`; numeric editor enforced at `SettingsActivity.kt:280-282`. | Registry-backed pass. |
+| `sync_settings_shortcut` | XML `settings.xml:241-245`; starts `SyncSettingsActivity` at `SettingsActivity.kt:284-287`. | Outside registry, adapted by iOS Settings data link to `SyncSettingsView`; broader shortcut presentation is tracked by #155. |
+| `ai_settings_shortcut` | XML `settings.xml:246-250`; starts `AiSettingsActivity` at `SettingsActivity.kt:289-292`. | Outside registry, deferred to the iOS AI parity track (#5, #74, #89-#92) and settings presentation track (#155). |
+| `reading_progress_settings_shortcut` | XML `settings.xml:251-255`; starts `ReadingProgressSettingsActivity` at `SettingsActivity.kt:294-297`. | Outside registry, partially adapted through the reader bridge/native reading-progress settings; top-level settings shortcut alignment is tracked by #155. |
+| `experimental_features` | XML `settings.xml:258-265`; option arrays are `arrays.xml:273-280`. | Registry-backed pass. |
+| `enable_bluetooth_pref` | XML `settings.xml:266-270`; default `true`. | Registry-backed adapted pass through iOS remote command handling. |
+| `request_sdcard_permission_pref` | XML `settings.xml:271-274`; hidden on Android Q+ at `SettingsActivity.kt:275-278`. | Registry-backed documented divergence. iOS has no SD-card permission model. |
+| `show_errorbox` | XML `settings.xml:275-280`; visible only for beta at `SettingsActivity.kt:243-244`. | Registry-backed adapted pass; iOS exposes only in debug builds. |
+| `open_links` | XML `settings.xml:281-286`; visible on Android S+ and opens app-link settings at `SettingsActivity.kt:368-383`. | Registry-backed adapted action; iOS opens app settings. |
+| `crash_app` | XML `settings.xml:287-291`; visible only for beta/debug at `SettingsActivity.kt:355-367`. | Registry-backed adapted action; iOS debug-only delayed crash. |
 
 ## List / Multi-Select Option Contracts
 
-| Key | Options contract | Reference |
+| Key | Options contract | Reference | iOS disposition |
+|---|---|---|---|
+| `toolbar_button_actions` | `default`, `swap-menu`, `swap-activity` | `arrays.xml:65-74` | Implemented. |
+| `bible_view_swipe_mode` | `CHAPTER`, `PAGE`, `NONE` | `arrays.xml:77-87` | Implemented with native iOS gestures. |
+| `night_mode_pref3` | runtime-dependent `system`/`automatic`/`manual` or `system`/`manual` | `arrays.xml:90-116`, `SettingsActivity.kt:233-242` | Adapted: iOS supports system/manual and documents excluded automatic behavior. |
+| `locale_pref` | Android language label/value arrays | `arrays.xml:121-230` | Partial: option drift tracked by #164. |
+| `notes_content_type` | `HTML`, `MARKDOWN` | `arrays.xml:264-271` | Missing: tracked by #163. |
+| `disable_bible_bookmark_modal_buttons` | Bible one-tap action IDs | `arrays.xml:231-250` | Implemented. |
+| `disable_gen_bookmark_modal_buttons` | Generic one-tap action IDs | `arrays.xml:251-262` | Implemented. |
+| `experimental_features` | `bookmark_edit_actions`, `add_paragraph_break` | `arrays.xml:273-280` | Implemented. |
+
+## Android Runtime Visibility / Dynamic Rules
+
+| Rule | Reference | iOS disposition |
 |---|---|---|
-| `toolbar_button_actions` | `default`, `swap-menu`, `swap-activity` with mapped descriptions | `arrays.xml:44-53` |
-| `bible_view_swipe_mode` | `CHAPTER`, `PAGE`, `NONE` | `arrays.xml:56-66` |
-| `night_mode_pref3` | runtime-dependent set from `system/automatic/manual` or `system/manual` | `arrays.xml:69-95`, `SettingsActivity.kt:225-234` |
-| `locale_pref` | description/value arrays in strict positional order | `arrays.xml:100-189` |
-| `disable_bible_bookmark_modal_buttons` | action names/ids arrays | `arrays.xml:190-209` |
-| `disable_gen_bookmark_modal_buttons` | action names/ids arrays | `arrays.xml:210-221` |
-| `experimental_features` | names/ids arrays | `arrays.xml:224-231` |
+| `night_mode_pref3` entries/default are adjusted by `autoModeAvailable`. | `SettingsActivity.kt:233-242` | Adapted. |
+| `show_errorbox` visible only in beta builds. | `SettingsActivity.kt:243-244` | Adapted to debug builds. |
+| Dictionary category hidden if no dictionary modules are available. | `SettingsActivity.kt:245-254` | Implemented. |
+| `font_size_multiplier` summary shows the current multiplier. | `SettingsActivity.kt:255-268` | Implemented with a SwiftUI stepper value. |
+| `request_sdcard_permission_pref` hidden on Android Q+. | `SettingsActivity.kt:275-278` | iOS divergence. |
+| `calculator_pin` editor forced to numeric input. | `SettingsActivity.kt:280-282` | Implemented. |
+| Sync, AI, and Reading Progress shortcuts open adjacent settings screens. | `SettingsActivity.kt:284-297` | Sync adapted; AI and top-level Reading Progress shortcut alignment tracked by #155 and AI parity issues. |
+| `global_text_display_settings` opens global text-display settings. | `SettingsActivity.kt:299-308` | Adapted through Look & feel settings links and `SettingsStore.globalTextDisplaySettingsKey`. |
+| `discrete_mode` and `show_calculator` hidden in discrete flavor. | `SettingsActivity.kt:310-324` | Adapted through iOS app-icon/calculator behavior. |
+| `discrete_help` shows flavor-dependent help dialog. | `SettingsActivity.kt:325-353` | Adapted as iOS help sheet. |
+| `crash_app` visible only in beta/debug. | `SettingsActivity.kt:355-367` | Adapted to debug builds. |
+| `open_links` visible only on Android S+; otherwise hidden. | `SettingsActivity.kt:368-383` | Adapted to iOS app settings. |
 
 ## Ownership And Review Checklist
 
@@ -95,8 +140,11 @@ Primary sources:
 
 Checklist for parity updates:
 
-- Confirm `settings.xml` key set still matches this contract.
+- Confirm `settings.xml` actionable row set still matches this inventory.
+- Confirm new Android rows are either added to `AppPreferenceRegistry`, tracked by a
+  follow-up issue, or documented as an intentional divergence.
 - Confirm defaults in XML/runtime code still match this contract.
 - Confirm labels/summaries and option arrays still match this contract.
 - Confirm runtime visibility/dynamic rules still match this contract.
-- Update iOS backlog tickets when Android contract changes.
+- Confirm the verification matrix does not summarize parity as a 35-key Android
+  contract unless Android source still proves that count.

--- a/docs/parity/settings/dispositions.md
+++ b/docs/parity/settings/dispositions.md
@@ -57,6 +57,26 @@ This file records explicit iOS disposition decisions for Android parity tickets 
   - This preference is intentionally not surfaced in iOS settings UI.
   - No iOS runtime consumer is added.
 
+## SETPAR-154 — `eink_mode`
+
+- Android contract:
+  - Key: `eink_mode`
+  - Source: `and-bible/app/src/main/res/xml/settings.xml:201-206`
+  - Runtime preference reader: `and-bible/app/src/main/java/net/bible/service/common/CommonUtils.kt:453`
+  - Reader payload: `and-bible/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt:1531`
+  - Vue consumers: `and-bible/app/bibleview-js/src/components/BibleView.vue:74-83`
+- Android behavior:
+  - Enables Android e-ink-specific reader affordances, specifically scroll helper lines and page scroll buttons when the corresponding text-display settings are enabled.
+  - This is distinct from `monochrome_mode` and `disable_animations`, which are already represented on iOS.
+- iOS disposition (Android-only divergence):
+  - Do not add `eink_mode` to `AppPreferenceRegistry`, Settings UI, or the iOS reader payload unless iOS gains equivalent e-ink-specific behavior.
+  - Adding a no-op switch would create dead UI and would not improve behavioral parity.
+  - `monochrome_mode` and `disable_animations` remain the supported cross-platform rendering preferences on iOS.
+- Tracking:
+  - #154 records the source-backed audit.
+  - #156 should not be implemented as written because it bundles this Android-only e-ink setting with the separate `notes_content_type` gap.
+  - #163 tracks the real `notes_content_type` follow-up independently.
+
 ## SETPAR-505 — `open_links`
 
 - Android contract:

--- a/docs/parity/settings/verification-matrix.md
+++ b/docs/parity/settings/verification-matrix.md
@@ -1,69 +1,101 @@
 # SETPAR-701 Verification Matrix (Android Application Preferences -> iOS)
 
-Date: 2026-03-11
+Date: 2026-05-31
 
 ## Scope and Method
 
-- Contract baseline: `docs/parity/settings/contract.md`.
-- Key inventory: `Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift` (`AppPreferenceKey.allCases` = 35).
-- Verification method: direct code inspection of iOS UI persistence points and runtime consumers, backed by simulator regression evidence in `docs/parity/settings/regression-report.md`.
+- Android source baseline: `docs/parity/settings/contract.md`, re-audited from
+  `and-bible/app/src/main/res/xml/settings.xml:23-293`.
+- Android actionable preference rows: 41.
+- iOS registry baseline: `Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift`
+  (`AppPreferenceKey.allCases` = 35).
+- Verification method: direct inspection of Android XML/runtime sources, iOS registry,
+  iOS Settings UI, iOS reader payload, and the Android/iOS Vue `appSettings` contracts.
+
+The previous matrix treated the 35 iOS registry keys as the complete Android contract.
+That was incorrect. The matrix now distinguishes registry-backed iOS parity from
+Android rows that are action shortcuts, deferred feature gaps, or platform-specific
+divergences.
 
 ## Status Legend
 
-- `Pass`: key has iOS UI/action + persisted value + runtime consumer.
+- `Pass`: key has iOS UI/action + persisted value + runtime consumer where applicable.
 - `Adapted Pass`: parity delivered with explicit iOS platform adaptation.
-- `Partial`: key exists, but parity is incomplete (for example runtime-only without iOS UI, or behavior drift).
+- `Partial`: iOS has some behavior, but the source-backed Android contract is not complete.
+- `Tracked Gap`: not implemented on iOS and tracked by a follow-up issue.
 - `Documented Divergence`: intentionally not implemented on iOS; disposition documented.
+- `Outside Registry`: Android action row is handled outside `AppPreferenceRegistry`.
 
 ## Summary
 
-- `Pass`: 24/35
-- `Adapted Pass`: 9/35
-- `Partial`: 0/35
-- `Documented Divergence`: 2/35
+- Android actionable rows inventoried: 41/41.
+- iOS registry-backed rows: 35.
+- Registry-backed `Pass`: 21.
+- Registry-backed `Adapted Pass`: 11.
+- Registry-backed `Partial`: 1 (`locale_pref`, tracked by #164).
+- Registry-backed `Documented Divergence`: 2 (`volume_keys_scroll`, `request_sdcard_permission_pref`).
+- Non-registry tracked gap: 1 (`notes_content_type`, tracked by #163).
+- Non-registry documented divergence: 1 (`eink_mode`).
+- Android action shortcuts outside registry: 4 (`global_text_display_settings`,
+  `sync_settings_shortcut`, `ai_settings_shortcut`, `reading_progress_settings_shortcut`).
 
 ## Key-by-Key Matrix
 
-| Key | iOS Evidence (UI/persistence) | iOS Evidence (runtime consumer) | Status | Notes |
-|---|---|---|---|---|
-| `strongs_greek_dictionary` | `SettingsView.swift:161-187,745,802,1152` | `BibleReaderController.swift:2658-2670` | Pass | Selected-set semantics match Android (empty = runtime default/all). |
-| `strongs_hebrew_dictionary` | `SettingsView.swift:190-215,746,806,1161` | `BibleReaderController.swift:2658-2670` | Pass | Same pattern as Greek selection. |
-| `robinson_greek_morphology` | `SettingsView.swift:218-243,747,810,1170` | `BibleReaderController.swift:2701-2720` | Pass | Multi-select + stale-value fallback behavior present. |
-| `disabled_word_lookup_dictionaries` | `SettingsView.swift:246-271,748,814,1178` | `BibleReaderController.swift:2746-2764,2773-2795` | Pass | Inverse selection is consumed by lookup path. |
-| `navigate_to_verse_pref` | `SettingsView.swift:276-295,761` | `BibleReaderView.swift:75,241,334-340`; `BookChooserView.swift:46-60` | Pass | Verse-step chooser flow is wired. |
-| `open_links_in_special_window_pref` | `SettingsView.swift:460-477,750` | `BibleWindowPane.swift:341-347` | Pass | Switches between current-window navigation and links-window behavior. |
-| `screen_keep_on_pref` | `SettingsView.swift:297-313,761,1121-1124` | `BibleReaderView.swift:250` | Pass | Uses `UIApplication.isIdleTimerDisabled`. |
-| `double_tap_to_fullscreen` | `SettingsView.swift:315-333,763` | `BibleReaderController.swift:3231-3234` | Pass | Double-tap bridge event is preference-gated. |
-| `auto_fullscreen_pref` | `SettingsView.swift:335-350,764` | `BibleReaderView.swift:1627-1654` | Pass | Direction-aware threshold logic implemented. |
-| `toolbar_button_actions` | `SettingsView.swift:352-377,767,1211-1217` | `BibleReaderView.swift:1459-1497,1499-1563` | Adapted Pass | Android chooser/activity concept adapted to iOS sheet/module picker. |
-| `disable_two_step_bookmarking` | `SettingsView.swift:379-397,765` | `BibleWindowPane.swift:395-447` | Pass | One-step and two-step bookmark flows implemented. |
-| `bible_view_swipe_mode` | `SettingsView.swift:399-424,769,1202-1208` | `BibleReaderView.swift:1656-1676`; `WebViewCoordinator.swift:82-109,122-137` | Adapted Pass | Native iOS swipe recognizers/scroll delegate bridge into chapter/page/none actions. |
-| `volume_keys_scroll` | `SettingsView.swift:426-451,770` | No runtime consumer; disposition in `dispositions.md:5-20` | Documented Divergence | Kept for parity/sync continuity; iOS cannot intercept hardware volume keys for app actions. |
-| `night_mode_pref3` | `SettingsView.swift:832-857,773,1192-1200` | `BibleReaderView.swift:65,234-240,1612-1618`; `ContentView.swift:20,46-63`; `NightModeSettings.swift:19-60` | Adapted Pass | `automatic` mode excluded by platform constraint (`autoModeAvailable = false`). |
-| `locale_pref` | `SettingsView.swift:1024-1050,782-797,1241-1281` | Applied via `AppleLanguages` override in `SettingsView.swift:1043-1049` | Pass | Android locale-value mapping and legacy code normalization are implemented. |
-| `monochrome_mode` | `SettingsView.swift:860-877,751,867` | `BibleReaderController.swift:4069,4102` | Pass | Emitted into Vue appSettings payload. |
-| `disable_animations` | `SettingsView.swift:878-895,752,885` | `BibleReaderController.swift:4070,4102` | Pass | Emitted into Vue appSettings payload. |
-| `disable_click_to_edit` | `SettingsView.swift:896-914,753,906` | `BibleReaderController.swift:4071,4102` | Pass | Emitted into Vue appSettings payload. |
-| `font_size_multiplier` | `SettingsView.swift:917-939,757,923` | `BibleReaderController.swift:4072-4073,4102` | Pass | 10-500 clamp and runtime min-guard present. |
-| `full_screen_hide_buttons_pref` | `SettingsView.swift:940-960,758,950` | `BibleReaderView.swift:139-141,246,1609` | Pass | Fullscreen tab-bar visibility follows preference. |
-| `hide_window_buttons` | `SettingsView.swift:961-980,759,971` | `BibleReaderView.swift:699`; `BibleWindowPane.swift:79-83` | Pass | Window hamburger control visibility follows preference. |
-| `hide_bible_reference_overlay` | `SettingsView.swift:982-1002,760,992` | `BibleReaderView.swift:143-147,199-210,1611` | Pass | Fullscreen Bible reference capsule overlay is preference-gated. |
-| `show_active_window_indicator` | `SettingsView.swift:1003-1023,754,1013` | `BibleReaderController.swift:4030-4033,4064-4065,4102` | Pass | Indicator propagated via both `set_active` event and config payload. |
-| `disable_bible_bookmark_modal_buttons` | `SettingsView.swift:1071-1093,780,852,1292-1304` | `BibleReaderController.swift:4074,4102` | Pass | Inverse multi-select editor now matches Android action IDs and persists disabled button set. |
-| `disable_gen_bookmark_modal_buttons` | `SettingsView.swift:1096-1118,781,857,1299-1304` | `BibleReaderController.swift:4075,4102` | Pass | Inverse multi-select editor now matches Android action IDs and persists disabled button set. |
-| `discrete_help` | `SettingsView.swift:483-499,688-709` | Action-only key shape validated by `AndBibleTests.swift:25-45` | Adapted Pass | Implemented as help action + sheet content. |
-| `discrete_mode` | `SettingsView.swift:500-503` | `AndBibleApp.swift:29,163-165,176-190` | Adapted Pass | iOS icon switching implemented via alternate icon API. |
-| `show_calculator` | `SettingsView.swift:505-508` | `AndBibleApp.swift:31,143-149` | Pass | Startup calculator gate follows persisted preference. |
-| `calculator_pin` | `SettingsView.swift:510-525` | `CalculatorView.swift:31-32,133-146` | Pass | Numeric PIN entry and unlock behavior are wired. |
-| `experimental_features` | `SettingsView.swift:551-571,771,818,1182-1189` | `BibleReaderController.swift:4076,4102` | Pass | Multi-select IDs are sanitized and emitted in appSettings. |
-| `enable_bluetooth_pref` | `SettingsView.swift:529-549,756,540` | `SpeakService.swift:85,107-113` | Adapted Pass | Android media-button behavior adapted to iOS `MPRemoteCommandCenter`. |
-| `request_sdcard_permission_pref` | Not surfaced in iOS settings UI | Disposition documented in `dispositions.md:49-58` | Documented Divergence | No iOS SD-card permission model equivalent. |
-| `show_errorbox` | `SettingsView.swift:603-624,789` | `BibleReaderController.swift:4068,4102` | Adapted Pass | Visibility is now debug-only (`#if DEBUG`) to match Android beta-only visibility contract. |
-| `open_links` | `SettingsView.swift:595-617,1127-1131` | iOS adaptation in `dispositions.md:60-72` | Adapted Pass | Opens iOS app settings as closest supported equivalent. |
-| `crash_app` | `SettingsView.swift:620-649,1134-1140` | iOS adaptation in `dispositions.md:73-84` | Adapted Pass | Debug-only destructive action with 10-second delay and single-shot guard. |
+| Key | iOS Evidence | Status | Notes |
+|---|---|---|---|
+| `strongs_greek_dictionary` | `AppPreferenceRegistry`; `SettingsView` dictionary section; `BibleReaderController` dictionary selection | Pass | Empty selected set retains Android all-enabled semantics. |
+| `strongs_hebrew_dictionary` | `AppPreferenceRegistry`; `SettingsView` dictionary section; `BibleReaderController` dictionary selection | Pass | Same pattern as Greek dictionary selection. |
+| `robinson_greek_morphology` | `AppPreferenceRegistry`; `SettingsView` dictionary section; `BibleReaderController` morphology lookup | Pass | Stale selections are sanitized against installed modules. |
+| `disabled_word_lookup_dictionaries` | `AppPreferenceRegistry`; `SettingsView` inverse dictionary selector; `BibleReaderController` lookup path | Pass | Stored set is disabled modules, matching Android inverse preference. |
+| `navigate_to_verse_pref` | `AppPreferenceRegistry`; `SettingsView`; reader/book chooser navigation | Pass | Verse-step chooser flow is wired. |
+| `open_links_in_special_window_pref` | `AppPreferenceRegistry`; `SettingsView`; `BibleWindowPane` link handling | Pass | Switches current-window versus links-window behavior. |
+| `screen_keep_on_pref` | `AppPreferenceRegistry`; `SettingsView.applyScreenKeepOn`; `BibleReaderView` idle timer state | Pass | Uses `UIApplication.isIdleTimerDisabled`. |
+| `double_tap_to_fullscreen` | `AppPreferenceRegistry`; `SettingsView`; `BibleReaderController` double-tap gate | Pass | Preference gates fullscreen gesture handling. |
+| `auto_fullscreen_pref` | `AppPreferenceRegistry`; `SettingsView`; `BibleReaderView` auto-fullscreen logic | Pass | Native scroll threshold implementation. |
+| `toolbar_button_actions` | `AppPreferenceRegistry`; `SettingsView` picker; `BibleReaderView` toolbar behavior | Adapted Pass | Android menu/activity concept adapted to iOS sheet/module picker. |
+| `disable_two_step_bookmarking` | `AppPreferenceRegistry`; `SettingsView`; `BibleWindowPane` bookmark flow | Pass | One-step and two-step bookmark flows implemented. |
+| `bible_view_swipe_mode` | `AppPreferenceRegistry`; `SettingsView` picker; `BibleReaderView`/`WebViewCoordinator` gestures | Adapted Pass | Implemented with native iOS swipe recognizers. |
+| `volume_keys_scroll` | `AppPreferenceRegistry`; `SettingsView` persistence plus iOS note; `dispositions.md` | Documented Divergence | iOS cannot intercept hardware volume buttons for arbitrary app scrolling. |
+| `night_mode_pref3` | `AppPreferenceRegistry`; `SettingsView`; `NightModeSettingsResolver`; app color-scheme state | Adapted Pass | Android automatic sensor mode is excluded by platform constraint. |
+| `global_text_display_settings` | `SettingsStore.globalTextDisplaySettingsKey`; `SettingsView.lookAndFeelSection`; `TextDisplaySettingsView`/`ColorSettingsView` | Outside Registry | Android action row is adapted as iOS Look & feel navigation, not a registry preference. |
+| `locale_pref` | `AppPreferenceRegistry`; `SettingsView.localeOptions`; `AppleLanguages` override | Partial | Persistence works, but Android locale arrays are not fully represented; tracked by #164. |
+| `disable_click_to_edit` | `AppPreferenceRegistry`; `SettingsView`; iOS Vue `appSettings.disableClickToEdit` | Pass | Emitted into iOS reader payload. |
+| `notes_content_type` | No iOS registry key; no iOS Vue `appSettings.notesContentType`; Android source emits and consumes it | Tracked Gap | Real note-editor parity gap tracked by #163. |
+| `font_size_multiplier` | `AppPreferenceRegistry`; `SettingsView` stepper; iOS Vue `fontSizeMultiplier` payload | Pass | 10-500 clamp and percent-to-float conversion implemented. |
+| `full_screen_hide_buttons_pref` | `AppPreferenceRegistry`; `SettingsView`; `BibleReaderView` fullscreen controls | Pass | Fullscreen button-bar visibility follows preference. |
+| `hide_window_buttons` | `AppPreferenceRegistry`; `SettingsView`; `BibleWindowPane` window control visibility | Pass | In-window button visibility follows preference. |
+| `hide_bible_reference_overlay` | `AppPreferenceRegistry`; `SettingsView`; `BibleReaderView` overlay gate | Pass | Fullscreen reference overlay follows preference. |
+| `show_active_window_indicator` | `AppPreferenceRegistry`; `SettingsView`; `BibleReaderController.emitActiveState` and config payload | Pass | Propagated through config and `set_active`. |
+| `disable_bible_bookmark_modal_buttons` | `AppPreferenceRegistry`; `SettingsView` inverse selector; iOS Vue modal button payload | Pass | Android action IDs are persisted as disabled set. |
+| `disable_gen_bookmark_modal_buttons` | `AppPreferenceRegistry`; `SettingsView` inverse selector; iOS Vue modal button payload | Pass | Android action IDs are persisted as disabled set. |
+| `monochrome_mode` | `AppPreferenceRegistry`; `SettingsView`; iOS Vue `monochromeMode` payload | Adapted Pass | iOS default is `false`; Android Onyx-device default does not apply. |
+| `eink_mode` | No iOS registry/UI/payload; Android Vue uses it for e-ink helper lines/page buttons | Documented Divergence | iOS has no e-ink-specific reader controls; see `dispositions.md`. |
+| `disable_animations` | `AppPreferenceRegistry`; `SettingsView`; iOS Vue `disableAnimations` payload | Adapted Pass | iOS default is `false`; Android Onyx-device default does not apply. |
+| `discrete_help` | `AppPreferenceRegistry` action; `SettingsView` help sheet | Adapted Pass | Android dialog is adapted to native iOS sheet. |
+| `discrete_mode` | `AppPreferenceRegistry`; `SettingsView`; `AndBibleApp` alternate icon behavior | Adapted Pass | Android launcher identity behavior adapted to iOS alternate icon API. |
+| `show_calculator` | `AppPreferenceRegistry`; `SettingsView`; `AndBibleApp` startup calculator gate | Pass | Startup calculator gate follows persisted preference. |
+| `calculator_pin` | `AppPreferenceRegistry`; `SettingsView` numeric field; `CalculatorView` unlock | Pass | Numeric PIN entry and unlock behavior are wired. |
+| `sync_settings_shortcut` | `SettingsView` Data section links to `SyncSettingsView` | Outside Registry | Shortcut adapted outside registry; presentation alignment tracked by #155. |
+| `ai_settings_shortcut` | No direct iOS Application preferences shortcut | Outside Registry | Deferred to AI parity issues (#5, #74, #89-#92) and settings presentation issue #155. |
+| `reading_progress_settings_shortcut` | Reader bridge presents native `ReadingProgressSettingsView`; no top-level Settings shortcut | Outside Registry | Runtime feature exists; top-level shortcut alignment tracked by #155. |
+| `experimental_features` | `AppPreferenceRegistry`; `SettingsView` multi-select; iOS Vue `enabledExperimentalFeatures` payload | Pass | Android feature IDs are sanitized and emitted. |
+| `enable_bluetooth_pref` | `AppPreferenceRegistry`; `SettingsView`; `SpeakService` remote command handling | Adapted Pass | Android media-button behavior adapted to iOS remote command center. |
+| `request_sdcard_permission_pref` | `AppPreferenceRegistry`; not surfaced; `dispositions.md` | Documented Divergence | iOS has no SD-card permission model equivalent. |
+| `show_errorbox` | `AppPreferenceRegistry`; debug-only `SettingsView`; iOS Vue `errorBox` payload | Adapted Pass | Android beta-only visibility adapted to iOS debug builds. |
+| `open_links` | `AppPreferenceRegistry` action; `SettingsView.openBibleLinkSystemSettings` | Adapted Pass | iOS opens app settings as closest supported equivalent. |
+| `crash_app` | `AppPreferenceRegistry` action; debug-only `SettingsView.triggerDebugCrash` | Adapted Pass | Debug-only destructive action with delayed crash and single-shot guard. |
 
-## Open Gaps Identified by This Matrix
+## Open Gaps Identified By This Matrix
 
-No functional gaps remain for the 35-key Android application-preferences contract. Remaining entries are documented platform divergences (`volume_keys_scroll`, `request_sdcard_permission_pref`).
+- #163: implement `notes_content_type` only after the iOS note editor supports the
+  same HTML/Markdown default behavior Android exposes.
+- #164: reconcile `locale_pref` option arrays with Android source and actual iOS
+  localization resources.
+- #155: decide how far iOS Application preferences should align Android's shortcut
+  presentation for Sync, AI settings, Reading Progress settings, search, reset, and
+  broader admin-flow placement.
+- `eink_mode` is not an implementation gap today. It is an Android-only e-ink
+  behavior and is intentionally documented as a divergence.
 
-Regression hardening note: Strong's "Find all occurrences" now has a module-backed simulator test to prevent recurrence of the `H02022` no-results failure.
+Regression hardening note: Strong's "Find all occurrences" retains module-backed
+simulator coverage to prevent recurrence of the `H02022` no-results failure.


### PR DESCRIPTION
## Summary

Re-audits Android Application preferences from source and updates iOS parity docs so they no longer treat the 35-key iOS registry as the complete Android contract. Also updates iOS CI so required check contexts are reported for docs-only PRs instead of being skipped by workflow path filters.

## Scope

- Documents the 41 actionable Android settings rows from `settings.xml`.
- Separates Android source inventory from the 35-key iOS `AppPreferenceRegistry` implementation layer.
- Records `eink_mode` as an intentional iOS divergence.
- Routes real follow-up gaps to #163 (`notes_content_type`) and #164 (`locale_pref`).
- References #155 for Android Features shortcut/presentation alignment.
- Ensures iOS CI starts for Markdown/docs-only PRs and short-circuits expensive simulator work when the change set is docs-only.

## Contract References

- Android: `settings.xml`, `SettingsActivity.kt`, `CommonUtils.kt`, `BibleView.kt`, Android `bibleview-js` config/components.
- iOS: `AppPreferenceRegistry.swift`, `SettingsView.swift`, `BibleReaderController.swift`, iOS `bibleview-js` config.
- CI: `.github/workflows/ios-ci.yml` required check contexts for repo standards, localization guardrails, BibleView JS, unit tests, and UI test shards.

## Change Details

- Rewrites `docs/parity/settings/contract.md` around a source-backed 41-row inventory.
- Replaces the verification matrix summary/table so registry-backed parity, outside-registry shortcuts, tracked gaps, and documented divergences are distinct.
- Adds an `eink_mode` disposition explaining why iOS should not implement a no-op e-ink switch.
- Closed #156 as not planned because its e-ink and note-content concerns are now split correctly.
- Removes workflow-level docs path filters from iOS CI.
- Adds a change classifier and docs-only pass paths while preserving the normal required job names and UI shard matrix names.

## Validation Evidence

- `git diff --check`
- Ruby YAML parse of `.github/workflows/ios-ci.yml`.
- `python3 scripts/build_ui_test_shards.py --test-file AndBibleUITests/AndBibleUITests*.swift --timings-file scripts/ui_test_timings.json --shard-count 2 --target-shard-duration-seconds 600 --timeout-minutes 90`
- Simulated classifier output: mixed workflow/docs change resolves to `false`; original docs-only commit resolves to `true`.
- GitNexus `detect_changes` on `and-bible-ios-154`: low risk, docs audit changed docs files with no affected execution flows.
- GitNexus `detect_changes` after the CI update: low risk, one workflow file, no affected execution flows.
- Source inspection against Android and iOS files listed above.

## Risks / Follow-ups

- Runtime app behavior is unchanged.
- CI behavior changes only for docs-only PRs: required contexts are now created, and expensive simulator jobs use docs-only pass paths.
- Code or workflow changes still run full iOS CI.
- Follow-up implementation issues: #163 and #164.
- Settings presentation/workflow alignment remains tracked by #155.

Closes #154
