### PR TITLE
feat(settings): align application preferences workflows

### DIFF
--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -61,6 +61,66 @@ extension AndBibleTests {
         }
     }
 
+    func testApplicationPreferencesResetContractExcludesActionRowsAndIncludesVisibleParityKeys() {
+        let resetKeys = AppPreferenceRegistry.applicationPreferencesResetKeys
+
+        XCTAssertTrue(resetKeys.contains(.navigateToVersePref))
+        XCTAssertTrue(resetKeys.contains(.volumeKeysScroll))
+        XCTAssertTrue(resetKeys.contains(.localePref))
+        XCTAssertTrue(resetKeys.contains(.calculatorPin))
+        XCTAssertTrue(resetKeys.contains(.experimentalFeatures))
+        XCTAssertFalse(resetKeys.contains(.discreteHelp))
+        XCTAssertFalse(resetKeys.contains(.openLinks))
+        XCTAssertFalse(resetKeys.contains(.crashApp))
+        XCTAssertEqual(Set(resetKeys).count, resetKeys.count)
+    }
+
+    func testSettingsStoreResetApplicationPreferencesRestoresRegistryDefaults() throws {
+        let userDefaultsKeys: [AppPreferenceKey] = [.localePref, .showCalculator, .calculatorPin, .discreteMode]
+        userDefaultsKeys.forEach { UserDefaults.standard.removeObject(forKey: $0.rawValue) }
+        defer {
+            userDefaultsKeys.forEach { UserDefaults.standard.removeObject(forKey: $0.rawValue) }
+        }
+
+        let settingsStore = try makeInMemorySettingsStore()
+        settingsStore.setBool(.navigateToVersePref, value: true)
+        settingsStore.setString(.toolbarButtonActions, value: "swap-menu")
+        settingsStore.setInt(.fontSizeMultiplier, value: 180)
+        settingsStore.setStringSet(.experimentalFeatures, values: ["feature_b", "feature_a"])
+        settingsStore.setString(.localePref, value: "fi")
+        settingsStore.setBool(.showCalculator, value: true)
+        settingsStore.setString(.calculatorPin, value: "9999")
+        settingsStore.setBool(.discreteMode, value: true)
+        settingsStore.setString(SettingsStore.globalTextDisplaySettingsKey, value: #"{"fontSize":22}"#)
+
+        settingsStore.resetApplicationPreferences()
+
+        XCTAssertEqual(settingsStore.getBool(.navigateToVersePref), false)
+        XCTAssertEqual(settingsStore.getString(.toolbarButtonActions), "default")
+        XCTAssertEqual(settingsStore.getInt(.fontSizeMultiplier), 100)
+        XCTAssertEqual(settingsStore.getStringSet(.experimentalFeatures), [])
+        XCTAssertEqual(settingsStore.getString(.localePref), "")
+        XCTAssertEqual(settingsStore.getBool(.showCalculator), false)
+        XCTAssertEqual(settingsStore.getString(.calculatorPin), "1234")
+        XCTAssertEqual(settingsStore.getBool(.discreteMode), false)
+        XCTAssertNotNil(settingsStore.getString(SettingsStore.globalTextDisplaySettingsKey))
+    }
+
+    func testSettingsSearchMatcherRequiresAllNormalizedTermsAcrossEntryText() {
+        let entry = AndBibleSettingsSearchEntry(
+            identifier: "settingsReadingProgressLink",
+            title: "Reading Progress Settings",
+            summary: "Configure automatic reading tracking",
+            detail: "Memorization",
+            keywords: ["features", "progress"]
+        )
+
+        XCTAssertTrue(AndBibleSettingsSearchMatcher.matches(query: "", entry: entry))
+        XCTAssertTrue(AndBibleSettingsSearchMatcher.matches(query: "reading tracking", entry: entry))
+        XCTAssertTrue(AndBibleSettingsSearchMatcher.matches(query: "FEATURES progress", entry: entry))
+        XCTAssertFalse(AndBibleSettingsSearchMatcher.matches(query: "sync tracking", entry: entry))
+    }
+
     func testTextDisplayAppDefaultsStartWithStrongsDisabled() {
         XCTAssertEqual(TextDisplaySettings.appDefaults.strongsMode, 0)
     }
@@ -288,18 +348,14 @@ extension AndBibleTests {
         XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderOverflowMenu"))
     }
 
-    func testBibleReaderActiveSheetContentBuildsSettingsSheet() {
+    func testBibleReaderActiveSheetContentBuildsDownloadsSheet() {
         let view = BibleReaderActiveSheetContent(
-            sheet: .settings,
+            sheet: .downloads,
             controller: nil,
-            displaySettings: Binding.constant(TextDisplaySettings()),
-            nightMode: Binding.constant(false),
-            nightModeMode: Binding.constant("system"),
             readingProgressInitialTab: .reading,
             chapterReadHistoryTarget: nil,
             downloadsInitialSearchText: "",
-            onDismiss: {},
-            onSettingsChanged: {}
+            onDismiss: {}
         )
 
         XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderActiveSheetContent"))

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -121,6 +121,51 @@ extension AndBibleTests {
         XCTAssertFalse(AndBibleSettingsSearchMatcher.matches(query: "sync tracking", entry: entry))
     }
 
+    func testSettingsSearchMatcherFiltersExactRenderedRowsWithinMatchingSection() {
+        let entries = [
+            AndBibleSettingsSearchEntry(
+                identifier: "monochrome_mode",
+                title: "Black & white mode",
+                summary: "Use application in monochrome mode"
+            ),
+            AndBibleSettingsSearchEntry(
+                identifier: "disable_animations",
+                title: "Disable animations",
+                summary: "Disable smooth scrolling animations"
+            ),
+        ]
+
+        XCTAssertTrue(entries.contains { AndBibleSettingsSearchMatcher.matches(query: "monochrome", entry: $0) })
+        XCTAssertTrue(
+            AndBibleSettingsSearchMatcher.matchesIdentifier(
+                "monochrome_mode",
+                query: "monochrome",
+                entries: entries
+            )
+        )
+        XCTAssertFalse(
+            AndBibleSettingsSearchMatcher.matchesIdentifier(
+                "disable_animations",
+                query: "monochrome",
+                entries: entries
+            )
+        )
+        XCTAssertFalse(
+            AndBibleSettingsSearchMatcher.matchesIdentifier(
+                "missing_row",
+                query: "monochrome",
+                entries: entries
+            )
+        )
+        XCTAssertTrue(
+            AndBibleSettingsSearchMatcher.matchesIdentifier(
+                "missing_row",
+                query: "",
+                entries: entries
+            )
+        )
+    }
+
     func testTextDisplayAppDefaultsStartWithStrongsDisabled() {
         XCTAssertEqual(TextDisplaySettings.appDefaults.strongsMode, 0)
     }

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1131,15 +1131,18 @@ extension AndBibleUITests {
         return nil
     }
 
-    /// Reads reader state from the early document-header chrome before probing the full WebView tree.
+    /// Reads reader state from the early document-header chrome before probing rendered content.
     func readerDocumentHeaderStateValue(in app: XCUIApplication) -> String? {
-        let header = app.otherElements["readerDocumentHeader"].firstMatch
-        guard header.exists,
-              let value = header.value as? String,
-              value.contains("windowOrder=") else {
+        let header = app.descendants(matching: .any)["readerDocumentHeader"].firstMatch
+        guard header.exists else {
             return nil
         }
-        return value
+        for candidateValue in [header.value as? String, header.label] {
+            if let candidateValue, candidateValue.contains("windowOrder=") {
+                return candidateValue
+            }
+        }
+        return nil
     }
 
     /// Returns compact reader state export queries without probing broad element sets.

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -634,6 +634,7 @@ extension AndBibleUITests {
             "settingsRepositoriesLink",
             "settingsImportExportLink",
             "settingsSyncLink",
+            "settingsReadingProgressLink",
             "settingsLabelsLink",
             "settingsTextDisplayLink",
             "settingsColorsLink":
@@ -670,6 +671,7 @@ extension AndBibleUITests {
             "labelManagerScreen",
             "labelEditScreen",
             "syncSettingsScreen",
+            "readingProgressSettingsScreen",
             "colorSettingsScreen",
             "importExportScreen",
             "modulePickerScreen",

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1228,7 +1228,8 @@ extension AndBibleUITests {
      *   - app: Running application under test.
      *   - timeout: Maximum number of seconds to wait before returning `false`.
      * - Returns: `true` when the reader's compact state export reports that transient reader
-     *   surfaces are closed and My Notes is no longer fronting the primary reader chrome.
+     *   surfaces and pushed reader destinations are closed, and My Notes is no longer fronting the
+     *   primary reader chrome.
      * - Side effects:
      *   - polls the compact reader state export while modal surfaces dismiss back to the reader
      *     shell, avoiding full-toolbar snapshots while WebView content is settling
@@ -1246,9 +1247,16 @@ extension AndBibleUITests {
                 let drawerClosed = state.contains("drawerVisible=false") || !state.contains("drawerVisible=")
                 let overflowClosed = state.contains("overflowVisible=false") || !state.contains("overflowVisible=")
                 let sheetClosed = state.contains("readerSheet=none") || !state.contains("readerSheet=")
+                let destinationClosed = state.contains("readerDestination=none") ||
+                    !state.contains("readerDestination=")
                 let searchClosed = state.contains("searchVisible=false") || !state.contains("searchVisible=")
                 let myNotesClosed = state.contains("myNotesVisible=false") || !state.contains("myNotesVisible=")
-                return drawerClosed && overflowClosed && sheetClosed && searchClosed && myNotesClosed
+                return drawerClosed &&
+                    overflowClosed &&
+                    sheetClosed &&
+                    destinationClosed &&
+                    searchClosed &&
+                    myNotesClosed
             } ?? false
 
             if readerState != nil,

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1133,13 +1133,17 @@ extension AndBibleUITests {
 
     /// Reads reader state from the early document-header chrome before probing rendered content.
     func readerDocumentHeaderStateValue(in app: XCUIApplication) -> String? {
-        let header = app.descendants(matching: .any)["readerDocumentHeader"].firstMatch
-        guard header.exists else {
-            return nil
-        }
-        for candidateValue in [header.value as? String, header.label] {
-            if let candidateValue, candidateValue.contains("windowOrder=") {
-                return candidateValue
+        let headerCandidates = [
+            app.otherElements["readerDocumentHeader"].firstMatch,
+            app.staticTexts["readerDocumentHeader"].firstMatch,
+        ]
+        for header in headerCandidates where header.exists {
+            if let value = header.value as? String, value.contains("windowOrder=") {
+                return value
+            }
+            let label = header.label
+            if label.contains("windowOrder=") {
+                return label
             }
         }
         return nil

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1122,11 +1122,9 @@ extension AndBibleUITests {
             return headerValue
         }
         for stateElement in readerRenderedContentStateElements(in: app) {
-            guard stateElement.exists,
-                  let value = stateElement.value as? String else {
-                continue
+            if let value = snapshotStateString(from: stateElement, containing: "windowOrder=") {
+                return value
             }
-            return value
         }
         return nil
     }
@@ -1137,14 +1135,44 @@ extension AndBibleUITests {
             app.otherElements["readerDocumentHeader"].firstMatch,
             app.staticTexts["readerDocumentHeader"].firstMatch,
         ]
-        for header in headerCandidates where header.exists {
-            if let value = header.value as? String, value.contains("windowOrder=") {
+        for header in headerCandidates {
+            if let value = snapshotStateString(from: header, containing: "windowOrder=") {
                 return value
             }
-            let label = header.label
-            if label.contains("windowOrder=") {
-                return label
-            }
+        }
+        return nil
+    }
+
+    /**
+     Reads an element's exported accessibility value or label without recording a snapshot failure.
+
+     The XCUITest convenience accessors `value` and `label` re-resolve their query and record a hard
+     "Failed to get matching snapshot" test failure when the element disappears between an earlier
+     `exists` check and the property read. Reader chrome (the document header and the compact state
+     export) is recreated during navigation transitions, so this optional probe instead takes a
+     single throwing `snapshot()` and tolerates absence via `try?`, returning `nil` rather than
+     failing the test when the element is mid-teardown.
+
+     - Parameters:
+       - element: Reader-state export element whose value or label should be read defensively.
+       - marker: Substring that must be present for the read to count as a valid reader-state export.
+     - Returns: The matching value or label string, or `nil` when the element cannot be snapshotted
+       or does not contain the marker.
+     - Side effects: none.
+     - Failure modes: never records an XCTest failure; absence resolves to `nil`.
+     */
+    private func snapshotStateString(
+        from element: XCUIElement,
+        containing marker: String
+    ) -> String? {
+        guard let snapshot = try? element.snapshot() else {
+            return nil
+        }
+        if let value = snapshot.value as? String, value.contains(marker) {
+            return value
+        }
+        if snapshot.label.contains(marker) {
+            return snapshot.label
         }
         return nil
     }

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -1135,6 +1135,8 @@ extension AndBibleUITests {
      * - Side effects:
      *   - scans the current Settings viewport, then scrolls through the form while re-querying
      *     the live XCUI hierarchy
+     *   - uses the production Settings search field as a final reveal path when CI scrolling cannot
+     *     reliably bring an offscreen row into the accessibility hierarchy
      * - Failure modes:
      *   - records an XCTest failure if the production row never appears
      */
@@ -1212,6 +1214,16 @@ extension AndBibleUITests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < recoveryDeadline
 
+        if let control = resolveSettingsNavigationControlViaSearch(
+            title: visibleTitle,
+            settingsForm: settingsForm,
+            app: app,
+            timeout: min(max(timeout / 2, 5), 10),
+            resolveControl: resolvedVisibleControl
+        ) {
+            return control
+        }
+
         let control = unresolvedElement(identifier, in: app)
         if control.exists {
             return control
@@ -1224,6 +1236,92 @@ extension AndBibleUITests {
             line: line
         )
         return control
+    }
+
+    /**
+     Reveals one Settings navigation row by narrowing the production Settings search field.
+
+     This is a fallback for hosted simulator runs where repeated `Form` swipes do not expose a
+     lower Settings row before the XCTest timeout. It does not bypass production navigation; after
+     search narrows the form, callers still tap the same native row element.
+     *
+     * - Parameters:
+     *   - title: Visible English title used as the search query.
+     *   - settingsForm: The live Settings form element.
+     *   - app: Running application under test.
+     *   - timeout: Maximum number of seconds to spend revealing and applying Settings search.
+     *   - resolveControl: Existing row resolver scoped to the live Settings hierarchy.
+     * - Returns: The resolved native row element, or `nil` when Settings search cannot reveal it.
+     * - Side effects:
+     *   - scrolls toward the top of the Settings form to reveal SwiftUI's searchable field
+     *   - types the visible row title into Settings search
+     * - Failure modes: This helper does not fail directly; the caller reports a single row-missing
+     *   assertion if both direct scanning and search reveal fail.
+     */
+    func resolveSettingsNavigationControlViaSearch(
+        title: String?,
+        settingsForm: XCUIElement,
+        app: XCUIApplication,
+        timeout: TimeInterval,
+        resolveControl: () -> XCUIElement?
+    ) -> XCUIElement? {
+        guard let title, !title.isEmpty else {
+            return nil
+        }
+
+        let searchDeadline = Date().addingTimeInterval(timeout)
+        var searchField: XCUIElement?
+        repeat {
+            if let field = settingsSearchFieldCandidates(in: app, settingsForm: settingsForm).first(
+                where: { $0.exists && !$0.frame.isEmpty }
+            ) {
+                searchField = field
+                break
+            }
+
+            guard settingsForm.exists, !settingsForm.frame.isEmpty else {
+                return nil
+            }
+            settingsForm.swipeDown()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < searchDeadline
+
+        guard let searchField else {
+            return nil
+        }
+
+        replaceText(in: searchField, with: title, placeholderHints: ["Search"])
+
+        let resultDeadline = Date().addingTimeInterval(min(max(timeout / 2, 3), 5))
+        repeat {
+            if let control = resolveControl() {
+                return control
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < resultDeadline
+
+        return nil
+    }
+
+    /**
+     Returns Settings search-field candidates exposed by SwiftUI's `searchable` modifier.
+
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - settingsForm: The live Settings form element.
+     * - Returns: Search and text-field candidates ordered from form-scoped to broader app queries.
+     * - Side effects: none.
+     * - Failure modes: This helper cannot fail.
+     */
+    func settingsSearchFieldCandidates(in app: XCUIApplication, settingsForm: XCUIElement) -> [XCUIElement] {
+        [
+            settingsForm.searchFields["Search"].firstMatch,
+            settingsForm.textFields["Search"].firstMatch,
+            app.navigationBars.searchFields["Search"].firstMatch,
+            app.navigationBars.textFields["Search"].firstMatch,
+            app.searchFields["Search"].firstMatch,
+            app.textFields["Search"].firstMatch,
+        ]
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -98,22 +98,22 @@ extension AndBibleUITests {
     }
 
     /**
-     Opens Label Manager through Settings navigation.
+     Opens Label Manager through the reader overflow admin route.
      *
      * - Parameter app: Running application under test.
      * - Returns: The root accessibility-identified Label Manager screen element.
      * - Side effects:
-     *   - opens Settings and pushes the Label Manager screen
+     *   - opens the reader overflow menu and presents the Label Manager screen
      * - Failure modes:
      *   - fails when the Label Manager screen never appears
      */
     func openLabelManager(in app: XCUIApplication) -> XCUIElement {
-        openSettingsDestination(
-            linkIdentifier: "settingsLabelsLink",
+        openReaderActionDestination(
+            actionIdentifier: "readerOpenLabelSettingsAction",
             destinationIdentifier: "labelManagerScreen",
             readinessIdentifiers: ["labelManagerAddButton"],
             in: app,
-            destinationTimeout: 20
+            timeout: 20
         )
     }
 
@@ -788,22 +788,22 @@ extension AndBibleUITests {
     }
 
     /**
-     Opens Import and Export through Settings navigation.
+     Opens Import and Export through the reader drawer administration route.
      *
      * - Parameter app: Running application under test.
      * - Returns: The root accessibility-identified Import and Export screen element.
      * - Side effects:
-     *   - opens Settings and pushes the Import and Export screen
+     *   - opens the reader drawer and presents the Import and Export screen
      * - Failure modes:
      *   - fails when the Import and Export screen never appears
      */
     func openImportExport(in app: XCUIApplication) -> XCUIElement {
-        openSettingsDestination(
-            linkIdentifier: "settingsImportExportLink",
+        openReaderActionDestination(
+            actionIdentifier: "readerOpenImportExportAction",
             destinationIdentifier: "importExportScreen",
             readinessIdentifiers: ["importExportImportButton", "importExportFullBackupButton"],
             in: app,
-            destinationTimeout: 20
+            timeout: 20
         )
     }
 
@@ -939,17 +939,22 @@ extension AndBibleUITests {
     }
 
     /**
-     Dismisses the Settings sheet back to the reader shell.
+     Dismisses the integrated Settings destination back to the reader shell.
      *
      * - Parameter app: Running application whose Settings sheet should be dismissed.
      * - Side effects:
-     *   - drags the production Settings form downward to close the sheet
+     *   - activates the navigation back button when Settings is pushed on the reader stack
      * - Failure modes:
-     *   - fails when the Settings sheet cannot be dismissed back to the reader shell
+     *   - fails when Settings cannot be dismissed back to the reader shell
      */
     func dismissSettings(in app: XCUIApplication) {
         let settingsForm = requireElement("settingsForm", in: app, timeout: 10)
-        dismissSheetByDraggingDown(settingsForm)
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists {
+            tapElementReliably(backButton, timeout: 10)
+        } else {
+            settingsForm.swipeRight()
+        }
         waitForElementToDisappear(settingsForm, timeout: 10)
         XCTAssertTrue(
             waitForReaderShellReady(in: app, timeout: 20),
@@ -1242,7 +1247,9 @@ extension AndBibleUITests {
         case "settingsImportExportLink":
             "Import & Export"
         case "settingsSyncLink":
-            "iCloud Sync"
+            "Device synchronization"
+        case "settingsReadingProgressLink":
+            "Reading Progress Settings"
         case "settingsLabelsLink":
             "Labels"
         case "settingsTextDisplayLink":

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -1133,7 +1133,8 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The production settings row element.
      * - Side effects:
-     *   - scrolls the Settings form while re-querying the live XCUI hierarchy
+     *   - scans the current Settings viewport, then scrolls through the form while re-querying
+     *     the live XCUI hierarchy
      * - Failure modes:
      *   - records an XCTest failure if the production row never appears
      */
@@ -1186,19 +1187,6 @@ extension AndBibleUITests {
             return nil
         }
 
-        if visibleTitle != nil {
-            for _ in 0..<3 {
-                if let control = resolvedVisibleControl() {
-                    return control
-                }
-                guard settingsForm.exists, !settingsForm.frame.isEmpty, Date() < deadline else {
-                    break
-                }
-                settingsForm.swipeDown()
-                RunLoop.current.run(until: Date().addingTimeInterval(0.3))
-            }
-        }
-
         repeat {
             if let control = resolvedVisibleControl() {
                 return control
@@ -1210,6 +1198,19 @@ extension AndBibleUITests {
             settingsForm.swipeUp()
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
+
+        let recoveryDeadline = Date().addingTimeInterval(min(3, max(1, timeout / 4)))
+        repeat {
+            if let control = resolvedVisibleControl() {
+                return control
+            }
+            guard settingsForm.exists, !settingsForm.frame.isEmpty else {
+                break
+            }
+
+            settingsForm.swipeDown()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < recoveryDeadline
 
         let control = unresolvedElement(identifier, in: app)
         if control.exists {

--- a/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -857,6 +857,8 @@ extension AndBibleUITests {
             return "Backup & Restore"
         case "readerOpenSyncSettingsAction":
             return "Device synchronization"
+        case "readerOpenLabelSettingsAction":
+            return "Label Settings…"
         case "readerOpenHelpAction":
             return "Help & Tips"
         case "readerSponsorDevelopmentAction":

--- a/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
+++ b/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
@@ -153,8 +153,13 @@ extension AndBibleUITests {
 
         _ = openWorkspaceCreatePrompt(in: app, timeout: 10)
         let workspaceNameField = requireWorkspaceNamePromptField(in: app, timeout: 10)
-        focusResolvedPromptTextEntryElement(workspaceNameField, in: app, timeout: 10)
-        app.typeText(createdName)
+        typePromptText(
+            createdName,
+            into: workspaceNameField,
+            in: app,
+            timeout: 15,
+            accessibilityIdentifier: "workspaceNamePromptTextField"
+        )
         tapElementReliably(requireElement("workspaceNamePromptConfirmButton", in: app, timeout: 10), timeout: 10)
 
         XCTAssertTrue(

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -7,38 +7,31 @@ import UIKit
 
 extension AndBibleUITests {
     /**
-     Verifies that the reader overflow menu exposes its primary actions and that Settings can be
-     opened from the reader shell.
+     Verifies that Settings opens as a reader navigation destination and exposes Android-parity
+     application-preference shortcuts.
      *
      * - Side effects:
      *   - launches the app with the calculator gate disabled, in-memory persistence, and one
      *     deterministic seeded bookmark-label pair for stable reader-shell startup
-     *   - opens the reader overflow menu, validates the primary overflow rows, dismisses the menu,
-     *     and pushes the settings screen
+     *   - pushes Settings from the reader action surface and samples the exported reader/settings
+     *     accessibility state
      * - Failure modes:
-     *   - fails if any primary overflow-menu action is absent
      *   - fails if settings cannot be reached from the reader shell
-     *   - fails if the settings form does not render after navigation completes
+     *   - fails if Settings is still presented as a reader sheet rather than a navigation
+     *     destination
+     *   - fails if the feature shortcuts or reader-admin-flow contract are absent
      */
-    func testSettingsScreenShowsPrimaryNavigationRows() {
+    func testSettingsScreenShowsApplicationPreferenceShortcuts() {
         let app = makeApp()
         app.launch()
 
-        tapReaderMoreMenuButton(in: app)
-        XCTAssertTrue(requireElement("readerOverflowSectionTitlesToggle", in: app, timeout: 10).exists)
-        XCTAssertTrue(requireElement("readerOverflowStrongsModeAction", in: app, timeout: 10).exists)
-        XCTAssertTrue(requireElement("readerOverflowVerseNumbersToggle", in: app, timeout: 10).exists)
-        dismissReaderOverflowMenu(in: app, timeout: 15)
-        XCTAssertTrue(
-            waitForReaderShellReady(in: app, timeout: 20),
-            "Expected overflow dismissal to restore the reader shell before opening Settings."
-        )
-
         openSettings(in: app)
         XCTAssertTrue(requireElement("settingsForm", in: app, timeout: 10).exists)
-        waitForSettingsState(containing: "settingsImportExportLink", in: app, timeout: 10)
+        waitForReaderRenderedContentState(containing: "readerSheet=none", in: app, timeout: 10)
+        waitForReaderRenderedContentState(containing: "readerDestination=settings", in: app, timeout: 10)
         waitForSettingsState(containing: "settingsSyncLink", in: app, timeout: 10)
-        waitForSettingsState(containing: "settingsLabelsLink", in: app, timeout: 10)
+        waitForSettingsState(containing: "settingsReadingProgressLink", in: app, timeout: 10)
+        waitForSettingsState(containing: "adminFlows=readerActions", in: app, timeout: 10)
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -269,6 +269,30 @@ extension AndBibleUITests {
     }
 
     /**
+     Verifies that Reading Progress settings are exposed from the Android-parity Settings features section.
+
+     - Side effects:
+     *   - launches the app on the reader shell and opens Settings
+     *   - opens Reading Progress Settings from the settings screen
+     - Failure modes:
+     *   - fails if the Settings reading-progress shortcut is missing or never becomes hittable
+     *   - fails if the Reading Progress settings screen does not render after navigation completes
+     */
+    func testSettingsReadingProgressLinkOpensReadingProgressSettings() {
+        let app = makeApp()
+        app.launch()
+
+        XCTAssertTrue(
+            openSettingsDestination(
+                linkIdentifier: "settingsReadingProgressLink",
+                destinationIdentifier: "readingProgressSettingsScreen",
+                in: app,
+                destinationTimeout: 20
+            ).exists
+        )
+    }
+
+    /**
      Verifies that invalid NextCloud server input surfaces the expected validation status.
      *
      * - Side effects:

--- a/Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift
@@ -392,6 +392,25 @@ public enum AppPreferenceRegistry {
     }
 
     /**
+     * Returns the durable application-preference keys cleared by Android's reset action.
+     *
+     * The reset contract is derived from storage metadata rather than from the Settings UI so it
+     * stays stable when rows move between reader navigation, feature shortcuts, and platform-only
+     * presentation surfaces. Action rows are excluded because they do not represent persisted
+     * user choices.
+     *
+     * - Returns: Registered non-action preference keys in `AppPreferenceKey.allCases` order.
+     * - Side Effects: None.
+     * - Failure: Missing registry entries are filtered by `definitions`; completeness remains
+     *   enforced by `definition(for:)` and registry tests.
+     */
+    public static var applicationPreferencesResetKeys: [AppPreferenceKey] {
+        definitions
+            .filter { $0.storage != .action }
+            .map(\.key)
+    }
+
+    /**
      * Returns the registry definition for a single parity key.
      * - Parameter key: Android parity preference key.
      * - Returns: The corresponding definition.

--- a/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift
@@ -565,6 +565,35 @@ public extension SettingsStore {
     }
 
     /**
+     Clears all persisted Android-parity application preferences back to registry defaults.
+
+     Reset is expressed as removal rather than writing default values so future registry default
+     changes are picked up consistently and storage remains equivalent to a fresh install. The
+     key list lives in `AppPreferenceRegistry.applicationPreferencesResetKeys`; UI placement does
+     not decide what is reset.
+
+     - Side Effects:
+       - deletes SwiftData `Setting` rows for resettable `.swiftData` preferences
+       - removes `UserDefaults` objects for resettable `.userDefaults` preferences
+       - leaves `.action` rows and unrelated settings, including global text display JSON, intact
+     - Failure: SwiftData save failures are swallowed by `remove(_:)`, matching other settings
+       writes in this store.
+     */
+    func resetApplicationPreferences() {
+        for key in AppPreferenceRegistry.applicationPreferencesResetKeys {
+            let definition = AppPreferenceRegistry.definition(for: key)
+            switch definition.storage {
+            case .swiftData:
+                remove(key.rawValue)
+            case .userDefaults:
+                UserDefaults.standard.removeObject(forKey: key.rawValue)
+            case .action:
+                break
+            }
+        }
+    }
+
+    /**
      * Reads a parity preference as a raw string regardless of the configured storage backend.
      * - Parameter key: Android parity preference key.
      * - Returns: Raw stored representation, or `nil` when absent or when the preference is an action.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
@@ -6,13 +6,10 @@ import SwiftUI
 
  `BibleReaderView` decides when a sheet is active and supplies the focused controller. This view
  owns only the sheet content switch and forwards dismiss/navigation side effects through closures.
- */
+    */
 struct BibleReaderActiveSheetContent: View {
     let sheet: BibleReaderView.ReaderSheet
     let controller: BibleReaderController?
-    @Binding var displaySettings: TextDisplaySettings
-    @Binding var nightMode: Bool
-    @Binding var nightModeMode: String
     let readingProgressInitialTab: ReadingProgressTab
     let chapterReadHistoryTarget: ChapterReadHistoryTarget?
 
@@ -26,7 +23,6 @@ struct BibleReaderActiveSheetContent: View {
     let onDefaultDownloadActivityChanged: (Bool) -> Void
 
     let onDismiss: () -> Void
-    let onSettingsChanged: () -> Void
 
     /**
      Creates active reader sheet content for the currently presented sheet route.
@@ -34,9 +30,6 @@ struct BibleReaderActiveSheetContent: View {
      - Parameters:
        - sheet: Reader sheet route to render.
        - controller: Focused reader controller backing sheet navigation actions.
-       - displaySettings: Shared text display settings binding for Settings.
-       - nightMode: Shared night-mode binding for Settings.
-       - nightModeMode: Shared night-mode mode binding for Settings.
        - readingProgressInitialTab: Initial reading-progress tab for progress routes.
        - chapterReadHistoryTarget: Optional chapter read-history target.
        - downloadsInitialSearchText: Initial Downloads filter from Android-compatible links.
@@ -44,7 +37,6 @@ struct BibleReaderActiveSheetContent: View {
        - onDefaultDownloadActivityChanged: Callback invoked when Easy Start Downloads starts or
          finishes refresh/install activity.
        - onDismiss: Callback used to close the active sheet.
-       - onSettingsChanged: Callback used after Settings mutates display preferences.
 
      Side effects:
      - none during initialization
@@ -55,29 +47,21 @@ struct BibleReaderActiveSheetContent: View {
     init(
         sheet: BibleReaderView.ReaderSheet,
         controller: BibleReaderController?,
-        displaySettings: Binding<TextDisplaySettings>,
-        nightMode: Binding<Bool>,
-        nightModeMode: Binding<String>,
         readingProgressInitialTab: ReadingProgressTab,
         chapterReadHistoryTarget: ChapterReadHistoryTarget?,
         downloadsInitialSearchText: String,
         downloadsDefaultDownloadMode: ModuleBrowserDefaultDownloadMode = .disabled,
         onDefaultDownloadActivityChanged: @escaping (Bool) -> Void = { _ in },
-        onDismiss: @escaping () -> Void,
-        onSettingsChanged: @escaping () -> Void
+        onDismiss: @escaping () -> Void
     ) {
         self.sheet = sheet
         self.controller = controller
-        self._displaySettings = displaySettings
-        self._nightMode = nightMode
-        self._nightModeMode = nightModeMode
         self.readingProgressInitialTab = readingProgressInitialTab
         self.chapterReadHistoryTarget = chapterReadHistoryTarget
         self.downloadsInitialSearchText = downloadsInitialSearchText
         self.downloadsDefaultDownloadMode = downloadsDefaultDownloadMode
         self.onDefaultDownloadActivityChanged = onDefaultDownloadActivityChanged
         self.onDismiss = onDismiss
-        self.onSettingsChanged = onSettingsChanged
     }
 
     var body: some View {
@@ -93,20 +77,6 @@ struct BibleReaderActiveSheetContent: View {
                         controller?.loadStudyPadDocument(labelId: labelId)
                     }
                 )
-            }
-        case .settings:
-            NavigationStack {
-                SettingsView(
-                    displaySettings: $displaySettings,
-                    nightMode: $nightMode,
-                    nightModeMode: $nightModeMode,
-                    onSettingsChanged: onSettingsChanged
-                )
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button(String(localized: "done"), action: onDismiss)
-                    }
-                }
             }
         case .downloads:
             NavigationStack {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderOverflowMenu.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderOverflowMenu.swift
@@ -107,6 +107,7 @@ struct BibleReaderOverflowMenu: View {
             button(
                 title: ellipsisTitle(String(localized: "label_settings")),
                 assetName: "OverflowLabelSettings",
+                identifier: "readerOpenLabelSettingsAction",
                 action: .openLabelSettings
             )
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -92,7 +92,6 @@ public struct BibleReaderView: View {
     /// Top-level sheets launched from the reader shell or its global shortcuts.
     enum ReaderSheet: String, Identifiable {
         case bookmarks
-        case settings
         case downloads
         case history
         case readingPlans
@@ -101,6 +100,13 @@ public struct BibleReaderView: View {
         case chapterReadHistory
         case workspaces
         case about
+
+        var id: String { rawValue }
+    }
+
+    /// Reader-stack destinations opened from global reader actions.
+    enum ReaderDestination: String, Identifiable, Hashable {
+        case settings
 
         var id: String { rawValue }
     }
@@ -173,6 +179,9 @@ public struct BibleReaderView: View {
 
     /// Presents the current top-level reader sheet driven by the overflow menu and shortcuts.
     @State private var activeReaderSheet: ReaderSheet?
+
+    /// Presents the current reader-stack destination driven by drawer and overflow actions.
+    @State private var activeReaderDestination: ReaderDestination?
 
     /// Initial search applied when Downloads is opened from an Android-compatible download link.
     @State private var downloadsInitialSearchText = ""
@@ -432,9 +441,10 @@ public struct BibleReaderView: View {
         let drawerToken = "drawerVisible=\(showReaderNavigationDrawer ? "true" : "false")"
         let overflowToken = "overflowVisible=\(showReaderOverflowMenu ? "true" : "false")"
         let sheetToken = "readerSheet=\(activeReaderSheet?.rawValue ?? "none")"
+        let destinationToken = "readerDestination=\(activeReaderDestination?.rawValue ?? "none")"
         let modalToken = "readerModal=\(activeReaderModal?.rawValue ?? "none")"
         let searchToken = "searchVisible=\(showSearch ? "true" : "false")"
-        return "\(windowToken);\(contentToken);\(myNotesToken);\(studyPadToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(modalToken);\(searchToken)"
+        return "\(windowToken);\(contentToken);\(myNotesToken);\(studyPadToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(destinationToken);\(modalToken);\(searchToken)"
     }
 
     /// Compact dedicated state export used by UI tests instead of snapshotting the full reader.
@@ -584,6 +594,9 @@ public struct BibleReaderView: View {
         .sheet(item: $activeReaderSheet) { presentedSheet in
             activeReaderSheetContent(presentedSheet)
         }
+        .navigationDestination(item: $activeReaderDestination) { destination in
+            readerDestinationContent(destination)
+        }
         .confirmationDialog(
             String(localized: "picker_no_bible_modules"),
             isPresented: $showStartupDownloadPrompt,
@@ -609,6 +622,9 @@ public struct BibleReaderView: View {
         }
         .onChange(of: activeReaderSheet) { oldValue, newValue in
             handleActiveReaderSheetChange(from: oldValue, to: newValue)
+        }
+        .onChange(of: activeReaderDestination) { oldValue, newValue in
+            handleActiveReaderDestinationChange(from: oldValue, to: newValue)
         }
         .onChange(of: showReaderOverflowMenu) { oldValue, newValue in
             guard oldValue, !newValue else {
@@ -772,9 +788,6 @@ public struct BibleReaderView: View {
         BibleReaderActiveSheetContent(
             sheet: presentedSheet,
             controller: panePresentationController,
-            displaySettings: $globalDisplaySettings,
-            nightMode: $nightMode,
-            nightModeMode: $nightModeMode,
             readingProgressInitialTab: readingProgressInitialTab,
             chapterReadHistoryTarget: chapterReadHistoryTarget,
             downloadsInitialSearchText: downloadsInitialSearchText,
@@ -782,9 +795,26 @@ public struct BibleReaderView: View {
             onDefaultDownloadActivityChanged: { isInFlight in
                 handleStartupDefaultDownloadActivityChanged(isInFlight: isInFlight)
             },
-            onDismiss: dismissReaderSheet,
-            onSettingsChanged: applyGlobalDisplaySettingsChange
+            onDismiss: dismissReaderSheet
         )
+    }
+
+    /// Builds reader-stack destinations opened from the drawer, overflow, or keyboard shortcuts.
+    @ViewBuilder
+    private func readerDestinationContent(_ destination: ReaderDestination) -> some View {
+        switch destination {
+        case .settings:
+            SettingsView(
+                displaySettings: $globalDisplaySettings,
+                nightMode: $nightMode,
+                nightModeMode: $nightModeMode,
+                readingProgressController: panePresentationController,
+                onSettingsChanged: applyGlobalDisplaySettingsChange
+            )
+            #if os(iOS)
+            .toolbar(.visible, for: .navigationBar)
+            #endif
+        }
     }
 
     /// Buttons shown when startup detects there are no installed Bible modules.
@@ -871,7 +901,7 @@ public struct BibleReaderView: View {
             onNavigateNext: { navigateNextIfReaderCanHostNavigate(focusedController) },
             onCloseClientModal: { _ = closeFocusedWebModalIfNeeded() },
             onOpenDownloads: { presentDownloads(from: windowManager.activeWindow?.id) },
-            onOpenSettings: { presentReaderSheet(.settings, from: windowManager.activeWindow?.id) }
+            onOpenSettings: { presentSettings(from: windowManager.activeWindow?.id) }
         )
     }
 
@@ -940,6 +970,17 @@ public struct BibleReaderView: View {
         activeReaderSheet = sheet
     }
 
+    /// Presents a reader-stack destination and captures the pane target that should back it.
+    private func presentReaderDestination(_ destination: ReaderDestination, from windowId: UUID? = nil) {
+        setPanePresentationTarget(windowId)
+        activeReaderDestination = destination
+    }
+
+    /// Opens Application preferences as an integrated reader-stack destination.
+    private func presentSettings(from windowId: UUID? = nil) {
+        presentReaderDestination(.settings, from: windowId)
+    }
+
     /**
      Presents Downloads and seeds its free-text search from an Android `download://` target.
 
@@ -1006,7 +1047,6 @@ public struct BibleReaderView: View {
        - currentSheet: Sheet now visible after SwiftUI reported the change.
 
      Side effects:
-     - reloads behavior preferences after Settings closes
      - clears Downloads launch state after Downloads closes
      - refreshes installed-module caches for each reader controller
      - reopens the startup prompt when Downloads closes without an installed Bible unless Easy Start
@@ -1024,8 +1064,6 @@ public struct BibleReaderView: View {
         }
 
         switch previousSheet {
-        case .settings:
-            reloadBehaviorPreferences()
         case .downloads:
             downloadsInitialSearchText = ""
             downloadsDefaultDownloadMode = .disabled
@@ -1040,6 +1078,29 @@ public struct BibleReaderView: View {
         default:
             break
         }
+    }
+
+    /**
+     Handles side effects that belong to a reader-stack destination closing.
+
+     Settings is now a navigation destination instead of a sheet. Reloading behavior preferences on
+     pop keeps the same refresh boundary as the former modal route without coupling the behavior to
+     sheet state.
+
+     - Parameters:
+       - previousDestination: Destination that was visible before SwiftUI reported the change.
+       - currentDestination: Destination now visible after SwiftUI reported the change.
+     - Side Effects: Reloads reader behavior preferences after Settings closes.
+     - Failure: Non-closing destination transitions are ignored.
+     */
+    private func handleActiveReaderDestinationChange(
+        from previousDestination: ReaderDestination?,
+        to currentDestination: ReaderDestination?
+    ) {
+        guard currentDestination == nil, previousDestination == .settings else {
+            return
+        }
+        reloadBehaviorPreferences()
     }
 
     /// Presents a follow-up top-level sheet after another flow already captured the pane target.
@@ -1541,7 +1602,7 @@ public struct BibleReaderView: View {
             case .readingPlans:
                 presentReaderSheet(.readingPlans, from: windowManager.activeWindow?.id)
             case .settings:
-                presentReaderSheet(.settings, from: windowManager.activeWindow?.id)
+                presentSettings(from: windowManager.activeWindow?.id)
             case .workspaces:
                 presentReaderSheet(.workspaces, from: windowManager.activeWindow?.id)
             case .downloads:
@@ -1577,7 +1638,7 @@ public struct BibleReaderView: View {
 
     /** Opens Settings from the reader shell. */
     private func openSettingsFromReaderAction() {
-        presentReaderSheet(.settings, from: windowManager.activeWindow?.id)
+        presentSettings(from: windowManager.activeWindow?.id)
     }
 
     /** Opens Workspaces from the reader shell. */
@@ -1614,7 +1675,7 @@ public struct BibleReaderView: View {
             onShowBookChooser: { presentBookChooser(from: window.id) },
             onShowSearch: { presentSearch(from: window.id) },
             onShowBookmarks: { presentReaderSheet(.bookmarks, from: window.id) },
-            onShowSettings: { presentReaderSheet(.settings, from: window.id) },
+            onShowSettings: { presentSettings(from: window.id) },
             onShowDownloads: { initialSearchText in
                 presentDownloads(from: window.id, initialSearchText: initialSearchText)
             },
@@ -1995,7 +2056,7 @@ public struct BibleReaderView: View {
             dismissReaderNavigationDrawerAndPerform { presentReaderModal(.syncSettings) }
         case .settings:
             dismissReaderNavigationDrawerAndPerform {
-                presentReaderSheet(.settings, from: windowManager.activeWindow?.id)
+                presentSettings(from: windowManager.activeWindow?.id)
             }
         case .help:
             dismissReaderNavigationDrawerAndPerform { presentReaderModal(.help) }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -814,6 +814,13 @@ public struct BibleReaderView: View {
             #if os(iOS)
             .toolbar(.visible, for: .navigationBar)
             #endif
+            // The reader shell is removed from the accessibility tree while a destination is
+            // pushed, so re-emit the compact reader-state export here. This keeps reader routing
+            // tokens (for example `readerSheet=none;readerDestination=settings`) observable by UI
+            // tests on the pushed destination without exposing reader internals to SettingsView.
+            .overlay(alignment: .topLeading) {
+                readerRenderedContentStateExport
+            }
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2117,9 +2117,7 @@ public struct BibleReaderView: View {
 
     /// Current app version string shown in the drawer footer.
     private var readerNavigationDrawerVersionText: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-        return "Version \(version) (\(build))"
+        AndBibleAppVersionMetadata.current().drawerFooterText
     }
 
     /// Category-specific browse icon used when reading non-Bible content.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReadingProgressViews.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReadingProgressViews.swift
@@ -119,6 +119,17 @@ struct ReadingProgressView: View {
     }
 }
 
+/**
+ Native settings form for reading and memorization progress behavior.
+
+ The view edits the focused reader controller's progress settings when a controller is available
+ and otherwise renders default values for routes opened before a pane controller is ready.
+
+ - Parameters:
+   - controller: Optional reader controller that owns the progress stores to mutate.
+ - Side effects: User edits call `saveReadingProgressSettings(_:)` on the supplied controller.
+ - Failure modes: Missing controllers keep edits local to the view state.
+ */
 struct ReadingProgressSettingsView: View {
     let controller: BibleReaderController?
     @State private var settings: ReadingProgressSettingsSnapshot
@@ -152,8 +163,18 @@ struct ReadingProgressSettingsView: View {
             }
         }
         .navigationTitle(String(localized: "reading_progress_settings", defaultValue: "Reading Progress Settings"))
+        .accessibilityIdentifier("readingProgressSettingsScreen")
     }
 
+    /**
+     Creates a binding that persists one reading-progress setting after each edit.
+
+     - Parameter keyPath: Writable key path for the setting value inside the local snapshot.
+     - Returns: A SwiftUI binding suitable for toggles and pickers.
+     - Side Effects: Mutates local state and saves through the optional reader controller.
+     - Failure: When the controller is absent or saving fails, the local edited value remains until
+       the view is recreated.
+     */
     private func settingBinding<Value>(_ keyPath: WritableKeyPath<ReadingProgressSettingsSnapshot, Value>) -> Binding<Value> {
         Binding(
             get: { settings[keyPath: keyPath] },

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AboutView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AboutView.swift
@@ -20,14 +20,16 @@ public struct AboutView: View {
     /// Dismiss action inherited from the surrounding navigation presentation.
     @Environment(\.dismiss) private var dismiss
 
-    /// Human-readable marketing version shown beneath the app title.
-    private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
-    }
+    /**
+     Bundle-backed version metadata shown beneath the app title.
 
-    /// Internal build number shown alongside the marketing version.
-    private var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+     - Inputs: `Bundle.main` metadata.
+     - Outputs: The marketing version and build number used by the about screen.
+     - Side effects: none.
+     - Failure modes: Missing bundle values fall back through `AndBibleAppVersionMetadata`.
+     */
+    private var versionMetadata: AndBibleAppVersionMetadata {
+        AndBibleAppVersionMetadata.current()
     }
 
     /**
@@ -51,7 +53,7 @@ public struct AboutView: View {
                         .font(.title.bold())
                         .accessibilityIdentifier("aboutAppTitle")
 
-                    Text(String(localized: "version \(appVersion) (\(buildNumber))"))
+                    Text(String(localized: "version \(versionMetadata.detailText)"))
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AboutView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AboutView.swift
@@ -53,7 +53,7 @@ public struct AboutView: View {
                         .font(.title.bold())
                         .accessibilityIdentifier("aboutAppTitle")
 
-                    Text(String(localized: "version \(versionMetadata.detailText)"))
+                    Text(verbatim: "\(String(localized: "version")) \(versionMetadata.detailText)")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/**
+ One searchable settings row or shortcut.
+
+ `SettingsView` uses entries to keep search text, identifiers, summaries, and Android-parity
+ keywords out of ad hoc string comparisons. Entries are value types so tests can exercise the
+ matcher without rendering SwiftUI.
+
+ - Parameters:
+   - identifier: Stable accessibility or settings-row identifier.
+   - title: User-visible row title.
+   - summary: Optional row summary text.
+   - detail: Optional state/detail text.
+   - keywords: Additional non-visible search aliases such as Android category names.
+ - Side effects: none.
+ - Failure modes: none.
+ */
+struct AndBibleSettingsSearchEntry: Equatable {
+    /// Stable accessibility or settings-row identifier.
+    let identifier: String
+
+    /// User-visible row title.
+    let title: String
+
+    /// Optional row summary text.
+    let summary: String
+
+    /// Optional state/detail text.
+    let detail: String
+
+    /// Additional aliases that should match search terms even when not visible.
+    let keywords: [String]
+
+    /**
+     Creates one searchable settings entry.
+
+     - Parameters:
+       - identifier: Stable accessibility or settings-row identifier.
+       - title: User-visible row title.
+       - summary: Optional row summary text.
+       - detail: Optional state/detail text.
+       - keywords: Additional non-visible search aliases.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(
+        identifier: String,
+        title: String,
+        summary: String = "",
+        detail: String = "",
+        keywords: [String] = []
+    ) {
+        self.identifier = identifier
+        self.title = title
+        self.summary = summary
+        self.detail = detail
+        self.keywords = keywords
+    }
+}
+
+/**
+ Normalizes and evaluates Settings search queries.
+
+ Matching is intentionally independent from SwiftUI so the search contract can be tested directly
+ and reused by future settings hosts. Every query term must appear somewhere in the entry text,
+ matching Android's preference-search expectation that multi-word queries narrow results instead
+ of widening them.
+ */
+enum AndBibleSettingsSearchMatcher {
+    /**
+     Splits and normalizes a raw query into comparable search terms.
+
+     - Parameter query: User-entered search text.
+     - Returns: Lowercase, diacritic-insensitive, whitespace-delimited terms.
+     - Side effects: none.
+     - Failure modes: Malformed Unicode is handled by Foundation string folding.
+     */
+    static func normalizedTerms(from query: String) -> [String] {
+        normalized(query)
+            .split { $0.isWhitespace }
+            .map(String.init)
+            .filter { !$0.isEmpty }
+    }
+
+    /**
+     Returns whether one settings entry matches a raw query.
+
+     Empty queries match all entries. Non-empty queries require every normalized term to be present
+     in the combined identifier, visible text, detail text, or keyword aliases.
+
+     - Parameters:
+       - query: User-entered search text.
+       - entry: Searchable settings entry.
+     - Returns: `true` when the entry should remain visible for the query.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func matches(query: String, entry: AndBibleSettingsSearchEntry) -> Bool {
+        let terms = normalizedTerms(from: query)
+        guard !terms.isEmpty else {
+            return true
+        }
+
+        let haystack = normalized(
+            ([entry.identifier, entry.title, entry.summary, entry.detail] + entry.keywords)
+                .joined(separator: " ")
+        )
+        return terms.allSatisfy { haystack.contains($0) }
+    }
+
+    /**
+     Applies the shared case/diacritic normalization used for both query and entry text.
+
+     - Parameter value: Raw text to normalize.
+     - Returns: Folded lowercase text suitable for containment checks.
+     - Side effects: none.
+     - Failure modes: Foundation folding handles text without throwing.
+     */
+    private static func normalized(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .lowercased()
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift
@@ -110,6 +110,36 @@ enum AndBibleSettingsSearchMatcher {
     }
 
     /**
+     Returns whether one concrete rendered row should remain visible for a query.
+
+     Settings sections can match because any child row matches, but row rendering must stay tied to
+     the specific entry behind that row. This helper centralizes that exact-entry lookup so
+     `SettingsView` does not duplicate matcher rules or accidentally keep unrelated rows visible.
+
+     - Parameters:
+       - identifier: Stable identifier of the row that is about to be rendered.
+       - query: User-entered search text.
+       - entries: Search entries for the containing visible section.
+     - Returns: `true` when search is empty, or when the matching entry exists and satisfies the
+       query; `false` for unknown identifiers during active search.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func matchesIdentifier(
+        _ identifier: String,
+        query: String,
+        entries: [AndBibleSettingsSearchEntry]
+    ) -> Bool {
+        guard !normalizedTerms(from: query).isEmpty else {
+            return true
+        }
+        guard let entry = entries.first(where: { $0.identifier == identifier }) else {
+            return false
+        }
+        return matches(query: query, entry: entry)
+    }
+
+    /**
      Applies the shared case/diacritic normalization used for both query and entry text.
 
      - Parameter value: Raw text to normalize.

--- a/Sources/BibleUI/Sources/BibleUI/Settings/HelpView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/HelpView.swift
@@ -54,12 +54,10 @@ struct HelpView: View {
 
                 Divider()
 
-                if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-                    Text("AndBible v\(version)")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
+                Text(AndBibleAppVersionMetadata.current().helpFooterText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             .padding()
         }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -1031,7 +1031,7 @@ public struct SettingsView: View {
                     title: String(localized: "version")
                 )
                 Spacer()
-                Text("1.0.0")
+                Text(AndBibleAppVersionMetadata.current().detailText)
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 8)
             }
@@ -1359,7 +1359,6 @@ public struct SettingsView: View {
                 } else {
                     UserDefaults.standard.removeObject(forKey: "AppleLanguages")
                 }
-                UserDefaults.standard.synchronize()
                 showRestartAlert = true
             }
         } header: {
@@ -2290,7 +2289,6 @@ public struct SettingsView: View {
         let store = SettingsStore(modelContext: modelContext)
         store.resetApplicationPreferences()
         UserDefaults.standard.removeObject(forKey: "AppleLanguages")
-        UserDefaults.standard.synchronize()
         loadSettingsState()
         onSettingsChanged?()
     }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -446,39 +446,47 @@ public struct SettingsView: View {
      Adds persistence observers for multi-select settings whose state is edited in child screens.
 
      - Side Effects: Writes selected dictionary/action/experimental-feature values into SwiftData and
-       refreshes reader content for options that affect rendered documents.
+       refreshes reader content for options that affect rendered documents after initial preference
+       hydration has completed.
      - Failure Modes: Store writes use the same `SettingsStore` defaults and model-context error
        handling as the rest of settings.
      */
     private var settingsFormWithPreferencePersistence: some View {
         settingsFormWithPresentation
             .onChange(of: selectedStrongsGreekDictionaryNames) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.strongsGreekDictionary, values: Array(newValue))
             }
             .onChange(of: selectedStrongsHebrewDictionaryNames) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.strongsHebrewDictionary, values: Array(newValue))
             }
             .onChange(of: selectedRobinsonMorphologyDictionaryNames) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.robinsonGreekMorphology, values: Array(newValue))
             }
             .onChange(of: disabledWordLookupDictionaryNames) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.disabledWordLookupDictionaries, values: Array(newValue))
             }
             .onChange(of: disabledBibleBookmarkModalButtons) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.disableBibleBookmarkModalButtons, values: Array(newValue))
                 onSettingsChanged?()
             }
             .onChange(of: disabledGenBookmarkModalButtons) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.disableGenBookmarkModalButtons, values: Array(newValue))
                 onSettingsChanged?()
             }
             .onChange(of: enabledExperimentalFeatures) { _, newValue in
+                guard hasLoadedPreferences else { return }
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.experimentalFeatures, values: Array(newValue))
                 onSettingsChanged?()

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -49,6 +49,15 @@ public struct SettingsView: View {
     /// Callback invoked when settings mutations should trigger reader refreshes.
     var onSettingsChanged: (() -> Void)?
 
+    /// Reader controller used by feature shortcuts that edit pane-backed reading-progress settings.
+    let readingProgressController: BibleReaderController?
+
+    /// Current settings search query.
+    @State private var settingsSearchText = ""
+
+    /// Controls the confirmation prompt for resetting application preferences.
+    @State private var showResetConfirmation = false
+
     /// Installed dictionaries that advertise Greek Strong's definitions.
     @State private var strongsGreekDictionaries: [ModuleInfo] = []
 
@@ -315,17 +324,20 @@ public struct SettingsView: View {
        - displaySettings: Shared text-display settings edited by nested settings views.
        - nightMode: Shared effective night-mode state used by the reader.
        - nightModeMode: Shared persisted night-mode mode string.
+       - readingProgressController: Optional reader controller used by Reading Progress Settings.
        - onSettingsChanged: Optional callback invoked when changes should refresh reader content.
      */
     public init(
         displaySettings: Binding<TextDisplaySettings>,
         nightMode: Binding<Bool>,
         nightModeMode: Binding<String>,
+        readingProgressController: BibleReaderController? = nil,
         onSettingsChanged: (() -> Void)? = nil
     ) {
         self._displaySettings = displaySettings
         self._nightMode = nightMode
         self._nightModeMode = nightModeMode
+        self.readingProgressController = readingProgressController
         self.onSettingsChanged = onSettingsChanged
     }
 
@@ -333,693 +345,113 @@ public struct SettingsView: View {
      Builds the full settings form, preference hydration, alerts, and settings-side effects.
      */
     public var body: some View {
+        settingsFormWithPreferencePersistence
+    }
+
+    /**
+     Composes the visible settings sections without presentation modifiers or persistence observers.
+
+     Keeping this as a small builder gives SwiftUI a stable root expression and keeps search gating
+     declarative at the section level.
+     *
+     - Side Effects: none directly; child controls perform their own preference writes.
+     - Failure Modes: Sections omitted by search or missing data are simply not rendered.
+     */
+    @ViewBuilder
+    private var settingsForm: some View {
         Form {
-                settingsUITestShortcutSection
-
-                if hasDictionaryPreferences {
-                    Section {
-                        if !strongsGreekDictionaries.isEmpty {
-                            NavigationLink {
-                                DictionaryMultiSelectView(
-                                    title: String(
-                                        localized: "choose_strongs_greek_dictionary_title",
-                                        defaultValue: "Strongs Greek dictionary"
-                                    ),
-                                    dictionaries: strongsGreekDictionaries,
-                                    selectedNames: $selectedStrongsGreekDictionaryNames
-                                )
-                            } label: {
-                                settingsSelectionRow(
-                                    preferenceKey: .strongsGreekDictionary,
-                                    title: String(
-                                        localized: "choose_strongs_greek_dictionary_title",
-                                        defaultValue: "Strongs Greek dictionary"
-                                    ),
-                                    summary: String(
-                                        localized: "choose_strongs_greek_dictionary_summary",
-                                        defaultValue: "Choose Strongs dictionary for Greek word definitions"
-                                    ),
-                                    detail: selectionSummary(
-                                        selectedNames: selectedStrongsGreekDictionaryNames,
-                                        available: strongsGreekDictionaries
-                                    )
-                                )
-                            }
-                            .accessibilityIdentifier("settingsStrongsGreekDictionaryLink")
-                        }
-
-                        if !strongsHebrewDictionaries.isEmpty {
-                            NavigationLink {
-                                DictionaryMultiSelectView(
-                                    title: String(
-                                        localized: "choose_strongs_hebrew_dictionary_title",
-                                        defaultValue: "Strongs Hebrew dictionary"
-                                    ),
-                                    dictionaries: strongsHebrewDictionaries,
-                                    selectedNames: $selectedStrongsHebrewDictionaryNames
-                                )
-                            } label: {
-                                settingsSelectionRow(
-                                    preferenceKey: .strongsHebrewDictionary,
-                                    title: String(
-                                        localized: "choose_strongs_hebrew_dictionary_title",
-                                        defaultValue: "Strongs Hebrew dictionary"
-                                    ),
-                                    summary: String(
-                                        localized: "choose_strongs_hebrew_dictionary_summary",
-                                        defaultValue: "Choose Strongs dictionary for Hebrew word definitions"
-                                    ),
-                                    detail: selectionSummary(
-                                        selectedNames: selectedStrongsHebrewDictionaryNames,
-                                        available: strongsHebrewDictionaries
-                                    )
-                                )
-                            }
-                            .accessibilityIdentifier("settingsStrongsHebrewDictionaryLink")
-                        }
-
-                        if !robinsonMorphologyDictionaries.isEmpty {
-                            NavigationLink {
-                                DictionaryMultiSelectView(
-                                    title: String(
-                                        localized: "choose_strongs_greek_morphology_title",
-                                        defaultValue: "Robinson Greek morphology"
-                                    ),
-                                    dictionaries: robinsonMorphologyDictionaries,
-                                    selectedNames: $selectedRobinsonMorphologyDictionaryNames
-                                )
-                            } label: {
-                                settingsSelectionRow(
-                                    preferenceKey: .robinsonGreekMorphology,
-                                    title: String(
-                                        localized: "choose_strongs_greek_morphology_title",
-                                        defaultValue: "Robinson Greek morphology"
-                                    ),
-                                    summary: String(
-                                        localized: "choose_strongs_greek_morphology_summary",
-                                        defaultValue: "Choose dictionary for Robinson Greek morphology definitions"
-                                    ),
-                                    detail: selectionSummary(
-                                        selectedNames: selectedRobinsonMorphologyDictionaryNames,
-                                        available: robinsonMorphologyDictionaries
-                                    )
-                                )
-                            }
-                            .accessibilityIdentifier("settingsRobinsonMorphologyLink")
-                        }
-
-                        if !wordLookupDictionaries.isEmpty {
-                            NavigationLink {
-                                DictionaryInverseMultiSelectView(
-                                    title: String(
-                                        localized: "choose_word_lookup_dictionary_title",
-                                        defaultValue: "Word lookup dictionaries"
-                                    ),
-                                    dictionaries: wordLookupDictionaries,
-                                    disabledNames: $disabledWordLookupDictionaryNames
-                                )
-                            } label: {
-                                settingsSelectionRow(
-                                    preferenceKey: .disabledWordLookupDictionaries,
-                                    title: String(
-                                        localized: "choose_word_lookup_dictionary_title",
-                                        defaultValue: "Word lookup dictionaries"
-                                    ),
-                                    summary: String(
-                                        localized: "choose_word_lookup_dictionary_summary",
-                                        defaultValue: "Choose dictionaries for looking up words"
-                                    ),
-                                    detail: inverseSelectionSummary(
-                                        disabledNames: disabledWordLookupDictionaryNames,
-                                        available: wordLookupDictionaries
-                                    )
-                                )
-                            }
-                            .accessibilityIdentifier("settingsWordLookupDictionariesLink")
-                        }
-                    } header: {
-                        settingsSectionHeader(String(localized: "settings_dictionaries"))
-                    }
-                }
-
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { navigateToVerse },
-                        set: { newValue in
-                            navigateToVerse = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.navigateToVersePref, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .navigateToVersePref,
-                            title: String(
-                                localized: "prefs_navigate_to_verse_title",
-                                defaultValue: "Navigate to verse"
-                            ),
-                            summary: String(
-                                localized: "prefs_navigate_to_verse_summary",
-                                defaultValue: "Choose verse (and chapter) when selecting a passage"
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { openLinksInSpecialWindow },
-                        set: { newValue in
-                            openLinksInSpecialWindow = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.openLinksInSpecialWindowPref, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .openLinksInSpecialWindowPref,
-                            title: String(
-                                localized: "prefs_open_links_in_special_window_title",
-                                defaultValue: "Links window"
-                            ),
-                            summary: String(
-                                localized: "prefs_open_links_in_special_window_summary",
-                                defaultValue: "Open links in special window, for quicker display of cross-references and Strongs"
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { screenKeepOn },
-                        set: { newValue in
-                            screenKeepOn = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.screenKeepOnPref, value: newValue)
-                            applyScreenKeepOn(newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .screenKeepOnPref,
-                            title: String(localized: "prefs_screen_keep_on_title", defaultValue: "Keep screen on"),
-                            summary: String(
-                                localized: "prefs_screen_keep_on_summary",
-                                defaultValue: "Prevent screen sleeping while using this app"
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { doubleTapToFullscreen },
-                        set: { newValue in
-                            doubleTapToFullscreen = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.doubleTapToFullscreen, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .doubleTapToFullscreen,
-                            title: String(
-                                localized: "prefs_double_tap_to_fullscreen_title",
-                                defaultValue: "Double-tap to Fullscreen"
-                            ),
-                            summary: String(
-                                localized: "prefs_double_tap_to_fullscreen_summary",
-                                defaultValue: "Enter fullscreen mode by double-tapping window"
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { autoFullscreen },
-                        set: { newValue in
-                            autoFullscreen = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.autoFullscreenPref, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .autoFullscreenPref,
-                            title: String(localized: "auto_fullscreen", defaultValue: "Fullscreen by scrolling"),
-                            summary: String(
-                                localized: "auto_fullscreen_summary",
-                                defaultValue: "Switch automatically to fullscreen when scrolling text. Tip: you can always also switch to full screen by doubletapping screen."
-                            )
-                        )
-                    }
-                    Picker(selection: Binding(
-                            get: { Self.normalizedToolbarButtonActionsMode(toolbarButtonActionsMode) },
-                            set: { newValue in
-                                toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(newValue)
-                                let store = SettingsStore(modelContext: modelContext)
-                                store.setString(.toolbarButtonActions, value: toolbarButtonActionsMode)
-                            }
-                        )) {
-                        Text(String(localized: "prefs_toolbar_button_action_default", defaultValue: "Default"))
-                            .tag("default")
-                        Text(String(localized: "prefs_toolbar_button_action_swap_menu", defaultValue: "Swap menu"))
-                            .tag("swap-menu")
-                        Text(String(localized: "prefs_toolbar_button_action_swap_activity", defaultValue: "Swap activity"))
-                            .tag("swap-activity")
-                    } label: {
-                        settingsRowLabel(
-                            preferenceKey: .toolbarButtonActions,
-                            title: String(
-                                localized: "prefs_toolbar_button_action_title",
-                                defaultValue: "Bible/commentary toolbar button action"
-                            ),
-                            summary: String(
-                                localized: "prefs_toolbar_button_action_summary",
-                                defaultValue: "Choose if one-tap of Bible/commentary toolbar buttons shows menu or activity directly."
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { disableTwoStepBookmarking },
-                        set: { newValue in
-                            disableTwoStepBookmarking = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.disableTwoStepBookmarking, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .disableTwoStepBookmarking,
-                            title: String(
-                                localized: "prefs_disable_two_step_bookmarking_title",
-                                defaultValue: "One-step bookmarking"
-                            ),
-                            summary: String(
-                                localized: "prefs_disable_two_step_bookmarking_summary",
-                                defaultValue: "Show \"Selection\" and \"Verses\" items directly in Bible view Selection menu"
-                            )
-                        )
-                    }
-                    Picker(selection: Binding(
-                            get: { Self.normalizedBibleViewSwipeMode(bibleViewSwipeMode) },
-                            set: { newValue in
-                                bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(newValue)
-                                let store = SettingsStore(modelContext: modelContext)
-                                store.setString(.bibleViewSwipeMode, value: bibleViewSwipeMode)
-                            }
-                        )) {
-                        Text(String(localized: "prefs_swipe_mode_chapter", defaultValue: "Chapter"))
-                            .tag("CHAPTER")
-                        Text(String(localized: "prefs_swipe_mode_page", defaultValue: "Page"))
-                            .tag("PAGE")
-                        Text(String(localized: "prefs_swipe_mode_none", defaultValue: "None"))
-                            .tag("NONE")
-                    } label: {
-                        settingsRowLabel(
-                            preferenceKey: .bibleViewSwipeMode,
-                            title: String(
-                                localized: "prefs_bible_view_swipe_mode_title",
-                                defaultValue: "Action for swipe left / right gesture"
-                            ),
-                            summary: String(
-                                localized: "prefs_bible_view_swipe_mode_summary",
-                                defaultValue: "Swipe left / right gesture can be used to go to next page / chapter."
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { volumeKeysScroll },
-                        set: { newValue in
-                            volumeKeysScroll = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.volumeKeysScroll, value: newValue)
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .volumeKeysScroll,
-                            title: String(
-                                localized: "prefs_volume_keys_scroll_title",
-                                defaultValue: "Volume buttons scroll"
-                            ),
-                            summary: String(
-                                localized: "prefs_volume_keys_scroll_summary",
-                                defaultValue: "Use volume up/down to scroll Bible text"
-                            ),
-                            detail: String(
-                                localized: "prefs_volume_keys_scroll_ios_note",
-                                defaultValue: "iOS does not expose volume-button presses to apps. This setting is kept for Android parity and cross-device sync."
-                            )
-                        )
-                    }
-                    Toggle(isOn: Binding(
-                        get: { displaySettings.enableVerseSelection ?? true },
-                        set: {
-                            displaySettings.enableVerseSelection = $0
-                            onSettingsChanged?()
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: nil,
-                            title: String(localized: "verse_selection")
-                        )
-                    }
-                } header: {
-                    settingsSectionHeader(
-                        String(localized: "prefs_behavior_customization_cat", defaultValue: "Application behavior")
-                    )
-                }
-
-                lookAndFeelSection
-
-                Section {
-                    Button {
-                        showDiscreteHelp = true
-                    } label: {
-                        settingsRowLabel(
-                            preferenceKey: .discreteHelp,
-                            title: String(localized: "discrete_help_title"),
-                            summary: String(localized: "discrete_help_summary")
-                        )
-                    }
-
-                    Toggle(isOn: $discreteMode) {
-                        settingsRowLabel(
-                            preferenceKey: .discreteMode,
-                            title: String(localized: "discrete_mode"),
-                            summary: String(localized: "discrete_mode_description")
-                        )
-                    }
-
-                    Toggle(isOn: $showCalculator) {
-                        settingsRowLabel(
-                            preferenceKey: .showCalculator,
-                            title: String(localized: "show_calculator"),
-                            summary: String(localized: "show_calculator_description")
-                        )
-                    }
-
-                    HStack(alignment: .top, spacing: 12) {
-                        settingsRowLabel(
-                            preferenceKey: .calculatorPin,
-                            title: String(localized: "calculator_pin"),
-                            summary: String(localized: "calculator_pin_description")
-                        )
-                        Spacer()
-                        TextField(String(localized: "calculator_pin_placeholder"), text: $calculatorPin)
-                            #if os(iOS)
-                            .keyboardType(.numberPad)
-                            #endif
-                            .multilineTextAlignment(.trailing)
-                            .frame(width: 100)
-                            .onChange(of: calculatorPin) { _, newValue in
-                                let filtered = newValue.filter { $0.isNumber }
-                                if filtered != newValue { calculatorPin = filtered }
-                            }
-                    }
-                } header: {
-                    settingsSectionHeader(String(localized: "settings_security"))
-                }
-
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { enableBluetoothMediaButtons },
-                        set: { newValue in
-                            enableBluetoothMediaButtons = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.enableBluetoothPref, value: newValue)
-                            onSettingsChanged?()
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .enableBluetoothPref,
-                            title: String(
-                                localized: "prefs_enable_bluetooth_title",
-                                defaultValue: "Enable Bluetooth media buttons"
-                            ),
-                            summary: String(
-                                localized: "prefs_enable_bluetooth_summary",
-                                defaultValue: "Handle Bluetooth media buttons to start/stop speaking."
-                            )
-                        )
-                    }
-                    NavigationLink {
-                        ExperimentalFeaturesMultiSelectView(
-                            title: String(
-                                localized: "prefs_experimental_features_title",
-                                defaultValue: "Experimental features"
-                            ),
-                            options: Self.experimentalFeatureOptions,
-                            selectedValues: $enabledExperimentalFeatures
-                        )
-                    } label: {
-                        settingsSelectionRow(
-                            preferenceKey: .experimentalFeatures,
-                            title: String(
-                                localized: "prefs_experimental_features_title",
-                                defaultValue: "Experimental features"
-                            ),
-                            summary: String(
-                                localized: "prefs_experimental_features_summary",
-                                defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
-                            ),
-                            detail: experimentalFeaturesSummary(selectedValues: enabledExperimentalFeatures)
-                        )
-                    }
-                    #if DEBUG
-                    Toggle(isOn: Binding(
-                        get: { showErrorBox },
-                        set: { newValue in
-                            showErrorBox = newValue
-                            let store = SettingsStore(modelContext: modelContext)
-                            store.setBool(.showErrorBox, value: newValue)
-                            onSettingsChanged?()
-                        }
-                    )) {
-                        settingsRowLabel(
-                            preferenceKey: .showErrorBox,
-                            title: String(
-                                localized: "prefs_show_error_box_title",
-                                defaultValue: "Show Javascript error box"
-                            ),
-                            summary: String(
-                                localized: "prefs_show_error_box_summary",
-                                defaultValue: "Useful for developers when debugging BibleView javascript side errors. This will make the app slower."
-                            )
-                        )
-                    }
-                    #endif
-
-                    #if os(iOS)
-                    Button {
-                        openBibleLinkSystemSettings()
-                    } label: {
-                        settingsRowLabel(
-                            preferenceKey: .openLinks,
-                            title: String(
-                                localized: "open_bible_links_title",
-                                defaultValue: "Open Bible links in AndBible"
-                            ),
-                            summary: String(
-                                localized: "open_bible_links_summary",
-                                defaultValue: "When clicking links that refer to AndBible supported Bible URL, open them in AndBible"
-                            )
-                        )
-                    }
-                    #endif
-
-                    #if DEBUG
-                    Button(role: .destructive) {
-                        triggerDebugCrash()
-                    } label: {
-                        settingsRowLabel(
-                            preferenceKey: .crashApp,
-                            title: String(
-                                localized: "crash_app",
-                                defaultValue: "Crash app!"
-                            ),
-                            summary: debugCrashScheduled
-                                ? String(
-                                    localized: "crash_app_scheduled_summary",
-                                    defaultValue: "Crash scheduled in 10 seconds."
-                                )
-                                : String(
-                                    localized: "crash_app_summary",
-                                    defaultValue: "Crash app after 10 seconds. Debugging feature, visible only in debug builds."
-                                ),
-                            isEnabled: !debugCrashScheduled
-                        )
-                    }
-                    .disabled(debugCrashScheduled)
-                    #endif
-                } header: {
-                    settingsSectionHeader(
-                        String(localized: "prefs_advanced_settings_cat", defaultValue: "Advanced settings")
-                    )
-                }
-
-                Section {
-                    settingsNavigationLink(
-                        title: String(localized: "downloads"),
-                        accessibilityIdentifier: "settingsDownloadsLink"
-                    ) {
-                        ModuleBrowserView()
-                    }
-                    settingsNavigationLink(
-                        title: String(localized: "repositories"),
-                        accessibilityIdentifier: "settingsRepositoriesLink"
-                    ) {
-                        RepositoryManagerView()
-                    }
-                    settingsNavigationLink(
-                        title: String(localized: "import_export"),
-                        accessibilityIdentifier: "settingsImportExportLink"
-                    ) {
-                        ImportExportView()
-                    }
-                    settingsNavigationLink(
-                        title: String(localized: "icloud_sync"),
-                        accessibilityIdentifier: "settingsSyncLink"
-                    ) {
-                        SyncSettingsView()
-                    }
-                    settingsNavigationLink(
-                        title: String(localized: "labels"),
-                        accessibilityIdentifier: "settingsLabelsLink"
-                    ) {
-                        LabelManagerView()
-                    }
-                } header: {
-                    settingsSectionHeader(String(localized: "settings_data"))
-                }
-
-                Section {
-                    HStack(alignment: .top, spacing: 12) {
-                        settingsRowLabel(
-                            preferenceKey: nil,
-                            title: String(localized: "version")
-                        )
-                        Spacer()
-                        Text("1.0.0")
-                            .foregroundStyle(.secondary)
-                            .padding(.vertical, 8)
-                    }
-                } header: {
-                    settingsSectionHeader(String(localized: "settings_about"))
-                }
+            if shouldShowFeaturesSection {
+                featuresSettingsSection
             }
+
+            if shouldShowDictionarySection {
+                dictionarySettingsSection
+            }
+
+            if shouldShowBehaviorSection {
+                behaviorSettingsSection
+            }
+
+            if shouldShowLookAndFeelSection {
+                lookAndFeelSection
+            }
+
+            if shouldShowSecuritySection {
+                securitySettingsSection
+            }
+
+            if shouldShowAdvancedSection {
+                advancedSettingsSection
+            }
+
+            if shouldShowAboutSection {
+                aboutSettingsSection
+            }
+
+            if shouldShowNoSettingsSearchResults {
+                noSettingsSearchResultsSection
+            }
+        }
+    }
+
+    /**
+     Applies navigation, alerts, sheet presentation, search, and toolbar controls to the form.
+
+     - Side Effects: `onAppear` reloads persisted state; toolbar and alerts mutate local presentation
+       state and reset preferences when confirmed.
+     - Failure Modes: Reset uses registry-backed defaults and falls back through `SettingsStore`.
+     */
+    private var settingsFormWithPresentation: some View {
+        settingsForm
             .accessibilityIdentifier("settingsForm")
             .accessibilityValue(settingsAccessibilityValue)
-            .navigationTitle(String(localized: "settings"))
+            .navigationTitle(settingsNavigationTitleText)
             .alert(
-                String(localized: "prefs_interface_locale_title", defaultValue: "Application language"),
+                languageRestartAlertTitleText,
                 isPresented: $showRestartAlert
             ) {
                 Button(String(localized: "ok")) {}
             } message: {
-                Text(String(localized: "language_restart_required"))
+                Text(languageRestartAlertMessageText)
+            }
+            .alert(
+                settingsResetTitleText,
+                isPresented: $showResetConfirmation
+            ) {
+                Button(String(localized: "cancel"), role: .cancel) {}
+                Button(String(localized: "reset", defaultValue: "Reset"), role: .destructive) {
+                    resetApplicationPreferences()
+                }
+            } message: {
+                Text(settingsResetMessageText)
             }
             .sheet(isPresented: $showDiscreteHelp) {
-                NavigationStack {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text(String(localized: "discrete_help_par1"))
-                            Text(String(localized: "discrete_help_par2"))
-                            Text(String(localized: "discrete_help_par3"))
-                            Text(String(localized: "discrete_help_ios_note"))
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding()
-                    }
-                    .navigationTitle(String(localized: "settings_security"))
-                    #if os(iOS)
-                    .navigationBarTitleDisplayMode(.inline)
-                    #endif
-                    .toolbar {
-                        ToolbarItem(placement: .confirmationAction) {
-                            Button(String(localized: "done")) { showDiscreteHelp = false }
-                        }
-                    }
+                discreteHelpSheetContent
+            }
+            .searchable(
+                text: $settingsSearchText,
+                prompt: settingsSearchPromptText
+            )
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    settingsResetToolbarButton
                 }
             }
             .onAppear {
-                // Load installed dictionary modules
-                if let mgr = SwordManager() {
-                    let all = mgr.installedModules()
-                    strongsGreekDictionaries = all
-                        .filter {
-                            ($0.category == .dictionary || $0.category == .glossary) &&
-                                StrongsDictionaryPolicy.isSupportedDictionaryModuleName($0.name) &&
-                                $0.features.contains(.greekDef)
-                        }
-                        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                    strongsHebrewDictionaries = all
-                        .filter {
-                            ($0.category == .dictionary || $0.category == .glossary) &&
-                                StrongsDictionaryPolicy.isSupportedDictionaryModuleName($0.name) &&
-                                $0.features.contains(.hebrewDef)
-                        }
-                        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                    robinsonMorphologyDictionaries = all
-                        .filter {
-                            ($0.category == .dictionary || $0.category == .glossary) &&
-                                $0.features.contains(.greekParse)
-                        }
-                        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                    wordLookupDictionaries = all
-                        .filter {
-                            $0.category == .dictionary &&
-                                !$0.features.contains(.greekDef) &&
-                                !$0.features.contains(.hebrewDef) &&
-                                !$0.features.contains(.greekParse)
-                        }
-                        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                }
-                hasLoadedPreferences = false
-                // Load persisted preferences
-                let store = SettingsStore(modelContext: modelContext)
-                selectedStrongsGreekDictionaryNames = Set(store.getStringSet(.strongsGreekDictionary))
-                selectedStrongsHebrewDictionaryNames = Set(store.getStringSet(.strongsHebrewDictionary))
-                selectedRobinsonMorphologyDictionaryNames = Set(store.getStringSet(.robinsonGreekMorphology))
-                disabledWordLookupDictionaryNames = Set(store.getStringSet(.disabledWordLookupDictionaries))
-                disabledBibleBookmarkModalButtons = Set(store.getStringSet(.disableBibleBookmarkModalButtons))
-                disabledGenBookmarkModalButtons = Set(store.getStringSet(.disableGenBookmarkModalButtons))
-                sanitizeDictionaryPreferences(store: store)
-                sanitizeBookmarkModalActionPreferences(store: store)
-                openLinksInSpecialWindow = store.getBool(.openLinksInSpecialWindowPref)
-                monochromeMode = store.getBool(.monochromeMode)
-                disableAnimations = store.getBool(.disableAnimations)
-                disableClickToEdit = store.getBool(.disableClickToEdit)
-                showActiveWindowIndicator = store.getBool(.showActiveWindowIndicator)
-                showErrorBox = store.getBool(.showErrorBox)
-                enableBluetoothMediaButtons = store.getBool(.enableBluetoothPref)
-                fontSizeMultiplier = store.getInt(.fontSizeMultiplier)
-                fullScreenHideButtons = store.getBool(.fullScreenHideButtonsPref)
-                hideWindowButtons = store.getBool(.hideWindowButtons)
-                hideBibleReferenceOverlay = store.getBool(.hideBibleReferenceOverlay)
-                navigateToVerse = store.getBool(.navigateToVersePref)
-                screenKeepOn = store.getBool(.screenKeepOnPref)
-                doubleTapToFullscreen = store.getBool(.doubleTapToFullscreen)
-                autoFullscreen = store.getBool(.autoFullscreenPref)
-                disableTwoStepBookmarking = store.getBool(.disableTwoStepBookmarking)
-                toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(
-                    store.getString(.toolbarButtonActions)
-                )
-                bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(store.getString(.bibleViewSwipeMode))
-                volumeKeysScroll = store.getBool(.volumeKeysScroll)
-                enabledExperimentalFeatures = Set(store.getStringSet(.experimentalFeatures))
-                sanitizeExperimentalFeatures(store: store)
-                nightModeMode = store.getString(.nightModePref3)
-                let manualNightMode = store.getBool("night_mode")
-                nightMode = NightModeSettingsResolver.isNightMode(
-                    rawValue: nightModeMode,
-                    manualNightMode: manualNightMode,
-                    systemIsDark: colorScheme == .dark
-                )
-                applyScreenKeepOn(screenKeepOn)
-                // Load locale_pref first. Fallback to any existing AppleLanguages override from older builds.
-                let persistedLocale = store.getString(.localePref)
-                if Self.localeOptions.contains(where: { $0.value == persistedLocale }) {
-                    selectedLanguage = persistedLocale
-                } else {
-                    selectedLanguage = ""
-                    if !persistedLocale.isEmpty {
-                        store.setString(.localePref, value: "")
-                    }
-                }
-                if selectedLanguage.isEmpty,
-                   let overrideLangs = UserDefaults.standard.array(forKey: "AppleLanguages") as? [String],
-                   let first = overrideLangs.first,
-                   let mapped = Self.localePrefValue(forAppleLanguage: first) {
-                    selectedLanguage = mapped
-                    store.setString(.localePref, value: mapped)
-                }
-                hasLoadedPreferences = true
+                loadSettingsState()
             }
+    }
+
+    /**
+     Adds persistence observers for multi-select settings whose state is edited in child screens.
+
+     - Side Effects: Writes selected dictionary/action/experimental-feature values into SwiftData and
+       refreshes reader content for options that affect rendered documents.
+     - Failure Modes: Store writes use the same `SettingsStore` defaults and model-context error
+       handling as the rest of settings.
+     */
+    private var settingsFormWithPreferencePersistence: some View {
+        settingsFormWithPresentation
             .onChange(of: selectedStrongsGreekDictionaryNames) { _, newValue in
                 let store = SettingsStore(modelContext: modelContext)
                 store.setStringSet(.strongsGreekDictionary, values: Array(newValue))
@@ -1053,10 +485,579 @@ public struct SettingsView: View {
             }
     }
 
+    /**
+     Builds the module-backed dictionary settings section when relevant dictionaries are installed.
+
+     - Side Effects: Navigation destinations mutate the bound dictionary-selection state; persistence is
+       handled by the parent view's `onChange` observers.
+     - Failure Modes: Empty module lists omit their rows instead of rendering disabled placeholders.
+     */
     @ViewBuilder
+    private var dictionarySettingsSection: some View {
+        Section {
+            if !strongsGreekDictionaries.isEmpty {
+                NavigationLink {
+                    DictionaryMultiSelectView(
+                        title: String(
+                            localized: "choose_strongs_greek_dictionary_title",
+                            defaultValue: "Strongs Greek dictionary"
+                        ),
+                        dictionaries: strongsGreekDictionaries,
+                        selectedNames: $selectedStrongsGreekDictionaryNames
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .strongsGreekDictionary,
+                        title: String(
+                            localized: "choose_strongs_greek_dictionary_title",
+                            defaultValue: "Strongs Greek dictionary"
+                        ),
+                        summary: String(
+                            localized: "choose_strongs_greek_dictionary_summary",
+                            defaultValue: "Choose Strongs dictionary for Greek word definitions"
+                        ),
+                        detail: selectionSummary(
+                            selectedNames: selectedStrongsGreekDictionaryNames,
+                            available: strongsGreekDictionaries
+                        )
+                    )
+                }
+                .accessibilityIdentifier("settingsStrongsGreekDictionaryLink")
+            }
+
+            if !strongsHebrewDictionaries.isEmpty {
+                NavigationLink {
+                    DictionaryMultiSelectView(
+                        title: String(
+                            localized: "choose_strongs_hebrew_dictionary_title",
+                            defaultValue: "Strongs Hebrew dictionary"
+                        ),
+                        dictionaries: strongsHebrewDictionaries,
+                        selectedNames: $selectedStrongsHebrewDictionaryNames
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .strongsHebrewDictionary,
+                        title: String(
+                            localized: "choose_strongs_hebrew_dictionary_title",
+                            defaultValue: "Strongs Hebrew dictionary"
+                        ),
+                        summary: String(
+                            localized: "choose_strongs_hebrew_dictionary_summary",
+                            defaultValue: "Choose Strongs dictionary for Hebrew word definitions"
+                        ),
+                        detail: selectionSummary(
+                            selectedNames: selectedStrongsHebrewDictionaryNames,
+                            available: strongsHebrewDictionaries
+                        )
+                    )
+                }
+                .accessibilityIdentifier("settingsStrongsHebrewDictionaryLink")
+            }
+
+            if !robinsonMorphologyDictionaries.isEmpty {
+                NavigationLink {
+                    DictionaryMultiSelectView(
+                        title: String(
+                            localized: "choose_strongs_greek_morphology_title",
+                            defaultValue: "Robinson Greek morphology"
+                        ),
+                        dictionaries: robinsonMorphologyDictionaries,
+                        selectedNames: $selectedRobinsonMorphologyDictionaryNames
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .robinsonGreekMorphology,
+                        title: String(
+                            localized: "choose_strongs_greek_morphology_title",
+                            defaultValue: "Robinson Greek morphology"
+                        ),
+                        summary: String(
+                            localized: "choose_strongs_greek_morphology_summary",
+                            defaultValue: "Choose dictionary for Robinson Greek morphology definitions"
+                        ),
+                        detail: selectionSummary(
+                            selectedNames: selectedRobinsonMorphologyDictionaryNames,
+                            available: robinsonMorphologyDictionaries
+                        )
+                    )
+                }
+                .accessibilityIdentifier("settingsRobinsonMorphologyLink")
+            }
+
+            if !wordLookupDictionaries.isEmpty {
+                NavigationLink {
+                    DictionaryInverseMultiSelectView(
+                        title: String(
+                            localized: "choose_word_lookup_dictionary_title",
+                            defaultValue: "Word lookup dictionaries"
+                        ),
+                        dictionaries: wordLookupDictionaries,
+                        disabledNames: $disabledWordLookupDictionaryNames
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .disabledWordLookupDictionaries,
+                        title: String(
+                            localized: "choose_word_lookup_dictionary_title",
+                            defaultValue: "Word lookup dictionaries"
+                        ),
+                        summary: String(
+                            localized: "choose_word_lookup_dictionary_summary",
+                            defaultValue: "Choose dictionaries for looking up words"
+                        ),
+                        detail: inverseSelectionSummary(
+                            disabledNames: disabledWordLookupDictionaryNames,
+                            available: wordLookupDictionaries
+                        )
+                    )
+                }
+                .accessibilityIdentifier("settingsWordLookupDictionariesLink")
+            }
+        } header: {
+            settingsSectionHeader(String(localized: "settings_dictionaries"))
+        }
+    }
+
+    /**
+     Builds Android-parity behavior preferences backed by `SettingsStore` and reader callbacks.
+
+     - Side Effects: Writes changed values to SwiftData-backed preferences and refreshes reader content
+       for display-affecting options.
+     - Failure Modes: Store read/write helpers fall back to registry defaults if no persisted value exists.
+     */
+    @ViewBuilder
+    private var behaviorSettingsSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { navigateToVerse },
+                set: { newValue in
+                    navigateToVerse = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.navigateToVersePref, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .navigateToVersePref,
+                    title: String(
+                        localized: "prefs_navigate_to_verse_title",
+                        defaultValue: "Navigate to verse"
+                    ),
+                    summary: String(
+                        localized: "prefs_navigate_to_verse_summary",
+                        defaultValue: "Choose verse (and chapter) when selecting a passage"
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { openLinksInSpecialWindow },
+                set: { newValue in
+                    openLinksInSpecialWindow = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.openLinksInSpecialWindowPref, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .openLinksInSpecialWindowPref,
+                    title: String(
+                        localized: "prefs_open_links_in_special_window_title",
+                        defaultValue: "Links window"
+                    ),
+                    summary: String(
+                        localized: "prefs_open_links_in_special_window_summary",
+                        defaultValue: "Open links in special window, for quicker display of cross-references and Strongs"
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { screenKeepOn },
+                set: { newValue in
+                    screenKeepOn = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.screenKeepOnPref, value: newValue)
+                    applyScreenKeepOn(newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .screenKeepOnPref,
+                    title: String(localized: "prefs_screen_keep_on_title", defaultValue: "Keep screen on"),
+                    summary: String(
+                        localized: "prefs_screen_keep_on_summary",
+                        defaultValue: "Prevent screen sleeping while using this app"
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { doubleTapToFullscreen },
+                set: { newValue in
+                    doubleTapToFullscreen = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.doubleTapToFullscreen, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .doubleTapToFullscreen,
+                    title: String(
+                        localized: "prefs_double_tap_to_fullscreen_title",
+                        defaultValue: "Double-tap to Fullscreen"
+                    ),
+                    summary: String(
+                        localized: "prefs_double_tap_to_fullscreen_summary",
+                        defaultValue: "Enter fullscreen mode by double-tapping window"
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { autoFullscreen },
+                set: { newValue in
+                    autoFullscreen = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.autoFullscreenPref, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .autoFullscreenPref,
+                    title: String(localized: "auto_fullscreen", defaultValue: "Fullscreen by scrolling"),
+                    summary: String(
+                        localized: "auto_fullscreen_summary",
+                        defaultValue: "Switch automatically to fullscreen when scrolling text. Tip: you can always also switch to full screen by doubletapping screen."
+                    )
+                )
+            }
+            Picker(selection: Binding(
+                    get: { Self.normalizedToolbarButtonActionsMode(toolbarButtonActionsMode) },
+                    set: { newValue in
+                        toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(newValue)
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setString(.toolbarButtonActions, value: toolbarButtonActionsMode)
+                    }
+                )) {
+                Text(String(localized: "prefs_toolbar_button_action_default", defaultValue: "Default"))
+                    .tag("default")
+                Text(String(localized: "prefs_toolbar_button_action_swap_menu", defaultValue: "Swap menu"))
+                    .tag("swap-menu")
+                Text(String(localized: "prefs_toolbar_button_action_swap_activity", defaultValue: "Swap activity"))
+                    .tag("swap-activity")
+            } label: {
+                settingsRowLabel(
+                    preferenceKey: .toolbarButtonActions,
+                    title: String(
+                        localized: "prefs_toolbar_button_action_title",
+                        defaultValue: "Bible/commentary toolbar button action"
+                    ),
+                    summary: String(
+                        localized: "prefs_toolbar_button_action_summary",
+                        defaultValue: "Choose if one-tap of Bible/commentary toolbar buttons shows menu or activity directly."
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { disableTwoStepBookmarking },
+                set: { newValue in
+                    disableTwoStepBookmarking = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.disableTwoStepBookmarking, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .disableTwoStepBookmarking,
+                    title: String(
+                        localized: "prefs_disable_two_step_bookmarking_title",
+                        defaultValue: "One-step bookmarking"
+                    ),
+                    summary: String(
+                        localized: "prefs_disable_two_step_bookmarking_summary",
+                        defaultValue: "Show \"Selection\" and \"Verses\" items directly in Bible view Selection menu"
+                    )
+                )
+            }
+            Picker(selection: Binding(
+                    get: { Self.normalizedBibleViewSwipeMode(bibleViewSwipeMode) },
+                    set: { newValue in
+                        bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(newValue)
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setString(.bibleViewSwipeMode, value: bibleViewSwipeMode)
+                    }
+            )) {
+                Text(String(localized: "prefs_swipe_mode_chapter", defaultValue: "Chapter"))
+                    .tag("CHAPTER")
+                Text(String(localized: "prefs_swipe_mode_page", defaultValue: "Page"))
+                    .tag("PAGE")
+                Text(String(localized: "prefs_swipe_mode_none", defaultValue: "None"))
+                    .tag("NONE")
+            } label: {
+                bibleViewSwipeModeSettingsRow
+            }
+            Toggle(isOn: Binding(
+                get: { volumeKeysScroll },
+                set: { newValue in
+                    volumeKeysScroll = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.volumeKeysScroll, value: newValue)
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .volumeKeysScroll,
+                    title: String(
+                        localized: "prefs_volume_keys_scroll_title",
+                        defaultValue: "Volume buttons scroll"
+                    ),
+                    summary: String(
+                        localized: "prefs_volume_keys_scroll_summary",
+                        defaultValue: "Use volume up/down to scroll Bible text"
+                    ),
+                    detail: String(
+                        localized: "prefs_volume_keys_scroll_ios_note",
+                        defaultValue: "iOS does not expose volume-button presses to apps. This setting is kept for Android parity and cross-device sync."
+                    )
+                )
+            }
+            Toggle(isOn: Binding(
+                get: { displaySettings.enableVerseSelection ?? true },
+                set: {
+                    displaySettings.enableVerseSelection = $0
+                    onSettingsChanged?()
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: nil,
+                    title: String(localized: "verse_selection")
+                )
+            }
+        } header: {
+            settingsSectionHeader(
+                String(localized: "prefs_behavior_customization_cat", defaultValue: "Application behavior")
+            )
+        }
+    }
+
+    /**
+     Builds the discrete-mode security section.
+
+     - Side Effects: Updates local security state; `calculatorPin` filtering strips non-numeric input.
+     - Failure Modes: Invalid PIN characters are ignored rather than persisted.
+     */
+    @ViewBuilder
+    private var securitySettingsSection: some View {
+        Section {
+            Button {
+                showDiscreteHelp = true
+            } label: {
+                settingsRowLabel(
+                    preferenceKey: .discreteHelp,
+                    title: String(localized: "discrete_help_title"),
+                    summary: String(localized: "discrete_help_summary")
+                )
+            }
+
+            Toggle(isOn: $discreteMode) {
+                settingsRowLabel(
+                    preferenceKey: .discreteMode,
+                    title: String(localized: "discrete_mode"),
+                    summary: String(localized: "discrete_mode_description")
+                )
+            }
+
+            Toggle(isOn: $showCalculator) {
+                settingsRowLabel(
+                    preferenceKey: .showCalculator,
+                    title: String(localized: "show_calculator"),
+                    summary: String(localized: "show_calculator_description")
+                )
+            }
+
+            HStack(alignment: .top, spacing: 12) {
+                settingsRowLabel(
+                    preferenceKey: .calculatorPin,
+                    title: String(localized: "calculator_pin"),
+                    summary: String(localized: "calculator_pin_description")
+                )
+                Spacer()
+                TextField(String(localized: "calculator_pin_placeholder"), text: $calculatorPin)
+                    #if os(iOS)
+                    .keyboardType(.numberPad)
+                    #endif
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 100)
+                    .onChange(of: calculatorPin) { _, newValue in
+                        let filtered = newValue.filter { $0.isNumber }
+                        if filtered != newValue { calculatorPin = filtered }
+                    }
+            }
+        } header: {
+            settingsSectionHeader(String(localized: "settings_security"))
+        }
+    }
+
+    /**
+     Builds advanced preferences and debug-only action rows.
+
+     - Side Effects: Writes advanced preferences through `SettingsStore`, can open system settings on
+       iOS, and can schedule a debug crash in DEBUG builds.
+     - Failure Modes: Debug-only actions are omitted from release builds.
+     */
+    @ViewBuilder
+    private var advancedSettingsSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { enableBluetoothMediaButtons },
+                set: { newValue in
+                    enableBluetoothMediaButtons = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.enableBluetoothPref, value: newValue)
+                    onSettingsChanged?()
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .enableBluetoothPref,
+                    title: String(
+                        localized: "prefs_enable_bluetooth_title",
+                        defaultValue: "Enable Bluetooth media buttons"
+                    ),
+                    summary: String(
+                        localized: "prefs_enable_bluetooth_summary",
+                        defaultValue: "Handle Bluetooth media buttons to start/stop speaking."
+                    )
+                )
+            }
+            NavigationLink {
+                ExperimentalFeaturesMultiSelectView(
+                    title: String(
+                        localized: "prefs_experimental_features_title",
+                        defaultValue: "Experimental features"
+                    ),
+                    options: Self.experimentalFeatureOptions,
+                    selectedValues: $enabledExperimentalFeatures
+                )
+            } label: {
+                settingsSelectionRow(
+                    preferenceKey: .experimentalFeatures,
+                    title: String(
+                        localized: "prefs_experimental_features_title",
+                        defaultValue: "Experimental features"
+                    ),
+                    summary: String(
+                        localized: "prefs_experimental_features_summary",
+                        defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
+                    ),
+                    detail: experimentalFeaturesSummary(selectedValues: enabledExperimentalFeatures)
+                )
+            }
+            #if DEBUG
+            Toggle(isOn: Binding(
+                get: { showErrorBox },
+                set: { newValue in
+                    showErrorBox = newValue
+                    let store = SettingsStore(modelContext: modelContext)
+                    store.setBool(.showErrorBox, value: newValue)
+                    onSettingsChanged?()
+                }
+            )) {
+                settingsRowLabel(
+                    preferenceKey: .showErrorBox,
+                    title: String(
+                        localized: "prefs_show_error_box_title",
+                        defaultValue: "Show Javascript error box"
+                    ),
+                    summary: String(
+                        localized: "prefs_show_error_box_summary",
+                        defaultValue: "Useful for developers when debugging BibleView javascript side errors. This will make the app slower."
+                    )
+                )
+            }
+            #endif
+
+            #if os(iOS)
+            Button {
+                openBibleLinkSystemSettings()
+            } label: {
+                settingsRowLabel(
+                    preferenceKey: .openLinks,
+                    title: String(
+                        localized: "open_bible_links_title",
+                        defaultValue: "Open Bible links in AndBible"
+                    ),
+                    summary: String(
+                        localized: "open_bible_links_summary",
+                        defaultValue: "When clicking links that refer to AndBible supported Bible URL, open them in AndBible"
+                    )
+                )
+            }
+            #endif
+
+            #if DEBUG
+            Button(role: .destructive) {
+                triggerDebugCrash()
+            } label: {
+                settingsRowLabel(
+                    preferenceKey: .crashApp,
+                    title: String(
+                        localized: "crash_app",
+                        defaultValue: "Crash app!"
+                    ),
+                    summary: debugCrashScheduled
+                        ? String(
+                            localized: "crash_app_scheduled_summary",
+                            defaultValue: "Crash scheduled in 10 seconds."
+                        )
+                        : String(
+                            localized: "crash_app_summary",
+                            defaultValue: "Crash app after 10 seconds. Debugging feature, visible only in debug builds."
+                        ),
+                    isEnabled: !debugCrashScheduled
+                )
+            }
+            .disabled(debugCrashScheduled)
+            #endif
+        } header: {
+            settingsSectionHeader(
+                String(localized: "prefs_advanced_settings_cat", defaultValue: "Advanced settings")
+            )
+        }
+    }
+
+    /**
+     Builds the static about/version section.
+
+     - Side Effects: none.
+     - Failure Modes: none.
+     */
+    @ViewBuilder
+    private var aboutSettingsSection: some View {
+        Section {
+            HStack(alignment: .top, spacing: 12) {
+                settingsRowLabel(
+                    preferenceKey: nil,
+                    title: String(localized: "version")
+                )
+                Spacer()
+                Text("1.0.0")
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            }
+        } header: {
+            settingsSectionHeader(String(localized: "settings_about"))
+        }
+    }
+
+    /**
+     Builds the empty-search-results section shown only for active queries with no matches.
+
+     - Side Effects: none.
+     - Failure Modes: none.
+     */
+    @ViewBuilder
+    private var noSettingsSearchResultsSection: some View {
+        Section {
+            Text(String(localized: "settings_search_no_results", defaultValue: "No settings found"))
+                .foregroundStyle(.secondary)
+        }
+    }
+
     /**
      Builds the "Look & feel" section, including nested display editors and appearance toggles.
      */
+    @ViewBuilder
     private var lookAndFeelSection: some View {
         Section {
             settingsNavigationLink(
@@ -1374,10 +1375,614 @@ public struct SettingsView: View {
             !wordLookupDictionaries.isEmpty
     }
 
+    /// Whether the module-backed dictionary section should render for the current search state.
+    private var shouldShowDictionarySection: Bool {
+        hasDictionaryPreferences && settingsSearchMatchesSection(dictionarySettingsSearchEntries)
+    }
+
+    /// Whether the behavior section should render for the current search state.
+    private var shouldShowBehaviorSection: Bool {
+        settingsSearchMatchesSection(behaviorSettingsSearchEntries)
+    }
+
+    /// Whether the look-and-feel section should render for the current search state.
+    private var shouldShowLookAndFeelSection: Bool {
+        settingsSearchMatchesSection(lookAndFeelSettingsSearchEntries)
+    }
+
+    /// Whether the security section should render for the current search state.
+    private var shouldShowSecuritySection: Bool {
+        settingsSearchMatchesSection(securitySettingsSearchEntries)
+    }
+
+    /// Whether the advanced section should render for the current search state.
+    private var shouldShowAdvancedSection: Bool {
+        settingsSearchMatchesSection(advancedSettingsSearchEntries)
+    }
+
+    /// Whether the about section should render for the current search state.
+    private var shouldShowAboutSection: Bool {
+        settingsSearchMatchesSection(aboutSettingsSearchEntries)
+    }
+
+    /// Extracted swipe-mode picker label that keeps the main settings form type-checkable.
+    private var bibleViewSwipeModeSettingsRow: AndBibleSettingsRowLabel {
+        settingsRowLabel(
+            preferenceKey: .bibleViewSwipeMode,
+            title: String(
+                localized: "prefs_bible_view_swipe_mode_title",
+                defaultValue: "Action for swipe left / right gesture"
+            ),
+            summary: String(
+                localized: "prefs_bible_view_swipe_mode_summary",
+                defaultValue: "Swipe left / right gesture can be used to go to next page / chapter."
+            )
+        )
+    }
+
+    /// Localized navigation title kept outside the main SwiftUI modifier chain.
+    private var settingsNavigationTitleText: String {
+        String(localized: "settings")
+    }
+
+    /// Localized restart-alert title kept outside the main SwiftUI modifier chain.
+    private var languageRestartAlertTitleText: String {
+        String(localized: "prefs_interface_locale_title", defaultValue: "Application language")
+    }
+
+    /// Localized restart-alert message kept outside the main SwiftUI modifier chain.
+    private var languageRestartAlertMessageText: String {
+        String(localized: "language_restart_required")
+    }
+
+    /// Localized reset-alert title kept outside the main SwiftUI modifier chain.
+    private var settingsResetTitleText: String {
+        String(localized: "settings_reset_title", defaultValue: "Reset settings")
+    }
+
+    /// Localized reset-alert message kept outside the main SwiftUI modifier chain.
+    private var settingsResetMessageText: String {
+        String(
+            localized: "settings_reset_message",
+            defaultValue: "Reset application preferences to their default values?"
+        )
+    }
+
+    /// Localized search prompt kept outside the main SwiftUI modifier chain.
+    private var settingsSearchPromptText: String {
+        String(localized: "search", defaultValue: "Search")
+    }
+
+    /**
+     Builds the toolbar reset action used by Application preferences.
+
+     - Side Effects: Sets local confirmation state so the destructive reset runs only after the alert.
+     - Failure Modes: none.
+     */
     @ViewBuilder
+    private var settingsResetToolbarButton: some View {
+        Button {
+            showResetConfirmation = true
+        } label: {
+            Image(systemName: "arrow.counterclockwise")
+        }
+        .accessibilityLabel(String(localized: "reset", defaultValue: "Reset"))
+        .accessibilityIdentifier("settingsResetButton")
+    }
+
+    /**
+     Builds the discrete-mode help sheet outside the main form expression.
+
+     Splitting this sheet content keeps the large settings screen type-checkable while preserving
+     the same modal behavior and toolbar dismissal.
+     */
+    @ViewBuilder
+    private var discreteHelpSheetContent: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(String(localized: "discrete_help_par1"))
+                    Text(String(localized: "discrete_help_par2"))
+                    Text(String(localized: "discrete_help_par3"))
+                    Text(String(localized: "discrete_help_ios_note"))
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+            }
+            .navigationTitle(String(localized: "settings_security"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "done")) { showDiscreteHelp = false }
+                }
+            }
+        }
+    }
+
+    /**
+     Builds Android's feature-shortcut section using native SwiftUI navigation.
+
+     iOS implements the feature shortcuts that have real local destinations. The Android AI row is
+     intentionally absent because this app has no AI settings contract to open.
+     */
+    @ViewBuilder
+    private var featuresSettingsSection: some View {
+        Section {
+            let syncEntry = syncSettingsSearchEntry
+            if settingsSearchMatchesEntry(syncEntry) {
+                settingsNavigationLink(
+                    title: syncEntry.title,
+                    androidKey: "sync_settings_shortcut",
+                    summary: syncEntry.summary,
+                    accessibilityIdentifier: syncEntry.identifier
+                ) {
+                    SyncSettingsView()
+                }
+            }
+
+            let readingProgressEntry = readingProgressSettingsSearchEntry
+            if settingsSearchMatchesEntry(readingProgressEntry) {
+                settingsNavigationLink(
+                    title: readingProgressEntry.title,
+                    androidKey: "reading_progress_settings_shortcut",
+                    summary: readingProgressEntry.summary,
+                    accessibilityIdentifier: readingProgressEntry.identifier
+                ) {
+                    ReadingProgressSettingsView(controller: readingProgressController)
+                        .accessibilityIdentifier("readingProgressSettingsScreen")
+                }
+            }
+        } header: {
+            settingsSectionHeader(String(localized: "features", defaultValue: "Features"))
+        }
+    }
+
+    /// Whether the current query should show the Android feature-shortcut section.
+    private var shouldShowFeaturesSection: Bool {
+        settingsSearchMatchesSection(featuresSettingsSearchEntries)
+    }
+
+    /// Search entry for the sync feature shortcut.
+    private var syncSettingsSearchEntry: AndBibleSettingsSearchEntry {
+        AndBibleSettingsSearchEntry(
+            identifier: "settingsSyncLink",
+            title: String(localized: "cloud_sync_title", defaultValue: "Device synchronization"),
+            summary: String(localized: "icloud_sync_description"),
+            keywords: ["features", "sync", "icloud", "cloud", "sync_settings_shortcut"]
+        )
+    }
+
+    /// Search entry for the reading-progress feature shortcut.
+    private var readingProgressSettingsSearchEntry: AndBibleSettingsSearchEntry {
+        AndBibleSettingsSearchEntry(
+            identifier: "settingsReadingProgressLink",
+            title: String(localized: "reading_progress_settings", defaultValue: "Reading Progress Settings"),
+            summary: String(
+                localized: "reading_progress_settings_summary",
+                defaultValue: "Configure automatic reading and memorization progress tracking."
+            ),
+            keywords: ["features", "reading", "progress", "memorization", "reading_progress_settings_shortcut"]
+        )
+    }
+
+    /// Search entries for feature shortcuts that can be opened from Application preferences.
+    private var featuresSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [syncSettingsSearchEntry, readingProgressSettingsSearchEntry]
+    }
+
+    /// Search entries for module-backed dictionary preference rows currently visible on this device.
+    private var dictionarySettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        var entries: [AndBibleSettingsSearchEntry] = []
+        if !strongsGreekDictionaries.isEmpty {
+            entries.append(
+                .init(
+                    identifier: "settingsStrongsGreekDictionaryLink",
+                    title: String(
+                        localized: "choose_strongs_greek_dictionary_title",
+                        defaultValue: "Strongs Greek dictionary"
+                    ),
+                    summary: String(
+                        localized: "choose_strongs_greek_dictionary_summary",
+                        defaultValue: "Choose Strongs dictionary for Greek word definitions"
+                    ),
+                    keywords: ["dictionaries", AppPreferenceKey.strongsGreekDictionary.rawValue]
+                )
+            )
+        }
+        if !strongsHebrewDictionaries.isEmpty {
+            entries.append(
+                .init(
+                    identifier: "settingsStrongsHebrewDictionaryLink",
+                    title: String(
+                        localized: "choose_strongs_hebrew_dictionary_title",
+                        defaultValue: "Strongs Hebrew dictionary"
+                    ),
+                    summary: String(
+                        localized: "choose_strongs_hebrew_dictionary_summary",
+                        defaultValue: "Choose Strongs dictionary for Hebrew word definitions"
+                    ),
+                    keywords: ["dictionaries", AppPreferenceKey.strongsHebrewDictionary.rawValue]
+                )
+            )
+        }
+        if !robinsonMorphologyDictionaries.isEmpty {
+            entries.append(
+                .init(
+                    identifier: "settingsRobinsonMorphologyLink",
+                    title: String(
+                        localized: "choose_strongs_greek_morphology_title",
+                        defaultValue: "Robinson Greek morphology"
+                    ),
+                    summary: String(
+                        localized: "choose_strongs_greek_morphology_summary",
+                        defaultValue: "Choose dictionary for Robinson Greek morphology definitions"
+                    ),
+                    keywords: ["dictionaries", AppPreferenceKey.robinsonGreekMorphology.rawValue]
+                )
+            )
+        }
+        if !wordLookupDictionaries.isEmpty {
+            entries.append(
+                .init(
+                    identifier: "settingsWordLookupDictionariesLink",
+                    title: String(
+                        localized: "choose_word_lookup_dictionary_title",
+                        defaultValue: "Word lookup dictionaries"
+                    ),
+                    summary: String(
+                        localized: "choose_word_lookup_dictionary_summary",
+                        defaultValue: "Choose dictionaries for looking up words"
+                    ),
+                    keywords: ["dictionaries", AppPreferenceKey.disabledWordLookupDictionaries.rawValue]
+                )
+            )
+        }
+        return entries
+    }
+
+    /// Search entries for behavior preferences.
+    private var behaviorSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [
+            preferenceSearchEntry(
+                .navigateToVersePref,
+                title: String(localized: "prefs_navigate_to_verse_title", defaultValue: "Navigate to verse"),
+                summary: String(
+                    localized: "prefs_navigate_to_verse_summary",
+                    defaultValue: "Choose verse (and chapter) when selecting a passage"
+                )
+            ),
+            preferenceSearchEntry(
+                .openLinksInSpecialWindowPref,
+                title: String(localized: "prefs_open_links_in_special_window_title", defaultValue: "Links window"),
+                summary: String(
+                    localized: "prefs_open_links_in_special_window_summary",
+                    defaultValue: "Open links in special window, for quicker display of cross-references and Strongs"
+                )
+            ),
+            preferenceSearchEntry(
+                .screenKeepOnPref,
+                title: String(localized: "prefs_screen_keep_on_title", defaultValue: "Keep screen on"),
+                summary: String(
+                    localized: "prefs_screen_keep_on_summary",
+                    defaultValue: "Prevent screen sleeping while using this app"
+                )
+            ),
+            preferenceSearchEntry(
+                .doubleTapToFullscreen,
+                title: String(localized: "prefs_double_tap_to_fullscreen_title", defaultValue: "Double-tap to Fullscreen"),
+                summary: String(
+                    localized: "prefs_double_tap_to_fullscreen_summary",
+                    defaultValue: "Enter fullscreen mode by double-tapping window"
+                )
+            ),
+            preferenceSearchEntry(
+                .autoFullscreenPref,
+                title: String(localized: "auto_fullscreen", defaultValue: "Fullscreen by scrolling"),
+                summary: String(
+                    localized: "auto_fullscreen_summary",
+                    defaultValue: "Switch automatically to fullscreen when scrolling text. Tip: you can always also switch to full screen by doubletapping screen."
+                )
+            ),
+            preferenceSearchEntry(
+                .toolbarButtonActions,
+                title: String(
+                    localized: "prefs_toolbar_button_action_title",
+                    defaultValue: "Bible/commentary toolbar button action"
+                ),
+                summary: String(
+                    localized: "prefs_toolbar_button_action_summary",
+                    defaultValue: "Choose if one-tap of Bible/commentary toolbar buttons shows menu or activity directly."
+                )
+            ),
+            preferenceSearchEntry(
+                .disableTwoStepBookmarking,
+                title: String(
+                    localized: "prefs_disable_two_step_bookmarking_title",
+                    defaultValue: "One-step bookmarking"
+                ),
+                summary: String(
+                    localized: "prefs_disable_two_step_bookmarking_summary",
+                    defaultValue: "Show \"Selection\" and \"Verses\" items directly in Bible view Selection menu"
+                )
+            ),
+            preferenceSearchEntry(
+                .bibleViewSwipeMode,
+                title: String(
+                    localized: "prefs_bible_view_swipe_mode_title",
+                    defaultValue: "Action for swipe left / right gesture"
+                ),
+                summary: String(
+                    localized: "prefs_bible_view_swipe_mode_summary",
+                    defaultValue: "Swipe left / right gesture can be used to go to next page / chapter."
+                )
+            ),
+            preferenceSearchEntry(
+                .volumeKeysScroll,
+                title: String(localized: "prefs_volume_keys_scroll_title", defaultValue: "Volume buttons scroll"),
+                summary: String(
+                    localized: "prefs_volume_keys_scroll_summary",
+                    defaultValue: "Use volume up/down to scroll Bible text"
+                )
+            ),
+            .init(
+                identifier: "settingsVerseSelection",
+                title: String(localized: "verse_selection"),
+                keywords: ["application behavior", "selection"]
+            ),
+        ]
+    }
+
+    /// Search entries for appearance and global text-display preferences.
+    private var lookAndFeelSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [
+            .init(
+                identifier: "settingsTextDisplayLink",
+                title: String(localized: "settings_text_display"),
+                keywords: ["look and feel", "display", "font", "text"]
+            ),
+            .init(
+                identifier: "settingsColorsLink",
+                title: String(localized: "settings_colors"),
+                keywords: ["look and feel", "colors", "theme"]
+            ),
+            preferenceSearchEntry(
+                .nightModePref3,
+                title: String(localized: "prefs_night_mode_title", defaultValue: "Night mode switching"),
+                summary: String(
+                    localized: "prefs_night_mode_summary",
+                    defaultValue: "Whether to switch to night mode manually or via system setting. Manual switching can be done from the 3-dot options menu on the main screen."
+                )
+            ),
+            preferenceSearchEntry(
+                .monochromeMode,
+                title: String(localized: "prefs_e_ink_mode_title", defaultValue: "Black & white mode"),
+                summary: String(
+                    localized: "prefs_eink_mode_summary",
+                    defaultValue: "Use application in monochrome mode (no colors), making it more suitable for E-ink devices."
+                )
+            ),
+            preferenceSearchEntry(
+                .disableAnimations,
+                title: String(localized: "prefs_disable_animations_title", defaultValue: "Disable animations"),
+                summary: String(
+                    localized: "prefs_disable_animations_summary",
+                    defaultValue: "Disable various animations such as smooth scrolling."
+                )
+            ),
+            preferenceSearchEntry(
+                .disableClickToEdit,
+                title: String(
+                    localized: "prefs_disable_click_to_edit_title",
+                    defaultValue: "Disable Study Pad click-to-edit"
+                ),
+                summary: String(
+                    localized: "prefs_disable_click_to_edit_summary",
+                    defaultValue: "Requires using the edit button to edit notes in the Study Pad."
+                )
+            ),
+            preferenceSearchEntry(
+                .fontSizeMultiplier,
+                title: String(localized: "pref_font_size_multiplier_title", defaultValue: "Font size multiplier")
+            ),
+            preferenceSearchEntry(
+                .fullScreenHideButtonsPref,
+                title: String(
+                    localized: "full_screen_hide_buttons_pref_title",
+                    defaultValue: "Hide window button bar in fullscreen"
+                )
+            ),
+            preferenceSearchEntry(
+                .hideWindowButtons,
+                title: String(localized: "hide_window_buttons_title", defaultValue: "Hide window buttons")
+            ),
+            preferenceSearchEntry(
+                .hideBibleReferenceOverlay,
+                title: String(
+                    localized: "hide_bible_reference_overlay_title",
+                    defaultValue: "Hide Bible reference overlay"
+                )
+            ),
+            preferenceSearchEntry(
+                .showActiveWindowIndicator,
+                title: String(
+                    localized: "active_window_indicator_title",
+                    defaultValue: "Show active window indicator"
+                )
+            ),
+            preferenceSearchEntry(
+                .disableBibleBookmarkModalButtons,
+                title: String(
+                    localized: "prefs_in_window_bible_bookmark_modal_buttons_title",
+                    defaultValue: "One-tap actions (Bibles)"
+                )
+            ),
+            preferenceSearchEntry(
+                .disableGenBookmarkModalButtons,
+                title: String(
+                    localized: "prefs_in_window_gen_bookmark_modal_buttons_title",
+                    defaultValue: "One-tap actions (Other)"
+                )
+            ),
+            preferenceSearchEntry(
+                .localePref,
+                title: String(localized: "prefs_interface_locale_title", defaultValue: "Application language")
+            ),
+        ]
+    }
+
+    /// Search entries for security preferences.
+    private var securitySettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [
+            preferenceSearchEntry(
+                .discreteHelp,
+                title: String(localized: "discrete_help_title"),
+                summary: String(localized: "discrete_help_summary")
+            ),
+            preferenceSearchEntry(
+                .discreteMode,
+                title: String(localized: "discrete_mode"),
+                summary: String(localized: "discrete_mode_description")
+            ),
+            preferenceSearchEntry(
+                .showCalculator,
+                title: String(localized: "show_calculator"),
+                summary: String(localized: "show_calculator_description")
+            ),
+            preferenceSearchEntry(
+                .calculatorPin,
+                title: String(localized: "calculator_pin"),
+                summary: String(localized: "calculator_pin_description")
+            ),
+        ]
+    }
+
+    /// Search entries for advanced preferences and developer/debug action rows.
+    private var advancedSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [
+            preferenceSearchEntry(
+                .enableBluetoothPref,
+                title: String(localized: "prefs_enable_bluetooth_title", defaultValue: "Enable Bluetooth media buttons"),
+                summary: String(
+                    localized: "prefs_enable_bluetooth_summary",
+                    defaultValue: "Handle Bluetooth media buttons to start/stop speaking."
+                )
+            ),
+            preferenceSearchEntry(
+                .experimentalFeatures,
+                title: String(localized: "prefs_experimental_features_title", defaultValue: "Experimental features"),
+                summary: String(
+                    localized: "prefs_experimental_features_summary",
+                    defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
+                )
+            ),
+            preferenceSearchEntry(
+                .showErrorBox,
+                title: String(localized: "prefs_show_error_box_title", defaultValue: "Show Javascript error box")
+            ),
+            preferenceSearchEntry(
+                .openLinks,
+                title: String(localized: "open_bible_links_title", defaultValue: "Open Bible links in AndBible")
+            ),
+            preferenceSearchEntry(
+                .crashApp,
+                title: String(localized: "crash_app", defaultValue: "Crash app!")
+            ),
+        ]
+    }
+
+    /// Search entry for static application information retained in Settings.
+    private var aboutSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
+        [
+            .init(
+                identifier: "settingsVersion",
+                title: String(localized: "version"),
+                keywords: ["about", "application"]
+            ),
+        ]
+    }
+
+    /// Whether a non-empty query currently filters out every available settings section.
+    private var shouldShowNoSettingsSearchResults: Bool {
+        guard isSettingsSearchActive else {
+            return false
+        }
+        return !shouldShowFeaturesSection &&
+            !shouldShowDictionarySection &&
+            !shouldShowBehaviorSection &&
+            !shouldShowLookAndFeelSection &&
+            !shouldShowSecuritySection &&
+            !shouldShowAdvancedSection &&
+            !shouldShowAboutSection
+    }
+
+    /// Whether the current search text contains at least one normalized term.
+    private var isSettingsSearchActive: Bool {
+        !AndBibleSettingsSearchMatcher.normalizedTerms(from: settingsSearchText).isEmpty
+    }
+
+    /**
+     Creates one searchable entry from an Android parity preference key.
+
+     - Parameters:
+       - key: Registry key backing the row.
+       - title: User-visible title.
+       - summary: Optional row summary.
+       - detail: Optional current-value detail.
+       - keywords: Additional aliases for search.
+     - Returns: A normalized settings search entry.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func preferenceSearchEntry(
+        _ key: AppPreferenceKey,
+        title: String,
+        summary: String = "",
+        detail: String = "",
+        keywords: [String] = []
+    ) -> AndBibleSettingsSearchEntry {
+        AndBibleSettingsSearchEntry(
+            identifier: key.rawValue,
+            title: title,
+            summary: summary,
+            detail: detail,
+            keywords: keywords + [key.rawValue]
+        )
+    }
+
+    /**
+     Returns whether a settings section should remain visible for the current query.
+
+     - Parameter entries: Search entries represented by the section.
+     - Returns: `true` for all sections when search is empty, otherwise `true` only when at least
+       one row in the section matches every query term.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func settingsSearchMatchesSection(_ entries: [AndBibleSettingsSearchEntry]) -> Bool {
+        guard isSettingsSearchActive else {
+            return true
+        }
+        return entries.contains(where: settingsSearchMatchesEntry)
+    }
+
+    /**
+     Returns whether one settings entry matches the current query.
+
+     - Parameter entry: Candidate settings entry.
+     - Returns: `true` when the entry should be visible.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func settingsSearchMatchesEntry(_ entry: AndBibleSettingsSearchEntry) -> Bool {
+        AndBibleSettingsSearchMatcher.matches(query: settingsSearchText, entry: entry)
+    }
+
     /**
      Builds the common title/summary/detail row used by selection-style settings links.
      */
+    @ViewBuilder
     private func settingsSelectionRow(
         preferenceKey: AppPreferenceKey? = nil,
         title: String,
@@ -1392,13 +1997,13 @@ public struct SettingsView: View {
         )
     }
 
-    @ViewBuilder
     /**
      Builds one Settings navigation row using the same `NavigationLink` semantics as production.
      *
      * This preserves the native list-row interaction model instead of routing navigation through
      * test-only state toggles.
      */
+    @ViewBuilder
     private func settingsNavigationLink<Destination: View>(
         title: String,
         preferenceKey: AppPreferenceKey? = nil,
@@ -1419,7 +2024,6 @@ public struct SettingsView: View {
         .accessibilityIdentifier(accessibilityIdentifier)
     }
 
-    @ViewBuilder
     /**
      Builds a single-line navigation row used by nested settings links.
      *
@@ -1428,6 +2032,7 @@ public struct SettingsView: View {
      * - Side effects: none.
      * - Failure modes: This helper cannot fail.
      */
+    @ViewBuilder
     private func settingsNavigationRow(
         title: String,
         preferenceKey: AppPreferenceKey? = nil,
@@ -1516,70 +2121,178 @@ public struct SettingsView: View {
         AndBibleSettingsSectionHeader(title: title)
     }
 
-    @ViewBuilder
-    private var settingsUITestShortcutSection: some View {
-        if UITestRuntimeConfiguration.enablesDetailedAccessibilityExports {
-            Section(String(localized: "settings", defaultValue: "Settings")) {
-                settingsNavigationLink(
-                    title: String(localized: "downloads"),
-                    accessibilityIdentifier: "settingsDownloadsLink"
-                ) {
-                    ModuleBrowserView()
-                }
-                settingsNavigationLink(
-                    title: String(localized: "repositories"),
-                    accessibilityIdentifier: "settingsRepositoriesLink"
-                ) {
-                    RepositoryManagerView()
-                }
-                settingsNavigationLink(
-                    title: String(localized: "import_export"),
-                    accessibilityIdentifier: "settingsImportExportLink"
-                ) {
-                    ImportExportView()
-                }
-                settingsNavigationLink(
-                    title: String(localized: "icloud_sync"),
-                    accessibilityIdentifier: "settingsSyncLink"
-                ) {
-                    SyncSettingsView()
-                }
-                settingsNavigationLink(
-                    title: String(localized: "labels"),
-                    accessibilityIdentifier: "settingsLabelsLink"
-                ) {
-                    LabelManagerView()
-                }
-                settingsNavigationLink(
-                    title: String(localized: "settings_text_display"),
-                    accessibilityIdentifier: "settingsTextDisplayLink"
-                ) {
-                    TextDisplaySettingsView(settings: $displaySettings, onChange: onSettingsChanged)
-                }
-                settingsNavigationLink(
-                    title: String(localized: "settings_colors"),
-                    accessibilityIdentifier: "settingsColorsLink"
-                ) {
-                    ColorSettingsView(settings: $displaySettings, onChange: onSettingsChanged)
-                }
-            }
-        }
-    }
-
     private var settingsAccessibilityValue: String {
         guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports else {
             return ""
         }
         let primaryLinks = [
-            "settingsDownloadsLink",
-            "settingsRepositoriesLink",
-            "settingsImportExportLink",
             "settingsSyncLink",
-            "settingsLabelsLink",
+            "settingsReadingProgressLink",
             "settingsTextDisplayLink",
             "settingsColorsLink",
         ].joined(separator: ",")
-        return "primaryLinks=\(primaryLinks)"
+        let searchToken = isSettingsSearchActive ? "active" : "inactive"
+        return "primaryLinks=\(primaryLinks);adminFlows=readerActions;search=\(searchToken)"
+    }
+
+    /**
+     Reloads installed modules and persisted application preferences into local view state.
+
+     This is shared by initial presentation and reset so the settings UI rehydrates from the same
+     registry-backed store path in both flows.
+     *
+     - Side Effects:
+       - queries SWORD for installed modules
+       - reads SwiftData/UserDefaults-backed preferences through `SettingsStore`
+       - sanitizes stale dictionary, bookmark-action, and experimental-feature selections
+       - applies the keep-screen-on idle-timer side effect for the loaded value
+     - Failure: Module discovery failures leave dictionary arrays empty; settings fetch failures
+       fall back through `SettingsStore` defaults.
+     */
+    private func loadSettingsState() {
+        loadInstalledDictionaryModules()
+        hasLoadedPreferences = false
+
+        let store = SettingsStore(modelContext: modelContext)
+        selectedStrongsGreekDictionaryNames = Set(store.getStringSet(.strongsGreekDictionary))
+        selectedStrongsHebrewDictionaryNames = Set(store.getStringSet(.strongsHebrewDictionary))
+        selectedRobinsonMorphologyDictionaryNames = Set(store.getStringSet(.robinsonGreekMorphology))
+        disabledWordLookupDictionaryNames = Set(store.getStringSet(.disabledWordLookupDictionaries))
+        disabledBibleBookmarkModalButtons = Set(store.getStringSet(.disableBibleBookmarkModalButtons))
+        disabledGenBookmarkModalButtons = Set(store.getStringSet(.disableGenBookmarkModalButtons))
+        sanitizeDictionaryPreferences(store: store)
+        sanitizeBookmarkModalActionPreferences(store: store)
+        openLinksInSpecialWindow = store.getBool(.openLinksInSpecialWindowPref)
+        monochromeMode = store.getBool(.monochromeMode)
+        disableAnimations = store.getBool(.disableAnimations)
+        disableClickToEdit = store.getBool(.disableClickToEdit)
+        showActiveWindowIndicator = store.getBool(.showActiveWindowIndicator)
+        showErrorBox = store.getBool(.showErrorBox)
+        enableBluetoothMediaButtons = store.getBool(.enableBluetoothPref)
+        fontSizeMultiplier = store.getInt(.fontSizeMultiplier)
+        fullScreenHideButtons = store.getBool(.fullScreenHideButtonsPref)
+        hideWindowButtons = store.getBool(.hideWindowButtons)
+        hideBibleReferenceOverlay = store.getBool(.hideBibleReferenceOverlay)
+        navigateToVerse = store.getBool(.navigateToVersePref)
+        screenKeepOn = store.getBool(.screenKeepOnPref)
+        doubleTapToFullscreen = store.getBool(.doubleTapToFullscreen)
+        autoFullscreen = store.getBool(.autoFullscreenPref)
+        disableTwoStepBookmarking = store.getBool(.disableTwoStepBookmarking)
+        toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(
+            store.getString(.toolbarButtonActions)
+        )
+        bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(store.getString(.bibleViewSwipeMode))
+        volumeKeysScroll = store.getBool(.volumeKeysScroll)
+        enabledExperimentalFeatures = Set(store.getStringSet(.experimentalFeatures))
+        sanitizeExperimentalFeatures(store: store)
+        nightModeMode = store.getString(.nightModePref3)
+        let manualNightMode = store.getBool("night_mode")
+        nightMode = NightModeSettingsResolver.isNightMode(
+            rawValue: nightModeMode,
+            manualNightMode: manualNightMode,
+            systemIsDark: colorScheme == .dark
+        )
+        applyScreenKeepOn(screenKeepOn)
+        loadPersistedInterfaceLanguage(using: store)
+        hasLoadedPreferences = true
+    }
+
+    /**
+     Refreshes installed dictionary module lists used by module-backed preferences.
+
+     - Side Effects: Reads installed SWORD module metadata and updates the dictionary state arrays.
+     - Failure: If the SWORD manager cannot be created, dictionary arrays are cleared.
+     */
+    private func loadInstalledDictionaryModules() {
+        guard let mgr = SwordManager() else {
+            strongsGreekDictionaries = []
+            strongsHebrewDictionaries = []
+            robinsonMorphologyDictionaries = []
+            wordLookupDictionaries = []
+            return
+        }
+
+        let all = mgr.installedModules()
+        strongsGreekDictionaries = all
+            .filter {
+                ($0.category == .dictionary || $0.category == .glossary) &&
+                    StrongsDictionaryPolicy.isSupportedDictionaryModuleName($0.name) &&
+                    $0.features.contains(.greekDef)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        strongsHebrewDictionaries = all
+            .filter {
+                ($0.category == .dictionary || $0.category == .glossary) &&
+                    StrongsDictionaryPolicy.isSupportedDictionaryModuleName($0.name) &&
+                    $0.features.contains(.hebrewDef)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        robinsonMorphologyDictionaries = all
+            .filter {
+                ($0.category == .dictionary || $0.category == .glossary) &&
+                    $0.features.contains(.greekParse)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        wordLookupDictionaries = all
+            .filter {
+                $0.category == .dictionary &&
+                    !$0.features.contains(.greekDef) &&
+                    !$0.features.contains(.hebrewDef) &&
+                    !$0.features.contains(.greekParse)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /**
+     Loads the Android-parity interface language preference and migrates legacy iOS overrides.
+
+     - Parameter store: Settings store used to read and repair `locale_pref`.
+     - Side Effects:
+       - may clear an invalid `locale_pref`
+       - may persist a migrated value derived from `AppleLanguages`
+     - Failure: Unsupported locale values fall back to the default empty language selection.
+     */
+    private func loadPersistedInterfaceLanguage(using store: SettingsStore) {
+        let persistedLocale = store.getString(.localePref)
+        if Self.localeOptions.contains(where: { $0.value == persistedLocale }) {
+            selectedLanguage = persistedLocale
+        } else {
+            selectedLanguage = ""
+            if !persistedLocale.isEmpty {
+                store.setString(.localePref, value: "")
+            }
+        }
+
+        if selectedLanguage.isEmpty,
+           let overrideLangs = UserDefaults.standard.array(forKey: "AppleLanguages") as? [String],
+           let first = overrideLangs.first,
+           let mapped = Self.localePrefValue(forAppleLanguage: first) {
+            selectedLanguage = mapped
+            store.setString(.localePref, value: mapped)
+        }
+    }
+
+    /**
+     Resets Android-parity application preferences and rehydrates visible settings state.
+
+     Reset delegates the durable key contract to `SettingsStore.resetApplicationPreferences()` and
+     only handles UI/platform side effects here, including clearing the iOS language override that
+     backs `locale_pref`.
+     *
+     - Side Effects:
+       - removes resettable SwiftData and UserDefaults preference values
+       - clears the `AppleLanguages` override associated with interface-language selection
+       - reapplies loaded keep-screen-on state
+       - invokes `onSettingsChanged` so reader panes refresh global display/behavior settings
+     - Failure: Store failures follow the soft-failure behavior documented by `SettingsStore`.
+     */
+    private func resetApplicationPreferences() {
+        let store = SettingsStore(modelContext: modelContext)
+        store.resetApplicationPreferences()
+        UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+        UserDefaults.standard.synchronize()
+        loadSettingsState()
+        onSettingsChanged?()
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -503,7 +503,11 @@ public struct SettingsView: View {
     @ViewBuilder
     private var dictionarySettingsSection: some View {
         Section {
-            if !strongsGreekDictionaries.isEmpty {
+            if !strongsGreekDictionaries.isEmpty,
+               settingsSearchMatchesIdentifier(
+                   "settingsStrongsGreekDictionaryLink",
+                   in: dictionarySettingsSearchEntries
+               ) {
                 NavigationLink {
                     DictionaryMultiSelectView(
                         title: String(
@@ -533,7 +537,11 @@ public struct SettingsView: View {
                 .accessibilityIdentifier("settingsStrongsGreekDictionaryLink")
             }
 
-            if !strongsHebrewDictionaries.isEmpty {
+            if !strongsHebrewDictionaries.isEmpty,
+               settingsSearchMatchesIdentifier(
+                   "settingsStrongsHebrewDictionaryLink",
+                   in: dictionarySettingsSearchEntries
+               ) {
                 NavigationLink {
                     DictionaryMultiSelectView(
                         title: String(
@@ -563,7 +571,11 @@ public struct SettingsView: View {
                 .accessibilityIdentifier("settingsStrongsHebrewDictionaryLink")
             }
 
-            if !robinsonMorphologyDictionaries.isEmpty {
+            if !robinsonMorphologyDictionaries.isEmpty,
+               settingsSearchMatchesIdentifier(
+                   "settingsRobinsonMorphologyLink",
+                   in: dictionarySettingsSearchEntries
+               ) {
                 NavigationLink {
                     DictionaryMultiSelectView(
                         title: String(
@@ -593,7 +605,11 @@ public struct SettingsView: View {
                 .accessibilityIdentifier("settingsRobinsonMorphologyLink")
             }
 
-            if !wordLookupDictionaries.isEmpty {
+            if !wordLookupDictionaries.isEmpty,
+               settingsSearchMatchesIdentifier(
+                   "settingsWordLookupDictionariesLink",
+                   in: dictionarySettingsSearchEntries
+               ) {
                 NavigationLink {
                     DictionaryInverseMultiSelectView(
                         title: String(
@@ -637,200 +653,220 @@ public struct SettingsView: View {
     @ViewBuilder
     private var behaviorSettingsSection: some View {
         Section {
-            Toggle(isOn: Binding(
-                get: { navigateToVerse },
-                set: { newValue in
-                    navigateToVerse = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.navigateToVersePref, value: newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .navigateToVersePref,
-                    title: String(
-                        localized: "prefs_navigate_to_verse_title",
-                        defaultValue: "Navigate to verse"
-                    ),
-                    summary: String(
-                        localized: "prefs_navigate_to_verse_summary",
-                        defaultValue: "Choose verse (and chapter) when selecting a passage"
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { openLinksInSpecialWindow },
-                set: { newValue in
-                    openLinksInSpecialWindow = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.openLinksInSpecialWindowPref, value: newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .openLinksInSpecialWindowPref,
-                    title: String(
-                        localized: "prefs_open_links_in_special_window_title",
-                        defaultValue: "Links window"
-                    ),
-                    summary: String(
-                        localized: "prefs_open_links_in_special_window_summary",
-                        defaultValue: "Open links in special window, for quicker display of cross-references and Strongs"
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { screenKeepOn },
-                set: { newValue in
-                    screenKeepOn = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.screenKeepOnPref, value: newValue)
-                    applyScreenKeepOn(newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .screenKeepOnPref,
-                    title: String(localized: "prefs_screen_keep_on_title", defaultValue: "Keep screen on"),
-                    summary: String(
-                        localized: "prefs_screen_keep_on_summary",
-                        defaultValue: "Prevent screen sleeping while using this app"
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { doubleTapToFullscreen },
-                set: { newValue in
-                    doubleTapToFullscreen = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.doubleTapToFullscreen, value: newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .doubleTapToFullscreen,
-                    title: String(
-                        localized: "prefs_double_tap_to_fullscreen_title",
-                        defaultValue: "Double-tap to Fullscreen"
-                    ),
-                    summary: String(
-                        localized: "prefs_double_tap_to_fullscreen_summary",
-                        defaultValue: "Enter fullscreen mode by double-tapping window"
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { autoFullscreen },
-                set: { newValue in
-                    autoFullscreen = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.autoFullscreenPref, value: newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .autoFullscreenPref,
-                    title: String(localized: "auto_fullscreen", defaultValue: "Fullscreen by scrolling"),
-                    summary: String(
-                        localized: "auto_fullscreen_summary",
-                        defaultValue: "Switch automatically to fullscreen when scrolling text. Tip: you can always also switch to full screen by doubletapping screen."
-                    )
-                )
-            }
-            Picker(selection: Binding(
-                    get: { Self.normalizedToolbarButtonActionsMode(toolbarButtonActionsMode) },
+            if settingsSearchMatchesPreference(.navigateToVersePref, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { navigateToVerse },
                     set: { newValue in
-                        toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(newValue)
+                        navigateToVerse = newValue
                         let store = SettingsStore(modelContext: modelContext)
-                        store.setString(.toolbarButtonActions, value: toolbarButtonActionsMode)
+                        store.setBool(.navigateToVersePref, value: newValue)
                     }
                 )) {
-                Text(String(localized: "prefs_toolbar_button_action_default", defaultValue: "Default"))
-                    .tag("default")
-                Text(String(localized: "prefs_toolbar_button_action_swap_menu", defaultValue: "Swap menu"))
-                    .tag("swap-menu")
-                Text(String(localized: "prefs_toolbar_button_action_swap_activity", defaultValue: "Swap activity"))
-                    .tag("swap-activity")
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .toolbarButtonActions,
-                    title: String(
-                        localized: "prefs_toolbar_button_action_title",
-                        defaultValue: "Bible/commentary toolbar button action"
-                    ),
-                    summary: String(
-                        localized: "prefs_toolbar_button_action_summary",
-                        defaultValue: "Choose if one-tap of Bible/commentary toolbar buttons shows menu or activity directly."
+                    settingsRowLabel(
+                        preferenceKey: .navigateToVersePref,
+                        title: String(
+                            localized: "prefs_navigate_to_verse_title",
+                            defaultValue: "Navigate to verse"
+                        ),
+                        summary: String(
+                            localized: "prefs_navigate_to_verse_summary",
+                            defaultValue: "Choose verse (and chapter) when selecting a passage"
+                        )
                     )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { disableTwoStepBookmarking },
-                set: { newValue in
-                    disableTwoStepBookmarking = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.disableTwoStepBookmarking, value: newValue)
                 }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .disableTwoStepBookmarking,
-                    title: String(
-                        localized: "prefs_disable_two_step_bookmarking_title",
-                        defaultValue: "One-step bookmarking"
-                    ),
-                    summary: String(
-                        localized: "prefs_disable_two_step_bookmarking_summary",
-                        defaultValue: "Show \"Selection\" and \"Verses\" items directly in Bible view Selection menu"
-                    )
-                )
             }
-            Picker(selection: Binding(
-                    get: { Self.normalizedBibleViewSwipeMode(bibleViewSwipeMode) },
+            if settingsSearchMatchesPreference(.openLinksInSpecialWindowPref, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { openLinksInSpecialWindow },
                     set: { newValue in
-                        bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(newValue)
+                        openLinksInSpecialWindow = newValue
                         let store = SettingsStore(modelContext: modelContext)
-                        store.setString(.bibleViewSwipeMode, value: bibleViewSwipeMode)
+                        store.setBool(.openLinksInSpecialWindowPref, value: newValue)
                     }
-            )) {
-                Text(String(localized: "prefs_swipe_mode_chapter", defaultValue: "Chapter"))
-                    .tag("CHAPTER")
-                Text(String(localized: "prefs_swipe_mode_page", defaultValue: "Page"))
-                    .tag("PAGE")
-                Text(String(localized: "prefs_swipe_mode_none", defaultValue: "None"))
-                    .tag("NONE")
-            } label: {
-                bibleViewSwipeModeSettingsRow
-            }
-            Toggle(isOn: Binding(
-                get: { volumeKeysScroll },
-                set: { newValue in
-                    volumeKeysScroll = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.volumeKeysScroll, value: newValue)
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .volumeKeysScroll,
-                    title: String(
-                        localized: "prefs_volume_keys_scroll_title",
-                        defaultValue: "Volume buttons scroll"
-                    ),
-                    summary: String(
-                        localized: "prefs_volume_keys_scroll_summary",
-                        defaultValue: "Use volume up/down to scroll Bible text"
-                    ),
-                    detail: String(
-                        localized: "prefs_volume_keys_scroll_ios_note",
-                        defaultValue: "iOS does not expose volume-button presses to apps. This setting is kept for Android parity and cross-device sync."
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .openLinksInSpecialWindowPref,
+                        title: String(
+                            localized: "prefs_open_links_in_special_window_title",
+                            defaultValue: "Links window"
+                        ),
+                        summary: String(
+                            localized: "prefs_open_links_in_special_window_summary",
+                            defaultValue: "Open links in special window, for quicker display of cross-references and Strongs"
+                        )
                     )
-                )
-            }
-            Toggle(isOn: Binding(
-                get: { displaySettings.enableVerseSelection ?? true },
-                set: {
-                    displaySettings.enableVerseSelection = $0
-                    onSettingsChanged?()
                 }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: nil,
-                    title: String(localized: "verse_selection")
-                )
+            }
+            if settingsSearchMatchesPreference(.screenKeepOnPref, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { screenKeepOn },
+                    set: { newValue in
+                        screenKeepOn = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.screenKeepOnPref, value: newValue)
+                        applyScreenKeepOn(newValue)
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .screenKeepOnPref,
+                        title: String(localized: "prefs_screen_keep_on_title", defaultValue: "Keep screen on"),
+                        summary: String(
+                            localized: "prefs_screen_keep_on_summary",
+                            defaultValue: "Prevent screen sleeping while using this app"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.doubleTapToFullscreen, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { doubleTapToFullscreen },
+                    set: { newValue in
+                        doubleTapToFullscreen = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.doubleTapToFullscreen, value: newValue)
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .doubleTapToFullscreen,
+                        title: String(
+                            localized: "prefs_double_tap_to_fullscreen_title",
+                            defaultValue: "Double-tap to Fullscreen"
+                        ),
+                        summary: String(
+                            localized: "prefs_double_tap_to_fullscreen_summary",
+                            defaultValue: "Enter fullscreen mode by double-tapping window"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.autoFullscreenPref, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { autoFullscreen },
+                    set: { newValue in
+                        autoFullscreen = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.autoFullscreenPref, value: newValue)
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .autoFullscreenPref,
+                        title: String(localized: "auto_fullscreen", defaultValue: "Fullscreen by scrolling"),
+                        summary: String(
+                            localized: "auto_fullscreen_summary",
+                            defaultValue: "Switch automatically to fullscreen when scrolling text. Tip: you can always also switch to full screen by doubletapping screen."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.toolbarButtonActions, in: behaviorSettingsSearchEntries) {
+                Picker(selection: Binding(
+                        get: { Self.normalizedToolbarButtonActionsMode(toolbarButtonActionsMode) },
+                        set: { newValue in
+                            toolbarButtonActionsMode = Self.normalizedToolbarButtonActionsMode(newValue)
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setString(.toolbarButtonActions, value: toolbarButtonActionsMode)
+                        }
+                    )) {
+                    Text(String(localized: "prefs_toolbar_button_action_default", defaultValue: "Default"))
+                        .tag("default")
+                    Text(String(localized: "prefs_toolbar_button_action_swap_menu", defaultValue: "Swap menu"))
+                        .tag("swap-menu")
+                    Text(String(localized: "prefs_toolbar_button_action_swap_activity", defaultValue: "Swap activity"))
+                        .tag("swap-activity")
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .toolbarButtonActions,
+                        title: String(
+                            localized: "prefs_toolbar_button_action_title",
+                            defaultValue: "Bible/commentary toolbar button action"
+                        ),
+                        summary: String(
+                            localized: "prefs_toolbar_button_action_summary",
+                            defaultValue: "Choose if one-tap of Bible/commentary toolbar buttons shows menu or activity directly."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.disableTwoStepBookmarking, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { disableTwoStepBookmarking },
+                    set: { newValue in
+                        disableTwoStepBookmarking = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.disableTwoStepBookmarking, value: newValue)
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .disableTwoStepBookmarking,
+                        title: String(
+                            localized: "prefs_disable_two_step_bookmarking_title",
+                            defaultValue: "One-step bookmarking"
+                        ),
+                        summary: String(
+                            localized: "prefs_disable_two_step_bookmarking_summary",
+                            defaultValue: "Show \"Selection\" and \"Verses\" items directly in Bible view Selection menu"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.bibleViewSwipeMode, in: behaviorSettingsSearchEntries) {
+                Picker(selection: Binding(
+                        get: { Self.normalizedBibleViewSwipeMode(bibleViewSwipeMode) },
+                        set: { newValue in
+                            bibleViewSwipeMode = Self.normalizedBibleViewSwipeMode(newValue)
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setString(.bibleViewSwipeMode, value: bibleViewSwipeMode)
+                        }
+                )) {
+                    Text(String(localized: "prefs_swipe_mode_chapter", defaultValue: "Chapter"))
+                        .tag("CHAPTER")
+                    Text(String(localized: "prefs_swipe_mode_page", defaultValue: "Page"))
+                        .tag("PAGE")
+                    Text(String(localized: "prefs_swipe_mode_none", defaultValue: "None"))
+                        .tag("NONE")
+                } label: {
+                    bibleViewSwipeModeSettingsRow
+                }
+            }
+            if settingsSearchMatchesPreference(.volumeKeysScroll, in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { volumeKeysScroll },
+                    set: { newValue in
+                        volumeKeysScroll = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.volumeKeysScroll, value: newValue)
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .volumeKeysScroll,
+                        title: String(
+                            localized: "prefs_volume_keys_scroll_title",
+                            defaultValue: "Volume buttons scroll"
+                        ),
+                        summary: String(
+                            localized: "prefs_volume_keys_scroll_summary",
+                            defaultValue: "Use volume up/down to scroll Bible text"
+                        ),
+                        detail: String(
+                            localized: "prefs_volume_keys_scroll_ios_note",
+                            defaultValue: "iOS does not expose volume-button presses to apps. This setting is kept for Android parity and cross-device sync."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesIdentifier("settingsVerseSelection", in: behaviorSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { displaySettings.enableVerseSelection ?? true },
+                    set: {
+                        displaySettings.enableVerseSelection = $0
+                        onSettingsChanged?()
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: nil,
+                        title: String(localized: "verse_selection")
+                    )
+                }
             }
         } header: {
             settingsSectionHeader(
@@ -848,49 +884,57 @@ public struct SettingsView: View {
     @ViewBuilder
     private var securitySettingsSection: some View {
         Section {
-            Button {
-                showDiscreteHelp = true
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .discreteHelp,
-                    title: String(localized: "discrete_help_title"),
-                    summary: String(localized: "discrete_help_summary")
-                )
+            if settingsSearchMatchesPreference(.discreteHelp, in: securitySettingsSearchEntries) {
+                Button {
+                    showDiscreteHelp = true
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .discreteHelp,
+                        title: String(localized: "discrete_help_title"),
+                        summary: String(localized: "discrete_help_summary")
+                    )
+                }
             }
 
-            Toggle(isOn: $discreteMode) {
-                settingsRowLabel(
-                    preferenceKey: .discreteMode,
-                    title: String(localized: "discrete_mode"),
-                    summary: String(localized: "discrete_mode_description")
-                )
+            if settingsSearchMatchesPreference(.discreteMode, in: securitySettingsSearchEntries) {
+                Toggle(isOn: $discreteMode) {
+                    settingsRowLabel(
+                        preferenceKey: .discreteMode,
+                        title: String(localized: "discrete_mode"),
+                        summary: String(localized: "discrete_mode_description")
+                    )
+                }
             }
 
-            Toggle(isOn: $showCalculator) {
-                settingsRowLabel(
-                    preferenceKey: .showCalculator,
-                    title: String(localized: "show_calculator"),
-                    summary: String(localized: "show_calculator_description")
-                )
+            if settingsSearchMatchesPreference(.showCalculator, in: securitySettingsSearchEntries) {
+                Toggle(isOn: $showCalculator) {
+                    settingsRowLabel(
+                        preferenceKey: .showCalculator,
+                        title: String(localized: "show_calculator"),
+                        summary: String(localized: "show_calculator_description")
+                    )
+                }
             }
 
-            HStack(alignment: .top, spacing: 12) {
-                settingsRowLabel(
-                    preferenceKey: .calculatorPin,
-                    title: String(localized: "calculator_pin"),
-                    summary: String(localized: "calculator_pin_description")
-                )
-                Spacer()
-                TextField(String(localized: "calculator_pin_placeholder"), text: $calculatorPin)
-                    #if os(iOS)
-                    .keyboardType(.numberPad)
-                    #endif
-                    .multilineTextAlignment(.trailing)
-                    .frame(width: 100)
-                    .onChange(of: calculatorPin) { _, newValue in
-                        let filtered = newValue.filter { $0.isNumber }
-                        if filtered != newValue { calculatorPin = filtered }
-                    }
+            if settingsSearchMatchesPreference(.calculatorPin, in: securitySettingsSearchEntries) {
+                HStack(alignment: .top, spacing: 12) {
+                    settingsRowLabel(
+                        preferenceKey: .calculatorPin,
+                        title: String(localized: "calculator_pin"),
+                        summary: String(localized: "calculator_pin_description")
+                    )
+                    Spacer()
+                    TextField(String(localized: "calculator_pin_placeholder"), text: $calculatorPin)
+                        #if os(iOS)
+                        .keyboardType(.numberPad)
+                        #endif
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 100)
+                        .onChange(of: calculatorPin) { _, newValue in
+                            let filtered = newValue.filter { $0.isNumber }
+                            if filtered != newValue { calculatorPin = filtered }
+                        }
+                }
             }
         } header: {
             settingsSectionHeader(String(localized: "settings_security"))
@@ -907,115 +951,125 @@ public struct SettingsView: View {
     @ViewBuilder
     private var advancedSettingsSection: some View {
         Section {
-            Toggle(isOn: Binding(
-                get: { enableBluetoothMediaButtons },
-                set: { newValue in
-                    enableBluetoothMediaButtons = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.enableBluetoothPref, value: newValue)
-                    onSettingsChanged?()
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .enableBluetoothPref,
-                    title: String(
-                        localized: "prefs_enable_bluetooth_title",
-                        defaultValue: "Enable Bluetooth media buttons"
-                    ),
-                    summary: String(
-                        localized: "prefs_enable_bluetooth_summary",
-                        defaultValue: "Handle Bluetooth media buttons to start/stop speaking."
+            if settingsSearchMatchesPreference(.enableBluetoothPref, in: advancedSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { enableBluetoothMediaButtons },
+                    set: { newValue in
+                        enableBluetoothMediaButtons = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.enableBluetoothPref, value: newValue)
+                        onSettingsChanged?()
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .enableBluetoothPref,
+                        title: String(
+                            localized: "prefs_enable_bluetooth_title",
+                            defaultValue: "Enable Bluetooth media buttons"
+                        ),
+                        summary: String(
+                            localized: "prefs_enable_bluetooth_summary",
+                            defaultValue: "Handle Bluetooth media buttons to start/stop speaking."
+                        )
                     )
-                )
+                }
             }
-            NavigationLink {
-                ExperimentalFeaturesMultiSelectView(
-                    title: String(
-                        localized: "prefs_experimental_features_title",
-                        defaultValue: "Experimental features"
-                    ),
-                    options: Self.experimentalFeatureOptions,
-                    selectedValues: $enabledExperimentalFeatures
-                )
-            } label: {
-                settingsSelectionRow(
-                    preferenceKey: .experimentalFeatures,
-                    title: String(
-                        localized: "prefs_experimental_features_title",
-                        defaultValue: "Experimental features"
-                    ),
-                    summary: String(
-                        localized: "prefs_experimental_features_summary",
-                        defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
-                    ),
-                    detail: experimentalFeaturesSummary(selectedValues: enabledExperimentalFeatures)
-                )
+            if settingsSearchMatchesPreference(.experimentalFeatures, in: advancedSettingsSearchEntries) {
+                NavigationLink {
+                    ExperimentalFeaturesMultiSelectView(
+                        title: String(
+                            localized: "prefs_experimental_features_title",
+                            defaultValue: "Experimental features"
+                        ),
+                        options: Self.experimentalFeatureOptions,
+                        selectedValues: $enabledExperimentalFeatures
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .experimentalFeatures,
+                        title: String(
+                            localized: "prefs_experimental_features_title",
+                            defaultValue: "Experimental features"
+                        ),
+                        summary: String(
+                            localized: "prefs_experimental_features_summary",
+                            defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
+                        ),
+                        detail: experimentalFeaturesSummary(selectedValues: enabledExperimentalFeatures)
+                    )
+                }
             }
             #if DEBUG
-            Toggle(isOn: Binding(
-                get: { showErrorBox },
-                set: { newValue in
-                    showErrorBox = newValue
-                    let store = SettingsStore(modelContext: modelContext)
-                    store.setBool(.showErrorBox, value: newValue)
-                    onSettingsChanged?()
-                }
-            )) {
-                settingsRowLabel(
-                    preferenceKey: .showErrorBox,
-                    title: String(
-                        localized: "prefs_show_error_box_title",
-                        defaultValue: "Show Javascript error box"
-                    ),
-                    summary: String(
-                        localized: "prefs_show_error_box_summary",
-                        defaultValue: "Useful for developers when debugging BibleView javascript side errors. This will make the app slower."
+            if settingsSearchMatchesPreference(.showErrorBox, in: advancedSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                    get: { showErrorBox },
+                    set: { newValue in
+                        showErrorBox = newValue
+                        let store = SettingsStore(modelContext: modelContext)
+                        store.setBool(.showErrorBox, value: newValue)
+                        onSettingsChanged?()
+                    }
+                )) {
+                    settingsRowLabel(
+                        preferenceKey: .showErrorBox,
+                        title: String(
+                            localized: "prefs_show_error_box_title",
+                            defaultValue: "Show Javascript error box"
+                        ),
+                        summary: String(
+                            localized: "prefs_show_error_box_summary",
+                            defaultValue: "Useful for developers when debugging BibleView javascript side errors. This will make the app slower."
+                        )
                     )
-                )
+                }
             }
             #endif
 
             #if os(iOS)
-            Button {
-                openBibleLinkSystemSettings()
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .openLinks,
-                    title: String(
-                        localized: "open_bible_links_title",
-                        defaultValue: "Open Bible links in AndBible"
-                    ),
-                    summary: String(
-                        localized: "open_bible_links_summary",
-                        defaultValue: "When clicking links that refer to AndBible supported Bible URL, open them in AndBible"
+            if settingsSearchMatchesPreference(.openLinks, in: advancedSettingsSearchEntries) {
+                Button {
+                    openBibleLinkSystemSettings()
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .openLinks,
+                        title: String(
+                            localized: "open_bible_links_title",
+                            defaultValue: "Open Bible links in AndBible"
+                        ),
+                        summary: String(
+                            localized: "open_bible_links_summary",
+                            defaultValue: "When clicking links that refer to AndBible supported Bible URL, open them in AndBible"
+                        )
                     )
-                )
+                }
             }
             #endif
 
             #if DEBUG
-            Button(role: .destructive) {
-                triggerDebugCrash()
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .crashApp,
-                    title: String(
-                        localized: "crash_app",
-                        defaultValue: "Crash app!"
-                    ),
-                    summary: debugCrashScheduled
-                        ? String(
-                            localized: "crash_app_scheduled_summary",
-                            defaultValue: "Crash scheduled in 10 seconds."
-                        )
-                        : String(
-                            localized: "crash_app_summary",
-                            defaultValue: "Crash app after 10 seconds. Debugging feature, visible only in debug builds."
+            if settingsSearchMatchesPreference(.crashApp, in: advancedSettingsSearchEntries) {
+                Button(role: .destructive) {
+                    triggerDebugCrash()
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .crashApp,
+                        title: String(
+                            localized: "crash_app",
+                            defaultValue: "Crash app!"
                         ),
-                    isEnabled: !debugCrashScheduled
-                )
+                        summary: debugCrashScheduled
+                            ? String(
+                                localized: "crash_app_scheduled_summary",
+                                defaultValue: "Crash scheduled in 10 seconds."
+                            )
+                            : String(
+                                localized: "crash_app_summary",
+                                defaultValue: "Crash app after 10 seconds. Debugging feature, visible only in debug builds."
+                            ),
+                        isEnabled: !debugCrashScheduled
+                    )
+                }
+                .disabled(debugCrashScheduled)
             }
-            .disabled(debugCrashScheduled)
             #endif
         } header: {
             settingsSectionHeader(
@@ -1068,306 +1122,334 @@ public struct SettingsView: View {
     @ViewBuilder
     private var lookAndFeelSection: some View {
         Section {
-            settingsNavigationLink(
-                title: String(localized: "settings_text_display"),
-                androidKey: "global_text_display_settings",
-                accessibilityIdentifier: "settingsTextDisplayLink"
-            ) {
-                TextDisplaySettingsView(settings: $displaySettings, onChange: onSettingsChanged)
-            }
-            settingsNavigationLink(
-                title: String(localized: "settings_colors"),
-                accessibilityIdentifier: "settingsColorsLink"
-            ) {
-                ColorSettingsView(settings: $displaySettings, onChange: onSettingsChanged)
-            }
-            Picker(selection: Binding(
-                    get: { Self.nightModePickerSelection(from: nightModeMode) },
-                    set: { newValue in
-                        nightModeMode = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setString(.nightModePref3, value: newValue)
-                        let manualNightMode = store.getBool("night_mode")
-                        nightMode = NightModeSettingsResolver.isNightMode(
-                            rawValue: newValue,
-                            manualNightMode: manualNightMode,
-                            systemIsDark: colorScheme == .dark
-                        )
-                        onSettingsChanged?()
-                    }
-                )) {
-                ForEach(NightModeSettingsResolver.availableModes, id: \.rawValue) { mode in
-                    Text(Self.nightModeModeTitle(mode)).tag(mode.rawValue)
+            if settingsSearchMatchesIdentifier("settingsTextDisplayLink", in: lookAndFeelSettingsSearchEntries) {
+                settingsNavigationLink(
+                    title: String(localized: "settings_text_display"),
+                    androidKey: "global_text_display_settings",
+                    accessibilityIdentifier: "settingsTextDisplayLink"
+                ) {
+                    TextDisplaySettingsView(settings: $displaySettings, onChange: onSettingsChanged)
                 }
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .nightModePref3,
-                    title: String(localized: "prefs_night_mode_title", defaultValue: "Night mode switching"),
-                    summary: String(
-                        localized: "prefs_night_mode_summary",
-                        defaultValue: "Whether to switch to night mode manually or via system setting. Manual switching can be done from the 3-dot options menu on the main screen."
-                    )
-                )
             }
-            Toggle(isOn: Binding(
-                    get: { monochromeMode },
-                    set: { newValue in
-                        monochromeMode = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.monochromeMode, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .monochromeMode,
-                    title: String(localized: "prefs_e_ink_mode_title", defaultValue: "Black & white mode"),
-                    summary: String(
-                        localized: "prefs_eink_mode_summary",
-                        defaultValue: "Use application in monochrome mode (no colors), making it more suitable for E-ink devices."
-                    )
-                )
+            if settingsSearchMatchesIdentifier("settingsColorsLink", in: lookAndFeelSettingsSearchEntries) {
+                settingsNavigationLink(
+                    title: String(localized: "settings_colors"),
+                    accessibilityIdentifier: "settingsColorsLink"
+                ) {
+                    ColorSettingsView(settings: $displaySettings, onChange: onSettingsChanged)
+                }
             }
-            Toggle(isOn: Binding(
-                    get: { disableAnimations },
-                    set: { newValue in
-                        disableAnimations = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.disableAnimations, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .disableAnimations,
-                    title: String(localized: "prefs_disable_animations_title", defaultValue: "Disable animations"),
-                    summary: String(
-                        localized: "prefs_disable_animations_summary",
-                        defaultValue: "Disable various animations such as smooth scrolling."
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                    get: { disableClickToEdit },
-                    set: { newValue in
-                        disableClickToEdit = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.disableClickToEdit, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .disableClickToEdit,
-                    title: String(
-                        localized: "prefs_disable_click_to_edit_title",
-                        defaultValue: "Disable Study Pad click-to-edit"
-                    ),
-                    summary: String(
-                        localized: "prefs_disable_click_to_edit_summary",
-                        defaultValue: "Requires using the edit button to edit notes in the Study Pad."
-                    )
-                )
-            }
-            VStack(alignment: .leading, spacing: 8) {
-                settingsRowLabel(
-                    preferenceKey: .fontSizeMultiplier,
-                    title: String(
-                        localized: "pref_font_size_multiplier_title",
-                        defaultValue: "Font size multiplier"
-                    ),
-                    summary: String(
-                        format: String(
-                            localized: "prefs_font_size_multiplier_summary",
-                            defaultValue: "Multiply text font sizes by this number. Current value: %.1fx"
-                        ),
-                        Double(fontSizeMultiplier) / 100.0
-                    )
-                )
-                Slider(
-                    value: Binding(
-                        get: { Double(fontSizeMultiplier) },
+            if settingsSearchMatchesPreference(.nightModePref3, in: lookAndFeelSettingsSearchEntries) {
+                Picker(selection: Binding(
+                        get: { Self.nightModePickerSelection(from: nightModeMode) },
                         set: { newValue in
-                            let roundedValue = Int((newValue / 10.0).rounded() * 10.0)
-                            fontSizeMultiplier = min(max(roundedValue, 10), 500)
+                            nightModeMode = newValue
                             let store = SettingsStore(modelContext: modelContext)
-                            store.setInt(.fontSizeMultiplier, value: fontSizeMultiplier)
+                            store.setString(.nightModePref3, value: newValue)
+                            let manualNightMode = store.getBool("night_mode")
+                            nightMode = NightModeSettingsResolver.isNightMode(
+                                rawValue: newValue,
+                                manualNightMode: manualNightMode,
+                                systemIsDark: colorScheme == .dark
+                            )
                             onSettingsChanged?()
                         }
-                    ),
-                    in: 10...500,
-                    step: 10
-                )
-                .padding(.leading, 66)
-            }
-            Toggle(isOn: Binding(
-                    get: { fullScreenHideButtons },
-                    set: { newValue in
-                        fullScreenHideButtons = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.fullScreenHideButtonsPref, value: newValue)
-                        onSettingsChanged?()
+                    )) {
+                    ForEach(NightModeSettingsResolver.availableModes, id: \.rawValue) { mode in
+                        Text(Self.nightModeModeTitle(mode)).tag(mode.rawValue)
                     }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .fullScreenHideButtonsPref,
-                    title: String(
-                        localized: "full_screen_hide_buttons_pref_title",
-                        defaultValue: "Hide window button bar in fullscreen"
-                    ),
-                    summary: String(
-                        localized: "full_screen_hide_buttons_pref_summary",
-                        defaultValue: "When switching to fullscreen mode, hide automatically window button bar that is on the bottom of the screen"
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .nightModePref3,
+                        title: String(localized: "prefs_night_mode_title", defaultValue: "Night mode switching"),
+                        summary: String(
+                            localized: "prefs_night_mode_summary",
+                            defaultValue: "Whether to switch to night mode manually or via system setting. Manual switching can be done from the 3-dot options menu on the main screen."
+                        )
                     )
-                )
-            }
-            Toggle(isOn: Binding(
-                    get: { hideWindowButtons },
-                    set: { newValue in
-                        hideWindowButtons = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.hideWindowButtons, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .hideWindowButtons,
-                    title: String(
-                        localized: "hide_window_buttons_title",
-                        defaultValue: "Hide window buttons"
-                    ),
-                    summary: String(
-                        localized: "hide_window_buttons_summary",
-                        defaultValue: "Window buttons that are displayed on right side of the Bible views are hidden. Window navigation bar on the bottom is still displayed and you may open window popup menu by long-clicking them."
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                    get: { hideBibleReferenceOverlay },
-                    set: { newValue in
-                        hideBibleReferenceOverlay = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.hideBibleReferenceOverlay, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .hideBibleReferenceOverlay,
-                    title: String(
-                        localized: "hide_bible_reference_overlay_title",
-                        defaultValue: "Hide Bible reference overlay"
-                    ),
-                    summary: String(
-                        localized: "hide_bible_reference_overlay_summary",
-                        defaultValue: "Do not show the semi-transparent Bible reference overlay when app is in fullscreen mode"
-                    )
-                )
-            }
-            Toggle(isOn: Binding(
-                    get: { showActiveWindowIndicator },
-                    set: { newValue in
-                        showActiveWindowIndicator = newValue
-                        let store = SettingsStore(modelContext: modelContext)
-                        store.setBool(.showActiveWindowIndicator, value: newValue)
-                        onSettingsChanged?()
-                    }
-                )) {
-                settingsRowLabel(
-                    preferenceKey: .showActiveWindowIndicator,
-                    title: String(
-                        localized: "active_window_indicator_title",
-                        defaultValue: "Show active window indicator"
-                    ),
-                    summary: String(
-                        localized: "active_window_indicator_summary",
-                        defaultValue: "Highlight window corners to help recognising which window is active"
-                    )
-                )
-            }
-            NavigationLink {
-                BookmarkModalActionsInverseMultiSelectView(
-                    title: String(
-                        localized: "prefs_in_window_bible_bookmark_modal_buttons_title",
-                        defaultValue: "One-tap actions (Bibles)"
-                    ),
-                    options: Self.bibleBookmarkModalActionOptions,
-                    disabledValues: $disabledBibleBookmarkModalButtons
-                )
-            } label: {
-                settingsSelectionRow(
-                    preferenceKey: .disableBibleBookmarkModalButtons,
-                    title: String(
-                        localized: "prefs_in_window_bible_bookmark_modal_buttons_title",
-                        defaultValue: "One-tap actions (Bibles)"
-                    ),
-                    summary: String(
-                        localized: "prefs_in_window_bookmark_modal_buttons_description",
-                        defaultValue: "When a text is tapped, one-tap action window is shown. Which action buttons should be shown?"
-                    ),
-                    detail: inverseSelectionSummary(
-                        disabledValues: disabledBibleBookmarkModalButtons,
-                        options: Self.bibleBookmarkModalActionOptions
-                    )
-                )
-            }
-            NavigationLink {
-                BookmarkModalActionsInverseMultiSelectView(
-                    title: String(
-                        localized: "prefs_in_window_gen_bookmark_modal_buttons_title",
-                        defaultValue: "One-tap actions (Other)"
-                    ),
-                    options: Self.genBookmarkModalActionOptions,
-                    disabledValues: $disabledGenBookmarkModalButtons
-                )
-            } label: {
-                settingsSelectionRow(
-                    preferenceKey: .disableGenBookmarkModalButtons,
-                    title: String(
-                        localized: "prefs_in_window_gen_bookmark_modal_buttons_title",
-                        defaultValue: "One-tap actions (Other)"
-                    ),
-                    summary: String(
-                        localized: "prefs_in_window_bookmark_modal_buttons_description",
-                        defaultValue: "When a text is tapped, one-tap action window is shown. Which action buttons should be shown?"
-                    ),
-                    detail: inverseSelectionSummary(
-                        disabledValues: disabledGenBookmarkModalButtons,
-                        options: Self.genBookmarkModalActionOptions
-                    )
-                )
-            }
-            Picker(selection: $selectedLanguage) {
-                ForEach(Self.localeOptions) { lang in
-                    Text(Self.localizedLocaleOptionLabel(lang)).tag(lang.value)
                 }
-            } label: {
-                settingsRowLabel(
-                    preferenceKey: .localePref,
-                    title: String(localized: "prefs_interface_locale_title", defaultValue: "Application language"),
-                    summary: String(
-                        localized: "prefs_interface_locale_summary",
-                        defaultValue: "Select custom user interface language"
-                    ),
-                    detail: String(localized: "language_restart_required")
-                )
             }
-            .onChange(of: selectedLanguage) { _, newValue in
-                guard hasLoadedPreferences else { return }
-                let normalized = Self.localeOptions.contains(where: { $0.value == newValue }) ? newValue : ""
-                if normalized != selectedLanguage {
-                    selectedLanguage = normalized
-                    return
+            if settingsSearchMatchesPreference(.monochromeMode, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { monochromeMode },
+                        set: { newValue in
+                            monochromeMode = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.monochromeMode, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .monochromeMode,
+                        title: String(localized: "prefs_e_ink_mode_title", defaultValue: "Black & white mode"),
+                        summary: String(
+                            localized: "prefs_eink_mode_summary",
+                            defaultValue: "Use application in monochrome mode (no colors), making it more suitable for E-ink devices."
+                        )
+                    )
                 }
+            }
+            if settingsSearchMatchesPreference(.disableAnimations, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { disableAnimations },
+                        set: { newValue in
+                            disableAnimations = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.disableAnimations, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .disableAnimations,
+                        title: String(localized: "prefs_disable_animations_title", defaultValue: "Disable animations"),
+                        summary: String(
+                            localized: "prefs_disable_animations_summary",
+                            defaultValue: "Disable various animations such as smooth scrolling."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.disableClickToEdit, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { disableClickToEdit },
+                        set: { newValue in
+                            disableClickToEdit = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.disableClickToEdit, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .disableClickToEdit,
+                        title: String(
+                            localized: "prefs_disable_click_to_edit_title",
+                            defaultValue: "Disable Study Pad click-to-edit"
+                        ),
+                        summary: String(
+                            localized: "prefs_disable_click_to_edit_summary",
+                            defaultValue: "Requires using the edit button to edit notes in the Study Pad."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.fontSizeMultiplier, in: lookAndFeelSettingsSearchEntries) {
+                VStack(alignment: .leading, spacing: 8) {
+                    settingsRowLabel(
+                        preferenceKey: .fontSizeMultiplier,
+                        title: String(
+                            localized: "pref_font_size_multiplier_title",
+                            defaultValue: "Font size multiplier"
+                        ),
+                        summary: String(
+                            format: String(
+                                localized: "prefs_font_size_multiplier_summary",
+                                defaultValue: "Multiply text font sizes by this number. Current value: %.1fx"
+                            ),
+                            Double(fontSizeMultiplier) / 100.0
+                        )
+                    )
+                    Slider(
+                        value: Binding(
+                            get: { Double(fontSizeMultiplier) },
+                            set: { newValue in
+                                let roundedValue = Int((newValue / 10.0).rounded() * 10.0)
+                                fontSizeMultiplier = min(max(roundedValue, 10), 500)
+                                let store = SettingsStore(modelContext: modelContext)
+                                store.setInt(.fontSizeMultiplier, value: fontSizeMultiplier)
+                                onSettingsChanged?()
+                            }
+                        ),
+                        in: 10...500,
+                        step: 10
+                    )
+                    .padding(.leading, 66)
+                }
+            }
+            if settingsSearchMatchesPreference(.fullScreenHideButtonsPref, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { fullScreenHideButtons },
+                        set: { newValue in
+                            fullScreenHideButtons = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.fullScreenHideButtonsPref, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .fullScreenHideButtonsPref,
+                        title: String(
+                            localized: "full_screen_hide_buttons_pref_title",
+                            defaultValue: "Hide window button bar in fullscreen"
+                        ),
+                        summary: String(
+                            localized: "full_screen_hide_buttons_pref_summary",
+                            defaultValue: "When switching to fullscreen mode, hide automatically window button bar that is on the bottom of the screen"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.hideWindowButtons, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { hideWindowButtons },
+                        set: { newValue in
+                            hideWindowButtons = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.hideWindowButtons, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .hideWindowButtons,
+                        title: String(
+                            localized: "hide_window_buttons_title",
+                            defaultValue: "Hide window buttons"
+                        ),
+                        summary: String(
+                            localized: "hide_window_buttons_summary",
+                            defaultValue: "Window buttons that are displayed on right side of the Bible views are hidden. Window navigation bar on the bottom is still displayed and you may open window popup menu by long-clicking them."
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.hideBibleReferenceOverlay, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { hideBibleReferenceOverlay },
+                        set: { newValue in
+                            hideBibleReferenceOverlay = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.hideBibleReferenceOverlay, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .hideBibleReferenceOverlay,
+                        title: String(
+                            localized: "hide_bible_reference_overlay_title",
+                            defaultValue: "Hide Bible reference overlay"
+                        ),
+                        summary: String(
+                            localized: "hide_bible_reference_overlay_summary",
+                            defaultValue: "Do not show the semi-transparent Bible reference overlay when app is in fullscreen mode"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.showActiveWindowIndicator, in: lookAndFeelSettingsSearchEntries) {
+                Toggle(isOn: Binding(
+                        get: { showActiveWindowIndicator },
+                        set: { newValue in
+                            showActiveWindowIndicator = newValue
+                            let store = SettingsStore(modelContext: modelContext)
+                            store.setBool(.showActiveWindowIndicator, value: newValue)
+                            onSettingsChanged?()
+                        }
+                    )) {
+                    settingsRowLabel(
+                        preferenceKey: .showActiveWindowIndicator,
+                        title: String(
+                            localized: "active_window_indicator_title",
+                            defaultValue: "Show active window indicator"
+                        ),
+                        summary: String(
+                            localized: "active_window_indicator_summary",
+                            defaultValue: "Highlight window corners to help recognising which window is active"
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.disableBibleBookmarkModalButtons, in: lookAndFeelSettingsSearchEntries) {
+                NavigationLink {
+                    BookmarkModalActionsInverseMultiSelectView(
+                        title: String(
+                            localized: "prefs_in_window_bible_bookmark_modal_buttons_title",
+                            defaultValue: "One-tap actions (Bibles)"
+                        ),
+                        options: Self.bibleBookmarkModalActionOptions,
+                        disabledValues: $disabledBibleBookmarkModalButtons
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .disableBibleBookmarkModalButtons,
+                        title: String(
+                            localized: "prefs_in_window_bible_bookmark_modal_buttons_title",
+                            defaultValue: "One-tap actions (Bibles)"
+                        ),
+                        summary: String(
+                            localized: "prefs_in_window_bookmark_modal_buttons_description",
+                            defaultValue: "When a text is tapped, one-tap action window is shown. Which action buttons should be shown?"
+                        ),
+                        detail: inverseSelectionSummary(
+                            disabledValues: disabledBibleBookmarkModalButtons,
+                            options: Self.bibleBookmarkModalActionOptions
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.disableGenBookmarkModalButtons, in: lookAndFeelSettingsSearchEntries) {
+                NavigationLink {
+                    BookmarkModalActionsInverseMultiSelectView(
+                        title: String(
+                            localized: "prefs_in_window_gen_bookmark_modal_buttons_title",
+                            defaultValue: "One-tap actions (Other)"
+                        ),
+                        options: Self.genBookmarkModalActionOptions,
+                        disabledValues: $disabledGenBookmarkModalButtons
+                    )
+                } label: {
+                    settingsSelectionRow(
+                        preferenceKey: .disableGenBookmarkModalButtons,
+                        title: String(
+                            localized: "prefs_in_window_gen_bookmark_modal_buttons_title",
+                            defaultValue: "One-tap actions (Other)"
+                        ),
+                        summary: String(
+                            localized: "prefs_in_window_bookmark_modal_buttons_description",
+                            defaultValue: "When a text is tapped, one-tap action window is shown. Which action buttons should be shown?"
+                        ),
+                        detail: inverseSelectionSummary(
+                            disabledValues: disabledGenBookmarkModalButtons,
+                            options: Self.genBookmarkModalActionOptions
+                        )
+                    )
+                }
+            }
+            if settingsSearchMatchesPreference(.localePref, in: lookAndFeelSettingsSearchEntries) {
+                Picker(selection: $selectedLanguage) {
+                    ForEach(Self.localeOptions) { lang in
+                        Text(Self.localizedLocaleOptionLabel(lang)).tag(lang.value)
+                    }
+                } label: {
+                    settingsRowLabel(
+                        preferenceKey: .localePref,
+                        title: String(localized: "prefs_interface_locale_title", defaultValue: "Application language"),
+                        summary: String(
+                            localized: "prefs_interface_locale_summary",
+                            defaultValue: "Select custom user interface language"
+                        ),
+                        detail: String(localized: "language_restart_required")
+                    )
+                }
+                .onChange(of: selectedLanguage) { _, newValue in
+                    guard hasLoadedPreferences else { return }
+                    let normalized = Self.localeOptions.contains(where: { $0.value == newValue }) ? newValue : ""
+                    if normalized != selectedLanguage {
+                        selectedLanguage = normalized
+                        return
+                    }
 
-                let store = SettingsStore(modelContext: modelContext)
-                guard shouldPersistLanguageSelection(normalized, using: store) else {
-                    return
-                }
-                store.setString(.localePref, value: normalized)
+                    let store = SettingsStore(modelContext: modelContext)
+                    guard shouldPersistLanguageSelection(normalized, using: store) else {
+                        return
+                    }
+                    store.setString(.localePref, value: normalized)
 
-                if let mapped = Self.appleLanguageCode(forLocalePrefValue: normalized) {
-                    UserDefaults.standard.set([mapped], forKey: "AppleLanguages")
-                } else {
-                    UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                    if let mapped = Self.appleLanguageCode(forLocalePrefValue: normalized) {
+                        UserDefaults.standard.set([mapped], forKey: "AppleLanguages")
+                    } else {
+                        UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                    }
+                    showRestartAlert = true
                 }
-                showRestartAlert = true
             }
         } header: {
             settingsSectionHeader(String(localized: "prefs_display_customization_cat", defaultValue: "Look & feel"))
@@ -1876,7 +1958,7 @@ public struct SettingsView: View {
 
     /// Search entries for advanced preferences and developer/debug action rows.
     private var advancedSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
-        [
+        var entries = [
             preferenceSearchEntry(
                 .enableBluetoothPref,
                 title: String(localized: "prefs_enable_bluetooth_title", defaultValue: "Enable Bluetooth media buttons"),
@@ -1893,19 +1975,32 @@ public struct SettingsView: View {
                     defaultValue: "Select which experimental features to enable. These features are still in development and may change or be removed"
                 )
             ),
+        ]
+        #if DEBUG
+        entries.append(
             preferenceSearchEntry(
                 .showErrorBox,
                 title: String(localized: "prefs_show_error_box_title", defaultValue: "Show Javascript error box")
-            ),
+            )
+        )
+        #endif
+        #if os(iOS)
+        entries.append(
             preferenceSearchEntry(
                 .openLinks,
                 title: String(localized: "open_bible_links_title", defaultValue: "Open Bible links in AndBible")
-            ),
+            )
+        )
+        #endif
+        #if DEBUG
+        entries.append(
             preferenceSearchEntry(
                 .crashApp,
                 title: String(localized: "crash_app", defaultValue: "Crash app!")
-            ),
-        ]
+            )
+        )
+        #endif
+        return entries
     }
 
     /// Search entry for static application information retained in Settings.
@@ -1993,6 +2088,40 @@ public struct SettingsView: View {
      */
     private func settingsSearchMatchesEntry(_ entry: AndBibleSettingsSearchEntry) -> Bool {
         AndBibleSettingsSearchMatcher.matches(query: settingsSearchText, entry: entry)
+    }
+
+    /**
+     Returns whether a rendered row identifier matches the current search query.
+
+     - Parameters:
+       - identifier: Stable accessibility or preference identifier for the row.
+       - entries: Search entries for the row's section.
+     - Returns: `true` when search is inactive or the exact entry matches the current query.
+     - Side effects: none.
+     - Failure modes: Unknown identifiers are hidden only while search is active.
+     */
+    private func settingsSearchMatchesIdentifier(
+        _ identifier: String,
+        in entries: [AndBibleSettingsSearchEntry]
+    ) -> Bool {
+        AndBibleSettingsSearchMatcher.matchesIdentifier(identifier, query: settingsSearchText, entries: entries)
+    }
+
+    /**
+     Returns whether a preference-backed row matches the current search query.
+
+     - Parameters:
+       - key: Android parity key backing the rendered row.
+       - entries: Search entries for the row's section.
+     - Returns: `true` when search is inactive or the exact key-backed entry matches.
+     - Side effects: none.
+     - Failure modes: Unknown preference keys are hidden only while search is active.
+     */
+    private func settingsSearchMatchesPreference(
+        _ key: AppPreferenceKey,
+        in entries: [AndBibleSettingsSearchEntry]
+    ) -> Bool {
+        settingsSearchMatchesIdentifier(key.rawValue, in: entries)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift
@@ -1521,13 +1521,13 @@ public struct SettingsView: View {
                 }
             }
 
-            let readingProgressEntry = readingProgressSettingsSearchEntry
-            if settingsSearchMatchesEntry(readingProgressEntry) {
+            if canOpenReadingProgressSettings,
+               settingsSearchMatchesEntry(readingProgressSettingsSearchEntry) {
                 settingsNavigationLink(
-                    title: readingProgressEntry.title,
+                    title: readingProgressSettingsSearchEntry.title,
                     androidKey: "reading_progress_settings_shortcut",
-                    summary: readingProgressEntry.summary,
-                    accessibilityIdentifier: readingProgressEntry.identifier
+                    summary: readingProgressSettingsSearchEntry.summary,
+                    accessibilityIdentifier: readingProgressSettingsSearchEntry.identifier
                 ) {
                     ReadingProgressSettingsView(controller: readingProgressController)
                         .accessibilityIdentifier("readingProgressSettingsScreen")
@@ -1541,6 +1541,11 @@ public struct SettingsView: View {
     /// Whether the current query should show the Android feature-shortcut section.
     private var shouldShowFeaturesSection: Bool {
         settingsSearchMatchesSection(featuresSettingsSearchEntries)
+    }
+
+    /// Whether Reading Progress Settings can be opened and persisted from this settings instance.
+    private var canOpenReadingProgressSettings: Bool {
+        readingProgressController != nil
     }
 
     /// Search entry for the sync feature shortcut.
@@ -1568,7 +1573,11 @@ public struct SettingsView: View {
 
     /// Search entries for feature shortcuts that can be opened from Application preferences.
     private var featuresSettingsSearchEntries: [AndBibleSettingsSearchEntry] {
-        [syncSettingsSearchEntry, readingProgressSettingsSearchEntry]
+        var entries = [syncSettingsSearchEntry]
+        if canOpenReadingProgressSettings {
+            entries.append(readingProgressSettingsSearchEntry)
+        }
+        return entries
     }
 
     /// Search entries for module-backed dictionary preference rows currently visible on this device.
@@ -2124,14 +2133,16 @@ public struct SettingsView: View {
         guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports else {
             return ""
         }
-        let primaryLinks = [
-            "settingsSyncLink",
-            "settingsReadingProgressLink",
+        var primaryLinks = ["settingsSyncLink"]
+        if canOpenReadingProgressSettings {
+            primaryLinks.append("settingsReadingProgressLink")
+        }
+        primaryLinks.append(contentsOf: [
             "settingsTextDisplayLink",
             "settingsColorsLink",
-        ].joined(separator: ",")
+        ])
         let searchToken = isSettingsSearchActive ? "active" : "inactive"
-        return "primaryLinks=\(primaryLinks);adminFlows=readerActions;search=\(searchToken)"
+        return "primaryLinks=\(primaryLinks.joined(separator: ","));adminFlows=readerActions;search=\(searchToken)"
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Shared/AndBibleAppVersionMetadata.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/AndBibleAppVersionMetadata.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/**
+ Resolves the application version metadata shown by native iOS information surfaces.
+
+ This helper centralizes bundle metadata lookup so Settings, About, Help, and reader drawer
+ footer text do not drift or fall back to hard-coded display values.
+
+ - Inputs: A `Bundle`, defaulting to `Bundle.main`.
+ - Outputs: Marketing version, build number, and formatted display strings.
+ - Side effects: none.
+ - Failure modes: Missing or non-string bundle values fall back to stable development defaults.
+ */
+struct AndBibleAppVersionMetadata: Equatable {
+    let marketingVersion: String
+    let buildNumber: String
+
+    /// Compact version-and-build detail text suitable for secondary labels.
+    var detailText: String {
+        "\(marketingVersion) (\(buildNumber))"
+    }
+
+    /// App-prefixed help footer text.
+    var helpFooterText: String {
+        "AndBible v\(marketingVersion)"
+    }
+
+    /// Reader drawer footer text.
+    var drawerFooterText: String {
+        "Version \(detailText)"
+    }
+
+    /**
+     Reads application version metadata from a bundle.
+
+     - Parameter bundle: The bundle that owns `CFBundleShortVersionString` and `CFBundleVersion`.
+     - Returns: A metadata value with normalized fallback strings.
+     - Side effects: none.
+     - Failure modes: Invalid or absent bundle keys return `1.0` and `1`.
+     */
+    static func current(bundle: Bundle = .main) -> AndBibleAppVersionMetadata {
+        AndBibleAppVersionMetadata(
+            marketingVersion: bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0",
+            buildNumber: bundle.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        )
+    }
+}

--- a/docs/parity/settings/contract.md
+++ b/docs/parity/settings/contract.md
@@ -1,6 +1,6 @@
 # Android Settings Contract (Source Of Truth)
 
-Last audited: 2026-05-31 for #154.
+Last audited: 2026-06-01 for #155.
 
 This file records the Android Application preferences contract and the current iOS
 disposition for each Android preference row. It intentionally separates two layers:
@@ -24,6 +24,8 @@ Primary Android sources:
 Primary iOS sources:
 - Registry: `Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift`
 - Settings UI: `Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift`
+- Settings search: `Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift`
+- Android icon mapping: `Sources/BibleUI/Sources/BibleUI/Shared/AndBibleIconCatalog.swift`
 - Reader config payload: `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`
 - Shared Vue reader config: `bibleview-js/src/composables/config.ts`
 
@@ -37,6 +39,10 @@ Primary iOS sources:
   `ai_settings_shortcut`, and `reading_progress_settings_shortcut` are action rows,
   not durable preference values. They should not be added to `AppPreferenceRegistry`
   unless iOS intentionally models them as registry-backed actions.
+- iOS Application preferences reset uses `AppPreferenceRegistry.applicationPreferencesResetKeys`.
+  Action rows and global text-display settings are excluded from that reset contract.
+- iOS Application preferences search is native SwiftUI search over normalized row
+  identifiers, titles, summaries, details, and keywords. All query terms must match.
 - `eink_mode` is an Android e-ink feature switch and is intentionally not registered
   on iOS unless iOS gains equivalent e-ink behavior.
 - `notes_content_type` is a real Android preference and is tracked separately by #163
@@ -92,9 +98,9 @@ Primary iOS sources:
 | `discrete_mode` | XML `settings.xml:222-227`; hidden in discrete flavor at `SettingsActivity.kt:310-314`. | Registry-backed adapted pass. |
 | `show_calculator` | XML `settings.xml:228-232`; hidden/summary adjusted at `SettingsActivity.kt:315-324`. | Registry-backed pass. |
 | `calculator_pin` | XML `settings.xml:233-238`; numeric editor enforced at `SettingsActivity.kt:280-282`. | Registry-backed pass. |
-| `sync_settings_shortcut` | XML `settings.xml:241-245`; starts `SyncSettingsActivity` at `SettingsActivity.kt:284-287`. | Outside registry, adapted by iOS Settings data link to `SyncSettingsView`; broader shortcut presentation is tracked by #155. |
-| `ai_settings_shortcut` | XML `settings.xml:246-250`; starts `AiSettingsActivity` at `SettingsActivity.kt:289-292`. | Outside registry, deferred to the iOS AI parity track (#5, #74, #89-#92) and settings presentation track (#155). |
-| `reading_progress_settings_shortcut` | XML `settings.xml:251-255`; starts `ReadingProgressSettingsActivity` at `SettingsActivity.kt:294-297`. | Outside registry, partially adapted through the reader bridge/native reading-progress settings; top-level settings shortcut alignment is tracked by #155. |
+| `sync_settings_shortcut` | XML `settings.xml:241-245`; starts `SyncSettingsActivity` at `SettingsActivity.kt:284-287`. | Outside registry, adapted as an iOS Features shortcut to `SyncSettingsView` with Android-sourced icon mapping. |
+| `ai_settings_shortcut` | XML `settings.xml:246-250`; starts `AiSettingsActivity` at `SettingsActivity.kt:289-292`. | Outside registry, intentionally absent until iOS has an AI settings contract; tracked by the iOS AI parity issues (#5, #74, #89-#92). |
+| `reading_progress_settings_shortcut` | XML `settings.xml:251-255`; starts `ReadingProgressSettingsActivity` at `SettingsActivity.kt:294-297`. | Outside registry, adapted as an iOS Features shortcut to native `ReadingProgressSettingsView` with Android-sourced icon mapping. |
 | `experimental_features` | XML `settings.xml:258-265`; option arrays are `arrays.xml:273-280`. | Registry-backed pass. |
 | `enable_bluetooth_pref` | XML `settings.xml:266-270`; default `true`. | Registry-backed adapted pass through iOS remote command handling. |
 | `request_sdcard_permission_pref` | XML `settings.xml:271-274`; hidden on Android Q+ at `SettingsActivity.kt:275-278`. | Registry-backed documented divergence. iOS has no SD-card permission model. |
@@ -125,7 +131,7 @@ Primary iOS sources:
 | `font_size_multiplier` summary shows the current multiplier. | `SettingsActivity.kt:255-268` | Implemented with a SwiftUI stepper value. |
 | `request_sdcard_permission_pref` hidden on Android Q+. | `SettingsActivity.kt:275-278` | iOS divergence. |
 | `calculator_pin` editor forced to numeric input. | `SettingsActivity.kt:280-282` | Implemented. |
-| Sync, AI, and Reading Progress shortcuts open adjacent settings screens. | `SettingsActivity.kt:284-297` | Sync adapted; AI and top-level Reading Progress shortcut alignment tracked by #155 and AI parity issues. |
+| Sync, AI, and Reading Progress shortcuts open adjacent settings screens. | `SettingsActivity.kt:284-297` | Sync and Reading Progress are adapted as native iOS Features shortcuts. AI remains deferred because iOS has no AI settings workflow yet. |
 | `global_text_display_settings` opens global text-display settings. | `SettingsActivity.kt:299-308` | Adapted through Look & feel settings links and `SettingsStore.globalTextDisplaySettingsKey`. |
 | `discrete_mode` and `show_calculator` hidden in discrete flavor. | `SettingsActivity.kt:310-324` | Adapted through iOS app-icon/calculator behavior. |
 | `discrete_help` shows flavor-dependent help dialog. | `SettingsActivity.kt:325-353` | Adapted as iOS help sheet. |

--- a/docs/parity/settings/dispositions.md
+++ b/docs/parity/settings/dispositions.md
@@ -77,6 +77,39 @@ This file records explicit iOS disposition decisions for Android parity tickets 
   - #156 should not be implemented as written because it bundles this Android-only e-ink setting with the separate `notes_content_type` gap.
   - #163 tracks the real `notes_content_type` follow-up independently.
 
+## SETPAR-155 — Application preferences presentation and workflows
+
+- Android contract:
+  - `SettingsActivity` hosts Application preferences inside app chrome, adds
+    preference search, supports reset for the screen's preferences, and exposes
+    feature shortcuts for Sync, AI settings, and Reading Progress.
+  - Android keeps broader administration workflows, including downloads and backup,
+    outside Application preferences.
+- iOS adaptation (implemented):
+  - Keep the screen native SwiftUI, but open it as an integrated reader navigation
+    destination instead of a modal sheet.
+  - Use the shared Android icon catalog for Application preference rows and feature
+    shortcuts rather than inventing a separate iOS-only icon vocabulary.
+  - Add native search over Application preference row identifiers, titles,
+    summaries, details, and keywords.
+  - Add a reset action backed by `AppPreferenceRegistry.applicationPreferencesResetKeys`
+    and `SettingsStore.resetApplicationPreferences()`. Action rows and global
+    text-display settings are deliberately excluded from the reset scope.
+  - Add the Android-aligned Features shortcuts for Sync and Reading Progress.
+  - Keep Downloads, repositories, import/export, labels, and about in reader
+    drawer/overflow/admin flows rather than folding them into Application preferences.
+- iOS deviation:
+  - Do not add `ai_settings_shortcut` until iOS has an AI settings workflow. Adding a
+    dead row would make the screen look more Android-like while reducing functional
+    parity.
+- iOS references:
+  - Presentation and search UI: `Sources/BibleUI/Sources/BibleUI/Settings/SettingsView.swift`
+  - Search matcher: `Sources/BibleUI/Sources/BibleUI/Settings/AndBibleSettingsSearch.swift`
+  - Reset contract: `Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift`
+  - Reset implementation: `Sources/BibleCore/Sources/BibleCore/Database/SettingsStore.swift`
+  - Reader navigation destination: `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
+  - Icon mapping: `Sources/BibleUI/Sources/BibleUI/Shared/AndBibleIconCatalog.swift`
+
 ## SETPAR-505 — `open_links`
 
 - Android contract:

--- a/docs/parity/settings/regression-report.md
+++ b/docs/parity/settings/regression-report.md
@@ -1,10 +1,13 @@
 # SETPAR-702 Regression Report
 
-Date: 2026-03-11
+Date: 2026-06-01
 
 ## Scope
 
-Regression verification for settings parity work, Strong's search regression hardening, and CI/guardrail integration, using local simulator test execution and localization guardrail execution.
+Regression verification for settings parity work, #155 Application preferences
+workflow parity, Strong's search regression hardening, and CI/guardrail
+integration, using local simulator test execution and localization guardrail
+execution.
 
 ## Environment
 
@@ -13,6 +16,58 @@ Regression verification for settings parity work, Strong's search regression har
 - Simulator destination used: `platform=iOS Simulator,name=iPhone 17,OS=26.2`
 
 ## Executed Checks
+
+### 0. SETPAR-155 Application preferences workflow verification
+
+Date: 2026-06-01
+
+Commands:
+
+```bash
+xcodebuild \
+  -project AndBible.xcodeproj \
+  -scheme AndBible \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath /private/tmp/and-bible-ios-155-derived-data \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+```bash
+xcodebuild test \
+  -project AndBible.xcodeproj \
+  -scheme AndBible \
+  -destination 'id=98C37D62-54A5-4C52-846B-B0801AEAD2CB' \
+  -derivedDataPath /private/tmp/and-bible-ios-155-derived-data \
+  -only-testing:AndBibleTests/AndBibleTests/testApplicationPreferencesResetContractExcludesActionRowsAndIncludesVisibleParityKeys \
+  -only-testing:AndBibleTests/AndBibleTests/testSettingsStoreResetApplicationPreferencesRestoresRegistryDefaults \
+  -only-testing:AndBibleTests/AndBibleTests/testSettingsSearchMatcherRequiresAllNormalizedTermsAcrossEntryText
+```
+
+```bash
+xcodebuild test \
+  -project AndBible.xcodeproj \
+  -scheme AndBible \
+  -destination 'id=98C37D62-54A5-4C52-846B-B0801AEAD2CB' \
+  -derivedDataPath /private/tmp/and-bible-ios-155-derived-data \
+  -only-testing:AndBibleUITests/AndBibleUITests/testSettingsScreenShowsApplicationPreferenceShortcuts \
+  -only-testing:AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings
+```
+
+Results:
+
+- Simulator build: `PASS` (`** BUILD SUCCEEDED **`)
+- Focused unit tests: `PASS` (`Executed 3 tests, with 0 failures`)
+- Focused UI tests: `PASS` (`Executed 2 tests, with 0 failures`)
+
+Evidence:
+
+- Reset contract: `AppPreferenceRegistry.applicationPreferencesResetKeys`
+- Reset behavior: `SettingsStore.resetApplicationPreferences()`
+- Search contract: `AndBibleSettingsSearchMatcher`
+- Integrated presentation and shortcuts: `SettingsView` and `BibleReaderView`
 
 ### 1. SETPAR-603 localization guardrails (snapshot fallback path)
 
@@ -112,4 +167,5 @@ The CI workflow now includes the expected improvements and still runs guardrails
 
 ## Follow-up Inputs
 
-See `docs/parity/settings/verification-matrix.md` for current functional parity status by key. Current remaining items are only documented platform divergences.
+See `docs/parity/settings/verification-matrix.md` for current functional parity
+status by key. Current remaining items are documented gaps or platform divergences.

--- a/docs/parity/settings/verification-matrix.md
+++ b/docs/parity/settings/verification-matrix.md
@@ -1,6 +1,6 @@
 # SETPAR-701 Verification Matrix (Android Application Preferences -> iOS)
 
-Date: 2026-05-31
+Date: 2026-06-01
 
 ## Scope and Method
 
@@ -38,6 +38,8 @@ divergences.
 - Non-registry documented divergence: 1 (`eink_mode`).
 - Android action shortcuts outside registry: 4 (`global_text_display_settings`,
   `sync_settings_shortcut`, `ai_settings_shortcut`, `reading_progress_settings_shortcut`).
+  Three are implemented as native iOS navigation/actions; `ai_settings_shortcut`
+  remains deferred until iOS has an AI settings workflow.
 
 ## Key-by-Key Matrix
 
@@ -75,9 +77,9 @@ divergences.
 | `discrete_mode` | `AppPreferenceRegistry`; `SettingsView`; `AndBibleApp` alternate icon behavior | Adapted Pass | Android launcher identity behavior adapted to iOS alternate icon API. |
 | `show_calculator` | `AppPreferenceRegistry`; `SettingsView`; `AndBibleApp` startup calculator gate | Pass | Startup calculator gate follows persisted preference. |
 | `calculator_pin` | `AppPreferenceRegistry`; `SettingsView` numeric field; `CalculatorView` unlock | Pass | Numeric PIN entry and unlock behavior are wired. |
-| `sync_settings_shortcut` | `SettingsView` Data section links to `SyncSettingsView` | Outside Registry | Shortcut adapted outside registry; presentation alignment tracked by #155. |
-| `ai_settings_shortcut` | No direct iOS Application preferences shortcut | Outside Registry | Deferred to AI parity issues (#5, #74, #89-#92) and settings presentation issue #155. |
-| `reading_progress_settings_shortcut` | Reader bridge presents native `ReadingProgressSettingsView`; no top-level Settings shortcut | Outside Registry | Runtime feature exists; top-level shortcut alignment tracked by #155. |
+| `sync_settings_shortcut` | `SettingsView` Features section exposes `settingsSyncLink` to `SyncSettingsView`; `AndBibleIconCatalog` maps Android icon | Outside Registry | Implemented as a native iOS shortcut, not a durable preference. |
+| `ai_settings_shortcut` | No direct iOS Application preferences shortcut | Outside Registry | Deferred to AI parity issues (#5, #74, #89-#92) because iOS has no AI settings workflow to open. |
+| `reading_progress_settings_shortcut` | `SettingsView` Features section exposes `settingsReadingProgressLink` to `ReadingProgressSettingsView`; `AndBibleIconCatalog` maps Android icon | Outside Registry | Implemented as a native iOS shortcut, not a durable preference. |
 | `experimental_features` | `AppPreferenceRegistry`; `SettingsView` multi-select; iOS Vue `enabledExperimentalFeatures` payload | Pass | Android feature IDs are sanitized and emitted. |
 | `enable_bluetooth_pref` | `AppPreferenceRegistry`; `SettingsView`; `SpeakService` remote command handling | Adapted Pass | Android media-button behavior adapted to iOS remote command center. |
 | `request_sdcard_permission_pref` | `AppPreferenceRegistry`; not surfaced; `dispositions.md` | Documented Divergence | iOS has no SD-card permission model equivalent. |
@@ -91,11 +93,30 @@ divergences.
   same HTML/Markdown default behavior Android exposes.
 - #164: reconcile `locale_pref` option arrays with Android source and actual iOS
   localization resources.
-- #155: decide how far iOS Application preferences should align Android's shortcut
-  presentation for Sync, AI settings, Reading Progress settings, search, reset, and
-  broader admin-flow placement.
+- AI settings shortcut remains intentionally absent until the iOS AI settings workflow
+  exists. The shortcut is tracked with the AI parity issues (#5, #74, #89-#92), not
+  as a standalone dead Application preferences row.
 - `eink_mode` is not an implementation gap today. It is an Android-only e-ink
   behavior and is intentionally documented as a divergence.
+
+## Application Preferences Workflow Parity
+
+- Settings presentation: Application preferences are opened as an integrated reader
+  navigation destination, not as a modal sheet.
+- Search: native SwiftUI search filters visible Application preferences sections by
+  normalized all-term matching across row identifiers, titles, summaries, details,
+  and keywords.
+- Reset: native reset action restores registry-backed Application preferences through
+  `SettingsStore.resetApplicationPreferences()` and
+  `AppPreferenceRegistry.applicationPreferencesResetKeys`; action rows and global
+  text-display settings are outside that reset scope.
+- Feature shortcuts: Sync and Reading Progress are visible in the Android-aligned
+  Features section with Android-sourced icon mappings. AI is documented as deferred
+  because iOS has no AI settings workflow yet.
+- Admin-flow placement: Downloads, repositories, import/export, labels, and about
+  remain reader drawer/overflow/admin workflows rather than Application preferences
+  rows, matching Android's separation of Application preferences from broader app
+  administration.
 
 Regression hardening note: Strong's "Find all occurrences" retains module-backed
 simulator coverage to prevent recurrence of the `H02022` no-results failure.

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -36,7 +36,6 @@
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsApplicationPreferenceShortcuts": "baseline",
-  "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsPrimaryNavigationRows": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsSyncLinkOpensSyncSettings": "baseline",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow": "none",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsMyDocumentsCategoryToggleStartsManualSyncPath": "none",

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -34,6 +34,8 @@
   "AndBibleUITests/AndBibleUITests/testSettingsColorsLinkOpensColorEditor": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportFullBackupPresentsShareSheet": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": "baseline",
+  "AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings": "baseline",
+  "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsApplicationPreferenceShortcuts": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsPrimaryNavigationRows": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsSyncLinkOpensSyncSettings": "baseline",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsAdoptCreateConfirmationCreateChoiceSynchronizesFromVisibleWorkflow": "none",

--- a/scripts/ui_test_timings.json
+++ b/scripts/ui_test_timings.json
@@ -28,6 +28,8 @@
   "AndBibleUITests/AndBibleUITests/testSettingsColorsLinkOpensColorEditor": 18.54922103881836,
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportFullBackupPresentsShareSheet": 18.399284958839417,
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": 17.958650946617126,
+  "AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings": 16.167,
+  "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsApplicationPreferenceShortcuts": 14.295,
   "AndBibleUITests/AndBibleUITests/testSettingsSyncLinkOpensSyncSettings": 18.14947998523712,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchMutatesVisibleSection": 26.499693989753723,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchPersistsAcrossDirectReopen": 32.7494170665741,

--- a/scripts/ui_test_timings.json
+++ b/scripts/ui_test_timings.json
@@ -28,7 +28,6 @@
   "AndBibleUITests/AndBibleUITests/testSettingsColorsLinkOpensColorEditor": 18.54922103881836,
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportFullBackupPresentsShareSheet": 18.399284958839417,
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": 17.958650946617126,
-  "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsPrimaryNavigationRows": 17.689324975013733,
   "AndBibleUITests/AndBibleUITests/testSettingsSyncLinkOpensSyncSettings": 18.14947998523712,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchMutatesVisibleSection": 26.499693989753723,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsBackendSwitchPersistsAcrossDirectReopen": 32.7494170665741,


### PR DESCRIPTION
## Summary

Align iOS Application preferences with Android's integrated settings workflow while keeping the screen native SwiftUI.

## Scope

- Replace reader settings sheet presentation with an integrated reader navigation destination.
- Add Application preferences search, reset, and Android-aligned feature shortcuts for Sync and Reading Progress.
- Keep downloads, repositories, import/export, labels, and about outside Application preferences as reader/admin flows.
- Update parity docs and focused unit/UI coverage for the new workflow contract.

## Contract References

- GitHub issue: #155
- Android source contract: docs/parity/settings/contract.md
- iOS parity disposition: docs/parity/settings/dispositions.md
- Verification matrix: docs/parity/settings/verification-matrix.md

## Change Details

- Settings reset is registry-derived through AppPreferenceRegistry.applicationPreferencesResetKeys and SettingsStore.resetApplicationPreferences.
- Search uses a dedicated matcher over normalized identifiers, titles, summaries, details, and keywords.
- Sync and Reading Progress shortcuts use Android-sourced icon mappings and native SwiftUI destinations.
- AI settings remains documented as deferred because iOS has no AI settings workflow to open.

## Validation Evidence

- xcodebuild build -project AndBible.xcodeproj -scheme AndBible -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS Simulator CODE_SIGNING_ALLOWED=NO
- xcodebuild test for three focused settings reset/search unit tests on simulator 98C37D62-54A5-4C52-846B-B0801AEAD2CB
- xcodebuild test for two focused settings workflow UI tests on simulator 98C37D62-54A5-4C52-846B-B0801AEAD2CB
- git diff --cached --check
- python3 scripts/check_repo_standards.py docblocks --all-files
- python3 scripts/check_repo_standards.py all --base-ref origin/main --head-ref HEAD --all-files
- GitNexus detect_changes on staged worktree diff reported HIGH risk over the expected SettingsView and reader presentation surface.

## Risks And Follow-ups

- The changed surface is intentionally broad because #155 is workflow-level settings parity, not a single row tweak.
- Remaining documented gaps are notes_content_type (#163), locale option reconciliation (#164), and AI settings shortcut deferral until iOS has an AI settings workflow.

Closes #155

## Screenshots

#166 provided a framework for shared UI of the settings. This makes the settings behave like Android

| Old | New |
| --- | --- |
| <img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-05-30 at 15 05 47" src="https://github.com/user-attachments/assets/ad303816-9287-4d03-b769-9111e10d320c" /> | <img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-06-01 at 10 21 29" src="https://github.com/user-attachments/assets/aaa0566d-97e8-4f8e-a2ba-117754991e27" /> |