### PR TITLE
ci(actions): run iOS CI on PR events only

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -3,9 +3,6 @@ name: iOS CI
 on:
   pull_request:
     types: [opened,reopened,ready_for_review,synchronize]
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ios-ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Removes the iOS CI push trigger so this workflow reports through pull request events only.

## Scope
- Updates .github/workflows/ios-ci.yml only.
- Keeps pull_request events for opened, reopened, ready_for_review, and synchronize.

## Contract references
- New PR branch commits continue to trigger CI through pull_request.synchronize.
- Main branch merges no longer enqueue this workflow directly.
- References #176 as follow-up context; #176 is already closed.

## Change details
- Deleted the push trigger from the iOS CI workflow.
- Left the concurrency group unchanged so PR runs continue to cancel superseded runs.

## Validation evidence
- git diff --check -- .github/workflows/ios-ci.yml
- Verified #176 is already closed before using a non-closing reference.

## Risks/follow-ups
- Risk is low: workflow-only trigger change.
- Follow-up: monitor the new PR run to confirm pull_request.synchronize remains the only needed signal.

## Issue closure reference
- Closes: none
- Refs #176