### PR TITLE
feat(backup): restore Android database archives

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		DF4297E4F6F61467148CB772 /* AndBibleTests+RemoteSyncLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ED2258F0F324029C56991 /* AndBibleTests+RemoteSyncLifecycle.swift */; };
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
 		B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */; };
+		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -83,6 +84,7 @@
 		9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSyncRestoreTests.swift; sourceTree = "<group>"; };
 		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
 		D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDocumentDownloadPlannerTests.swift; sourceTree = "<group>"; };
+		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */,
 				D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
+				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -497,6 +500,7 @@
 				4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */,
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
 				B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */,
+				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -54,6 +54,42 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that future Android manifest categories do not block known database sections.
+
+     Setup:
+     - builds a valid bookmark database backup
+     - writes Android's manifest with one known category and one unknown future category string
+
+     Expected result:
+     - the archive still loads
+     - known categories remain available for restore/import
+     - unknown category strings are ignored rather than surfacing as invalid manifests
+
+     Failure meaning:
+     - iOS would reject otherwise restorable Android backups when Android adds a new backup
+       category before the iOS app learns how to display it.
+     */
+    func testAndroidDatabaseBackupIgnoresUnknownManifestCategories() throws {
+        let bookmarkDatabaseURL = try makeAndroidBookmarksDatabase(labels: [])
+        try setSQLiteUserVersion(12, at: bookmarkDatabaseURL)
+        let archiveData = try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "bookmarks.sqlite3": bookmarkDatabaseURL,
+            ],
+            containsRawValues: [
+                AndroidDatabaseBackupCategory.bookmarks.rawValue,
+                "FUTURE_ANDROID_CATEGORY",
+            ]
+        )
+
+        let archive = try AndroidDatabaseBackupService().loadArchive(from: archiveData)
+
+        XCTAssertEqual(archive.manifest.contains, [.bookmarks])
+        XCTAssertEqual(archive.sections.map(\.category), [.bookmarks])
+        XCTAssertEqual(archive.sections.first?.support, .supported)
+    }
+
+    /**
      Verifies Android-parity restore semantics for a selected database backup section.
 
      Setup:
@@ -273,11 +309,14 @@ extension AndBibleTests {
      - corrupts the end-of-central-directory size so declared central-directory bounds no longer
        contain the declared entry
      - corrupts a central-directory filename to invalid UTF-8 while leaving the local header intact
+     - corrupts an end-of-central-directory entry count to ZIP64's sentinel value
 
      Expected result:
      - central-directory size mismatches fail before the reader walks into bytes outside the
        declared directory
      - invalid central-directory names fail as malformed ZIP data rather than being silently skipped
+     - ZIP64 sentinels fail up front because this reader intentionally supports only non-ZIP64
+       Android backup archives
 
      Failure meaning:
      - iOS could treat corrupted Android backup archives as incomplete but valid inputs, producing
@@ -310,6 +349,50 @@ extension AndBibleTests {
                 .invalidArchive("Central directory entry name is not UTF-8")
             )
         }
+
+        var zip64EntryCountArchive = archive
+        let zip64RecordOffset = try endOfCentralDirectoryOffset(in: zip64EntryCountArchive)
+        replaceUInt16(UInt16.max, at: zip64RecordOffset + 10, in: &zip64EntryCountArchive)
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: zip64EntryCountArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("ZIP64 archives are not supported")
+            )
+        }
+    }
+
+    /**
+     Verifies Android-style deflated ZIP entries whose local headers use data descriptors.
+
+     Setup:
+     - builds one ZIP entry with compression method 8
+     - writes zero sizes in the local file header and the real sizes in the central directory
+     - appends a data descriptor after the compressed payload, matching Android `ZipOutputStream`
+       archives that cannot know sizes before compression finishes
+
+     Expected result:
+     - the reader uses central-directory metadata to locate and inflate the entry payload
+
+     Failure meaning:
+     - iOS would reject valid Android `.abdb.zip` backups that contain deflated entries with data
+       descriptors instead of local-header sizes.
+     */
+    func testZipArchiveReaderInflatesDescriptorBackedDeflatedEntries() throws {
+        let payload = Data("deflated backup payload".utf8)
+        let compressedPayload = Data([
+            75, 73, 77, 203, 73, 44, 73, 77, 81, 72, 74, 76, 206,
+            46, 45, 80, 40, 72, 172, 204, 201, 79, 76, 1, 0,
+        ])
+        let archive = try makeDeflatedDescriptorZip(
+            name: "db/bookmarks.sqlite3",
+            compressedData: compressedPayload,
+            uncompressedData: payload
+        )
+
+        let entries = try ZipArchiveReader.entries(in: archive)
+
+        XCTAssertEqual(entries, [.init(name: "db/bookmarks.sqlite3", data: payload)])
     }
 
     /**
@@ -421,7 +504,31 @@ extension AndBibleTests {
         contains: [AndroidDatabaseBackupCategory]
     ) throws -> Data {
         let databaseData = try databaseURLsByName.mapValues { try Data(contentsOf: $0) }
-        return try makeAndroidDatabaseBackupArchiveData(rawDatabaseDataByName: databaseData, contains: contains)
+        return try makeAndroidDatabaseBackupArchiveData(
+            rawDatabaseDataByName: databaseData,
+            containsRawValues: contains.map(\.rawValue)
+        )
+    }
+
+    /**
+     Builds a raw Android database backup ZIP from SQLite database files and raw manifest category names.
+
+     - Parameters:
+       - databaseURLsByName: Database filenames, such as `bookmarks.sqlite3`, mapped to local files.
+       - containsRawValues: Raw Android manifest category names to write into `contains`.
+     - Returns: Stored ZIP archive bytes.
+     - Side effects: reads the supplied SQLite database files.
+     - Failure modes: Rethrows file reads and ZIP construction failures.
+     */
+    private func makeAndroidDatabaseBackupArchiveData(
+        databaseURLsByName: [String: URL],
+        containsRawValues: [String]
+    ) throws -> Data {
+        let databaseData = try databaseURLsByName.mapValues { try Data(contentsOf: $0) }
+        return try makeAndroidDatabaseBackupArchiveData(
+            rawDatabaseDataByName: databaseData,
+            containsRawValues: containsRawValues
+        )
     }
 
     /**
@@ -438,9 +545,29 @@ extension AndBibleTests {
         rawDatabaseDataByName: [String: Data],
         contains: [AndroidDatabaseBackupCategory]
     ) throws -> Data {
+        return try makeAndroidDatabaseBackupArchiveData(
+            rawDatabaseDataByName: rawDatabaseDataByName,
+            containsRawValues: contains.map(\.rawValue)
+        )
+    }
+
+    /**
+     Builds a raw Android database backup ZIP from already-materialized payloads and raw category names.
+
+     - Parameters:
+       - rawDatabaseDataByName: Database filenames mapped to entry bytes.
+       - containsRawValues: Raw Android manifest category names to write into `contains`.
+     - Returns: Stored ZIP archive bytes.
+     - Side effects: none.
+     - Failure modes: Rethrows JSON manifest encoding or ZIP construction failures.
+     */
+    private func makeAndroidDatabaseBackupArchiveData(
+        rawDatabaseDataByName: [String: Data],
+        containsRawValues: [String]
+    ) throws -> Data {
         let manifest: [String: Any] = [
             "backupType": "DB_BACKUP",
-            "contains": contains.map(\.rawValue),
+            "contains": containsRawValues,
             "manifestVersion": 1,
             "andBibleVersion": 99_999,
         ]
@@ -594,6 +721,85 @@ extension AndBibleTests {
     }
 
     /**
+     Builds one deflated ZIP entry that uses data-descriptor sizes in the local file area.
+
+     The production reader should rely on central-directory sizes, matching Android-created ZIPs
+     whose local headers do not know the compressed size until after compression has completed.
+
+     - Parameters:
+       - name: Entry path to write into the local and central headers.
+       - compressedData: Raw deflate bytes for the entry payload.
+       - uncompressedData: Expected inflated payload, used only for central-directory sizing.
+     - Returns: Raw ZIP bytes with one deflated entry.
+     - Side effects: none.
+     - Failure modes: Throws if the entry exceeds this test helper's non-ZIP64 fixture limits.
+     */
+    private func makeDeflatedDescriptorZip(
+        name: String,
+        compressedData: Data,
+        uncompressedData: Data
+    ) throws -> Data {
+        guard let nameData = name.data(using: .utf8),
+              nameData.count <= Int(UInt16.max),
+              compressedData.count <= Int(UInt32.max),
+              uncompressedData.count <= Int(UInt32.max) else {
+            throw ZipArchiveReaderError.invalidArchive("Test ZIP entry is too large")
+        }
+
+        var archive = Data()
+        let localHeaderOffset = UInt32(archive.count)
+        appendUInt32(0x0403_4b50, to: &archive)
+        appendUInt16(20, to: &archive)
+        appendUInt16(0x0008, to: &archive)
+        appendUInt16(8, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt32(0, to: &archive)
+        appendUInt32(0, to: &archive)
+        appendUInt32(0, to: &archive)
+        appendUInt16(UInt16(nameData.count), to: &archive)
+        appendUInt16(0, to: &archive)
+        archive.append(nameData)
+        archive.append(compressedData)
+        appendUInt32(0x0807_4b50, to: &archive)
+        appendUInt32(0, to: &archive)
+        appendUInt32(UInt32(compressedData.count), to: &archive)
+        appendUInt32(UInt32(uncompressedData.count), to: &archive)
+
+        let centralDirectoryOffset = UInt32(archive.count)
+        var centralDirectory = Data()
+        appendUInt32(0x0201_4b50, to: &centralDirectory)
+        appendUInt16(20, to: &centralDirectory)
+        appendUInt16(20, to: &centralDirectory)
+        appendUInt16(0x0008, to: &centralDirectory)
+        appendUInt16(8, to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt32(0, to: &centralDirectory)
+        appendUInt32(UInt32(compressedData.count), to: &centralDirectory)
+        appendUInt32(UInt32(uncompressedData.count), to: &centralDirectory)
+        appendUInt16(UInt16(nameData.count), to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt16(0, to: &centralDirectory)
+        appendUInt32(0, to: &centralDirectory)
+        appendUInt32(localHeaderOffset, to: &centralDirectory)
+        centralDirectory.append(nameData)
+
+        archive.append(centralDirectory)
+        appendUInt32(0x0605_4b50, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(1, to: &archive)
+        appendUInt16(1, to: &archive)
+        appendUInt32(UInt32(centralDirectory.count), to: &archive)
+        appendUInt32(centralDirectoryOffset, to: &archive)
+        appendUInt16(0, to: &archive)
+        return archive
+    }
+
+    /**
      Appends one little-endian 16-bit integer to a ZIP fixture.
      */
     private func appendUInt16(_ value: UInt16, to data: inout Data) {
@@ -607,6 +813,23 @@ extension AndBibleTests {
     private func appendUInt32(_ value: UInt32, to data: inout Data) {
         var littleEndian = value.littleEndian
         withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    /**
+     Replaces one little-endian 16-bit integer inside a ZIP fixture.
+
+     - Parameters:
+       - value: Value to write.
+       - offset: Byte offset where the integer starts.
+       - data: Fixture bytes to mutate.
+     - Side effects: Mutates `data` in place.
+     - Failure modes: Callers must pass a valid two-byte range.
+     */
+    private func replaceUInt16(_ value: UInt16, at offset: Int, in data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { bytes in
+            data.replaceSubrange(offset..<(offset + 2), with: bytes)
+        }
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -266,6 +266,53 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies fail-closed ZIP parsing for malformed central-directory metadata.
+
+     Setup:
+     - builds a valid Android-style stored ZIP fixture
+     - corrupts the end-of-central-directory size so declared central-directory bounds no longer
+       contain the declared entry
+     - corrupts a central-directory filename to invalid UTF-8 while leaving the local header intact
+
+     Expected result:
+     - central-directory size mismatches fail before the reader walks into bytes outside the
+       declared directory
+     - invalid central-directory names fail as malformed ZIP data rather than being silently skipped
+
+     Failure meaning:
+     - iOS could treat corrupted Android backup archives as incomplete but valid inputs, producing
+       misleading backup errors or hiding required entries.
+     */
+    func testZipArchiveReaderRejectsMalformedCentralDirectoryBoundsAndNames() throws {
+        let archive = try makeStoredZip(entries: [
+            ("AndBibleBackupManifest.json", Data("{}".utf8)),
+        ])
+
+        var invalidSizeArchive = archive
+        let sizeRecordOffset = try endOfCentralDirectoryOffset(in: invalidSizeArchive)
+        replaceUInt32(0, at: sizeRecordOffset + 12, in: &invalidSizeArchive)
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: invalidSizeArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Central directory entry is truncated")
+            )
+        }
+
+        var invalidNameArchive = archive
+        let nameRecordOffset = try endOfCentralDirectoryOffset(in: invalidNameArchive)
+        let centralDirectoryOffset = Int(readUInt32(invalidNameArchive, at: nameRecordOffset + 16))
+        invalidNameArchive[centralDirectoryOffset + 46] = 0xff
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: invalidNameArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Central directory entry name is not UTF-8")
+            )
+        }
+    }
+
+    /**
      Verifies that newer Android database versions are visible but cannot be applied.
 
      Setup:
@@ -560,5 +607,61 @@ extension AndBibleTests {
     private func appendUInt32(_ value: UInt32, to data: inout Data) {
         var littleEndian = value.littleEndian
         withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    /**
+     Replaces one little-endian 32-bit integer inside a ZIP fixture.
+
+     - Parameters:
+       - value: Value to write.
+       - offset: Byte offset where the integer starts.
+       - data: Fixture bytes to mutate.
+     - Side effects: Mutates `data` in place.
+     - Failure modes: Callers must pass a valid four-byte range.
+     */
+    private func replaceUInt32(_ value: UInt32, at offset: Int, in data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { bytes in
+            data.replaceSubrange(offset..<(offset + 4), with: bytes)
+        }
+    }
+
+    /**
+     Finds the end-of-central-directory signature in a ZIP fixture.
+
+     - Parameter data: Raw ZIP fixture bytes.
+     - Returns: Offset of the EOCD signature.
+     - Side effects: none.
+     - Failure modes: Throws if the fixture does not contain an EOCD record in the legal search
+       range.
+     */
+    private func endOfCentralDirectoryOffset(in data: Data) throws -> Int {
+        let minimumOffset = max(0, data.count - 65_557)
+        var offset = data.count - 22
+        while offset >= minimumOffset {
+            if readUInt32(data, at: offset) == 0x0605_4b50 {
+                return offset
+            }
+            offset -= 1
+        }
+        throw ZipArchiveReaderError.missingCentralDirectory
+    }
+
+    /**
+     Reads one little-endian 32-bit integer from a ZIP fixture.
+
+     - Parameters:
+       - data: Fixture bytes.
+       - offset: Byte offset where the integer starts.
+     - Returns: Decoded integer value.
+     - Side effects: none.
+     - Failure modes: Callers must pass a valid four-byte range.
+     */
+    private func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        let b0 = UInt32(data[offset])
+        let b1 = UInt32(data[offset + 1]) << 8
+        let b2 = UInt32(data[offset + 2]) << 16
+        let b3 = UInt32(data[offset + 3]) << 24
+        return b0 | b1 | b2 | b3
     }
 }

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -363,6 +363,62 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies ZIP bomb protection before the eager reader extracts or inflates payload bytes.
+
+     Setup:
+     - builds small ZIP fixtures and rewrites central-directory size metadata to oversized values
+     - keeps local payloads tiny so the test proves rejection is based on declared size guards, not
+       actual fixture allocation
+
+     Expected result:
+     - a single entry over the per-entry cap fails as malformed archive data
+     - multiple entries below the per-entry cap but above the aggregate cap also fail
+
+     Failure meaning:
+     - iOS could allocate excessive memory while importing a crafted Android backup archive before
+       the restore path reaches SQLite validation.
+     */
+    func testZipArchiveReaderRejectsOversizedDeclaredPayloadsBeforeExtraction() throws {
+        var oversizedEntryArchive = try makeStoredZip(entries: [
+            ("db/bookmarks.sqlite3", Data([0x01])),
+        ])
+        try replaceCentralDirectorySizes(
+            compressedSize: 1,
+            uncompressedSize: UInt32(300 * 1024 * 1024),
+            for: "db/bookmarks.sqlite3",
+            in: &oversizedEntryArchive
+        )
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: oversizedEntryArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("ZIP entry exceeds maximum supported size")
+            )
+        }
+
+        var oversizedTotalArchive = try makeStoredZip(entries: [
+            ("db/bookmarks.sqlite3", Data([0x01])),
+            ("db/workspaces.sqlite3", Data([0x02])),
+            ("db/mydocuments.sqlite3", Data([0x03])),
+        ])
+        for entryName in ["db/bookmarks.sqlite3", "db/workspaces.sqlite3", "db/mydocuments.sqlite3"] {
+            try replaceCentralDirectorySizes(
+                compressedSize: 1,
+                uncompressedSize: UInt32(200 * 1024 * 1024),
+                for: entryName,
+                in: &oversizedTotalArchive
+            )
+        }
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: oversizedTotalArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("ZIP archive exceeds maximum supported size")
+            )
+        }
+    }
+
+    /**
      Verifies Android-style deflated ZIP entries whose local headers use data descriptors.
 
      Setup:
@@ -850,6 +906,60 @@ extension AndBibleTests {
     }
 
     /**
+     Rewrites central-directory size metadata for one ZIP fixture entry.
+
+     This helper intentionally leaves local headers and payloads unchanged so tests can model
+     malicious central-directory declarations without allocating large fixture data.
+
+     - Parameters:
+       - compressedSize: Declared compressed byte count to write.
+       - uncompressedSize: Declared uncompressed byte count to write.
+       - entryName: Central-directory entry name to mutate.
+       - data: ZIP fixture bytes to mutate in place.
+     - Side effects: Mutates central-directory size fields inside `data`.
+     - Failure modes: Throws if the fixture lacks a valid central directory or matching entry.
+     */
+    private func replaceCentralDirectorySizes(
+        compressedSize: UInt32,
+        uncompressedSize: UInt32,
+        for entryName: String,
+        in data: inout Data
+    ) throws {
+        let endRecordOffset = try endOfCentralDirectoryOffset(in: data)
+        let centralDirectoryOffset = Int(readUInt32(data, at: endRecordOffset + 16))
+        let centralDirectorySize = Int(readUInt32(data, at: endRecordOffset + 12))
+        let centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize
+        var offset = centralDirectoryOffset
+
+        while offset < centralDirectoryEnd {
+            guard offset + 46 <= centralDirectoryEnd,
+                  readUInt32(data, at: offset) == 0x0201_4b50 else {
+                throw ZipArchiveReaderError.invalidArchive("Test ZIP central directory is malformed")
+            }
+
+            let nameLength = Int(readUInt16(data, at: offset + 28))
+            let extraLength = Int(readUInt16(data, at: offset + 30))
+            let commentLength = Int(readUInt16(data, at: offset + 32))
+            let nameStart = offset + 46
+            let nameEnd = nameStart + nameLength
+            guard nameEnd <= centralDirectoryEnd,
+                  let name = String(data: data[nameStart..<nameEnd], encoding: .utf8) else {
+                throw ZipArchiveReaderError.invalidArchive("Test ZIP central directory entry name is malformed")
+            }
+
+            if name == entryName {
+                replaceUInt32(compressedSize, at: offset + 20, in: &data)
+                replaceUInt32(uncompressedSize, at: offset + 24, in: &data)
+                return
+            }
+
+            offset = nameEnd + extraLength + commentLength
+        }
+
+        throw ZipArchiveReaderError.invalidArchive("Test ZIP central directory entry is missing")
+    }
+
+    /**
      Finds the end-of-central-directory signature in a ZIP fixture.
 
      - Parameter data: Raw ZIP fixture bytes.
@@ -868,6 +978,22 @@ extension AndBibleTests {
             offset -= 1
         }
         throw ZipArchiveReaderError.missingCentralDirectory
+    }
+
+    /**
+     Reads one little-endian 16-bit integer from a ZIP fixture.
+
+     - Parameters:
+       - data: Fixture bytes.
+       - offset: Byte offset where the integer starts.
+     - Returns: Decoded integer value.
+     - Side effects: none.
+     - Failure modes: Callers must pass a valid two-byte range.
+     */
+    private func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        let b0 = UInt16(data[offset])
+        let b1 = UInt16(data[offset + 1]) << 8
+        return b0 | b1
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -650,6 +650,39 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that unsupported Android backup categories keep their unsupported-category reason even
+     when their SQLite schema version is newer than iOS recognizes.
+
+     Setup:
+     - builds an Android Settings database, which iOS intentionally cannot map yet
+     - sets its SQLite `user_version` above the known Android Settings schema version
+
+     Expected result:
+     - the archive still exposes the Settings section
+     - the section reason says iOS lacks a safe mapper rather than implying a version-only blocker
+
+     Failure meaning:
+     - the section picker would mislead users into thinking a future iOS version could restore the
+       category merely by recognizing the schema version, even though the category has no mapper.
+     */
+    func testAndroidDatabaseBackupUnsupportedCategoriesIgnoreVersionGate() throws {
+        let settingsDatabaseURL = try makeEmptySQLiteDatabase(userVersion: 99)
+        let archiveData = try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "settings.sqlite3": settingsDatabaseURL,
+            ],
+            contains: [.settings]
+        )
+
+        let archive = try AndroidDatabaseBackupService().loadArchive(from: archiveData)
+
+        XCTAssertEqual(
+            archive.sections.first { $0.category == .settings }?.support,
+            .unsupportedCategory("iOS does not yet have a safe mapper for Android Settings data.")
+        )
+    }
+
+    /**
      Builds a one-section Android bookmark backup archive for restore/import tests.
 
      - Parameters:

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -1,0 +1,564 @@
+import XCTest
+@testable import BibleCore
+import SwiftData
+import SQLite3
+
+extension AndBibleTests {
+    /**
+     Verifies that iOS reads Android `.abdb.zip` archives through the manifest and exposes both
+     restorable and unsupported sections.
+
+     Setup:
+     - builds a stored ZIP with Android's `AndBibleBackupManifest.json`
+     - includes a supported `bookmarks.sqlite3`, unsupported `settings.sqlite3`, and manifest-only
+       `MODULES` category
+
+     Expected result:
+     - the bookmark section is selectable for restore/import
+     - the settings and modules sections remain visible but disabled with unsupported-category reasons
+
+     Failure meaning:
+     - iOS would either hide valid Android backup contents or offer a section it cannot safely map.
+     */
+    func testAndroidDatabaseBackupLoadExposesSupportedAndUnsupportedSections() throws {
+        let bookmarkDatabaseURL = try makeAndroidBookmarksDatabase(
+            labels: [
+                .init(id: UUID(uuidString: "15000000-0000-0000-0000-000000000001")!, name: "Prayer", colour: 7),
+            ]
+        )
+        try setSQLiteUserVersion(12, at: bookmarkDatabaseURL)
+        let settingsDatabaseURL = try makeEmptySQLiteDatabase(userVersion: 1)
+        let archiveData = try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "bookmarks.sqlite3": bookmarkDatabaseURL,
+                "settings.sqlite3": settingsDatabaseURL,
+            ],
+            contains: [.bookmarks, .settings, .modules]
+        )
+
+        let archive = try AndroidDatabaseBackupService().loadArchive(from: archiveData)
+
+        XCTAssertEqual(archive.manifest.backupType, "DB_BACKUP")
+        XCTAssertEqual(archive.manifest.manifestVersion, 1)
+        XCTAssertEqual(archive.manifest.contains, [.bookmarks, .settings, .modules])
+        XCTAssertEqual(archive.sections.map(\.category), [.bookmarks, .modules, .settings])
+        XCTAssertEqual(archive.sections.first { $0.category == .bookmarks }?.support, .supported)
+        XCTAssertEqual(
+            archive.sections.first { $0.category == .modules }?.support,
+            .unsupportedCategory("iOS does not yet have a safe mapper for Android Modules data.")
+        )
+        XCTAssertEqual(
+            archive.sections.first { $0.category == .settings }?.support,
+            .unsupportedCategory("iOS does not yet have a safe mapper for Android Settings data.")
+        )
+    }
+
+    /**
+     Verifies Android-parity restore semantics for a selected database backup section.
+
+     Setup:
+     - starts with local bookmark data and pre-existing remote-sync bookkeeping
+     - loads an Android backup containing bookmarks plus an unsupported Settings section
+     - applies only the Bookmarks section in Restore mode
+
+     Expected result:
+     - local bookmark rows are replaced by the Android bookmark database
+     - unsupported sections are ignored when not selected
+     - affected remote-sync toggle, bootstrap state, patch progress, and patch statuses are cleared
+
+     Failure meaning:
+     - iOS would not match Android's destructive Restore behavior or would leave stale sync metadata
+       after a manual backup restore.
+     */
+    func testAndroidDatabaseBackupRestoreBookmarksReplacesLocalDataAndClearsSyncState() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let remoteSettingsStore = RemoteSyncSettingsStore(settingsStore: settingsStore)
+        let syncStateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+
+        let legacyLabel = Label(name: "Legacy")
+        modelContext.insert(legacyLabel)
+        let legacyBookmark = BibleBookmark(kjvOrdinalStart: 1, kjvOrdinalEnd: 1)
+        legacyBookmark.book = "Genesis"
+        modelContext.insert(legacyBookmark)
+        try modelContext.save()
+
+        remoteSettingsStore.setSyncEnabled(true, for: .bookmarks)
+        syncStateStore.setBootstrapState(
+            RemoteSyncBootstrapState(
+                syncFolderID: "/sync/bookmarks",
+                deviceFolderID: "/sync/bookmarks/ios",
+                secretFileName: "device-known-ios"
+            ),
+            for: .bookmarks
+        )
+        syncStateStore.setProgressState(
+            RemoteSyncProgressState(lastPatchWritten: 100, lastSynchronized: 200, disabledForVersion: 1),
+            for: .bookmarks
+        )
+        patchStatusStore.addStatus(
+            RemoteSyncPatchStatus(sourceDevice: "android", patchNumber: 1, sizeBytes: 50, appliedDate: 300),
+            for: .bookmarks
+        )
+
+        let remoteLabelID = UUID(uuidString: "15000000-0000-0000-0000-000000000010")!
+        let remoteBookmarkID = UUID(uuidString: "15000000-0000-0000-0000-000000000020")!
+        let bookmarkDatabaseURL = try makeAndroidBookmarksDatabase(
+            labels: [
+                .init(id: remoteLabelID, name: "Prayer", colour: 9),
+            ],
+            bibleBookmarks: [
+                .init(
+                    id: remoteBookmarkID,
+                    kjvOrdinalStart: 15,
+                    kjvOrdinalEnd: 15,
+                    ordinalStart: 15,
+                    ordinalEnd: 15,
+                    createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    primaryLabelID: remoteLabelID,
+                    lastUpdatedOn: Date(timeIntervalSince1970: 1_700_000_100)
+                ),
+            ],
+            bibleNotes: [
+                .init(bookmarkID: remoteBookmarkID, notes: "Android note"),
+            ],
+            bibleLinks: [
+                .init(bookmarkID: remoteBookmarkID, labelID: remoteLabelID, orderNumber: 0, indentLevel: 0, expandContent: false),
+            ]
+        )
+        try setSQLiteUserVersion(12, at: bookmarkDatabaseURL)
+        let settingsDatabaseURL = try makeEmptySQLiteDatabase(userVersion: 1)
+        let archiveData = try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "bookmarks.sqlite3": bookmarkDatabaseURL,
+                "settings.sqlite3": settingsDatabaseURL,
+            ],
+            contains: [.bookmarks, .settings]
+        )
+        let service = AndroidDatabaseBackupService()
+        let archive = try service.loadArchive(from: archiveData)
+
+        let report = try service.apply(
+            archive: archive,
+            selections: [.init(category: .bookmarks, mode: .restore)],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(
+            report.sections,
+            [
+                .init(category: .bookmarks, mode: .restore, summary: "1 bookmarks, 4 labels"),
+            ]
+        )
+        let labels = try modelContext.fetch(FetchDescriptor<Label>())
+        XCTAssertNil(labels.first { $0.name == "Legacy" })
+        XCTAssertEqual(labels.first { $0.name == "Prayer" }?.id, remoteLabelID)
+
+        let bookmarks = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        XCTAssertEqual(bookmarks.count, 1)
+        XCTAssertEqual(bookmarks.first?.id, remoteBookmarkID)
+        XCTAssertEqual(bookmarks.first?.notes?.notes, "Android note")
+
+        XCTAssertFalse(remoteSettingsStore.isSyncEnabled(for: .bookmarks))
+        XCTAssertEqual(syncStateStore.bootstrapState(for: .bookmarks), RemoteSyncBootstrapState())
+        XCTAssertEqual(syncStateStore.progressState(for: .bookmarks), RemoteSyncProgressState())
+        XCTAssertTrue(patchStatusStore.statuses(for: .bookmarks).isEmpty)
+    }
+
+    /**
+     Verifies Android-parity Import mode for Android bookmark database backups.
+
+     Setup:
+     - first restores a local bookmark snapshot
+     - then imports an Android backup containing one duplicate bookmark and one new bookmark
+
+     Expected result:
+     - duplicate local rows keep their local note content
+     - new backup rows are added
+
+     Failure meaning:
+     - iOS Import would drift from Android's `INSERT OR IGNORE` semantics by overwriting local rows
+       or skipping valid backup rows.
+     */
+    func testAndroidDatabaseBackupImportBookmarksKeepsExistingRowsAndAddsMissingRows() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let service = AndroidDatabaseBackupService()
+        let labelID = UUID(uuidString: "15000000-0000-0000-0000-000000000101")!
+        let existingBookmarkID = UUID(uuidString: "15000000-0000-0000-0000-000000000102")!
+        let newBookmarkID = UUID(uuidString: "15000000-0000-0000-0000-000000000103")!
+
+        let localArchive = try service.loadArchive(
+            from: makeAndroidBookmarkOnlyBackupData(
+                labelID: labelID,
+                bookmarks: [
+                    (existingBookmarkID, 20, "Local note"),
+                ]
+            )
+        )
+        _ = try service.apply(
+            archive: localArchive,
+            selections: [.init(category: .bookmarks, mode: .restore)],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let importArchive = try service.loadArchive(
+            from: makeAndroidBookmarkOnlyBackupData(
+                labelID: labelID,
+                bookmarks: [
+                    (existingBookmarkID, 20, "Backup replacement"),
+                    (newBookmarkID, 21, "Backup addition"),
+                ]
+            )
+        )
+        _ = try service.apply(
+            archive: importArchive,
+            selections: [.init(category: .bookmarks, mode: .import)],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let bookmarks = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        XCTAssertEqual(Set(bookmarks.map(\.id)), Set([existingBookmarkID, newBookmarkID]))
+        XCTAssertEqual(bookmarks.first { $0.id == existingBookmarkID }?.notes?.notes, "Local note")
+        XCTAssertEqual(bookmarks.first { $0.id == newBookmarkID }?.notes?.notes, "Backup addition")
+    }
+
+    /**
+     Verifies Android backup loader failures for malformed archive inputs.
+
+     Setup:
+     - builds one ZIP without `AndBibleBackupManifest.json`
+     - builds one ZIP whose bookmark entry is not a SQLite database
+
+     Expected result:
+     - missing manifests fail as `missingManifest`
+     - invalid SQLite entries fail before section selection or restore can start
+
+     Failure meaning:
+     - iOS would allow ambiguous or corrupt Android backup files into a destructive restore path.
+     */
+    func testAndroidDatabaseBackupRejectsMissingManifestAndInvalidSQLite() throws {
+        let service = AndroidDatabaseBackupService()
+        let missingManifestArchive = try makeStoredZip(entries: [
+            ("db/bookmarks.sqlite3", Data()),
+        ])
+
+        XCTAssertThrowsError(try service.loadArchive(from: missingManifestArchive)) { error in
+            XCTAssertEqual(error as? AndroidDatabaseBackupError, .missingManifest)
+        }
+
+        let invalidSQLiteArchive = try makeAndroidDatabaseBackupArchiveData(
+            rawDatabaseDataByName: [
+                "bookmarks.sqlite3": Data("not sqlite".utf8),
+            ],
+            contains: [.bookmarks]
+        )
+
+        XCTAssertThrowsError(try service.loadArchive(from: invalidSQLiteArchive)) { error in
+            XCTAssertEqual(error as? AndroidDatabaseBackupError, .invalidSQLiteDatabase("bookmarks.sqlite3"))
+        }
+    }
+
+    /**
+     Verifies that newer Android database versions are visible but cannot be applied.
+
+     Setup:
+     - builds a bookmark database whose SQLite `user_version` exceeds the supported Android schema
+
+     Expected result:
+     - the archive loads so the user can see the section
+     - the section is marked unsupported by version and apply refuses it
+
+     Failure meaning:
+     - iOS would either hide actionable compatibility information or risk restoring a schema it
+       cannot safely decode.
+     */
+    func testAndroidDatabaseBackupBlocksUnsupportedDatabaseVersion() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let bookmarkDatabaseURL = try makeAndroidBookmarksDatabase(labels: [])
+        try setSQLiteUserVersion(99, at: bookmarkDatabaseURL)
+        let archiveData = try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "bookmarks.sqlite3": bookmarkDatabaseURL,
+            ],
+            contains: [.bookmarks]
+        )
+        let service = AndroidDatabaseBackupService()
+        let archive = try service.loadArchive(from: archiveData)
+
+        XCTAssertEqual(
+            archive.sections.first?.support,
+            .unsupportedVersion(version: 99, supported: 12)
+        )
+        XCTAssertThrowsError(
+            try service.apply(
+                archive: archive,
+                selections: [.init(category: .bookmarks, mode: .restore)],
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? AndroidDatabaseBackupError,
+                .unsupportedSelectedSection(.bookmarks, "Requires database version 99; this app supports up to 12.")
+            )
+        }
+    }
+
+    /**
+     Builds a one-section Android bookmark backup archive for restore/import tests.
+
+     - Parameters:
+       - labelID: Android label ID linked to every generated bookmark.
+       - bookmarks: Tuples of bookmark ID, verse ordinal, and note text.
+     - Returns: Raw ZIP archive bytes with Android manifest and `db/bookmarks.sqlite3`.
+     - Side effects: writes a temporary SQLite database through `makeAndroidBookmarksDatabase`.
+     - Failure modes: Rethrows SQLite fixture and ZIP construction failures.
+     */
+    private func makeAndroidBookmarkOnlyBackupData(
+        labelID: UUID,
+        bookmarks: [(id: UUID, ordinal: Int, note: String)]
+    ) throws -> Data {
+        let databaseURL = try makeAndroidBookmarksDatabase(
+            labels: [
+                .init(id: labelID, name: "Prayer", colour: 8),
+            ],
+            bibleBookmarks: bookmarks.map {
+                .init(
+                    id: $0.id,
+                    kjvOrdinalStart: $0.ordinal,
+                    kjvOrdinalEnd: $0.ordinal,
+                    ordinalStart: $0.ordinal,
+                    ordinalEnd: $0.ordinal,
+                    createdAt: Date(timeIntervalSince1970: 1_700_100_000 + Double($0.ordinal)),
+                    primaryLabelID: labelID,
+                    lastUpdatedOn: Date(timeIntervalSince1970: 1_700_200_000 + Double($0.ordinal))
+                )
+            },
+            bibleNotes: bookmarks.map {
+                .init(bookmarkID: $0.id, notes: $0.note)
+            },
+            bibleLinks: bookmarks.map {
+                .init(bookmarkID: $0.id, labelID: labelID, orderNumber: $0.ordinal, indentLevel: 0, expandContent: false)
+            }
+        )
+        try setSQLiteUserVersion(12, at: databaseURL)
+        return try makeAndroidDatabaseBackupArchiveData(
+            databaseURLsByName: [
+                "bookmarks.sqlite3": databaseURL,
+            ],
+            contains: [.bookmarks]
+        )
+    }
+
+    /**
+     Builds a raw Android database backup ZIP from SQLite database files.
+
+     - Parameters:
+       - databaseURLsByName: Database filenames, such as `bookmarks.sqlite3`, mapped to local files.
+       - contains: Android manifest categories to write into `contains`.
+     - Returns: Stored ZIP archive bytes.
+     - Side effects: reads the supplied SQLite database files.
+     - Failure modes: Rethrows file reads and ZIP construction failures.
+     */
+    private func makeAndroidDatabaseBackupArchiveData(
+        databaseURLsByName: [String: URL],
+        contains: [AndroidDatabaseBackupCategory]
+    ) throws -> Data {
+        let databaseData = try databaseURLsByName.mapValues { try Data(contentsOf: $0) }
+        return try makeAndroidDatabaseBackupArchiveData(rawDatabaseDataByName: databaseData, contains: contains)
+    }
+
+    /**
+     Builds a raw Android database backup ZIP from already-materialized database payloads.
+
+     - Parameters:
+       - rawDatabaseDataByName: Database filenames mapped to entry bytes.
+       - contains: Android manifest categories to write into `contains`.
+     - Returns: Stored ZIP archive bytes.
+     - Side effects: none.
+     - Failure modes: Rethrows JSON manifest encoding or ZIP construction failures.
+     */
+    private func makeAndroidDatabaseBackupArchiveData(
+        rawDatabaseDataByName: [String: Data],
+        contains: [AndroidDatabaseBackupCategory]
+    ) throws -> Data {
+        let manifest: [String: Any] = [
+            "backupType": "DB_BACKUP",
+            "contains": contains.map(\.rawValue),
+            "manifestVersion": 1,
+            "andBibleVersion": 99_999,
+        ]
+        let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [.sortedKeys])
+        let databaseEntries = rawDatabaseDataByName
+            .sorted { $0.key < $1.key }
+            .map { ("db/\($0.key)", $0.value) }
+        return try makeStoredZip(entries: [("AndBibleBackupManifest.json", manifestData)] + databaseEntries)
+    }
+
+    /**
+     Creates a temporary SQLite database with only a `user_version` marker.
+
+     Unsupported Android backup sections are validated for SQLite shape and version before iOS
+     explains that no safe mapper exists, so these tests do not need Android's full Settings schema.
+
+     - Parameter userVersion: SQLite `PRAGMA user_version` to write.
+     - Returns: Temporary SQLite database URL.
+     - Side effects: writes a temporary file under the process temporary directory.
+     - Failure modes: Throws `AndroidDatabaseBackupError.invalidSQLiteDatabase` when SQLite setup fails.
+     */
+    private func makeEmptySQLiteDatabase(userVersion: Int) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("android-backup-empty-\(UUID().uuidString).sqlite3")
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        defer { sqlite3_close(database) }
+        guard sqlite3_exec(database, "CREATE TABLE Placeholder (id INTEGER PRIMARY KEY);", nil, nil, nil) == SQLITE_OK else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        try setSQLiteUserVersion(userVersion, on: database, fileName: url.lastPathComponent)
+        return url
+    }
+
+    /**
+     Sets SQLite `user_version` for a temporary Android database fixture.
+
+     - Parameters:
+       - userVersion: Version number to write.
+       - url: SQLite database URL.
+     - Side effects: opens and mutates the database file.
+     - Failure modes: Throws `AndroidDatabaseBackupError.invalidSQLiteDatabase` when SQLite rejects
+       the file or pragma.
+     */
+    private func setSQLiteUserVersion(_ userVersion: Int, at url: URL) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        defer { sqlite3_close(database) }
+        try setSQLiteUserVersion(userVersion, on: database, fileName: url.lastPathComponent)
+    }
+
+    /**
+     Writes SQLite `user_version` on an open fixture connection.
+
+     - Parameters:
+       - userVersion: Version number to write.
+       - database: Open SQLite connection.
+       - fileName: Name used in thrown validation errors.
+     - Side effects: mutates the open SQLite database.
+     - Failure modes: Throws when SQLite rejects the pragma.
+     */
+    private func setSQLiteUserVersion(_ userVersion: Int, on database: OpaquePointer, fileName: String) throws {
+        guard sqlite3_exec(database, "PRAGMA user_version = \(userVersion);", nil, nil, nil) == SQLITE_OK else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
+        }
+    }
+
+    /**
+     Builds a minimal stored ZIP archive understood by `ZipArchiveReader`.
+
+     The test helper writes central-directory metadata because Android `ZipOutputStream` archives
+     rely on central-directory sizes when local headers use descriptors. Test archives use stored
+     entries to keep fixtures deterministic and independent of compression libraries.
+
+     - Parameter entries: Entry names and uncompressed payloads.
+     - Returns: Raw ZIP bytes.
+     - Side effects: none.
+     - Failure modes: Throws when entry names or sizes exceed the non-ZIP64 limits supported by the
+       production reader.
+     */
+    private func makeStoredZip(entries: [(name: String, data: Data)]) throws -> Data {
+        var archive = Data()
+        var localHeaderOffsets: [String: UInt32] = [:]
+
+        for entry in entries {
+            guard let nameData = entry.name.data(using: .utf8),
+                  nameData.count <= Int(UInt16.max),
+                  entry.data.count <= Int(UInt32.max),
+                  archive.count <= Int(UInt32.max) else {
+                throw ZipArchiveReaderError.invalidArchive("Test ZIP entry is too large")
+            }
+            localHeaderOffsets[entry.name] = UInt32(archive.count)
+            appendUInt32(0x0403_4b50, to: &archive)
+            appendUInt16(20, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt32(0, to: &archive)
+            appendUInt32(UInt32(entry.data.count), to: &archive)
+            appendUInt32(UInt32(entry.data.count), to: &archive)
+            appendUInt16(UInt16(nameData.count), to: &archive)
+            appendUInt16(0, to: &archive)
+            archive.append(nameData)
+            archive.append(entry.data)
+        }
+
+        let centralDirectoryOffset = UInt32(archive.count)
+        var centralDirectory = Data()
+        for entry in entries {
+            guard let nameData = entry.name.data(using: .utf8),
+                  let localHeaderOffset = localHeaderOffsets[entry.name] else {
+                throw ZipArchiveReaderError.invalidArchive("Test ZIP entry is missing a local header")
+            }
+            appendUInt32(0x0201_4b50, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(0, to: &centralDirectory)
+            appendUInt32(UInt32(entry.data.count), to: &centralDirectory)
+            appendUInt32(UInt32(entry.data.count), to: &centralDirectory)
+            appendUInt16(UInt16(nameData.count), to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(0, to: &centralDirectory)
+            appendUInt32(localHeaderOffset, to: &centralDirectory)
+            centralDirectory.append(nameData)
+        }
+        guard centralDirectory.count <= Int(UInt32.max), entries.count <= Int(UInt16.max) else {
+            throw ZipArchiveReaderError.invalidArchive("Test ZIP central directory is too large")
+        }
+        archive.append(centralDirectory)
+        appendUInt32(0x0605_4b50, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(UInt16(entries.count), to: &archive)
+        appendUInt16(UInt16(entries.count), to: &archive)
+        appendUInt32(UInt32(centralDirectory.count), to: &archive)
+        appendUInt32(centralDirectoryOffset, to: &archive)
+        appendUInt16(0, to: &archive)
+        return archive
+    }
+
+    /**
+     Appends one little-endian 16-bit integer to a ZIP fixture.
+     */
+    private func appendUInt16(_ value: UInt16, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    /**
+     Appends one little-endian 32-bit integer to a ZIP fixture.
+     */
+    private func appendUInt32(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+}

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -311,6 +311,38 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that Android backup restore rejects duplicate ZIP member paths before selecting
+     manifest or database payloads.
+
+     Setup:
+     - builds a stored ZIP fixture with two central-directory entries named
+       `AndBibleBackupManifest.json`
+
+     Expected result:
+     - backup loading fails with a deterministic invalid-archive reason before manifest decoding or
+       SQLite staging begins
+
+     Failure meaning:
+     - iOS could accept an ambiguous Android backup where a later duplicate member silently replaces
+       the manifest or database bytes that were read earlier.
+     */
+    func testAndroidDatabaseBackupRejectsDuplicateArchiveEntries() throws {
+        let service = AndroidDatabaseBackupService()
+        let manifestData = Data(#"{"backupType":"DB_BACKUP","manifestVersion":1,"contains":[]}"#.utf8)
+        let duplicateManifestArchive = try makeStoredZip(entries: [
+            ("AndBibleBackupManifest.json", manifestData),
+            ("AndBibleBackupManifest.json", manifestData),
+        ])
+
+        XCTAssertThrowsError(try service.loadArchive(from: duplicateManifestArchive)) { error in
+            XCTAssertEqual(
+                error as? AndroidDatabaseBackupError,
+                .invalidArchive("ZIP archive contains duplicate entry AndBibleBackupManifest.json.")
+            )
+        }
+    }
+
+    /**
      Verifies fail-closed ZIP parsing for malformed central-directory metadata.
 
      Setup:
@@ -367,6 +399,48 @@ extension AndBibleTests {
             XCTAssertEqual(
                 error as? ZipArchiveReaderError,
                 .invalidArchive("ZIP64 archives are not supported")
+            )
+        }
+    }
+
+    /**
+     Verifies fail-closed ZIP parsing for spanned-archive end records.
+
+     Setup:
+     - builds a valid single-disk stored ZIP fixture
+     - mutates the end-of-central-directory disk number and per-disk entry count fields
+
+     Expected result:
+     - the reader rejects the archive before using central-directory offsets or entry counts
+
+     Failure meaning:
+     - iOS could parse a multi-disk or inconsistent ZIP as though it were the single-disk Android
+       backup shape, which would make offsets and payload selection unreliable.
+     */
+    func testZipArchiveReaderRejectsMultiDiskEndRecords() throws {
+        let archive = try makeStoredZip(entries: [
+            ("AndBibleBackupManifest.json", Data("{}".utf8)),
+        ])
+
+        var nonZeroDiskArchive = archive
+        let nonZeroDiskEndRecordOffset = try endOfCentralDirectoryOffset(in: nonZeroDiskArchive)
+        replaceUInt16(1, at: nonZeroDiskEndRecordOffset + 4, in: &nonZeroDiskArchive)
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: nonZeroDiskArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Multi-disk ZIP archives are not supported")
+            )
+        }
+
+        var mismatchedEntryCountArchive = archive
+        let mismatchedEntryCountEndRecordOffset = try endOfCentralDirectoryOffset(in: mismatchedEntryCountArchive)
+        replaceUInt16(0, at: mismatchedEntryCountEndRecordOffset + 8, in: &mismatchedEntryCountArchive)
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: mismatchedEntryCountArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Multi-disk ZIP archives are not supported")
             )
         }
     }

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -269,10 +269,12 @@ extension AndBibleTests {
      Verifies Android backup loader failures for malformed archive inputs.
 
      Setup:
+     - passes bytes that are not ZIP-shaped into the Android backup loader
      - builds one ZIP without `AndBibleBackupManifest.json`
      - builds one ZIP whose bookmark entry is not a SQLite database
 
      Expected result:
+     - malformed ZIP inputs surface a clean user-facing archive reason
      - missing manifests fail as `missingManifest`
      - invalid SQLite entries fail before section selection or restore can start
 
@@ -281,6 +283,13 @@ extension AndBibleTests {
      */
     func testAndroidDatabaseBackupRejectsMissingManifestAndInvalidSQLite() throws {
         let service = AndroidDatabaseBackupService()
+        XCTAssertThrowsError(try service.loadArchive(from: Data("not zip".utf8))) { error in
+            XCTAssertEqual(
+                error as? AndroidDatabaseBackupError,
+                .invalidArchive("The file is not a ZIP archive or its central directory is missing.")
+            )
+        }
+
         let missingManifestArchive = try makeStoredZip(entries: [
             ("db/bookmarks.sqlite3", Data()),
         ])
@@ -373,6 +382,7 @@ extension AndBibleTests {
      Expected result:
      - a single entry over the per-entry cap fails as malformed archive data
      - multiple entries below the per-entry cap but above the aggregate cap also fail
+     - Android backup service error mapping preserves concrete ZIP parser reasons
 
      Failure meaning:
      - iOS could allocate excessive memory while importing a crafted Android backup archive before
@@ -383,7 +393,7 @@ extension AndBibleTests {
             ("db/bookmarks.sqlite3", Data([0x01])),
         ])
         try replaceCentralDirectorySizes(
-            compressedSize: 1,
+            compressedSize: UInt32(300 * 1024 * 1024),
             uncompressedSize: UInt32(300 * 1024 * 1024),
             for: "db/bookmarks.sqlite3",
             in: &oversizedEntryArchive
@@ -403,7 +413,7 @@ extension AndBibleTests {
         ])
         for entryName in ["db/bookmarks.sqlite3", "db/workspaces.sqlite3", "db/mydocuments.sqlite3"] {
             try replaceCentralDirectorySizes(
-                compressedSize: 1,
+                compressedSize: UInt32(200 * 1024 * 1024),
                 uncompressedSize: UInt32(200 * 1024 * 1024),
                 for: entryName,
                 in: &oversizedTotalArchive
@@ -414,6 +424,72 @@ extension AndBibleTests {
             XCTAssertEqual(
                 error as? ZipArchiveReaderError,
                 .invalidArchive("ZIP archive exceeds maximum supported size")
+            )
+        }
+
+        let service = AndroidDatabaseBackupService()
+        XCTAssertThrowsError(try service.loadArchive(from: oversizedEntryArchive)) { error in
+            XCTAssertEqual(
+                error as? AndroidDatabaseBackupError,
+                .invalidArchive("ZIP entry exceeds maximum supported size")
+            )
+        }
+    }
+
+    /**
+     Verifies fail-closed ZIP parsing when central-directory sizes do not match materialized data.
+
+     Setup:
+     - mutates a stored entry so compressed and uncompressed size declarations disagree
+     - mutates a deflated entry so inflated bytes are smaller than the central-directory declaration
+
+     Expected result:
+     - stored entries require identical compressed and uncompressed sizes
+     - deflated entries require actual inflated byte count to match declared uncompressed size
+
+     Failure meaning:
+     - ZIP bomb accounting could be bypassed, or iOS could accept truncated Android backup payloads
+       as valid import data.
+     */
+    func testZipArchiveReaderRejectsInconsistentDeclaredPayloadSizes() throws {
+        var storedMismatchArchive = try makeStoredZip(entries: [
+            ("db/bookmarks.sqlite3", Data([0x01, 0x02, 0x03])),
+        ])
+        try replaceCentralDirectorySizes(
+            compressedSize: 3,
+            uncompressedSize: 2,
+            for: "db/bookmarks.sqlite3",
+            in: &storedMismatchArchive
+        )
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: storedMismatchArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Stored ZIP entry size metadata is inconsistent")
+            )
+        }
+
+        let payload = Data("deflated backup payload".utf8)
+        let compressedPayload = Data([
+            75, 73, 77, 203, 73, 44, 73, 77, 81, 72, 74, 76, 206,
+            46, 45, 80, 40, 72, 172, 204, 201, 79, 76, 1, 0,
+        ])
+        var deflatedMismatchArchive = try makeDeflatedDescriptorZip(
+            name: "db/bookmarks.sqlite3",
+            compressedData: compressedPayload,
+            uncompressedData: payload
+        )
+        try replaceCentralDirectorySizes(
+            compressedSize: UInt32(compressedPayload.count),
+            uncompressedSize: UInt32(payload.count + 1),
+            for: "db/bookmarks.sqlite3",
+            in: &deflatedMismatchArchive
+        )
+
+        XCTAssertThrowsError(try ZipArchiveReader.entries(in: deflatedMismatchArchive)) { error in
+            XCTAssertEqual(
+                error as? ZipArchiveReaderError,
+                .invalidArchive("Deflated ZIP entry size metadata is inconsistent")
             )
         }
     }

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -336,23 +336,20 @@ extension AndBibleUITests {
     /// Returns workspace-name prompt text-field candidates without probing arbitrary fields.
     func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
         let identifier = "workspaceNamePromptTextField"
+        let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
         let customSheetCandidates = ["Name", "name"].flatMap { title in
             [
                 app.textFields[title].firstMatch,
                 app.collectionViews.textFields[title].firstMatch,
                 app.tables.textFields[title].firstMatch,
                 app.scrollViews.textFields[title].firstMatch,
-                app.secureTextFields[title].firstMatch,
-                app.collectionViews.secureTextFields[title].firstMatch,
-                app.tables.secureTextFields[title].firstMatch,
-                app.scrollViews.secureTextFields[title].firstMatch,
             ]
         } + [
             app.textFields[identifier].firstMatch,
-            app.secureTextFields[identifier].firstMatch,
             app.otherElements[identifier].firstMatch,
+            app.textFields.matching(focusedPredicate).firstMatch,
         ]
-        return customSheetCandidates + focusedTextEntryCandidates(in: app)
+        return customSheetCandidates
     }
 
     /// Returns workspace-name prompt buttons without walking the custom sheet hierarchy.

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -567,19 +567,11 @@ extension AndBibleUITests {
         case "labelAssignmentCreateNewLabelButton":
             return screenScopedButtonCandidates(identifier, within: "labelAssignmentScreen", in: app)
         case "labelManagerNewLabelNameField":
-            if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
-                return modalTextFieldCandidates(
-                    in: prompt,
-                    identifiers: [identifier],
-                    titles: ["Label name"]
-                )
+            var candidates = appScopedLabelCreationPromptTextFieldCandidates(in: app)
+            if let prompt = resolvedLabelCreationPrompt(in: app) {
+                candidates += labelCreationPromptTextFieldCandidates(in: prompt)
             }
-            return [
-                app.alerts.firstMatch.textFields["Label name"].firstMatch,
-                app.sheets.firstMatch.textFields["Label name"].firstMatch,
-                app.alerts.firstMatch.textFields.element(boundBy: 0),
-                app.sheets.firstMatch.textFields.element(boundBy: 0),
-            ]
+            return candidates
         case "labelEditNameField":
             return [
                 app.textFields[identifier].firstMatch,
@@ -587,17 +579,11 @@ extension AndBibleUITests {
                 app.otherElements[identifier].firstMatch,
             ]
         case "labelManagerCreateButton":
-            if let prompt = resolvedModalPrompt(in: app, timeout: 0) {
-                return modalButtonCandidates(
-                    in: prompt,
-                    identifiers: [identifier],
-                    titles: ["Create"]
-                )
+            var candidates = appScopedLabelCreationPromptCreateButtonCandidates(in: app)
+            if let prompt = resolvedLabelCreationPrompt(in: app) {
+                candidates += labelCreationPromptCreateButtonCandidates(in: prompt)
             }
-            return [
-                app.alerts.firstMatch.buttons["Create"].firstMatch,
-                app.sheets.firstMatch.buttons["Create"].firstMatch,
-            ]
+            return candidates
         case "colorSettingsResetButton":
             return screenScopedButtonCandidates(identifier, within: "colorSettingsScreen", in: app)
         case "aboutAppTitle":

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -567,10 +567,11 @@ extension AndBibleUITests {
         case "labelAssignmentCreateNewLabelButton":
             return screenScopedButtonCandidates(identifier, within: "labelAssignmentScreen", in: app)
         case "labelManagerNewLabelNameField":
-            var candidates = appScopedLabelCreationPromptTextFieldCandidates(in: app)
+            var candidates: [XCUIElement] = []
             if let prompt = resolvedLabelCreationPrompt(in: app) {
                 candidates += labelCreationPromptTextFieldCandidates(in: prompt)
             }
+            candidates += appScopedLabelCreationPromptTextFieldCandidates(in: app)
             return candidates
         case "labelEditNameField":
             return [
@@ -579,10 +580,11 @@ extension AndBibleUITests {
                 app.otherElements[identifier].firstMatch,
             ]
         case "labelManagerCreateButton":
-            var candidates = appScopedLabelCreationPromptCreateButtonCandidates(in: app)
+            var candidates: [XCUIElement] = []
             if let prompt = resolvedLabelCreationPrompt(in: app) {
                 candidates += labelCreationPromptCreateButtonCandidates(in: prompt)
             }
+            candidates += appScopedLabelCreationPromptCreateButtonCandidates(in: app)
             return candidates
         case "colorSettingsResetButton":
             return screenScopedButtonCandidates(identifier, within: "colorSettingsScreen", in: app)

--- a/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -957,6 +957,96 @@ extension AndBibleUITests {
     }
 
     /**
+     Opens a visible My Notes row editor and verifies the semantic state transition.
+
+     - Parameters:
+       - actionsLabel: Accessibility label for the row action menu button.
+       - editorLabel: Accessibility label for the row's edit action.
+       - marker: Persisted note text that also proves the gated UI-test mutation has completed.
+       - app: Running application under test.
+       - timeout: Maximum time to retry the web-view menu and edit controls.
+       - file: Source file used for XCTest failure attribution.
+       - line: Source line used for XCTest failure attribution.
+     - Side effects:
+       - taps the production My Notes action menu and edit command until the compact reader state
+         reports `myNotesEditing=true` or the expected persisted marker
+     - Failure modes:
+       - records an XCTest failure when My Notes stays visible but never opens the editor or saves
+         the expected mutation
+     */
+    func openVisibleMyNotesEditor(
+        actionsLabel: String,
+        editorLabel: String,
+        orPersistedMarker marker: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        func reachedEditorOrPersistedMutation(_ state: String?) -> Bool {
+            guard let state else {
+                return false
+            }
+            return state.contains("myNotesVisible=true")
+                && (state.contains("myNotesEditing=true") || state.contains(marker))
+        }
+
+        repeat {
+            if reachedEditorOrPersistedMutation(readerRenderedContentStateValue(in: app)) {
+                return
+            }
+
+            let remaining = max(0.1, deadline.timeIntervalSinceNow)
+            if let editorControl = optionalMyNotesWebControl(
+                named: editorLabel,
+                in: app,
+                timeout: min(0.5, remaining)
+            ),
+               tapElementIfPossible(editorControl, timeout: min(1, remaining))
+            {
+                if waitForReaderRenderedContentStateIfPresent(
+                    containing: "myNotesEditing=true",
+                    in: app,
+                    timeout: min(2, max(0.1, deadline.timeIntervalSinceNow))
+                ) || waitForReaderRenderedContentStateIfPresent(
+                    containing: marker,
+                    in: app,
+                    timeout: min(2, max(0.1, deadline.timeIntervalSinceNow))
+                ) {
+                    if reachedEditorOrPersistedMutation(readerRenderedContentStateValue(in: app)) {
+                        return
+                    }
+                }
+            }
+
+            if let actionsControl = optionalMyNotesWebControl(
+                named: actionsLabel,
+                in: app,
+                timeout: min(0.5, remaining)
+            ) {
+                _ = tapElementIfPossible(
+                    actionsControl,
+                    timeout: min(1, max(0.1, deadline.timeIntervalSinceNow))
+                )
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let finalState = readerRenderedContentStateValue(in: app) ?? "nil"
+        XCTFail(
+            """
+            Expected visible My Notes editor activation or persisted marker '\(marker)' within \
+            \(timeout) seconds. Final value: '\(finalState)'.
+            """,
+            file: file,
+            line: line
+        )
+    }
+
+    /**
      Waits for the reader's compact My Notes state export to stop containing one token.
      */
     func waitForMyNotesState(

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -964,22 +964,26 @@ extension AndBibleUITests {
 
     /**
      Moves focus away from the active Search field so the lower Search option rows can surface.
+
+     This helper intentionally avoids `app.keyboards`. Hosted CI has timed out while resolving the
+     broad keyboard hierarchy after SwiftUI already dismissed the keyboard, while the Search input's
+     `hasKeyboardFocus` predicate remains bounded to one known field.
      *
      * - Parameter app: Running application under test.
      * - Side effects:
-     *   - uses one visible keyboard dismissal action when the software keyboard remains presented
+     *   - uses one visible keyboard dismissal action when the Search field still owns focus
      *     after query submission
      * - Failure modes:
      *   - silently leaves focus unchanged when no keyboard dismissal action is available
      */
     func dismissSearchFieldFocusIfNeeded(in app: XCUIApplication) {
-        let keyboard = app.keyboards.firstMatch
-        guard keyboard.exists || keyboard.waitForExistence(timeout: 0.2) else {
+        guard let searchField = resolveVisibleSearchInput(in: app, waitTimeout: 0.2),
+              waitForElementKeyboardFocus(searchField, timeout: 0.2) else {
             return
         }
 
         dismissKeyboardIfPresent(in: app)
-        guard keyboard.exists else {
+        guard waitForElementKeyboardFocus(searchField, timeout: 0.2) else {
             return
         }
         let searchScreen = unresolvedElement("searchScreen", in: app)

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -126,9 +126,24 @@ extension AndBibleUITests {
         let includeElementMetadata = accessibilityIdentifier == nil
         let deadline = Date().addingTimeInterval(timeout)
 
+        func promptFocusedTextEntryCandidates() -> [XCUIElement] {
+            switch accessibilityIdentifier {
+            case "labelManagerNewLabelNameField", "workspaceNamePromptTextField":
+                let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
+                return [app.textFields.matching(focusedPredicate).firstMatch]
+            default:
+                return focusedTextEntryCandidates(in: app)
+            }
+        }
+
         func resolvedPromptTextField() -> XCUIElement {
             if accessibilityIdentifier == "labelManagerNewLabelNameField",
                let field = resolveLabelCreationPromptTextField(in: app)
+            {
+                return field
+            }
+            if accessibilityIdentifier == "workspaceNamePromptTextField",
+               let field = firstExistingElement(workspaceNamePromptTextFieldCandidates(in: app), timeout: 0.2)
             {
                 return field
             }
@@ -145,7 +160,7 @@ extension AndBibleUITests {
                 }
             }
 
-            if let focusedField = firstExistingElement(focusedTextEntryCandidates(in: app), timeout: 0.2) {
+            if let focusedField = firstExistingElement(promptFocusedTextEntryCandidates(), timeout: 0.2) {
                 return focusedField
             }
 
@@ -153,7 +168,7 @@ extension AndBibleUITests {
         }
 
         func observedPromptTextValue() -> String {
-            let candidates = [resolvedPromptTextField(), element] + focusedTextEntryCandidates(in: app)
+            let candidates = [resolvedPromptTextField(), element] + promptFocusedTextEntryCandidates()
             var fallbackValue = ""
             for candidate in candidates where candidate.exists {
                 let candidateValue = currentTextEntryValue(
@@ -1298,10 +1313,10 @@ extension AndBibleUITests {
     /**
      Focuses a prompt-owned text-entry control without polling `isHittable`.
 
-     SwiftUI alert text fields can occasionally stall XCTest while resolving frame-based taps even
-     after the prompt-specific resolver has found the field. Prefer the alert's automatic keyboard
-     focus first, then tap the modal surface instead of the resolved field so XCTest does not rebuild
-     a slow text-field snapshot.
+     SwiftUI prompt surfaces can occasionally stall XCTest while resolving broad alert or sheet
+     snapshots after a prompt-specific resolver has already found the field. Prefer the prompt's
+     automatic keyboard focus first, then tap the resolved field coordinate or a stable app
+     coordinate instead of querying `app.alerts.firstMatch` or `app.sheets.firstMatch`.
      */
     func focusResolvedPromptTextEntryElement(
         _ element: XCUIElement,
@@ -1319,9 +1334,12 @@ extension AndBibleUITests {
         let tapOffset = CGVector(dx: preferTrailingEdge ? 0.92 : 0.5, dy: 0.5)
 
         repeat {
-            let coordinate = resolvedModalPrompt(in: app, timeout: 0.2)?
-                .coordinate(withNormalizedOffset: tapOffset)
-                ?? app.coordinate(withNormalizedOffset: tapOffset)
+            let coordinate: XCUICoordinate
+            if element.exists, !element.frame.isEmpty {
+                coordinate = element.coordinate(withNormalizedOffset: tapOffset)
+            } else {
+                coordinate = app.coordinate(withNormalizedOffset: tapOffset)
+            }
             coordinate.tap()
             if waitForElementKeyboardFocus(element, timeout: 0.75) {
                 return

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -138,15 +138,11 @@ extension AndBibleUITests {
         }
 
         func resolvedPromptTextField() -> XCUIElement {
-            if accessibilityIdentifier == "labelManagerNewLabelNameField",
-               let field = resolveLabelCreationPromptTextField(in: app)
-            {
-                return field
-            }
-            if accessibilityIdentifier == "workspaceNamePromptTextField",
-               let field = firstExistingElement(workspaceNamePromptTextFieldCandidates(in: app), timeout: 0.2)
-            {
-                return field
+            switch accessibilityIdentifier {
+            case "labelManagerNewLabelNameField", "workspaceNamePromptTextField":
+                return element
+            default:
+                break
             }
 
             if let prompt = resolvedModalPrompt(in: app, timeout: 0.2) {
@@ -168,10 +164,18 @@ extension AndBibleUITests {
             return element
         }
 
+        func promptTextEntryCandidates(preferred preferredCandidates: [XCUIElement]) -> [XCUIElement] {
+            var candidates = preferredCandidates
+            if preferredCandidates.isEmpty {
+                candidates.append(resolvedPromptTextField())
+            }
+            candidates.append(element)
+            candidates += promptFocusedTextEntryCandidates()
+            return candidates
+        }
+
         func observedPromptTextValue(preferred preferredCandidates: [XCUIElement] = []) -> String {
-            let candidates = preferredCandidates
-                + [resolvedPromptTextField(), element]
-                + promptFocusedTextEntryCandidates()
+            let candidates = promptTextEntryCandidates(preferred: preferredCandidates)
             var fallbackValue = ""
             for candidate in candidates where candidate.exists {
                 let candidateValue = currentTextEntryValue(
@@ -221,9 +225,7 @@ extension AndBibleUITests {
             preferred preferredCandidates: [XCUIElement],
             forceKeyboardDelete: Bool = false
         ) -> Bool {
-            let candidates = preferredCandidates
-                + [resolvedPromptTextField(), element]
-                + promptFocusedTextEntryCandidates()
+            let candidates = promptTextEntryCandidates(preferred: preferredCandidates)
             for candidate in candidates where candidate.exists {
                 if forceKeyboardDelete {
                     focusTextEntryElement(candidate, preferTrailingEdge: true, timeout: 1)

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -364,7 +364,7 @@ extension AndBibleUITests {
      Returns the visible native prompt container used by the create-label flow.
 
      - Parameter app: Running application under test.
-     - Returns: The title-matched alert/sheet first, then the generic modal surface fallback.
+     - Returns: The title-matched alert/sheet used by the create-label prompt.
      - Side effects: none.
      - Failure modes: returns `nil` when XCTest cannot observe a presented prompt.
      */
@@ -375,27 +375,25 @@ extension AndBibleUITests {
                 app.sheets["New Label"].firstMatch,
             ],
             timeout: 0.2
-        ) ?? resolvedModalPrompt(in: app, timeout: 0.2)
+        )
     }
 
     /**
      Returns app-scoped create-label text field candidates in stable lookup order.
 
-     Label Manager creation prompts are SwiftUI alerts. Polling `app.alerts.firstMatch` can force a
-     full hierarchy snapshot while the reader web view is still mounted, so label creation starts
-     with the production identifiers exposed by both label creation surfaces.
+     Label Manager creation prompts are SwiftUI alerts. Secure-field candidates are intentionally
+     omitted because the prompt never uses secure entry, and hosted runners can stall while proving
+     a non-existent secure field is absent.
 
      - Parameter app: Running application under test.
-     - Returns: Text-field candidates ordered from explicit identifier to localized placeholder.
+     - Returns: Text-field candidates ordered from localized placeholder to explicit identifier.
      - Side effects: none.
      - Failure modes: This helper cannot fail.
      */
     func appScopedLabelCreationPromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
         [
-            app.textFields["labelManagerNewLabelNameField"].firstMatch,
-            app.secureTextFields["labelManagerNewLabelNameField"].firstMatch,
             app.textFields["Label name"].firstMatch,
-            app.secureTextFields["Label name"].firstMatch,
+            app.textFields["labelManagerNewLabelNameField"].firstMatch,
         ]
     }
 
@@ -417,16 +415,14 @@ extension AndBibleUITests {
     /**
      Returns create-label text field candidates using stable alert names.
 
-     Hosted simulators can wedge XCTest while resolving the first ordinal `TextField` inside a
-     SwiftUI alert, so normal prompt polling avoids that query and relies on the explicit production
-     identifier/title instead.
+     Hosted simulators can wedge XCTest while resolving absent secure-field or ordinal text-entry
+     candidates inside a SwiftUI alert, so prompt polling uses only the visible title and explicit
+     production identifier.
      */
     func labelCreationPromptTextFieldCandidates(in prompt: XCUIElement) -> [XCUIElement] {
         [
-            prompt.textFields["labelManagerNewLabelNameField"].firstMatch,
-            prompt.secureTextFields["labelManagerNewLabelNameField"].firstMatch,
             prompt.textFields["Label name"].firstMatch,
-            prompt.secureTextFields["Label name"].firstMatch,
+            prompt.textFields["labelManagerNewLabelNameField"].firstMatch,
         ]
     }
 
@@ -443,36 +439,34 @@ extension AndBibleUITests {
 
     /// Resolves the create-label prompt text field by scoping queries to the visible prompt.
     func resolveLabelCreationPromptTextField(in app: XCUIApplication) -> XCUIElement? {
-        if let field = firstExistingElement(
-            appScopedLabelCreationPromptTextFieldCandidates(in: app),
-            timeout: 0.2
-        ) {
-            return field
-        }
         if let prompt = resolvedLabelCreationPrompt(in: app) {
-            return firstExistingElement(
+            if let field = firstExistingElement(
                 labelCreationPromptTextFieldCandidates(in: prompt),
                 timeout: 0.2
-            )
+            ) {
+                return field
+            }
         }
-        return nil
+        return firstExistingElement(
+            appScopedLabelCreationPromptTextFieldCandidates(in: app),
+            timeout: 0
+        )
     }
 
     /// Resolves the create-label prompt action button by scoping queries to the visible prompt.
     func resolveLabelCreationPromptCreateButton(in app: XCUIApplication) -> XCUIElement? {
-        if let button = firstExistingElement(
-            appScopedLabelCreationPromptCreateButtonCandidates(in: app),
-            timeout: 0.2
-        ) {
-            return button
-        }
         if let prompt = resolvedLabelCreationPrompt(in: app) {
-            return firstExistingElement(
+            if let button = firstExistingElement(
                 labelCreationPromptCreateButtonCandidates(in: prompt),
                 timeout: 0.2
-            )
+            ) {
+                return button
+            }
         }
-        return nil
+        return firstExistingElement(
+            appScopedLabelCreationPromptCreateButtonCandidates(in: app),
+            timeout: 0
+        )
     }
 
     /// Resolves the Search root element that owns the canonical UI-test state value.

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -127,17 +127,19 @@ extension AndBibleUITests {
         let deadline = Date().addingTimeInterval(timeout)
 
         func resolvedPromptTextField() -> XCUIElement {
+            if accessibilityIdentifier == "labelManagerNewLabelNameField",
+               let field = resolveLabelCreationPromptTextField(in: app)
+            {
+                return field
+            }
+
             if let prompt = resolvedModalPrompt(in: app, timeout: 0.2) {
                 let promptCandidates: [XCUIElement]
-                if accessibilityIdentifier == "labelManagerNewLabelNameField" {
-                    promptCandidates = labelCreationPromptTextFieldCandidates(in: prompt)
-                } else {
-                    promptCandidates = modalTextFieldCandidates(
-                        in: prompt,
-                        identifiers: accessibilityIdentifier.map { [$0] } ?? [],
-                        titles: placeholderHints
-                    )
-                }
+                promptCandidates = modalTextFieldCandidates(
+                    in: prompt,
+                    identifiers: accessibilityIdentifier.map { [$0] } ?? [],
+                    titles: placeholderHints
+                )
                 if let promptField = firstExistingElement(promptCandidates, timeout: 0.2) {
                     return promptField
                 }
@@ -358,9 +360,58 @@ extension AndBibleUITests {
         )
     }
 
-    /// Returns the visible prompt container used by the create-label flow.
+    /**
+     Returns the visible native prompt container used by the create-label flow.
+
+     - Parameter app: Running application under test.
+     - Returns: The title-matched alert/sheet first, then the generic modal surface fallback.
+     - Side effects: none.
+     - Failure modes: returns `nil` when XCTest cannot observe a presented prompt.
+     */
     func resolvedLabelCreationPrompt(in app: XCUIApplication) -> XCUIElement? {
-        resolvedModalPrompt(in: app, timeout: 0.2)
+        firstExistingElement(
+            [
+                app.alerts["New Label"].firstMatch,
+                app.sheets["New Label"].firstMatch,
+            ],
+            timeout: 0.2
+        ) ?? resolvedModalPrompt(in: app, timeout: 0.2)
+    }
+
+    /**
+     Returns app-scoped create-label text field candidates in stable lookup order.
+
+     Label Manager creation prompts are SwiftUI alerts. Polling `app.alerts.firstMatch` can force a
+     full hierarchy snapshot while the reader web view is still mounted, so label creation starts
+     with the production identifiers exposed by both label creation surfaces.
+
+     - Parameter app: Running application under test.
+     - Returns: Text-field candidates ordered from explicit identifier to localized placeholder.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    func appScopedLabelCreationPromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.textFields["labelManagerNewLabelNameField"].firstMatch,
+            app.secureTextFields["labelManagerNewLabelNameField"].firstMatch,
+            app.textFields["Label name"].firstMatch,
+            app.secureTextFields["Label name"].firstMatch,
+        ]
+    }
+
+    /**
+     Returns app-scoped create-label action candidates in stable lookup order.
+
+     - Parameter app: Running application under test.
+     - Returns: Button candidates ordered from explicit identifier to localized title.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    func appScopedLabelCreationPromptCreateButtonCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.buttons["labelManagerCreateButton"].firstMatch,
+            app.buttons["Create"].firstMatch,
+        ]
     }
 
     /**
@@ -392,6 +443,12 @@ extension AndBibleUITests {
 
     /// Resolves the create-label prompt text field by scoping queries to the visible prompt.
     func resolveLabelCreationPromptTextField(in app: XCUIApplication) -> XCUIElement? {
+        if let field = firstExistingElement(
+            appScopedLabelCreationPromptTextFieldCandidates(in: app),
+            timeout: 0.2
+        ) {
+            return field
+        }
         if let prompt = resolvedLabelCreationPrompt(in: app) {
             return firstExistingElement(
                 labelCreationPromptTextFieldCandidates(in: prompt),
@@ -403,6 +460,12 @@ extension AndBibleUITests {
 
     /// Resolves the create-label prompt action button by scoping queries to the visible prompt.
     func resolveLabelCreationPromptCreateButton(in app: XCUIApplication) -> XCUIElement? {
+        if let button = firstExistingElement(
+            appScopedLabelCreationPromptCreateButtonCandidates(in: app),
+            timeout: 0.2
+        ) {
+            return button
+        }
         if let prompt = resolvedLabelCreationPrompt(in: app) {
             return firstExistingElement(
                 labelCreationPromptCreateButtonCandidates(in: prompt),

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -107,7 +107,8 @@ extension AndBibleUITests {
        - line: Source line used for XCTest failure attribution.
      - Returns: `true` when the prompt field reports the expected value before submission.
      - Side effects:
-       - focuses the prompt field, emits keyboard input, and clears/retries if CI drops the input
+       - focuses the prompt field, verifies or clears any existing prompt value, emits keyboard
+         input, and clears/retries if CI drops the input without appending duplicate text
      - Failure modes:
        - records an XCTest failure when the field value never matches `text`
      */
@@ -167,8 +168,10 @@ extension AndBibleUITests {
             return element
         }
 
-        func observedPromptTextValue() -> String {
-            let candidates = [resolvedPromptTextField(), element] + promptFocusedTextEntryCandidates()
+        func observedPromptTextValue(preferred preferredCandidates: [XCUIElement] = []) -> String {
+            let candidates = preferredCandidates
+                + [resolvedPromptTextField(), element]
+                + promptFocusedTextEntryCandidates()
             var fallbackValue = ""
             for candidate in candidates where candidate.exists {
                 let candidateValue = currentTextEntryValue(
@@ -186,19 +189,76 @@ extension AndBibleUITests {
             return fallbackValue
         }
 
-        func waitForObservedPromptTextValue(timeout: TimeInterval) -> Bool {
+        func waitForObservedPromptTextValue(
+            preferred preferredCandidates: [XCUIElement] = [],
+            timeout: TimeInterval
+        ) -> Bool {
             let valueDeadline = Date().addingTimeInterval(timeout)
             repeat {
-                if observedPromptTextValue() == text {
+                if observedPromptTextValue(preferred: preferredCandidates) == text {
                     return true
                 }
                 RunLoop.current.run(until: Date().addingTimeInterval(0.2))
             } while Date() < valueDeadline
-            return observedPromptTextValue() == text
+            return observedPromptTextValue(preferred: preferredCandidates) == text
+        }
+
+        func waitForObservedPromptTextValueToClear(
+            preferred preferredCandidates: [XCUIElement],
+            timeout: TimeInterval
+        ) -> Bool {
+            let clearDeadline = Date().addingTimeInterval(timeout)
+            repeat {
+                if observedPromptTextValue(preferred: preferredCandidates).isEmpty {
+                    return true
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            } while Date() < clearDeadline
+            return observedPromptTextValue(preferred: preferredCandidates).isEmpty
+        }
+
+        func clearObservedPromptTextValue(
+            preferred preferredCandidates: [XCUIElement],
+            forceKeyboardDelete: Bool = false
+        ) -> Bool {
+            let candidates = preferredCandidates
+                + [resolvedPromptTextField(), element]
+                + promptFocusedTextEntryCandidates()
+            for candidate in candidates where candidate.exists {
+                if forceKeyboardDelete {
+                    focusTextEntryElement(candidate, preferTrailingEdge: true, timeout: 1)
+                    if waitForElementKeyboardFocus(candidate, timeout: 0.3) {
+                        app.typeText(
+                            String(repeating: XCUIKeyboardKey.delete.rawValue, count: max(text.count * 2, 32))
+                        )
+                        if waitForObservedPromptTextValueToClear(
+                            preferred: preferredCandidates + [candidate],
+                            timeout: 0.5
+                        ) {
+                            return true
+                        }
+                    }
+                }
+
+                if clearTextEntryElement(
+                    candidate,
+                    app: app,
+                    placeholderHints: placeholderHints,
+                    includeElementMetadata: includeElementMetadata
+                ) && waitForObservedPromptTextValueToClear(
+                    preferred: preferredCandidates + [candidate],
+                    timeout: 0.5
+                ) {
+                    return true
+                }
+            }
+
+            return observedPromptTextValue(preferred: preferredCandidates).isEmpty
         }
 
         repeat {
             let promptTextField = resolvedPromptTextField()
+            let preferredPromptCandidates = [promptTextField]
             focusResolvedPromptTextEntryElement(
                 promptTextField,
                 in: app,
@@ -206,41 +266,52 @@ extension AndBibleUITests {
                 file: file,
                 line: line
             )
-            if observedPromptTextValue() == text {
+            let existingValue = observedPromptTextValue(preferred: preferredPromptCandidates)
+            if existingValue == text {
                 return true
+            }
+            guard clearObservedPromptTextValue(preferred: preferredPromptCandidates, forceKeyboardDelete: true) else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                continue
             }
 
             promptTextField.typeText(text)
-            if waitForObservedPromptTextValue(timeout: min(3, max(0.5, deadline.timeIntervalSinceNow))) {
+            if waitForObservedPromptTextValue(
+                preferred: preferredPromptCandidates,
+                timeout: min(5, max(0.5, deadline.timeIntervalSinceNow))
+            ) {
                 return true
             }
 
             if waitForElementKeyboardFocus(promptTextField, timeout: 0.5) {
-                let currentValue = observedPromptTextValue()
+                let currentValue = observedPromptTextValue(preferred: preferredPromptCandidates)
                 if currentValue == text {
                     return true
                 }
                 if !currentValue.isEmpty {
-                    _ = clearTextEntryElement(
-                        resolvedPromptTextField(),
-                        app: app,
-                        placeholderHints: placeholderHints,
-                        includeElementMetadata: includeElementMetadata
-                    )
+                    _ = clearObservedPromptTextValue(preferred: preferredPromptCandidates, forceKeyboardDelete: true)
+                    RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                    continue
+                }
+
+                guard clearObservedPromptTextValue(
+                    preferred: preferredPromptCandidates,
+                    forceKeyboardDelete: true
+                ) else {
+                    RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                    continue
                 }
 
                 app.typeText(text)
-                if waitForObservedPromptTextValue(timeout: min(3, max(0.5, deadline.timeIntervalSinceNow))) {
+                if waitForObservedPromptTextValue(
+                    preferred: preferredPromptCandidates,
+                    timeout: min(3, max(0.5, deadline.timeIntervalSinceNow))
+                ) {
                     return true
                 }
             }
 
-            _ = clearTextEntryElement(
-                resolvedPromptTextField(),
-                app: app,
-                placeholderHints: placeholderHints,
-                includeElementMetadata: includeElementMetadata
-            )
+            _ = clearObservedPromptTextValue(preferred: preferredPromptCandidates, forceKeyboardDelete: true)
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 

--- a/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
+++ b/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
@@ -474,9 +474,13 @@ extension AndBibleUITests {
         waitForVisibleMyNotesState(containing: "myNotesCount=1", in: app, timeout: 20)
         waitForVisibleMyNotesState(containing: "|\(rowToken)=\(originalNote)|", in: app, timeout: 20)
 
-        tapElementReliably(requireMyNotesWebControl(named: actionsLabel, in: app, timeout: 15), timeout: 10)
-        tapElementReliably(requireMyNotesWebControl(named: openNoteEditorLabel, in: app, timeout: 15), timeout: 10)
-        waitForVisibleMyNotesEditorActivation(orPersistedMarker: updatedNoteMarker, in: app, timeout: 20)
+        openVisibleMyNotesEditor(
+            actionsLabel: actionsLabel,
+            editorLabel: openNoteEditorLabel,
+            orPersistedMarker: updatedNoteMarker,
+            in: app,
+            timeout: 20
+        )
         waitForVisibleMyNotesState(containing: updatedNoteMarker, in: app, timeout: 20)
         dismissMyNotesEditor(in: app, timeout: 15)
         waitForVisibleMyNotesState(containing: "myNotesEditing=false", in: app, timeout: 20)

--- a/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -227,9 +227,16 @@ extension AndBibleUITests {
         tapElementReliably(requireElement("labelManagerAddButton", in: app, timeout: 10), timeout: 10)
         waitForLabelManagerState(containing: "showNewLabel=true", in: app, timeout: 10)
         let newLabelNameField = requireLabelManagerNewLabelField(in: app, timeout: 10)
-        focusResolvedPromptTextEntryElement(newLabelNameField, in: app, timeout: 10)
-        app.typeText(originalName)
-        tapElementReliably(requireLabelManagerCreateButton(in: app, timeout: 10), timeout: 10)
+        guard typePromptText(
+            originalName,
+            into: newLabelNameField,
+            in: app,
+            timeout: 15,
+            accessibilityIdentifier: "labelManagerNewLabelNameField"
+        ) else {
+            return
+        }
+        tapLabelCreationPromptCreateButton(in: app, timeout: 10)
         waitForLabelManagerState(containing: labelManagerRowStateToken(originalName), in: app, timeout: 10)
 
         let createdRow = requireLabelRow(named: originalName, in: app, timeout: 10)

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -844,11 +844,11 @@ public final class AndroidDatabaseBackupService {
         for category: AndroidDatabaseBackupCategory,
         databaseVersion: Int
     ) -> AndroidDatabaseBackupSectionSupport {
-        if databaseVersion > category.supportedDatabaseVersion {
-            return .unsupportedVersion(version: databaseVersion, supported: category.supportedDatabaseVersion)
-        }
         guard category.remoteSyncCategory != nil else {
             return .unsupportedCategory("iOS does not yet have a safe mapper for Android \(category.displayName) data.")
+        }
+        if databaseVersion > category.supportedDatabaseVersion {
+            return .unsupportedVersion(version: databaseVersion, supported: category.supportedDatabaseVersion)
         }
         return .supported
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -612,10 +612,7 @@ public final class AndroidDatabaseBackupService {
             throw AndroidDatabaseBackupError.invalidArchive(error.localizedDescription)
         }
 
-        var entriesByName: [String: Data] = [:]
-        for entry in entries {
-            entriesByName[entry.name] = entry.data
-        }
+        let entriesByName = try Self.entriesByUniqueName(entries)
         guard let manifestData = entriesByName["AndBibleBackupManifest.json"] else {
             throw AndroidDatabaseBackupError.missingManifest
         }
@@ -778,6 +775,34 @@ public final class AndroidDatabaseBackupService {
             manifestVersion: dto.manifestVersion ?? 1,
             andBibleVersion: dto.andBibleVersion
         )
+    }
+
+    /**
+     Builds a deterministic ZIP entry lookup for Android backup archives.
+
+     ZIP archives may legally contain multiple file members with the same path. Android database
+     backup restore treats paths such as `AndBibleBackupManifest.json` and `db/bookmarks.sqlite3`
+     as authoritative inputs, so duplicate names would make the selected manifest or SQLite payload
+     ambiguous. Rejecting duplicates before validation keeps restore/import fail-closed instead of
+     letting a later central-directory entry replace an earlier one.
+
+     - Parameter entries: Non-directory entries extracted from `ZipArchiveReader` in central-directory order.
+     - Returns: Entry payloads keyed by their ZIP path.
+     - Side effects: none.
+     - Failure modes: Throws `AndroidDatabaseBackupError.invalidArchive` when any entry path appears
+       more than once.
+     */
+    private static func entriesByUniqueName(_ entries: [ZipArchiveEntry]) throws -> [String: Data] {
+        var entriesByName: [String: Data] = [:]
+        for entry in entries {
+            guard entriesByName[entry.name] == nil else {
+                throw AndroidDatabaseBackupError.invalidArchive(
+                    "ZIP archive contains duplicate entry \(entry.name)."
+                )
+            }
+            entriesByName[entry.name] = entry.data
+        }
+        return entriesByName
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -1,0 +1,1726 @@
+// AndroidDatabaseBackupService.swift — Android .abdb.zip restore/import support
+
+import Foundation
+import SQLite3
+import SwiftData
+
+/**
+ Android database categories that can appear in `AndBibleDatabaseBackup.abdb.zip` archives.
+
+ The raw values match Android's `DbType` enum when a manifest declares the category. `PROGRESS`
+ is included because Android's backup writer includes `progress.sqlite3` in the archive even
+ though the current manifest enum does not list it.
+ */
+public enum AndroidDatabaseBackupCategory: String, CaseIterable, Identifiable, Sendable, Codable {
+    /// Android bookmark, label, bookmark-note, and StudyPad database.
+    case bookmarks = "BOOKMARKS"
+
+    /// Android workspace/window/page-manager database.
+    case workspaces = "WORKSPACES"
+
+    /// Android reading-plan database.
+    case readingPlans = "READINGPLANS"
+
+    /// Android app settings database.
+    case settings = "SETTINGS"
+
+    /// Android module repository metadata database.
+    case repositories = "REPOSITORIES"
+
+    /// Android module backup marker; module payload restore is outside database backup restore.
+    case modules = "MODULES"
+
+    /// Android EPUB backup marker; EPUB payload restore is outside database backup restore.
+    case epubs = "EPUBS"
+
+    /// Android My Documents database.
+    case myDocuments = "MYDOCUMENTS"
+
+    /// Android AI settings database.
+    case aiSettings = "AI_SETTINGS"
+
+    /// Android reading/memorization progress database.
+    case progress = "PROGRESS"
+
+    /// Stable SwiftUI identity for category selection rows.
+    public var id: String { rawValue }
+
+    /// Android database filename for categories stored as DB files in the backup archive.
+    public var databaseFileName: String? {
+        switch self {
+        case .bookmarks:
+            "bookmarks.sqlite3"
+        case .workspaces:
+            "workspaces.sqlite3"
+        case .readingPlans:
+            "readingplans.sqlite3"
+        case .settings:
+            "settings.sqlite3"
+        case .repositories:
+            "repositories.sqlite3"
+        case .myDocuments:
+            "mydocuments.sqlite3"
+        case .aiSettings:
+            "ai_settings.sqlite3"
+        case .progress:
+            "progress.sqlite3"
+        case .modules, .epubs:
+            nil
+        }
+    }
+
+    /// User-visible section name matching Android's backup section labels.
+    public var displayName: String {
+        switch self {
+        case .bookmarks:
+            "Bookmarks"
+        case .workspaces:
+            "Workspaces"
+        case .readingPlans:
+            "Reading Plans"
+        case .settings:
+            "Settings"
+        case .repositories:
+            "Repositories"
+        case .modules:
+            "Modules"
+        case .epubs:
+            "EPUBs"
+        case .myDocuments:
+            "My Documents"
+        case .aiSettings:
+            "AI Settings"
+        case .progress:
+            "Progress"
+        }
+    }
+
+    /// Highest Android Room database version this iOS build recognizes for archive validation.
+    public var supportedDatabaseVersion: Int {
+        switch self {
+        case .bookmarks:
+            12
+        case .workspaces:
+            22
+        case .readingPlans:
+            1
+        case .settings:
+            1
+        case .repositories:
+            1
+        case .myDocuments:
+            RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        case .aiSettings:
+            22
+        case .progress:
+            9
+        case .modules, .epubs:
+            0
+        }
+    }
+
+    /// iOS remote-sync category used by the existing Android SQLite restore engines.
+    public var remoteSyncCategory: RemoteSyncCategory? {
+        switch self {
+        case .bookmarks:
+            .bookmarks
+        case .workspaces:
+            .workspaces
+        case .readingPlans:
+            .readingPlans
+        case .myDocuments:
+            .myDocuments
+        case .settings, .repositories, .modules, .epubs, .aiSettings, .progress:
+            nil
+        }
+    }
+
+    /// Database-backed categories Android writes under `db/` in `.abdb.zip` archives.
+    static var databaseBackedCases: [AndroidDatabaseBackupCategory] {
+        allCases.filter { $0.databaseFileName != nil }
+    }
+}
+
+/**
+ Compatibility state for one Android database backup section.
+
+ Supported sections can be restored or imported by the current iOS build. Unsupported sections are
+ still exposed to the UI so the user can see that the archive contains valid data that iOS cannot
+ yet map safely.
+ */
+public enum AndroidDatabaseBackupSectionSupport: Sendable, Equatable {
+    /// The section can be restored/imported by this iOS build.
+    case supported
+
+    /// The SQLite database version is newer than the highest version this iOS build recognizes.
+    case unsupportedVersion(version: Int, supported: Int)
+
+    /// The Android category has no iOS data mapper yet.
+    case unsupportedCategory(String)
+
+    /// Whether this support state permits restore/import.
+    public var isSupported: Bool {
+        if case .supported = self {
+            return true
+        }
+        return false
+    }
+
+    /// User-facing explanation for unsupported states.
+    public var explanation: String? {
+        switch self {
+        case .supported:
+            nil
+        case .unsupportedVersion(let version, let supported):
+            "Requires database version \(version); this app supports up to \(supported)."
+        case .unsupportedCategory(let message):
+            message
+        }
+    }
+}
+
+/**
+ One validated database section extracted from an Android backup archive.
+
+ The database file URL points at a temporary extracted SQLite file owned by
+ `AndroidDatabaseBackupArchive.temporaryDirectory`; callers should keep the archive value alive
+ until all selected restore/import operations have completed.
+ */
+public struct AndroidDatabaseBackupSection: Identifiable, Sendable, Equatable {
+    /// Stable category identity used for selection and dispatch.
+    public let category: AndroidDatabaseBackupCategory
+
+    /// Android database filename under the archive's `db/` directory.
+    public let fileName: String
+
+    /// Temporary extracted SQLite database URL.
+    public let databaseFileURL: URL
+
+    /// SQLite `PRAGMA user_version` read from the extracted database.
+    public let databaseVersion: Int
+
+    /// Whether the archive manifest declared this category.
+    public let declaredInManifest: Bool
+
+    /// Restore/import compatibility for this iOS build.
+    public let support: AndroidDatabaseBackupSectionSupport
+
+    /// Stable SwiftUI identity for section rows.
+    public var id: AndroidDatabaseBackupCategory { category }
+
+    /// Whether this section was backed by an extracted SQLite database file.
+    public var hasDatabaseFile: Bool { !fileName.isEmpty }
+
+    /**
+     Creates one extracted Android database backup section.
+
+     - Parameters:
+       - category: Logical Android category represented by the database.
+       - fileName: Android database filename under `db/`.
+       - databaseFileURL: Temporary extracted SQLite database URL.
+       - databaseVersion: SQLite `user_version`.
+       - declaredInManifest: Whether `AndBibleBackupManifest.json` listed the category.
+       - support: Restore/import compatibility for the current iOS build.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        category: AndroidDatabaseBackupCategory,
+        fileName: String,
+        databaseFileURL: URL,
+        databaseVersion: Int,
+        declaredInManifest: Bool,
+        support: AndroidDatabaseBackupSectionSupport
+    ) {
+        self.category = category
+        self.fileName = fileName
+        self.databaseFileURL = databaseFileURL
+        self.databaseVersion = databaseVersion
+        self.declaredInManifest = declaredInManifest
+        self.support = support
+    }
+}
+
+/**
+ Manifest payload read from `AndBibleBackupManifest.json`.
+
+ Android currently writes `backupType = DB_BACKUP`, `manifestVersion = 1`, and an optional
+ `contains` set. iOS uses the manifest to reject non-database backup archives before staging any
+ destructive restore UI.
+ */
+public struct AndroidDatabaseBackupManifest: Sendable, Equatable {
+    /// Android backup type string, expected to be `DB_BACKUP`.
+    public let backupType: String
+
+    /// Optional category set declared by Android's manifest.
+    public let contains: Set<AndroidDatabaseBackupCategory>
+
+    /// Manifest schema version.
+    public let manifestVersion: Int
+
+    /// Android application version number that created the backup.
+    public let andBibleVersion: Int?
+
+    /**
+     Creates one decoded Android database backup manifest.
+
+     - Parameters:
+       - backupType: Android backup type string.
+       - contains: Optional category set declared by Android.
+       - manifestVersion: Manifest schema version.
+       - andBibleVersion: Android application version number, when present.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        backupType: String,
+        contains: Set<AndroidDatabaseBackupCategory>,
+        manifestVersion: Int,
+        andBibleVersion: Int?
+    ) {
+        self.backupType = backupType
+        self.contains = contains
+        self.manifestVersion = manifestVersion
+        self.andBibleVersion = andBibleVersion
+    }
+}
+
+/**
+ Loaded Android database backup archive with staged SQLite database files.
+
+ The archive owns a temporary directory. Call `AndroidDatabaseBackupService.cleanup(_:)` after the
+ UI is dismissed or after restore/import completes.
+ */
+public struct AndroidDatabaseBackupArchive: Identifiable, Sendable {
+    /// Stable identity for SwiftUI sheet presentation.
+    public let id: UUID
+
+    /// Decoded Android backup manifest.
+    public let manifest: AndroidDatabaseBackupManifest
+
+    /// Valid database sections extracted from the archive.
+    public let sections: [AndroidDatabaseBackupSection]
+
+    /// Temporary root directory containing staged SQLite files.
+    public let temporaryDirectory: URL
+
+    /**
+     Creates one loaded Android backup archive.
+
+     - Parameters:
+       - id: Stable identity for UI presentation.
+       - manifest: Decoded Android backup manifest.
+       - sections: Valid database sections extracted from the archive.
+       - temporaryDirectory: Temporary root directory containing staged SQLite files.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        id: UUID = UUID(),
+        manifest: AndroidDatabaseBackupManifest,
+        sections: [AndroidDatabaseBackupSection],
+        temporaryDirectory: URL
+    ) {
+        self.id = id
+        self.manifest = manifest
+        self.sections = sections
+        self.temporaryDirectory = temporaryDirectory
+    }
+}
+
+/**
+ User-selected operation for one Android backup section.
+ */
+public enum AndroidDatabaseBackupApplyMode: String, CaseIterable, Identifiable, Sendable, Codable {
+    /// Replace local category data with the selected Android database section.
+    case restore
+
+    /// Add backup rows that do not already exist locally without overwriting existing rows.
+    case `import`
+
+    /// Stable identity for SwiftUI segmented controls.
+    public var id: String { rawValue }
+
+    /// User-visible label.
+    public var displayName: String {
+        switch self {
+        case .restore:
+            "Restore"
+        case .import:
+            "Import"
+        }
+    }
+}
+
+/**
+ One selected section and operation mode from the Android backup UI.
+ */
+public struct AndroidDatabaseBackupSelection: Sendable, Equatable {
+    /// Selected Android backup category.
+    public let category: AndroidDatabaseBackupCategory
+
+    /// Restore/import operation requested for the category.
+    public let mode: AndroidDatabaseBackupApplyMode
+
+    /**
+     Creates one restore/import selection.
+
+     - Parameters:
+       - category: Selected Android backup category.
+       - mode: Restore/import operation requested for the category.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(category: AndroidDatabaseBackupCategory, mode: AndroidDatabaseBackupApplyMode) {
+        self.category = category
+        self.mode = mode
+    }
+}
+
+/**
+ Summary for one section applied from an Android database backup archive.
+ */
+public struct AndroidDatabaseBackupAppliedSectionReport: Sendable, Equatable {
+    /// Applied Android backup category.
+    public let category: AndroidDatabaseBackupCategory
+
+    /// Operation mode used for the category.
+    public let mode: AndroidDatabaseBackupApplyMode
+
+    /// Human-readable row summary for status UI and tests.
+    public let summary: String
+
+    /**
+     Creates one applied-section report.
+
+     - Parameters:
+       - category: Applied Android backup category.
+       - mode: Operation mode used for the category.
+       - summary: Human-readable row summary for status UI and tests.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(category: AndroidDatabaseBackupCategory, mode: AndroidDatabaseBackupApplyMode, summary: String) {
+        self.category = category
+        self.mode = mode
+        self.summary = summary
+    }
+}
+
+/**
+ Summary for a completed Android database backup restore/import batch.
+ */
+public struct AndroidDatabaseBackupApplyReport: Sendable, Equatable {
+    /// Per-section reports in the order requested by the user.
+    public let sections: [AndroidDatabaseBackupAppliedSectionReport]
+
+    /**
+     Creates a completed batch report.
+
+     - Parameter sections: Per-section reports in the order requested by the user.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(sections: [AndroidDatabaseBackupAppliedSectionReport]) {
+        self.sections = sections
+    }
+}
+
+/**
+ Errors raised while loading or applying Android database backup archives.
+ */
+public enum AndroidDatabaseBackupError: LocalizedError, Equatable {
+    /// The archive could not be parsed as ZIP.
+    case invalidArchive(String)
+
+    /// The required Android manifest file was missing.
+    case missingManifest
+
+    /// The Android manifest could not be decoded.
+    case invalidManifest
+
+    /// The manifest described a backup type other than `DB_BACKUP`.
+    case unsupportedBackupType(String)
+
+    /// The manifest version is newer than this iOS build understands.
+    case unsupportedManifestVersion(Int)
+
+    /// The archive contained no recognizable Android database backup sections.
+    case noValidDatabaseSections
+
+    /// One expected SQLite database could not be opened or did not have a SQLite header.
+    case invalidSQLiteDatabase(String)
+
+    /// The caller requested no sections.
+    case emptySelection
+
+    /// The requested category was not present in the loaded archive.
+    case missingSelectedSection(AndroidDatabaseBackupCategory)
+
+    /// The requested category is present but cannot be mapped by this iOS build.
+    case unsupportedSelectedSection(AndroidDatabaseBackupCategory, String)
+
+    /// User-visible error description.
+    public var errorDescription: String? {
+        switch self {
+        case .invalidArchive(let message):
+            "Invalid Android backup archive: \(message)"
+        case .missingManifest:
+            "The Android backup manifest is missing."
+        case .invalidManifest:
+            "The Android backup manifest could not be read."
+        case .unsupportedBackupType(let type):
+            "This archive is \(type), not an Android database backup."
+        case .unsupportedManifestVersion(let version):
+            "This Android backup manifest version (\(version)) is newer than iOS supports."
+        case .noValidDatabaseSections:
+            "No Android database backup sections were found."
+        case .invalidSQLiteDatabase(let fileName):
+            "\(fileName) is not a valid Android SQLite database."
+        case .emptySelection:
+            "Choose at least one Android backup section."
+        case .missingSelectedSection(let category):
+            "\(category.displayName) was not found in this backup."
+        case .unsupportedSelectedSection(let category, let reason):
+            "\(category.displayName) cannot be restored: \(reason)"
+        }
+    }
+}
+
+/**
+ Loads Android `.abdb.zip` archives and applies selected sections to iOS SwiftData.
+
+ Android's manual backup restore offers section selection and a per-section Restore/Import choice.
+ This service preserves those semantics for iOS:
+ - `Restore` replaces local category data from the selected Android SQLite database
+ - `Import` builds a merged Android-shaped snapshot that keeps local rows first and adds backup
+   rows only when their Android uniqueness keys are absent
+ - after each selected section is applied, Android-aligned remote-sync bookkeeping for that
+   category is disabled and cleared so manual restore/import does not masquerade as synchronized
+   remote state
+ */
+public final class AndroidDatabaseBackupService {
+    /**
+     Decodable shape of Android's manifest JSON before iOS normalizes optional fields.
+
+     Android backup manifests have evolved with optional `contains`, `manifestVersion`, and app
+     version fields. Keeping this DTO private lets `decodeManifest(from:)` preserve Android defaults
+     without making partially decoded manifests part of the public API.
+     */
+    private struct ManifestDTO: Decodable {
+        let backupType: String
+        let contains: Set<AndroidDatabaseBackupCategory>?
+        let manifestVersion: Int?
+        let andBibleVersion: Int?
+    }
+
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+    private let bookmarkRestoreService: RemoteSyncBookmarkRestoreService
+    private let bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService
+    private let readingPlanRestoreService: RemoteSyncReadingPlanRestoreService
+    private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
+    private let workspaceRestoreService: RemoteSyncWorkspaceRestoreService
+    private let myDocumentRestoreService: RemoteSyncMyDocumentRestoreService
+    private let myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService
+
+    /**
+     Creates an Android database backup service.
+
+     - Parameters:
+       - fileManager: File manager used for temporary extraction and cleanup.
+       - temporaryDirectory: Root scratch directory for extracted archive contents.
+       - bookmarkRestoreService: Bookmark restore engine for Android `bookmarks.sqlite3`.
+       - bookmarkSnapshotService: Bookmark snapshot engine used for non-destructive import merges.
+       - readingPlanRestoreService: Reading-plan restore engine for Android `readingplans.sqlite3`.
+       - readingPlanSnapshotService: Reading-plan snapshot engine used for import merges.
+       - workspaceRestoreService: Workspace restore engine for Android `workspaces.sqlite3`.
+       - myDocumentRestoreService: My Documents restore engine for Android `mydocuments.sqlite3`.
+       - myDocumentSnapshotService: My Documents snapshot engine used for import merges.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil,
+        bookmarkRestoreService: RemoteSyncBookmarkRestoreService = RemoteSyncBookmarkRestoreService(),
+        bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService = RemoteSyncBookmarkSnapshotService(),
+        readingPlanRestoreService: RemoteSyncReadingPlanRestoreService = RemoteSyncReadingPlanRestoreService(),
+        readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(),
+        workspaceRestoreService: RemoteSyncWorkspaceRestoreService = RemoteSyncWorkspaceRestoreService(),
+        myDocumentRestoreService: RemoteSyncMyDocumentRestoreService = RemoteSyncMyDocumentRestoreService(),
+        myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService()
+    ) {
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        self.bookmarkRestoreService = bookmarkRestoreService
+        self.bookmarkSnapshotService = bookmarkSnapshotService
+        self.readingPlanRestoreService = readingPlanRestoreService
+        self.readingPlanSnapshotService = readingPlanSnapshotService
+        self.workspaceRestoreService = workspaceRestoreService
+        self.myDocumentRestoreService = myDocumentRestoreService
+        self.myDocumentSnapshotService = myDocumentSnapshotService
+    }
+
+    /**
+     Loads and validates an Android `.abdb.zip` database backup archive.
+
+     - Parameter data: Raw backup archive bytes selected by the user.
+     - Returns: Loaded archive with extracted SQLite database sections.
+     - Side effects:
+       - creates one temporary directory
+       - writes recognized Android database entries into that directory
+       - opens each extracted SQLite file read-only to verify the header and `user_version`
+     - Failure modes:
+       - throws `AndroidDatabaseBackupError` for missing manifests, non-database backups, invalid
+         SQLite files, or archives without recognizable database sections
+       - throws file-system errors when temporary staging cannot be created
+     */
+    public func loadArchive(from data: Data) throws -> AndroidDatabaseBackupArchive {
+        let entries: [ZipArchiveEntry]
+        do {
+            entries = try ZipArchiveReader.entries(in: data)
+        } catch {
+            throw AndroidDatabaseBackupError.invalidArchive(String(describing: error))
+        }
+
+        var entriesByName: [String: Data] = [:]
+        for entry in entries {
+            entriesByName[entry.name] = entry.data
+        }
+        guard let manifestData = entriesByName["AndBibleBackupManifest.json"] else {
+            throw AndroidDatabaseBackupError.missingManifest
+        }
+        let manifest = try decodeManifest(from: manifestData)
+        guard manifest.backupType == "DB_BACKUP" else {
+            throw AndroidDatabaseBackupError.unsupportedBackupType(manifest.backupType)
+        }
+        guard manifest.manifestVersion <= 1 else {
+            throw AndroidDatabaseBackupError.unsupportedManifestVersion(manifest.manifestVersion)
+        }
+
+        let stagingDirectory = temporaryDirectory.appendingPathComponent(
+            "android-db-backup-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+
+        var sections: [AndroidDatabaseBackupSection] = []
+        do {
+            for category in AndroidDatabaseBackupCategory.databaseBackedCases {
+                guard let fileName = category.databaseFileName,
+                      let databaseData = entriesByName["db/\(fileName)"] else {
+                    continue
+                }
+
+                guard Self.hasSQLiteHeader(databaseData) else {
+                    throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
+                }
+
+                let databaseURL = stagingDirectory.appendingPathComponent(fileName)
+                try databaseData.write(to: databaseURL, options: .atomic)
+                let databaseVersion = try sqliteUserVersion(at: databaseURL, fileName: fileName)
+                let support = supportState(for: category, databaseVersion: databaseVersion)
+                sections.append(
+                    AndroidDatabaseBackupSection(
+                        category: category,
+                        fileName: fileName,
+                        databaseFileURL: databaseURL,
+                        databaseVersion: databaseVersion,
+                        declaredInManifest: manifest.contains.contains(category),
+                        support: support
+                    )
+                )
+            }
+            for category in manifest.contains
+                where category.databaseFileName == nil {
+                sections.append(
+                    AndroidDatabaseBackupSection(
+                        category: category,
+                        fileName: "",
+                        databaseFileURL: stagingDirectory,
+                        databaseVersion: 0,
+                        declaredInManifest: true,
+                        support: supportState(for: category, databaseVersion: 0)
+                    )
+                )
+            }
+
+            guard !sections.isEmpty else {
+                throw AndroidDatabaseBackupError.noValidDatabaseSections
+            }
+            return AndroidDatabaseBackupArchive(
+                manifest: manifest,
+                sections: sections.sorted { $0.category.displayName < $1.category.displayName },
+                temporaryDirectory: stagingDirectory
+            )
+        } catch {
+            try? fileManager.removeItem(at: stagingDirectory)
+            throw error
+        }
+    }
+
+    /**
+     Applies selected Android backup sections to local SwiftData.
+
+     - Parameters:
+       - archive: Previously loaded Android backup archive.
+       - selections: User-selected category/mode pairs.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Local-only settings store used by restore engines and sync-state reset.
+     - Returns: Per-section apply summaries.
+     - Side effects:
+       - mutates category data in `modelContext`
+       - writes or clears category-specific local-only fidelity state through `settingsStore`
+       - disables and clears Android-aligned remote-sync bookkeeping for every applied category
+     - Failure modes:
+       - throws when a selected section is missing, unsupported, malformed, or cannot be saved
+     */
+    public func apply(
+        archive: AndroidDatabaseBackupArchive,
+        selections: [AndroidDatabaseBackupSelection],
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> AndroidDatabaseBackupApplyReport {
+        guard !selections.isEmpty else {
+            throw AndroidDatabaseBackupError.emptySelection
+        }
+
+        let sectionsByCategory = Dictionary(uniqueKeysWithValues: archive.sections.map { ($0.category, $0) })
+        var reports: [AndroidDatabaseBackupAppliedSectionReport] = []
+        for selection in selections {
+            guard let section = sectionsByCategory[selection.category] else {
+                throw AndroidDatabaseBackupError.missingSelectedSection(selection.category)
+            }
+            guard section.support.isSupported else {
+                throw AndroidDatabaseBackupError.unsupportedSelectedSection(
+                    selection.category,
+                    section.support.explanation ?? "Unsupported by this iOS build."
+                )
+            }
+
+            let summary = try applySupportedSection(
+                section,
+                mode: selection.mode,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            if let category = section.category.remoteSyncCategory {
+                resetManualBackupSyncState(for: category, settingsStore: settingsStore)
+            }
+            reports.append(
+                AndroidDatabaseBackupAppliedSectionReport(
+                    category: section.category,
+                    mode: selection.mode,
+                    summary: summary
+                )
+            )
+        }
+
+        return AndroidDatabaseBackupApplyReport(sections: reports)
+    }
+
+    /**
+     Removes temporary files owned by a loaded archive.
+
+     - Parameter archive: Loaded archive whose temporary directory should be deleted.
+     - Side effects: deletes the archive staging directory when present.
+     - Failure modes: Delete errors are swallowed because cleanup is best effort.
+     */
+    public func cleanup(_ archive: AndroidDatabaseBackupArchive) {
+        try? fileManager.removeItem(at: archive.temporaryDirectory)
+    }
+
+    /**
+     Decodes Android's JSON backup manifest into the normalized manifest model.
+
+     - Parameter data: Raw `AndBibleBackupManifest.json` bytes.
+     - Returns: Manifest with missing optional fields normalized to Android-compatible defaults.
+     - Side effects: none.
+     - Failure modes: throws `AndroidDatabaseBackupError.invalidManifest` when JSON does not match
+       Android's manifest shape.
+     */
+    private func decodeManifest(from data: Data) throws -> AndroidDatabaseBackupManifest {
+        guard let dto = try? JSONDecoder().decode(ManifestDTO.self, from: data) else {
+            throw AndroidDatabaseBackupError.invalidManifest
+        }
+        return AndroidDatabaseBackupManifest(
+            backupType: dto.backupType,
+            contains: dto.contains ?? [],
+            manifestVersion: dto.manifestVersion ?? 1,
+            andBibleVersion: dto.andBibleVersion
+        )
+    }
+
+    /**
+     Determines whether this iOS build can safely apply one extracted Android database section.
+
+     - Parameters:
+       - category: Android backup category represented by the database.
+       - databaseVersion: SQLite `user_version` read from the extracted file.
+     - Returns: Supported state, unsupported-version state, or unsupported-category state.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func supportState(
+        for category: AndroidDatabaseBackupCategory,
+        databaseVersion: Int
+    ) -> AndroidDatabaseBackupSectionSupport {
+        if databaseVersion > category.supportedDatabaseVersion {
+            return .unsupportedVersion(version: databaseVersion, supported: category.supportedDatabaseVersion)
+        }
+        guard category.remoteSyncCategory != nil else {
+            return .unsupportedCategory("iOS does not yet have a safe mapper for Android \(category.displayName) data.")
+        }
+        return .supported
+    }
+
+    /**
+     Reads SQLite `PRAGMA user_version` from an extracted Android database file.
+
+     - Parameters:
+       - url: Extracted SQLite database URL.
+       - fileName: Android database filename used in thrown errors.
+     - Returns: Integer user-version marker.
+     - Side effects: opens the database read-only and finalizes its statement.
+     - Failure modes: throws `AndroidDatabaseBackupError.invalidSQLiteDatabase` if SQLite cannot
+       open or read the version pragma.
+     */
+    private func sqliteUserVersion(at url: URL, fileName: String) throws -> Int {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let database else {
+            if let database {
+                sqlite3_close(database)
+            }
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
+        }
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, "PRAGMA user_version;", -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            if let statement {
+                sqlite3_finalize(statement)
+            }
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
+        }
+        return Int(sqlite3_column_int(statement, 0))
+    }
+
+    /**
+     Checks the SQLite file magic before writing archive bytes to a staging path.
+
+     - Parameter data: Raw database entry bytes from the ZIP archive.
+     - Returns: `true` when the entry starts with SQLite's canonical header.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func hasSQLiteHeader(_ data: Data) -> Bool {
+        data.count >= 16 && Data(data.prefix(16)) == Data("SQLite format 3\u{0}".utf8)
+    }
+
+    /**
+     Dispatches a validated supported backup section to its category-specific restore/import path.
+
+     - Parameters:
+       - section: Supported section selected by the user.
+       - mode: Restore or Import operation.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Local settings store used by fidelity stores and sync reset.
+     - Returns: User-visible row summary for the section.
+     - Side effects: mutates local category data through the selected restore engine.
+     - Failure modes: rethrows category restore/import failures; unsupported categories throw
+       `AndroidDatabaseBackupError.unsupportedSelectedSection`.
+     */
+    private func applySupportedSection(
+        _ section: AndroidDatabaseBackupSection,
+        mode: AndroidDatabaseBackupApplyMode,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> String {
+        switch section.category {
+        case .bookmarks:
+            let report = try applyBookmarks(section, mode: mode, modelContext: modelContext, settingsStore: settingsStore)
+            return "\(report.restoredBibleBookmarkCount + report.restoredGenericBookmarkCount) bookmarks, \(report.restoredLabelCount) labels"
+        case .readingPlans:
+            let report = try applyReadingPlans(section, mode: mode, modelContext: modelContext, settingsStore: settingsStore)
+            return "\(report.restoredPlanCodes.count) reading plans"
+        case .workspaces:
+            let report = try applyWorkspaces(section, mode: mode, modelContext: modelContext, settingsStore: settingsStore)
+            return "\(report.restoredWorkspaceCount) workspaces, \(report.restoredWindowCount) windows"
+        case .myDocuments:
+            let report = try applyMyDocuments(
+                section,
+                mode: mode,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            return "\(report.restoredDocumentCount) documents, \(report.restoredPageCount) pages"
+        case .settings, .repositories, .modules, .epubs, .aiSettings, .progress:
+            throw AndroidDatabaseBackupError.unsupportedSelectedSection(
+                section.category,
+                section.support.explanation ?? "Unsupported by this iOS build."
+            )
+        }
+    }
+
+    /**
+     Applies Android bookmark backup rows using restore or local-first import semantics.
+
+     - Parameters:
+       - section: Extracted `bookmarks.sqlite3` section.
+       - mode: Restore replaces local bookmarks; Import adds missing Android rows only.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Settings store used for Android bookmark fidelity side stores.
+     - Returns: Bookmark restore report from the shared Android restore engine.
+     - Side effects: rewrites local bookmark SwiftData rows and bookmark fidelity settings.
+     - Failure modes: rethrows malformed Android database or SwiftData save failures.
+     */
+    private func applyBookmarks(
+        _ section: AndroidDatabaseBackupSection,
+        mode: AndroidDatabaseBackupApplyMode,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncBookmarkRestoreReport {
+        let backupSnapshot = try bookmarkRestoreService.readSnapshot(from: section.databaseFileURL)
+        let finalSnapshot: RemoteSyncAndroidBookmarkSnapshot
+        switch mode {
+        case .restore:
+            finalSnapshot = backupSnapshot
+        case .import:
+            finalSnapshot = mergeBookmarkSnapshots(
+                local: currentBookmarkSnapshot(modelContext: modelContext, settingsStore: settingsStore),
+                imported: backupSnapshot
+            )
+        }
+        return try bookmarkRestoreService.replaceLocalBookmarks(
+            from: finalSnapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Applies Android reading-plan backup rows using restore or local-first import semantics.
+
+     - Parameters:
+       - section: Extracted `readingplans.sqlite3` section.
+       - mode: Restore replaces local plans; Import adds missing plan/status rows only.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Settings store used for preserved Android status payloads.
+     - Returns: Reading-plan restore report from the shared Android restore engine.
+     - Side effects: rewrites local reading-plan SwiftData rows and preserved status settings.
+     - Failure modes: rethrows unsupported plan definitions, malformed status JSON, or save failures.
+     */
+    private func applyReadingPlans(
+        _ section: AndroidDatabaseBackupSection,
+        mode: AndroidDatabaseBackupApplyMode,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncReadingPlanRestoreReport {
+        let backupSnapshot = try readingPlanRestoreService.readSnapshot(from: section.databaseFileURL)
+        let finalSnapshot: RemoteSyncAndroidReadingPlanSnapshot
+        switch mode {
+        case .restore:
+            finalSnapshot = backupSnapshot
+        case .import:
+            finalSnapshot = mergeReadingPlanSnapshots(
+                local: currentReadingPlanSnapshot(modelContext: modelContext, settingsStore: settingsStore),
+                imported: backupSnapshot
+            )
+        }
+        return try readingPlanRestoreService.replaceLocalReadingPlans(
+            from: finalSnapshot,
+            modelContext: modelContext,
+            statusStore: RemoteSyncReadingPlanStatusStore(settingsStore: settingsStore)
+        )
+    }
+
+    /**
+     Applies Android workspace backup rows using restore or local-first import semantics.
+
+     - Parameters:
+       - section: Extracted `workspaces.sqlite3` section.
+       - mode: Restore replaces local workspaces; Import adds missing workspace/window/history rows.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Settings store used for Android workspace fidelity side stores.
+     - Returns: Workspace restore report from the shared Android restore engine.
+     - Side effects: rewrites local workspace SwiftData rows and workspace fidelity settings.
+     - Failure modes: rethrows malformed serialized values, orphan references, or save failures.
+     */
+    private func applyWorkspaces(
+        _ section: AndroidDatabaseBackupSection,
+        mode: AndroidDatabaseBackupApplyMode,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncWorkspaceRestoreReport {
+        let backupSnapshot = try workspaceRestoreService.readSnapshot(from: section.databaseFileURL)
+        let finalSnapshot: RemoteSyncAndroidWorkspaceSnapshot
+        switch mode {
+        case .restore:
+            finalSnapshot = backupSnapshot
+        case .import:
+            finalSnapshot = mergeWorkspaceSnapshots(
+                local: currentWorkspaceSnapshot(modelContext: modelContext, settingsStore: settingsStore),
+                imported: backupSnapshot
+            )
+        }
+        return try workspaceRestoreService.replaceLocalWorkspaces(
+            from: finalSnapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Applies Android My Documents backup rows using restore or local-first import semantics.
+
+     - Parameters:
+       - section: Extracted `mydocuments.sqlite3` section.
+       - mode: Restore replaces local documents; Import adds missing document/page/content rows.
+       - modelContext: SwiftData context to mutate.
+       - settingsStore: Settings store required for current-state Android key projection.
+     - Returns: My Documents restore report from the shared Android restore engine.
+     - Side effects: rewrites local My Documents SwiftData rows.
+     - Failure modes: rethrows Android database validation, current local snapshot, or save failures.
+     */
+    private func applyMyDocuments(
+        _ section: AndroidDatabaseBackupSection,
+        mode: AndroidDatabaseBackupApplyMode,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncMyDocumentRestoreReport {
+        let backupSnapshot = try myDocumentRestoreService.readSnapshot(from: section.databaseFileURL)
+        let finalSnapshot: RemoteSyncAndroidMyDocumentSnapshot
+        switch mode {
+        case .restore:
+            finalSnapshot = backupSnapshot
+        case .import:
+            finalSnapshot = try mergeMyDocumentSnapshots(
+                local: currentMyDocumentSnapshot(modelContext: modelContext, settingsStore: settingsStore),
+                imported: backupSnapshot
+            )
+        }
+        return try myDocumentRestoreService.replaceLocalMyDocuments(from: finalSnapshot, modelContext: modelContext)
+    }
+
+    /**
+     Clears Android-aligned remote-sync bookkeeping after a manual backup apply.
+
+     Manual Restore/Import changes local data outside the remote patch stream. Android disables and
+     clears affected sync state after such restores so later sync cannot treat the restored rows as
+     already reconciled remote state; iOS mirrors that category-scoped behavior here.
+
+     - Parameters:
+       - category: Remote-sync category affected by the manual backup operation.
+       - settingsStore: Settings store containing sync toggles and metadata rows.
+     - Side effects: disables sync and clears bootstrap, patch status, log-entry, and fingerprint
+       rows for the category.
+     - Failure modes: underlying settings-store writes are best effort.
+     */
+    private func resetManualBackupSyncState(for category: RemoteSyncCategory, settingsStore: SettingsStore) {
+        RemoteSyncSettingsStore(settingsStore: settingsStore).setSyncEnabled(false, for: category)
+        RemoteSyncStateStore(settingsStore: settingsStore).clearCategory(category)
+        RemoteSyncPatchStatusStore(settingsStore: settingsStore).clearCategory(category)
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).clearCategory(category)
+        RemoteSyncRowFingerprintStore(settingsStore: settingsStore).clearCategory(category)
+    }
+
+    /**
+     Reads current local bookmarks as a direct Android restore snapshot for Import merging.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns local bookmark rows.
+       - settingsStore: Settings store used for preserved Android bookmark fidelity.
+     - Returns: Android-shaped bookmark snapshot sorted deterministically.
+     - Side effects: reads SwiftData and local fidelity settings.
+     - Failure modes: underlying snapshot service treats fetch failures as an empty snapshot.
+     */
+    private func currentBookmarkSnapshot(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) -> RemoteSyncAndroidBookmarkSnapshot {
+        let current = bookmarkSnapshotService.snapshotCurrentState(modelContext: modelContext, settingsStore: settingsStore)
+        return RemoteSyncAndroidBookmarkSnapshot(
+            labels: current.labelRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            bibleBookmarks: current.bibleBookmarkRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            genericBookmarks: current.genericBookmarkRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            studyPadEntries: current.studyPadEntryRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString }
+        )
+    }
+
+    /**
+     Merges bookmark snapshots with Android Import's local-first uniqueness behavior.
+
+     - Parameters:
+       - local: Current local bookmark rows projected into Android form.
+       - imported: Backup bookmark rows read from Android's database.
+     - Returns: Snapshot containing every local row plus imported rows whose Android keys are absent.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail; system-label IDs are canonicalized during merge.
+     */
+    private func mergeBookmarkSnapshots(
+        local: RemoteSyncAndroidBookmarkSnapshot,
+        imported: RemoteSyncAndroidBookmarkSnapshot
+    ) -> RemoteSyncAndroidBookmarkSnapshot {
+        let systemLabelIDByName = [
+            Label.speakLabelName: Label.speakLabelId,
+            Label.unlabeledName: Label.unlabeledId,
+            Label.paragraphBreakLabelName: Label.paragraphBreakLabelId,
+        ]
+        let importedLabelIDMap = Dictionary(
+            uniqueKeysWithValues: imported.labels.map { label in
+                (label.id, systemLabelIDByName[label.name] ?? label.id)
+            }
+        )
+
+        var labelsByID = Dictionary(uniqueKeysWithValues: local.labels.map { ($0.id, $0) })
+        for label in imported.labels {
+            let mappedID = importedLabelIDMap[label.id] ?? label.id
+            guard labelsByID[mappedID] == nil else {
+                continue
+            }
+            labelsByID[mappedID] = RemoteSyncAndroidLabel(
+                id: mappedID,
+                name: label.name,
+                color: label.color,
+                markerStyle: label.markerStyle,
+                markerStyleWholeVerse: label.markerStyleWholeVerse,
+                underlineStyle: label.underlineStyle,
+                underlineStyleWholeVerse: label.underlineStyleWholeVerse,
+                hideStyle: label.hideStyle,
+                hideStyleWholeVerse: label.hideStyleWholeVerse,
+                favourite: label.favourite,
+                type: label.type,
+                customIcon: label.customIcon
+            )
+        }
+
+        var bibleBookmarksByID = Dictionary(uniqueKeysWithValues: local.bibleBookmarks.map { ($0.id, $0) })
+        for bookmark in imported.bibleBookmarks.map({ remapBookmarkLabels($0, using: importedLabelIDMap) }) {
+            if let existing = bibleBookmarksByID[bookmark.id] {
+                bibleBookmarksByID[bookmark.id] = mergeBibleBookmark(local: existing, imported: bookmark)
+            } else {
+                bibleBookmarksByID[bookmark.id] = bookmark
+            }
+        }
+
+        var genericBookmarksByID = Dictionary(uniqueKeysWithValues: local.genericBookmarks.map { ($0.id, $0) })
+        for bookmark in imported.genericBookmarks.map({ remapBookmarkLabels($0, using: importedLabelIDMap) }) {
+            if let existing = genericBookmarksByID[bookmark.id] {
+                genericBookmarksByID[bookmark.id] = mergeGenericBookmark(local: existing, imported: bookmark)
+            } else {
+                genericBookmarksByID[bookmark.id] = bookmark
+            }
+        }
+
+        var studyPadEntriesByID = Dictionary(uniqueKeysWithValues: local.studyPadEntries.map { ($0.id, $0) })
+        for entry in imported.studyPadEntries {
+            guard studyPadEntriesByID[entry.id] == nil else {
+                continue
+            }
+            studyPadEntriesByID[entry.id] = RemoteSyncAndroidStudyPadEntry(
+                id: entry.id,
+                labelID: importedLabelIDMap[entry.labelID] ?? entry.labelID,
+                orderNumber: entry.orderNumber,
+                indentLevel: entry.indentLevel,
+                text: entry.text
+            )
+        }
+
+        return RemoteSyncAndroidBookmarkSnapshot(
+            labels: labelsByID.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            bibleBookmarks: bibleBookmarksByID.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            genericBookmarks: genericBookmarksByID.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            studyPadEntries: studyPadEntriesByID.values.sorted { $0.id.uuidString < $1.id.uuidString }
+        )
+    }
+
+    /**
+     Rewrites imported Bible bookmark label references through canonical iOS system-label aliases.
+
+     - Parameters:
+       - bookmark: Imported Android Bible bookmark row.
+       - labelIDMap: Remote-to-local label ID map for Android system labels.
+     - Returns: Bookmark row whose primary label and label links reference local IDs.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func remapBookmarkLabels(
+        _ bookmark: RemoteSyncAndroidBibleBookmark,
+        using labelIDMap: [UUID: UUID]
+    ) -> RemoteSyncAndroidBibleBookmark {
+        RemoteSyncAndroidBibleBookmark(
+            id: bookmark.id,
+            kjvOrdinalStart: bookmark.kjvOrdinalStart,
+            kjvOrdinalEnd: bookmark.kjvOrdinalEnd,
+            ordinalStart: bookmark.ordinalStart,
+            ordinalEnd: bookmark.ordinalEnd,
+            v11n: bookmark.v11n,
+            playbackSettingsJSON: bookmark.playbackSettingsJSON,
+            createdAt: bookmark.createdAt,
+            book: bookmark.book,
+            startOffset: bookmark.startOffset,
+            endOffset: bookmark.endOffset,
+            primaryLabelID: bookmark.primaryLabelID.map { labelIDMap[$0] ?? $0 },
+            notes: bookmark.notes,
+            lastUpdatedOn: bookmark.lastUpdatedOn,
+            wholeVerse: bookmark.wholeVerse,
+            type: bookmark.type,
+            customIcon: bookmark.customIcon,
+            editAction: bookmark.editAction,
+            labelLinks: bookmark.labelLinks.map {
+                RemoteSyncAndroidBookmarkLabelLink(
+                    labelID: labelIDMap[$0.labelID] ?? $0.labelID,
+                    orderNumber: $0.orderNumber,
+                    indentLevel: $0.indentLevel,
+                    expandContent: $0.expandContent
+                )
+            }
+        )
+    }
+
+    /**
+     Rewrites imported generic bookmark label references through canonical iOS system-label aliases.
+
+     - Parameters:
+       - bookmark: Imported Android generic bookmark row.
+       - labelIDMap: Remote-to-local label ID map for Android system labels.
+     - Returns: Bookmark row whose primary label and label links reference local IDs.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func remapBookmarkLabels(
+        _ bookmark: RemoteSyncAndroidGenericBookmark,
+        using labelIDMap: [UUID: UUID]
+    ) -> RemoteSyncAndroidGenericBookmark {
+        RemoteSyncAndroidGenericBookmark(
+            id: bookmark.id,
+            key: bookmark.key,
+            createdAt: bookmark.createdAt,
+            bookInitials: bookmark.bookInitials,
+            ordinalStart: bookmark.ordinalStart,
+            ordinalEnd: bookmark.ordinalEnd,
+            startOffset: bookmark.startOffset,
+            endOffset: bookmark.endOffset,
+            primaryLabelID: bookmark.primaryLabelID.map { labelIDMap[$0] ?? $0 },
+            notes: bookmark.notes,
+            lastUpdatedOn: bookmark.lastUpdatedOn,
+            wholeVerse: bookmark.wholeVerse,
+            playbackSettingsJSON: bookmark.playbackSettingsJSON,
+            customIcon: bookmark.customIcon,
+            editAction: bookmark.editAction,
+            labelLinks: bookmark.labelLinks.map {
+                RemoteSyncAndroidBookmarkLabelLink(
+                    labelID: labelIDMap[$0.labelID] ?? $0.labelID,
+                    orderNumber: $0.orderNumber,
+                    indentLevel: $0.indentLevel,
+                    expandContent: $0.expandContent
+                )
+            }
+        )
+    }
+
+    /**
+     Merges a duplicate Bible bookmark using Android Import's "keep existing row" semantics.
+
+     - Parameters:
+       - local: Existing local Android-shaped bookmark row.
+       - imported: Imported row with the same Android bookmark ID.
+     - Returns: Local row with only missing optional fidelity filled from the imported row.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeBibleBookmark(
+        local: RemoteSyncAndroidBibleBookmark,
+        imported: RemoteSyncAndroidBibleBookmark
+    ) -> RemoteSyncAndroidBibleBookmark {
+        RemoteSyncAndroidBibleBookmark(
+            id: local.id,
+            kjvOrdinalStart: local.kjvOrdinalStart,
+            kjvOrdinalEnd: local.kjvOrdinalEnd,
+            ordinalStart: local.ordinalStart,
+            ordinalEnd: local.ordinalEnd,
+            v11n: local.v11n,
+            playbackSettingsJSON: local.playbackSettingsJSON ?? imported.playbackSettingsJSON,
+            createdAt: local.createdAt,
+            book: local.book,
+            startOffset: local.startOffset,
+            endOffset: local.endOffset,
+            primaryLabelID: local.primaryLabelID ?? imported.primaryLabelID,
+            notes: local.notes ?? imported.notes,
+            lastUpdatedOn: local.lastUpdatedOn,
+            wholeVerse: local.wholeVerse,
+            type: local.type,
+            customIcon: local.customIcon,
+            editAction: local.editAction,
+            labelLinks: mergeLabelLinks(local: local.labelLinks, imported: imported.labelLinks)
+        )
+    }
+
+    /**
+     Merges a duplicate generic bookmark using Android Import's "keep existing row" semantics.
+
+     - Parameters:
+       - local: Existing local Android-shaped generic bookmark row.
+       - imported: Imported row with the same Android bookmark ID.
+     - Returns: Local row with only missing optional fidelity filled from the imported row.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeGenericBookmark(
+        local: RemoteSyncAndroidGenericBookmark,
+        imported: RemoteSyncAndroidGenericBookmark
+    ) -> RemoteSyncAndroidGenericBookmark {
+        RemoteSyncAndroidGenericBookmark(
+            id: local.id,
+            key: local.key,
+            createdAt: local.createdAt,
+            bookInitials: local.bookInitials,
+            ordinalStart: local.ordinalStart,
+            ordinalEnd: local.ordinalEnd,
+            startOffset: local.startOffset,
+            endOffset: local.endOffset,
+            primaryLabelID: local.primaryLabelID ?? imported.primaryLabelID,
+            notes: local.notes ?? imported.notes,
+            lastUpdatedOn: local.lastUpdatedOn,
+            wholeVerse: local.wholeVerse,
+            playbackSettingsJSON: local.playbackSettingsJSON ?? imported.playbackSettingsJSON,
+            customIcon: local.customIcon,
+            editAction: local.editAction,
+            labelLinks: mergeLabelLinks(local: local.labelLinks, imported: imported.labelLinks)
+        )
+    }
+
+    /**
+     Unions bookmark label links without replacing existing local link metadata.
+
+     - Parameters:
+       - local: Existing label links for one bookmark.
+       - imported: Imported label links for the same bookmark.
+     - Returns: Deterministically sorted links keyed by label ID.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeLabelLinks(
+        local: [RemoteSyncAndroidBookmarkLabelLink],
+        imported: [RemoteSyncAndroidBookmarkLabelLink]
+    ) -> [RemoteSyncAndroidBookmarkLabelLink] {
+        var linksByLabelID = Dictionary(uniqueKeysWithValues: local.map { ($0.labelID, $0) })
+        for link in imported where linksByLabelID[link.labelID] == nil {
+            linksByLabelID[link.labelID] = link
+        }
+        return linksByLabelID.values.sorted { $0.labelID.uuidString < $1.labelID.uuidString }
+    }
+
+    /**
+     Reads current local reading plans as a direct Android restore snapshot for Import merging.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns local reading-plan rows.
+       - settingsStore: Settings store containing preserved Android status payloads.
+     - Returns: Android-shaped reading-plan snapshot.
+     - Side effects: reads SwiftData and local status-fidelity settings.
+     - Failure modes: underlying snapshot service treats fetch failures as an empty snapshot.
+     */
+    private func currentReadingPlanSnapshot(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) -> RemoteSyncAndroidReadingPlanSnapshot {
+        let current = readingPlanSnapshotService.snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let statuses = current.statusRowsByKey.values.map {
+            RemoteSyncAndroidReadingPlanStatus(
+                id: $0.id,
+                planCode: $0.planCode,
+                dayNumber: $0.planDay,
+                readingStatusJSON: $0.readingStatusJSON
+            )
+        }
+        let statusesByPlanCode = Dictionary(grouping: statuses, by: \.planCode)
+        let plans = current.planRowsByKey.values.map { row in
+            RemoteSyncAndroidReadingPlan(
+                id: row.id,
+                planCode: row.planCode,
+                startDate: Date(timeIntervalSince1970: Double(row.planStartDateMillis) / 1000.0),
+                currentDay: row.planCurrentDay,
+                statuses: statusesByPlanCode[row.planCode, default: []]
+            )
+        }
+        return RemoteSyncAndroidReadingPlanSnapshot(plans: plans, orphanStatuses: [])
+    }
+
+    /**
+     Reads current local My Documents as a direct Android restore snapshot for Import merging.
+
+     This path uses the throwing snapshot variant because treating a failed local fetch as empty
+     would make Import behave like Restore and risk data loss.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns local My Documents rows.
+       - settingsStore: Settings store used for Android log-key projection.
+     - Returns: Android-shaped My Documents snapshot.
+     - Side effects: reads SwiftData rows.
+     - Failure modes: rethrows SwiftData fetch failures from the snapshot service.
+     */
+    private func currentMyDocumentSnapshot(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAndroidMyDocumentSnapshot {
+        let current = try myDocumentSnapshotService.snapshotCurrentStateThrowing(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        return RemoteSyncAndroidMyDocumentSnapshot(
+            documents: current.documentRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            pages: current.pageRowsByKey.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            pageContents: current.pageContentRowsByKey.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            aiPageCacheEntries: current.aiPageCacheEntryRowsByKey.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            orphanReferences: []
+        )
+    }
+
+    /**
+     Merges reading-plan snapshots with Android Import's local-first uniqueness behavior.
+
+     - Parameters:
+       - local: Current local reading-plan rows projected into Android form.
+       - imported: Backup reading-plan rows read from Android's database.
+     - Returns: Snapshot preserving local plans/statuses and adding imported missing rows.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeReadingPlanSnapshots(
+        local: RemoteSyncAndroidReadingPlanSnapshot,
+        imported: RemoteSyncAndroidReadingPlanSnapshot
+    ) -> RemoteSyncAndroidReadingPlanSnapshot {
+        var plansByCode = Dictionary(uniqueKeysWithValues: local.plans.map { ($0.planCode, $0) })
+        for plan in imported.plans where plansByCode[plan.planCode] == nil {
+            plansByCode[plan.planCode] = plan
+        }
+
+        var statusesByKey: [String: RemoteSyncAndroidReadingPlanStatus] = [:]
+        for status in local.plans.flatMap(\.statuses) {
+            statusesByKey["\(status.planCode)#\(status.dayNumber)"] = status
+        }
+        for status in imported.plans.flatMap(\.statuses) where statusesByKey["\(status.planCode)#\(status.dayNumber)"] == nil {
+            statusesByKey["\(status.planCode)#\(status.dayNumber)"] = status
+        }
+        let statusesByPlanCode = Dictionary(grouping: statusesByKey.values, by: \.planCode)
+        let plans = plansByCode.values.map { plan in
+            RemoteSyncAndroidReadingPlan(
+                id: plan.id,
+                planCode: plan.planCode,
+                startDate: plan.startDate,
+                currentDay: plan.currentDay,
+                statuses: statusesByPlanCode[plan.planCode, default: []].sorted { $0.dayNumber < $1.dayNumber }
+            )
+        }
+        return RemoteSyncAndroidReadingPlanSnapshot(
+            plans: plans.sorted { $0.planCode < $1.planCode },
+            orphanStatuses: []
+        )
+    }
+
+    /**
+     Reads current local workspaces as a direct Android restore snapshot for Import merging.
+
+     The local model does not store Android history IDs directly, so the workspace fidelity store is
+     used when available and deterministic negative IDs are assigned for local-only history rows.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns workspace, window, page-manager, and history rows.
+       - settingsStore: Settings store containing Android workspace fidelity aliases.
+     - Returns: Android-shaped workspace snapshot sorted in display order.
+     - Side effects: reads SwiftData and workspace fidelity settings.
+     - Failure modes: SwiftData fetch failures are treated as an empty workspace list, matching the
+       existing non-throwing outbound snapshot style.
+     */
+    private func currentWorkspaceSnapshot(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) -> RemoteSyncAndroidWorkspaceSnapshot {
+        let fidelityStore = RemoteSyncWorkspaceFidelityStore(settingsStore: settingsStore)
+        let workspaceFidelityByID = Dictionary(
+            uniqueKeysWithValues: fidelityStore.allWorkspaceEntries().map { ($0.workspaceID, $0) }
+        )
+        let pageManagerFidelityByWindowID = Dictionary(
+            uniqueKeysWithValues: fidelityStore.allPageManagerEntries().map { ($0.windowID, $0) }
+        )
+        let historyAliasByLocalID = Dictionary(
+            uniqueKeysWithValues: fidelityStore.allHistoryItemAliases().map { ($0.localHistoryItemID, $0.remoteHistoryItemID) }
+        )
+        let workspaces = ((try? modelContext.fetch(FetchDescriptor<Workspace>())) ?? [])
+            .sorted { lhs, rhs in
+                if lhs.orderNumber == rhs.orderNumber {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.orderNumber < rhs.orderNumber
+            }
+
+        var generatedRemoteHistoryID: Int64 = -1
+        let androidWorkspaces = workspaces.map { workspace in
+            let windows = (workspace.windows ?? []).sorted { lhs, rhs in
+                if lhs.orderNumber == rhs.orderNumber {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.orderNumber < rhs.orderNumber
+            }.map { window in
+                let pageManager = window.pageManager
+                let pageFidelity = pageManagerFidelityByWindowID[window.id]
+                let androidPageManager = RemoteSyncAndroidWorkspacePageManager(
+                    windowID: window.id,
+                    bibleDocument: pageManager?.bibleDocument,
+                    bibleVersification: pageManager?.bibleVersification,
+                    bibleBook: pageManager?.bibleBibleBook,
+                    bibleChapterNo: pageManager?.bibleChapterNo,
+                    bibleVerseNo: pageManager?.bibleVerseNo,
+                    commentaryDocument: pageManager?.commentaryDocument,
+                    commentaryAnchorOrdinal: pageManager?.commentaryAnchorOrdinal,
+                    commentarySourceBookAndKey: pageFidelity?.commentarySourceBookAndKey,
+                    dictionaryDocument: pageManager?.dictionaryDocument,
+                    dictionaryKey: pageManager?.dictionaryKey,
+                    dictionaryAnchorOrdinal: pageFidelity?.dictionaryAnchorOrdinal,
+                    generalBookDocument: pageManager?.generalBookDocument,
+                    generalBookKey: pageManager?.generalBookKey,
+                    generalBookAnchorOrdinal: pageFidelity?.generalBookAnchorOrdinal,
+                    mapDocument: pageManager?.mapDocument,
+                    mapKey: pageManager?.mapKey,
+                    mapAnchorOrdinal: pageFidelity?.mapAnchorOrdinal,
+                    currentCategoryName: pageFidelity?.rawCurrentCategoryName
+                        ?? (pageManager?.currentCategoryName.uppercased() ?? "BIBLE"),
+                    textDisplaySettings: pageManager?.textDisplaySettings,
+                    jsState: pageManager?.jsState
+                )
+                let historyItems = (window.historyItems ?? []).sorted { lhs, rhs in
+                    if lhs.createdAt == rhs.createdAt {
+                        return lhs.id.uuidString < rhs.id.uuidString
+                    }
+                    return lhs.createdAt < rhs.createdAt
+                }.map { item in
+                    let remoteID = historyAliasByLocalID[item.id] ?? {
+                        defer { generatedRemoteHistoryID -= 1 }
+                        return generatedRemoteHistoryID
+                    }()
+                    return RemoteSyncAndroidWorkspaceHistoryItem(
+                        remoteID: remoteID,
+                        windowID: window.id,
+                        createdAt: item.createdAt,
+                        document: item.document,
+                        key: item.key,
+                        anchorOrdinal: item.anchorOrdinal
+                    )
+                }
+                return RemoteSyncAndroidWorkspaceWindow(
+                    id: window.id,
+                    workspaceID: workspace.id,
+                    isSynchronized: window.isSynchronized,
+                    isPinMode: window.isPinMode,
+                    isLinksWindow: window.isLinksWindow,
+                    orderNumber: window.orderNumber,
+                    targetLinksWindowID: window.targetLinksWindowId,
+                    syncGroup: window.syncGroup,
+                    layoutState: window.layoutState,
+                    layoutWeight: window.layoutWeight,
+                    pageManager: androidPageManager,
+                    historyItems: historyItems
+                )
+            }
+            return RemoteSyncAndroidWorkspace(
+                id: workspace.id,
+                name: workspace.name,
+                contentsText: workspace.contentsText,
+                orderNumber: workspace.orderNumber,
+                textDisplaySettings: workspace.textDisplaySettings,
+                workspaceSettings: workspace.workspaceSettings ?? WorkspaceSettings(),
+                speakSettingsJSON: workspaceFidelityByID[workspace.id]?.speakSettingsJSON,
+                unPinnedWeight: workspace.unPinnedWeight,
+                maximizedWindowID: workspace.maximizedWindowId,
+                primaryTargetLinksWindowID: workspace.primaryTargetLinksWindowId,
+                workspaceColor: workspace.workspaceColor,
+                windows: windows
+            )
+        }
+        return RemoteSyncAndroidWorkspaceSnapshot(workspaces: androidWorkspaces)
+    }
+
+    /**
+     Merges workspace snapshots with Android Import's local-first uniqueness behavior.
+
+     - Parameters:
+       - local: Current local workspace rows projected into Android form.
+       - imported: Backup workspace rows read from Android's database.
+     - Returns: Snapshot preserving local workspaces/windows and adding imported missing children.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeWorkspaceSnapshots(
+        local: RemoteSyncAndroidWorkspaceSnapshot,
+        imported: RemoteSyncAndroidWorkspaceSnapshot
+    ) -> RemoteSyncAndroidWorkspaceSnapshot {
+        var workspacesByID = Dictionary(uniqueKeysWithValues: local.workspaces.map { ($0.id, $0) })
+        for workspace in imported.workspaces {
+            if let existing = workspacesByID[workspace.id] {
+                workspacesByID[workspace.id] = mergeWorkspace(local: existing, imported: workspace)
+            } else {
+                workspacesByID[workspace.id] = workspace
+            }
+        }
+        return RemoteSyncAndroidWorkspaceSnapshot(
+            workspaces: workspacesByID.values.sorted {
+                if $0.orderNumber == $1.orderNumber {
+                    return $0.id.uuidString < $1.id.uuidString
+                }
+                return $0.orderNumber < $1.orderNumber
+            }
+        )
+    }
+
+    /**
+     Merges one duplicate workspace while preserving local workspace-level fields.
+
+     - Parameters:
+       - local: Existing local Android-shaped workspace.
+       - imported: Imported workspace with the same ID.
+     - Returns: Workspace with local metadata and unioned windows/history.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeWorkspace(
+        local: RemoteSyncAndroidWorkspace,
+        imported: RemoteSyncAndroidWorkspace
+    ) -> RemoteSyncAndroidWorkspace {
+        var windowsByID = Dictionary(uniqueKeysWithValues: local.windows.map { ($0.id, $0) })
+        for window in imported.windows {
+            if let existing = windowsByID[window.id] {
+                windowsByID[window.id] = mergeWorkspaceWindow(local: existing, imported: window)
+            } else {
+                windowsByID[window.id] = window
+            }
+        }
+        return RemoteSyncAndroidWorkspace(
+            id: local.id,
+            name: local.name,
+            contentsText: local.contentsText,
+            orderNumber: local.orderNumber,
+            textDisplaySettings: local.textDisplaySettings,
+            workspaceSettings: local.workspaceSettings,
+            speakSettingsJSON: local.speakSettingsJSON ?? imported.speakSettingsJSON,
+            unPinnedWeight: local.unPinnedWeight,
+            maximizedWindowID: local.maximizedWindowID,
+            primaryTargetLinksWindowID: local.primaryTargetLinksWindowID,
+            workspaceColor: local.workspaceColor,
+            windows: windowsByID.values.sorted {
+                if $0.orderNumber == $1.orderNumber {
+                    return $0.id.uuidString < $1.id.uuidString
+                }
+                return $0.orderNumber < $1.orderNumber
+            }
+        )
+    }
+
+    /**
+     Merges one duplicate workspace window while preserving local page-manager state.
+
+     - Parameters:
+       - local: Existing local Android-shaped window.
+       - imported: Imported window with the same ID.
+     - Returns: Window with local fields and imported missing history rows.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func mergeWorkspaceWindow(
+        local: RemoteSyncAndroidWorkspaceWindow,
+        imported: RemoteSyncAndroidWorkspaceWindow
+    ) -> RemoteSyncAndroidWorkspaceWindow {
+        var historyByRemoteID = Dictionary(uniqueKeysWithValues: local.historyItems.map { ($0.remoteID, $0) })
+        for history in imported.historyItems where historyByRemoteID[history.remoteID] == nil {
+            historyByRemoteID[history.remoteID] = history
+        }
+        return RemoteSyncAndroidWorkspaceWindow(
+            id: local.id,
+            workspaceID: local.workspaceID,
+            isSynchronized: local.isSynchronized,
+            isPinMode: local.isPinMode,
+            isLinksWindow: local.isLinksWindow,
+            orderNumber: local.orderNumber,
+            targetLinksWindowID: local.targetLinksWindowID,
+            syncGroup: local.syncGroup,
+            layoutState: local.layoutState,
+            layoutWeight: local.layoutWeight,
+            pageManager: local.pageManager,
+            historyItems: historyByRemoteID.values.sorted {
+                if $0.createdAt == $1.createdAt {
+                    return $0.remoteID < $1.remoteID
+                }
+                return $0.createdAt < $1.createdAt
+            }
+        )
+    }
+
+    /**
+     Merges My Documents snapshots with Android Import's local-first uniqueness behavior.
+
+     Document IDs, document initials, page IDs, page keys, content page IDs, and cache page IDs are
+     treated as Android uniqueness boundaries. Imported children whose parent rows are not present
+     after the merge are skipped to preserve Android foreign-key safety.
+
+     - Parameters:
+       - local: Current local My Documents rows projected into Android form.
+       - imported: Backup My Documents rows read from Android's database.
+     - Returns: Snapshot preserving local rows and adding imported rows whose uniqueness keys are
+       absent and whose parents exist.
+     - Side effects: none.
+     - Failure modes: This helper currently cannot fail; it is marked throwing to preserve room for
+       stricter validation without changing callers.
+     */
+    private func mergeMyDocumentSnapshots(
+        local: RemoteSyncAndroidMyDocumentSnapshot,
+        imported: RemoteSyncAndroidMyDocumentSnapshot
+    ) throws -> RemoteSyncAndroidMyDocumentSnapshot {
+        var documentsByID = Dictionary(uniqueKeysWithValues: local.documents.map { ($0.id, $0) })
+        var documentInitials = Set(local.documents.map(\.initials))
+        for document in imported.documents where documentsByID[document.id] == nil && !documentInitials.contains(document.initials) {
+            documentsByID[document.id] = document
+            documentInitials.insert(document.initials)
+        }
+
+        var pagesByID = Dictionary(uniqueKeysWithValues: local.pages.map { ($0.id, $0) })
+        var pageKeys = Set(local.pages.map { "\($0.documentId.uuidString)#\($0.pageKey)" })
+        let validDocumentIDs = Set(documentsByID.keys)
+        for page in imported.pages
+            where pagesByID[page.id] == nil
+                && validDocumentIDs.contains(page.documentId)
+                && !pageKeys.contains("\(page.documentId.uuidString)#\(page.pageKey)") {
+            pagesByID[page.id] = page
+            pageKeys.insert("\(page.documentId.uuidString)#\(page.pageKey)")
+        }
+
+        var contentsByPageID = Dictionary(uniqueKeysWithValues: local.pageContents.map { ($0.pageId, $0) })
+        let validPageIDs = Set(pagesByID.keys)
+        for content in imported.pageContents where contentsByPageID[content.pageId] == nil && validPageIDs.contains(content.pageId) {
+            contentsByPageID[content.pageId] = content
+        }
+
+        var cacheEntriesByPageID = Dictionary(uniqueKeysWithValues: local.aiPageCacheEntries.map { ($0.pageId, $0) })
+        for cacheEntry in imported.aiPageCacheEntries where cacheEntriesByPageID[cacheEntry.pageId] == nil && validPageIDs.contains(cacheEntry.pageId) {
+            cacheEntriesByPageID[cacheEntry.pageId] = cacheEntry
+        }
+
+        return RemoteSyncAndroidMyDocumentSnapshot(
+            documents: documentsByID.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            pages: pagesByID.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            pageContents: contentsByPageID.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            aiPageCacheEntries: cacheEntriesByPageID.values.sorted { $0.pageId.uuidString < $1.pageId.uuidString },
+            orphanReferences: []
+        )
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -598,14 +598,18 @@ public final class AndroidDatabaseBackupService {
      - Failure modes:
        - throws `AndroidDatabaseBackupError` for missing manifests, non-database backups, invalid
          SQLite files, or archives without recognizable database sections
+       - maps ZIP parser failures into user-facing archive reasons before surfacing them through
+         Settings status text
        - throws file-system errors when temporary staging cannot be created
      */
     public func loadArchive(from data: Data) throws -> AndroidDatabaseBackupArchive {
         let entries: [ZipArchiveEntry]
         do {
             entries = try ZipArchiveReader.entries(in: data)
+        } catch let error as ZipArchiveReaderError {
+            throw AndroidDatabaseBackupError.invalidArchive(Self.archiveErrorMessage(for: error))
         } catch {
-            throw AndroidDatabaseBackupError.invalidArchive(String(describing: error))
+            throw AndroidDatabaseBackupError.invalidArchive(error.localizedDescription)
         }
 
         var entriesByName: [String: Data] = [:]
@@ -774,6 +778,31 @@ public final class AndroidDatabaseBackupService {
             manifestVersion: dto.manifestVersion ?? 1,
             andBibleVersion: dto.andBibleVersion
         )
+    }
+
+    /**
+     Converts low-level ZIP parser errors into Settings-safe archive failure messages.
+
+     `ZipArchiveReaderError` is useful for tests and parser internals but its enum case names are
+     not suitable for user-facing import status text. This mapper preserves concrete malformed
+     archive reasons while replacing enum-only failures with concise explanations.
+
+     - Parameter error: ZIP parser error raised while loading an Android backup file.
+     - Returns: User-facing archive error detail used by `AndroidDatabaseBackupError.invalidArchive`.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func archiveErrorMessage(for error: ZipArchiveReaderError) -> String {
+        switch error {
+        case .missingCentralDirectory:
+            return "The file is not a ZIP archive or its central directory is missing."
+        case .invalidArchive(let reason):
+            return reason
+        case .unsupportedCompressionMethod(let method):
+            return "ZIP entry uses unsupported compression method \(method)."
+        case .decompressionFailed:
+            return "A compressed ZIP entry could not be decompressed."
+        }
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -505,13 +505,37 @@ public final class AndroidDatabaseBackupService {
 
      Android backup manifests have evolved with optional `contains`, `manifestVersion`, and app
      version fields. Keeping this DTO private lets `decodeManifest(from:)` preserve Android defaults
-     without making partially decoded manifests part of the public API.
+     without making partially decoded manifests part of the public API. Unknown `contains` values
+     are ignored so future Android-only categories do not block restore of known database sections.
      */
     private struct ManifestDTO: Decodable {
         let backupType: String
-        let contains: Set<AndroidDatabaseBackupCategory>?
+        let contains: Set<AndroidDatabaseBackupCategory>
         let manifestVersion: Int?
         let andBibleVersion: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case backupType
+            case contains
+            case manifestVersion
+            case andBibleVersion
+        }
+
+        /**
+         Decodes Android's manifest while preserving known categories and skipping future ones.
+
+         - Parameter decoder: JSON decoder input for `AndBibleBackupManifest.json`.
+         - Side effects: none.
+         - Failure modes: Throws when required manifest fields are missing or have invalid types.
+         */
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            backupType = try container.decode(String.self, forKey: .backupType)
+            let rawContains = try container.decodeIfPresent([String].self, forKey: .contains) ?? []
+            contains = Set(rawContains.compactMap(AndroidDatabaseBackupCategory.init(rawValue:)))
+            manifestVersion = try container.decodeIfPresent(Int.self, forKey: .manifestVersion)
+            andBibleVersion = try container.decodeIfPresent(Int.self, forKey: .andBibleVersion)
+        }
     }
 
     private let fileManager: FileManager
@@ -746,7 +770,7 @@ public final class AndroidDatabaseBackupService {
         }
         return AndroidDatabaseBackupManifest(
             backupType: dto.backupType,
-            contains: dto.contains ?? [],
+            contains: dto.contains,
             manifestVersion: dto.manifestVersion ?? 1,
             andBibleVersion: dto.andBibleVersion
         )

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -97,6 +97,8 @@ public enum ZipArchiveReader {
      - Failure modes:
        - throws `ZipArchiveReaderError.missingCentralDirectory` when the archive is not ZIP-shaped
        - throws `ZipArchiveReaderError.invalidArchive` when a header is truncated or inconsistent
+       - throws `ZipArchiveReaderError.invalidArchive` when the end record describes a spanned
+         archive instead of the single-disk ZIP shape Android backups use
        - throws `ZipArchiveReaderError.invalidArchive` when declared entry/archive sizes exceed
          the eager extraction limits
        - throws `ZipArchiveReaderError.invalidArchive` when materialized entry sizes do not match
@@ -106,6 +108,8 @@ public enum ZipArchiveReader {
      */
     public static func entries(in data: Data) throws -> [ZipArchiveEntry] {
         let endRecordOffset = try endOfCentralDirectoryOffset(in: data)
+        let diskNumberRaw = readUInt16(data, at: endRecordOffset + 4)
+        let centralDirectoryDiskRaw = readUInt16(data, at: endRecordOffset + 6)
         let diskEntryCountRaw = readUInt16(data, at: endRecordOffset + 8)
         let entryCountRaw = readUInt16(data, at: endRecordOffset + 10)
         let centralDirectorySizeRaw = readUInt32(data, at: endRecordOffset + 12)
@@ -116,6 +120,11 @@ public enum ZipArchiveReader {
               centralDirectorySizeRaw != zip64Sentinel,
               centralDirectoryOffsetRaw != zip64Sentinel else {
             throw ZipArchiveReaderError.invalidArchive("ZIP64 archives are not supported")
+        }
+        guard diskNumberRaw == 0,
+              centralDirectoryDiskRaw == 0,
+              diskEntryCountRaw == entryCountRaw else {
+            throw ZipArchiveReaderError.invalidArchive("Multi-disk ZIP archives are not supported")
         }
         let entryCount = Int(entryCountRaw)
         let centralDirectorySize = Int(centralDirectorySizeRaw)

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -65,6 +65,7 @@ public enum ZipArchiveReader {
     private static let centralDirectoryHeaderSignature: UInt32 = 0x0201_4b50
     private static let endOfCentralDirectorySignature: UInt32 = 0x0605_4b50
     private static let zip64Sentinel: UInt32 = 0xffff_ffff
+    private static let zip64EntryCountSentinel: UInt16 = 0xffff
 
     /**
      Extracts supported file entries from raw ZIP data.
@@ -80,13 +81,19 @@ public enum ZipArchiveReader {
      */
     public static func entries(in data: Data) throws -> [ZipArchiveEntry] {
         let endRecordOffset = try endOfCentralDirectoryOffset(in: data)
-        let entryCount = Int(readUInt16(data, at: endRecordOffset + 10))
-        let centralDirectorySize = Int(readUInt32(data, at: endRecordOffset + 12))
+        let diskEntryCountRaw = readUInt16(data, at: endRecordOffset + 8)
+        let entryCountRaw = readUInt16(data, at: endRecordOffset + 10)
+        let centralDirectorySizeRaw = readUInt32(data, at: endRecordOffset + 12)
         let centralDirectoryOffsetRaw = readUInt32(data, at: endRecordOffset + 16)
 
-        guard centralDirectoryOffsetRaw != zip64Sentinel else {
+        guard diskEntryCountRaw != zip64EntryCountSentinel,
+              entryCountRaw != zip64EntryCountSentinel,
+              centralDirectorySizeRaw != zip64Sentinel,
+              centralDirectoryOffsetRaw != zip64Sentinel else {
             throw ZipArchiveReaderError.invalidArchive("ZIP64 archives are not supported")
         }
+        let entryCount = Int(entryCountRaw)
+        let centralDirectorySize = Int(centralDirectorySizeRaw)
         let centralDirectoryOffset = Int(centralDirectoryOffsetRaw)
         guard centralDirectoryOffset >= 0,
               centralDirectorySize >= 0,

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -8,8 +8,8 @@ import Foundation
 
  The reader is intentionally small and supports the ZIP shapes AndBible consumes locally:
  central-directory based stored or deflated file entries. Unsupported compression methods and
- malformed offsets are rejected explicitly so callers can surface actionable archive errors instead
- of treating missing entries as valid empty archives.
+ malformed offsets/sizes are rejected explicitly so callers can surface actionable archive errors
+ instead of treating missing entries as valid empty archives.
  */
 public enum ZipArchiveReaderError: Error, Equatable {
     /// The archive did not contain a readable ZIP end-of-central-directory record.
@@ -66,9 +66,19 @@ public enum ZipArchiveReader {
     private static let endOfCentralDirectorySignature: UInt32 = 0x0605_4b50
     private static let zip64Sentinel: UInt32 = 0xffff_ffff
     private static let zip64EntryCountSentinel: UInt16 = 0xffff
+    /// Maximum compressed or uncompressed bytes accepted for one eagerly materialized entry.
+    private static let maximumEntryByteCount = 256 * 1024 * 1024
+    /// Maximum compressed bytes accepted across all extracted entries.
+    private static let maximumTotalCompressedByteCount = 512 * 1024 * 1024
+    /// Maximum uncompressed bytes accepted across all extracted entries.
+    private static let maximumTotalUncompressedByteCount = 512 * 1024 * 1024
 
     /**
      Extracts supported file entries from raw ZIP data.
+
+     The reader is intentionally eager because Android backup restore needs materialized database
+     bytes before staging SQLite files. Size limits are enforced before local payload extraction or
+     inflation so a malicious archive cannot force unbounded memory allocation.
 
      - Parameter data: Raw ZIP archive bytes.
      - Returns: Uncompressed non-directory entries in central-directory order.
@@ -76,6 +86,8 @@ public enum ZipArchiveReader {
      - Failure modes:
        - throws `ZipArchiveReaderError.missingCentralDirectory` when the archive is not ZIP-shaped
        - throws `ZipArchiveReaderError.invalidArchive` when a header is truncated or inconsistent
+       - throws `ZipArchiveReaderError.invalidArchive` when declared entry/archive sizes exceed
+         the eager extraction limits
        - throws `ZipArchiveReaderError.unsupportedCompressionMethod` for non-stored/non-deflated entries
        - throws `ZipArchiveReaderError.decompressionFailed` when the C inflater cannot decode an entry
      */
@@ -104,6 +116,8 @@ public enum ZipArchiveReader {
 
         var entries: [ZipArchiveEntry] = []
         var offset = centralDirectoryOffset
+        var totalCompressedSize = 0
+        var totalUncompressedSize = 0
         for _ in 0..<entryCount {
             guard offset + 46 <= centralDirectoryEnd else {
                 throw ZipArchiveReaderError.invalidArchive("Central directory entry is truncated")
@@ -147,6 +161,13 @@ public enum ZipArchiveReader {
             let localHeaderOffset = Int(localHeaderOffsetRaw)
             let compressedSize = Int(compressedSizeRaw)
             let uncompressedSize = Int(uncompressedSizeRaw)
+            try validateEntrySize(compressedSize: compressedSize, uncompressedSize: uncompressedSize)
+            try accumulateEntrySizes(
+                compressedSize: compressedSize,
+                uncompressedSize: uncompressedSize,
+                totalCompressedSize: &totalCompressedSize,
+                totalUncompressedSize: &totalUncompressedSize
+            )
             let compressedData = try compressedEntryData(
                 archive: data,
                 localHeaderOffset: localHeaderOffset,
@@ -169,6 +190,54 @@ public enum ZipArchiveReader {
         }
 
         return entries
+    }
+
+    /**
+     Validates one central-directory entry's declared compressed and uncompressed sizes.
+
+     The ZIP reader materializes each supported entry in memory, so both the compressed payload
+     slice and inflated result must stay below the per-entry cap before extraction starts.
+
+     - Parameters:
+       - compressedSize: Declared compressed byte count from the central directory.
+       - uncompressedSize: Declared uncompressed byte count from the central directory.
+     - Side effects: none.
+     - Failure modes: Throws when either declared size exceeds the eager extraction cap.
+     */
+    private static func validateEntrySize(compressedSize: Int, uncompressedSize: Int) throws {
+        guard compressedSize <= maximumEntryByteCount,
+              uncompressedSize <= maximumEntryByteCount else {
+            throw ZipArchiveReaderError.invalidArchive("ZIP entry exceeds maximum supported size")
+        }
+    }
+
+    /**
+     Adds one entry's declared sizes to aggregate extraction totals.
+
+     Aggregate caps protect against archives containing many individually acceptable entries that
+     would still exhaust memory once the eager reader materializes them together.
+
+     - Parameters:
+       - compressedSize: Declared compressed byte count for the current file entry.
+       - uncompressedSize: Declared uncompressed byte count for the current file entry.
+       - totalCompressedSize: Running compressed byte total, mutated on success.
+       - totalUncompressedSize: Running uncompressed byte total, mutated on success.
+     - Side effects: Mutates the running totals after validating the addition.
+     - Failure modes: Throws when adding the entry would exceed aggregate extraction caps.
+     */
+    private static func accumulateEntrySizes(
+        compressedSize: Int,
+        uncompressedSize: Int,
+        totalCompressedSize: inout Int,
+        totalUncompressedSize: inout Int
+    ) throws {
+        guard totalCompressedSize <= maximumTotalCompressedByteCount - compressedSize,
+              totalUncompressedSize <= maximumTotalUncompressedByteCount - uncompressedSize else {
+            throw ZipArchiveReaderError.invalidArchive("ZIP archive exceeds maximum supported size")
+        }
+
+        totalCompressedSize += compressedSize
+        totalUncompressedSize += uncompressedSize
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -74,6 +74,17 @@ public enum ZipArchiveReader {
     private static let maximumTotalUncompressedByteCount = 512 * 1024 * 1024
 
     /**
+     Central-directory metadata for one file entry that passed pre-extraction validation.
+     */
+    private struct CentralDirectoryFileEntry {
+        let name: String
+        let method: UInt16
+        let compressedSize: Int
+        let uncompressedSize: Int
+        let localHeaderOffset: Int
+    }
+
+    /**
      Extracts supported file entries from raw ZIP data.
 
      The reader is intentionally eager because Android backup restore needs materialized database
@@ -88,6 +99,8 @@ public enum ZipArchiveReader {
        - throws `ZipArchiveReaderError.invalidArchive` when a header is truncated or inconsistent
        - throws `ZipArchiveReaderError.invalidArchive` when declared entry/archive sizes exceed
          the eager extraction limits
+       - throws `ZipArchiveReaderError.invalidArchive` when materialized entry sizes do not match
+         central-directory declarations
        - throws `ZipArchiveReaderError.unsupportedCompressionMethod` for non-stored/non-deflated entries
        - throws `ZipArchiveReaderError.decompressionFailed` when the C inflater cannot decode an entry
      */
@@ -114,7 +127,7 @@ public enum ZipArchiveReader {
         }
         let centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize
 
-        var entries: [ZipArchiveEntry] = []
+        var fileEntries: [CentralDirectoryFileEntry] = []
         var offset = centralDirectoryOffset
         var totalCompressedSize = 0
         var totalUncompressedSize = 0
@@ -162,34 +175,49 @@ public enum ZipArchiveReader {
             let compressedSize = Int(compressedSizeRaw)
             let uncompressedSize = Int(uncompressedSizeRaw)
             try validateEntrySize(compressedSize: compressedSize, uncompressedSize: uncompressedSize)
+            try validateCompressionMethod(method)
+            if method == 0 {
+                try validateStoredEntrySize(compressedSize: compressedSize, uncompressedSize: uncompressedSize)
+            }
             try accumulateEntrySizes(
                 compressedSize: compressedSize,
                 uncompressedSize: uncompressedSize,
                 totalCompressedSize: &totalCompressedSize,
                 totalUncompressedSize: &totalUncompressedSize
             )
-            let compressedData = try compressedEntryData(
-                archive: data,
-                localHeaderOffset: localHeaderOffset,
-                compressedSize: compressedSize
+            fileEntries.append(
+                CentralDirectoryFileEntry(
+                    name: name,
+                    method: method,
+                    compressedSize: compressedSize,
+                    uncompressedSize: uncompressedSize,
+                    localHeaderOffset: localHeaderOffset
+                )
             )
-
-            let fileData: Data
-            switch method {
-            case 0:
-                fileData = compressedData
-            case 8:
-                fileData = try inflateData(compressedData, uncompressedSize: uncompressedSize)
-            default:
-                throw ZipArchiveReaderError.unsupportedCompressionMethod(method)
-            }
-            entries.append(ZipArchiveEntry(name: name, data: fileData))
         }
         guard offset == centralDirectoryEnd else {
             throw ZipArchiveReaderError.invalidArchive("Central directory contains trailing bytes")
         }
 
-        return entries
+        return try fileEntries.map { entry in
+            let compressedData = try compressedEntryData(
+                archive: data,
+                localHeaderOffset: entry.localHeaderOffset,
+                compressedSize: entry.compressedSize
+            )
+
+            let fileData: Data
+            switch entry.method {
+            case 0:
+                fileData = compressedData
+            case 8:
+                fileData = try inflateData(compressedData, uncompressedSize: entry.uncompressedSize)
+                try validateInflatedEntrySize(fileData.count, expectedSize: entry.uncompressedSize)
+            default:
+                throw ZipArchiveReaderError.unsupportedCompressionMethod(entry.method)
+            }
+            return ZipArchiveEntry(name: entry.name, data: fileData)
+        }
     }
 
     /**
@@ -208,6 +236,19 @@ public enum ZipArchiveReader {
         guard compressedSize <= maximumEntryByteCount,
               uncompressedSize <= maximumEntryByteCount else {
             throw ZipArchiveReaderError.invalidArchive("ZIP entry exceeds maximum supported size")
+        }
+    }
+
+    /**
+     Validates that one central-directory entry uses a compression method supported by the reader.
+
+     - Parameter method: Compression method from the central-directory file header.
+     - Side effects: none.
+     - Failure modes: Throws when the entry is not stored or raw-deflated.
+     */
+    private static func validateCompressionMethod(_ method: UInt16) throws {
+        guard method == 0 || method == 8 else {
+            throw ZipArchiveReaderError.unsupportedCompressionMethod(method)
         }
     }
 
@@ -238,6 +279,43 @@ public enum ZipArchiveReader {
 
         totalCompressedSize += compressedSize
         totalUncompressedSize += uncompressedSize
+    }
+
+    /**
+     Validates central-directory size consistency for one stored ZIP entry.
+
+     Stored entries are not compressed, so ZIP metadata must declare identical compressed and
+     uncompressed sizes. Enforcing that invariant keeps aggregate size accounting honest before the
+     reader materializes the payload.
+
+     - Parameters:
+       - compressedSize: Declared compressed byte count for the stored entry.
+       - uncompressedSize: Declared uncompressed byte count for the stored entry.
+     - Side effects: none.
+     - Failure modes: Throws when stored-entry size metadata is internally inconsistent.
+     */
+    private static func validateStoredEntrySize(compressedSize: Int, uncompressedSize: Int) throws {
+        guard compressedSize == uncompressedSize else {
+            throw ZipArchiveReaderError.invalidArchive("Stored ZIP entry size metadata is inconsistent")
+        }
+    }
+
+    /**
+     Validates that an inflated ZIP entry produced the central-directory declared byte count.
+
+     The C inflater can report success for a smaller output than the declared size. The eager reader
+     rejects that mismatch so callers never receive truncated data that passed size accounting.
+
+     - Parameters:
+       - inflatedSize: Actual byte count returned by the inflater.
+       - expectedSize: Declared uncompressed byte count from the central directory.
+     - Side effects: none.
+     - Failure modes: Throws when inflated output does not match the declared uncompressed size.
+     */
+    private static func validateInflatedEntrySize(_ inflatedSize: Int, expectedSize: Int) throws {
+        guard inflatedSize == expectedSize else {
+            throw ZipArchiveReaderError.invalidArchive("Deflated ZIP entry size metadata is inconsistent")
+        }
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -93,11 +93,12 @@ public enum ZipArchiveReader {
               centralDirectoryOffset + centralDirectorySize <= data.count else {
             throw ZipArchiveReaderError.invalidArchive("Central directory points outside archive")
         }
+        let centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize
 
         var entries: [ZipArchiveEntry] = []
         var offset = centralDirectoryOffset
         for _ in 0..<entryCount {
-            guard offset + 46 <= data.count else {
+            guard offset + 46 <= centralDirectoryEnd else {
                 throw ZipArchiveReaderError.invalidArchive("Central directory entry is truncated")
             }
             guard readUInt32(data, at: offset) == centralDirectoryHeaderSignature else {
@@ -120,12 +121,14 @@ public enum ZipArchiveReader {
 
             let nameStart = offset + 46
             let nameEnd = nameStart + nameLength
-            guard nameEnd <= data.count else {
+            guard nameEnd <= centralDirectoryEnd else {
                 throw ZipArchiveReaderError.invalidArchive("Central directory entry name is truncated")
             }
-            let name = String(data: data[nameStart..<nameEnd], encoding: .utf8) ?? ""
+            guard let name = String(data: data[nameStart..<nameEnd], encoding: .utf8) else {
+                throw ZipArchiveReaderError.invalidArchive("Central directory entry name is not UTF-8")
+            }
             let nextOffset = nameEnd + extraLength + commentLength
-            guard nextOffset <= data.count else {
+            guard nextOffset <= centralDirectoryEnd else {
                 throw ZipArchiveReaderError.invalidArchive("Central directory entry metadata is truncated")
             }
             offset = nextOffset
@@ -153,6 +156,9 @@ public enum ZipArchiveReader {
                 throw ZipArchiveReaderError.unsupportedCompressionMethod(method)
             }
             entries.append(ZipArchiveEntry(name: name, data: fileData))
+        }
+        guard offset == centralDirectoryEnd else {
+            throw ZipArchiveReaderError.invalidArchive("Central directory contains trailing bytes")
         }
 
         return entries

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveReader.swift
@@ -1,0 +1,280 @@
+// ZipArchiveReader.swift — ZIP central-directory extraction helper
+
+import CLibSword
+import Foundation
+
+/**
+ Errors raised while reading ZIP archives.
+
+ The reader is intentionally small and supports the ZIP shapes AndBible consumes locally:
+ central-directory based stored or deflated file entries. Unsupported compression methods and
+ malformed offsets are rejected explicitly so callers can surface actionable archive errors instead
+ of treating missing entries as valid empty archives.
+ */
+public enum ZipArchiveReaderError: Error, Equatable {
+    /// The archive did not contain a readable ZIP end-of-central-directory record.
+    case missingCentralDirectory
+
+    /// A central-directory or local-file header was malformed or pointed outside the payload.
+    case invalidArchive(String)
+
+    /// The archive used a compression method this reader does not support.
+    case unsupportedCompressionMethod(UInt16)
+
+    /// A deflated member could not be inflated to the declared size.
+    case decompressionFailed
+}
+
+/**
+ One extracted file entry from a ZIP archive.
+
+ Directory entries are omitted by `ZipArchiveReader.entries(in:)`, so every returned entry has a
+ non-empty file name and materialized file bytes.
+ */
+public struct ZipArchiveEntry: Sendable, Equatable {
+    /// Path-like entry name recorded in the ZIP central directory.
+    public let name: String
+
+    /// Uncompressed file payload.
+    public let data: Data
+
+    /**
+     Creates one extracted ZIP entry.
+
+     - Parameters:
+       - name: Path-like entry name recorded in the ZIP central directory.
+       - data: Uncompressed file payload.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(name: String, data: Data) {
+        self.name = name
+        self.data = data
+    }
+}
+
+/**
+ Extracts stored and deflated ZIP file members using the archive's central directory.
+
+ Android's `ZipOutputStream` may write data descriptors after deflated entries, leaving local-file
+ header size fields unset. Reading the central directory first mirrors how platform ZIP readers
+ resolve those archives and prevents iOS backup restore from rejecting valid Android backups.
+ */
+public enum ZipArchiveReader {
+    private static let localFileHeaderSignature: UInt32 = 0x0403_4b50
+    private static let centralDirectoryHeaderSignature: UInt32 = 0x0201_4b50
+    private static let endOfCentralDirectorySignature: UInt32 = 0x0605_4b50
+    private static let zip64Sentinel: UInt32 = 0xffff_ffff
+
+    /**
+     Extracts supported file entries from raw ZIP data.
+
+     - Parameter data: Raw ZIP archive bytes.
+     - Returns: Uncompressed non-directory entries in central-directory order.
+     - Side effects: none.
+     - Failure modes:
+       - throws `ZipArchiveReaderError.missingCentralDirectory` when the archive is not ZIP-shaped
+       - throws `ZipArchiveReaderError.invalidArchive` when a header is truncated or inconsistent
+       - throws `ZipArchiveReaderError.unsupportedCompressionMethod` for non-stored/non-deflated entries
+       - throws `ZipArchiveReaderError.decompressionFailed` when the C inflater cannot decode an entry
+     */
+    public static func entries(in data: Data) throws -> [ZipArchiveEntry] {
+        let endRecordOffset = try endOfCentralDirectoryOffset(in: data)
+        let entryCount = Int(readUInt16(data, at: endRecordOffset + 10))
+        let centralDirectorySize = Int(readUInt32(data, at: endRecordOffset + 12))
+        let centralDirectoryOffsetRaw = readUInt32(data, at: endRecordOffset + 16)
+
+        guard centralDirectoryOffsetRaw != zip64Sentinel else {
+            throw ZipArchiveReaderError.invalidArchive("ZIP64 archives are not supported")
+        }
+        let centralDirectoryOffset = Int(centralDirectoryOffsetRaw)
+        guard centralDirectoryOffset >= 0,
+              centralDirectorySize >= 0,
+              centralDirectoryOffset + centralDirectorySize <= data.count else {
+            throw ZipArchiveReaderError.invalidArchive("Central directory points outside archive")
+        }
+
+        var entries: [ZipArchiveEntry] = []
+        var offset = centralDirectoryOffset
+        for _ in 0..<entryCount {
+            guard offset + 46 <= data.count else {
+                throw ZipArchiveReaderError.invalidArchive("Central directory entry is truncated")
+            }
+            guard readUInt32(data, at: offset) == centralDirectoryHeaderSignature else {
+                throw ZipArchiveReaderError.invalidArchive("Central directory entry has an invalid signature")
+            }
+
+            let method = readUInt16(data, at: offset + 10)
+            let compressedSizeRaw = readUInt32(data, at: offset + 20)
+            let uncompressedSizeRaw = readUInt32(data, at: offset + 24)
+            let nameLength = Int(readUInt16(data, at: offset + 28))
+            let extraLength = Int(readUInt16(data, at: offset + 30))
+            let commentLength = Int(readUInt16(data, at: offset + 32))
+            let localHeaderOffsetRaw = readUInt32(data, at: offset + 42)
+
+            guard compressedSizeRaw != zip64Sentinel,
+                  uncompressedSizeRaw != zip64Sentinel,
+                  localHeaderOffsetRaw != zip64Sentinel else {
+                throw ZipArchiveReaderError.invalidArchive("ZIP64 entry sizes are not supported")
+            }
+
+            let nameStart = offset + 46
+            let nameEnd = nameStart + nameLength
+            guard nameEnd <= data.count else {
+                throw ZipArchiveReaderError.invalidArchive("Central directory entry name is truncated")
+            }
+            let name = String(data: data[nameStart..<nameEnd], encoding: .utf8) ?? ""
+            let nextOffset = nameEnd + extraLength + commentLength
+            guard nextOffset <= data.count else {
+                throw ZipArchiveReaderError.invalidArchive("Central directory entry metadata is truncated")
+            }
+            offset = nextOffset
+
+            guard !name.isEmpty, !name.hasSuffix("/") else {
+                continue
+            }
+
+            let localHeaderOffset = Int(localHeaderOffsetRaw)
+            let compressedSize = Int(compressedSizeRaw)
+            let uncompressedSize = Int(uncompressedSizeRaw)
+            let compressedData = try compressedEntryData(
+                archive: data,
+                localHeaderOffset: localHeaderOffset,
+                compressedSize: compressedSize
+            )
+
+            let fileData: Data
+            switch method {
+            case 0:
+                fileData = compressedData
+            case 8:
+                fileData = try inflateData(compressedData, uncompressedSize: uncompressedSize)
+            default:
+                throw ZipArchiveReaderError.unsupportedCompressionMethod(method)
+            }
+            entries.append(ZipArchiveEntry(name: name, data: fileData))
+        }
+
+        return entries
+    }
+
+    /**
+     Finds the ZIP end-of-central-directory record by scanning backwards from the archive tail.
+
+     - Parameter data: Raw ZIP archive bytes.
+     - Returns: Byte offset of the EOCD signature.
+     - Side effects: none.
+     - Failure modes: throws when the signature cannot be found inside the legal ZIP comment range.
+     */
+    private static func endOfCentralDirectoryOffset(in data: Data) throws -> Int {
+        guard data.count >= 22 else {
+            throw ZipArchiveReaderError.missingCentralDirectory
+        }
+        let minimumOffset = max(0, data.count - 65_557)
+        var offset = data.count - 22
+        while offset >= minimumOffset {
+            if readUInt32(data, at: offset) == endOfCentralDirectorySignature {
+                return offset
+            }
+            offset -= 1
+        }
+        throw ZipArchiveReaderError.missingCentralDirectory
+    }
+
+    /**
+     Locates one local-file payload using central-directory size metadata.
+
+     - Parameters:
+       - archive: Raw ZIP archive bytes.
+       - localHeaderOffset: Offset of the matching local-file header.
+       - compressedSize: Compressed payload size from the central directory.
+     - Returns: Compressed entry payload.
+     - Side effects: none.
+     - Failure modes: throws when the local header or payload range is malformed.
+     */
+    private static func compressedEntryData(
+        archive: Data,
+        localHeaderOffset: Int,
+        compressedSize: Int
+    ) throws -> Data {
+        guard localHeaderOffset >= 0,
+              localHeaderOffset + 30 <= archive.count,
+              readUInt32(archive, at: localHeaderOffset) == localFileHeaderSignature else {
+            throw ZipArchiveReaderError.invalidArchive("Local file header is missing or truncated")
+        }
+
+        let localNameLength = Int(readUInt16(archive, at: localHeaderOffset + 26))
+        let localExtraLength = Int(readUInt16(archive, at: localHeaderOffset + 28))
+        let dataStart = localHeaderOffset + 30 + localNameLength + localExtraLength
+        guard compressedSize >= 0, dataStart >= 0, dataStart + compressedSize <= archive.count else {
+            throw ZipArchiveReaderError.invalidArchive("Local file payload points outside archive")
+        }
+
+        return Data(archive[dataStart..<dataStart + compressedSize])
+    }
+
+    /**
+     Reads a little-endian `UInt16` from the archive byte stream.
+
+     - Parameters:
+       - data: Source bytes.
+       - offset: Byte offset where the integer starts.
+     - Returns: Decoded little-endian integer.
+     - Side effects: none.
+     - Failure modes: Callers must ensure the range exists before invoking this helper.
+     */
+    private static func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        let b0 = UInt16(data[offset])
+        let b1 = UInt16(data[offset + 1]) << 8
+        return b0 | b1
+    }
+
+    /**
+     Reads a little-endian `UInt32` from the archive byte stream.
+
+     - Parameters:
+       - data: Source bytes.
+       - offset: Byte offset where the integer starts.
+     - Returns: Decoded little-endian integer.
+     - Side effects: none.
+     - Failure modes: Callers must ensure the range exists before invoking this helper.
+     */
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        let b0 = UInt32(data[offset])
+        let b1 = UInt32(data[offset + 1]) << 8
+        let b2 = UInt32(data[offset + 2]) << 16
+        let b3 = UInt32(data[offset + 3]) << 24
+        return b0 | b1 | b2 | b3
+    }
+
+    /**
+     Inflates one raw deflated ZIP member through the shared C adapter.
+
+     - Parameters:
+       - compressed: Deflated ZIP member bytes.
+       - uncompressedSize: Declared uncompressed size from the central directory.
+     - Returns: Inflated member bytes.
+     - Side effects: allocates and releases a C buffer through `CLibSword`.
+     - Failure modes: throws when the inflater cannot decode the supplied payload.
+     */
+    private static func inflateData(_ compressed: Data, uncompressedSize: Int) throws -> Data {
+        try compressed.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) -> Data in
+            guard let baseAddress = ptr.baseAddress else {
+                throw ZipArchiveReaderError.decompressionFailed
+            }
+
+            var outputLength: UInt = 0
+            guard let output = inflate_raw_data(
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                UInt(compressed.count),
+                UInt(uncompressedSize),
+                &outputLength
+            ) else {
+                throw ZipArchiveReaderError.decompressionFailed
+            }
+
+            defer { gunzip_free(output) }
+            return Data(bytes: output, count: Int(outputLength))
+        }
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
@@ -1,0 +1,340 @@
+// AndroidDatabaseBackupImportSheet.swift -- Android backup category selection UI
+
+import BibleCore
+import SwiftUI
+
+/**
+ Presents Android `.abdb.zip` database backup sections before iOS applies them.
+
+ Android exposes database backup restore as a category picker plus a Restore-or-Import choice. This
+ SwiftUI sheet mirrors that behavioral contract while keeping unsupported Android database sections
+ visible and disabled, so users can distinguish "not present" from "present but not safely mapped by
+ this iOS build."
+
+ Data dependencies:
+ - `archive` supplies validated manifest and database section metadata staged by
+   `AndroidDatabaseBackupService`
+ - `onApply` receives supported user selections after destructive restore confirmation, when needed
+
+ Side effects:
+ - mutates local sheet state for selected categories and modes
+ - invokes `onCancel` when dismissed
+ - invokes `onApply` only after the user confirms selections that include Restore mode
+
+ Failure modes:
+ - unsupported sections are disabled in the UI and cannot be emitted in `onApply`
+ - empty selections keep the Apply command disabled
+ */
+struct AndroidDatabaseBackupImportSheet: View {
+    /// Loaded Android backup archive whose validated sections are shown for selection.
+    let archive: AndroidDatabaseBackupArchive
+
+    /// Whether the parent view is currently applying selected sections.
+    let isApplying: Bool
+
+    /// Callback used to dismiss the sheet without applying data.
+    let onCancel: () -> Void
+
+    /// Callback used to apply selected supported sections.
+    let onApply: ([AndroidDatabaseBackupSelection]) -> Void
+
+    /// Supported categories currently selected by the user.
+    @State private var selectedCategories: Set<AndroidDatabaseBackupCategory>
+
+    /// Per-category operation modes for supported sections.
+    @State private var modesByCategory: [AndroidDatabaseBackupCategory: AndroidDatabaseBackupApplyMode]
+
+    /// Whether the destructive Restore confirmation alert is visible.
+    @State private var showRestoreConfirmation = false
+
+    /**
+     Creates a category-selection sheet for one validated Android backup archive.
+
+     - Parameters:
+       - archive: Loaded archive whose section metadata drives the form.
+       - isApplying: Parent-owned progress state that disables controls while a batch is running.
+       - onCancel: Dismiss callback.
+       - onApply: Apply callback receiving supported selections.
+     - Side effects: initializes local selection state with every supported section selected.
+     - Failure modes: This initializer cannot fail; unsupported sections are intentionally omitted
+       from the selected set.
+     */
+    init(
+        archive: AndroidDatabaseBackupArchive,
+        isApplying: Bool,
+        onCancel: @escaping () -> Void,
+        onApply: @escaping ([AndroidDatabaseBackupSelection]) -> Void
+    ) {
+        self.archive = archive
+        self.isApplying = isApplying
+        self.onCancel = onCancel
+        self.onApply = onApply
+
+        let supportedCategories = archive.sections
+            .filter { $0.support.isSupported }
+            .map(\.category)
+        _selectedCategories = State(initialValue: Set(supportedCategories))
+        _modesByCategory = State(
+            initialValue: Dictionary(
+                uniqueKeysWithValues: supportedCategories.map { ($0, AndroidDatabaseBackupApplyMode.restore) }
+            )
+        )
+    }
+
+    /**
+     Builds the Android manifest summary, selectable sections, and destructive confirmation.
+     */
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    LabeledContent(
+                        String(localized: "android_backup_manifest_version", defaultValue: "Manifest version"),
+                        value: "\(archive.manifest.manifestVersion)"
+                    )
+                    if let andBibleVersion = archive.manifest.andBibleVersion {
+                        LabeledContent(
+                            String(localized: "android_backup_app_version", defaultValue: "Android app version"),
+                            value: "\(andBibleVersion)"
+                        )
+                    }
+                    LabeledContent(
+                        String(localized: "android_backup_sections", defaultValue: "Sections"),
+                        value: "\(archive.sections.count)"
+                    )
+                } header: {
+                    Text(String(localized: "android_backup_archive", defaultValue: "Android backup archive"))
+                } footer: {
+                    Text(
+                        String(
+                            localized: "android_backup_import_footer",
+                            defaultValue: "Restore replaces selected local data. Import keeps existing local rows and adds backup rows that do not already exist."
+                        )
+                    )
+                }
+
+                Section {
+                    ForEach(archive.sections) { section in
+                        AndroidDatabaseBackupSectionRow(
+                            section: section,
+                            isSelected: bindingForSelection(section.category),
+                            mode: bindingForMode(section.category)
+                        )
+                    }
+                } header: {
+                    Text(String(localized: "android_backup_select_sections", defaultValue: "Select sections"))
+                }
+            }
+            .accessibilityIdentifier("androidDatabaseBackupImportSheet")
+            .navigationTitle(String(localized: "android_backup_restore_title", defaultValue: "Android Backup"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "cancel")) {
+                        onCancel()
+                    }
+                    .disabled(isApplying)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        submit()
+                    } label: {
+                        if isApplying {
+                            ProgressView()
+                        } else {
+                            Text(String(localized: "apply", defaultValue: "Apply"))
+                        }
+                    }
+                    .accessibilityIdentifier("androidDatabaseBackupApplyButton")
+                    .disabled(isApplying || selectedSelections.isEmpty)
+                }
+            }
+            .alert(
+                String(localized: "android_backup_restore_confirm_title", defaultValue: "Restore selected sections?"),
+                isPresented: $showRestoreConfirmation
+            ) {
+                Button(String(localized: "cancel"), role: .cancel) {}
+                Button(String(localized: "restore"), role: .destructive) {
+                    onApply(selectedSelections)
+                }
+            } message: {
+                Text(
+                    String(
+                        localized: "android_backup_restore_confirm_message",
+                        defaultValue: "Restore replaces the selected local data with the Android backup. Import selections in the same batch will remain non-destructive."
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     Current supported selections in the same order sections appear in the archive.
+
+     - Returns: Selected section/mode pairs filtered to supported categories.
+     - Side effects: none.
+     - Failure modes: Missing mode state falls back to Restore, matching the sheet's default.
+     */
+    private var selectedSelections: [AndroidDatabaseBackupSelection] {
+        archive.sections.compactMap { section in
+            guard section.support.isSupported,
+                  selectedCategories.contains(section.category) else {
+                return nil
+            }
+            return AndroidDatabaseBackupSelection(
+                category: section.category,
+                mode: modesByCategory[section.category] ?? .restore
+            )
+        }
+    }
+
+    /**
+     Submits the selected sections, requiring confirmation if any selection is destructive.
+
+     - Side effects: either presents the destructive confirmation alert or invokes `onApply`.
+     - Failure modes: Empty selections are ignored; the Apply button is disabled for that state.
+     */
+    private func submit() {
+        let selections = selectedSelections
+        guard !selections.isEmpty else {
+            return
+        }
+        if selections.contains(where: { $0.mode == .restore }) {
+            showRestoreConfirmation = true
+        } else {
+            onApply(selections)
+        }
+    }
+
+    /**
+     Produces a mutable binding for one category selection toggle.
+
+     - Parameter category: Category whose selected state should be exposed.
+     - Returns: Binding that adds or removes the category from `selectedCategories`.
+     - Side effects: writes local sheet state when the user toggles a supported section.
+     - Failure modes: none.
+     */
+    private func bindingForSelection(_ category: AndroidDatabaseBackupCategory) -> Binding<Bool> {
+        Binding(
+            get: { selectedCategories.contains(category) },
+            set: { isSelected in
+                if isSelected {
+                    selectedCategories.insert(category)
+                } else {
+                    selectedCategories.remove(category)
+                }
+            }
+        )
+    }
+
+    /**
+     Produces a mutable binding for one category's Restore/Import picker.
+
+     - Parameter category: Category whose mode should be exposed.
+     - Returns: Binding backed by `modesByCategory`.
+     - Side effects: writes local sheet state when the user changes operation mode.
+     - Failure modes: Missing values read as Restore.
+     */
+    private func bindingForMode(_ category: AndroidDatabaseBackupCategory) -> Binding<AndroidDatabaseBackupApplyMode> {
+        Binding(
+            get: { modesByCategory[category] ?? .restore },
+            set: { modesByCategory[category] = $0 }
+        )
+    }
+}
+
+/**
+ Renders one Android backup section with support status, selection state, and operation mode.
+
+ Supported rows expose a toggle and segmented Restore/Import picker. Unsupported rows stay visible
+ with the exact reason supplied by `AndroidDatabaseBackupService`, preserving Android backup
+ transparency without allowing unsafe partial restores.
+ */
+private struct AndroidDatabaseBackupSectionRow: View {
+    /// Validated section metadata for one Android backup database.
+    let section: AndroidDatabaseBackupSection
+
+    /// Selection binding owned by the parent sheet.
+    @Binding var isSelected: Bool
+
+    /// Restore/import mode binding owned by the parent sheet.
+    @Binding var mode: AndroidDatabaseBackupApplyMode
+
+    /**
+     Builds the row content for one Android backup section.
+     */
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if section.support.isSupported {
+                Toggle(isOn: $isSelected) {
+                    sectionLabel
+                }
+                .accessibilityIdentifier("androidBackupSectionToggle.\(section.category.rawValue)")
+
+                if isSelected {
+                    Picker(
+                        String(localized: "android_backup_mode", defaultValue: "Mode"),
+                        selection: $mode
+                    ) {
+                        ForEach(AndroidDatabaseBackupApplyMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("androidBackupSectionMode.\(section.category.rawValue)")
+                }
+            } else {
+                sectionLabel
+                if let explanation = section.support.explanation {
+                    Text(explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .disabled(!section.support.isSupported)
+    }
+
+    /**
+     Shared section label showing category name, database version, and manifest presence.
+     */
+    private var sectionLabel: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(section.category.displayName)
+                .font(.headline)
+            Text(detailText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /**
+     Human-readable metadata summary for the row.
+     */
+    private var detailText: String {
+        var pieces = section.hasDatabaseFile
+            ? [
+                String(
+                    localized: "android_backup_database_version",
+                    defaultValue: "Database version \(section.databaseVersion)"
+                ),
+            ]
+            : [
+                String(
+                    localized: "android_backup_manifest_category",
+                    defaultValue: "Manifest category"
+                ),
+            ]
+        if !section.declaredInManifest {
+            pieces.append(
+                String(
+                    localized: "android_backup_not_declared",
+                    defaultValue: "found in archive"
+                )
+            )
+        }
+        return pieces.joined(separator: " • ")
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
@@ -18,8 +18,11 @@ import SwiftUI
 
  Side effects:
  - mutates local sheet state for selected categories and modes
- - invokes `onCancel` when dismissed
+ - invokes `onCancel` from the explicit Cancel button; parent sheet dismissal cleanup handles
+   interactive dismissal when no apply is running
  - invokes `onApply` only after the user confirms selections that include Restore mode
+ - disables interactive dismissal while `isApplying` is true so staged database files cannot be
+   cleaned up while the parent is applying them
 
  Failure modes:
  - unsupported sections are disabled in the UI and cannot be emitted in `onApply`
@@ -168,6 +171,7 @@ struct AndroidDatabaseBackupImportSheet: View {
                 )
             }
         }
+        .interactiveDismissDisabled(isApplying)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
@@ -175,7 +175,7 @@ struct AndroidDatabaseBackupImportSheet: View {
     }
 
     /**
-     Current supported selections in the same order sections appear in the archive.
+     Current supported selections in the loader-provided section display order.
 
      - Returns: Selected section/mode pairs filtered to supported categories.
      - Side effects: none.

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
@@ -283,7 +283,7 @@ private struct AndroidDatabaseBackupSectionRow: View {
                         selection: $mode
                     ) {
                         ForEach(AndroidDatabaseBackupApplyMode.allCases) { mode in
-                            Text(mode.displayName).tag(mode)
+                            Text(mode.localizedBackupModeName).tag(mode)
                         }
                     }
                     .pickerStyle(.segmented)
@@ -291,7 +291,7 @@ private struct AndroidDatabaseBackupSectionRow: View {
                 }
             } else {
                 sectionLabel
-                if let explanation = section.support.explanation {
+                if let explanation = section.support.localizedBackupExplanation(for: section.category) {
                     Text(explanation)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -306,7 +306,7 @@ private struct AndroidDatabaseBackupSectionRow: View {
      */
     private var sectionLabel: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(section.category.displayName)
+            Text(section.category.localizedBackupSectionName)
                 .font(.headline)
             Text(detailText)
                 .font(.caption)

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift
@@ -120,6 +120,7 @@ struct AndroidDatabaseBackupImportSheet: View {
                     ForEach(archive.sections) { section in
                         AndroidDatabaseBackupSectionRow(
                             section: section,
+                            isApplying: isApplying,
                             isSelected: bindingForSelection(section.category),
                             mode: bindingForMode(section.category)
                         )
@@ -252,13 +253,18 @@ struct AndroidDatabaseBackupImportSheet: View {
 /**
  Renders one Android backup section with support status, selection state, and operation mode.
 
- Supported rows expose a toggle and segmented Restore/Import picker. Unsupported rows stay visible
- with the exact reason supplied by `AndroidDatabaseBackupService`, preserving Android backup
+ Supported rows expose a toggle and segmented Restore/Import picker until the parent begins an
+ apply operation. While applying, rows stay readable but controls are disabled so local selection
+ edits cannot diverge from the already-submitted apply snapshot. Unsupported rows stay visible with
+ the exact reason supplied by `AndroidDatabaseBackupService`, preserving Android backup
  transparency without allowing unsafe partial restores.
  */
 private struct AndroidDatabaseBackupSectionRow: View {
     /// Validated section metadata for one Android backup database.
     let section: AndroidDatabaseBackupSection
+
+    /// Whether the parent sheet is applying a submitted selection snapshot.
+    let isApplying: Bool
 
     /// Selection binding owned by the parent sheet.
     @Binding var isSelected: Bool
@@ -298,7 +304,7 @@ private struct AndroidDatabaseBackupSectionRow: View {
                 }
             }
         }
-        .disabled(!section.support.isSupported)
+        .disabled(isApplying || !section.support.isSupported)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupPresentationLocalization.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupPresentationLocalization.swift
@@ -1,0 +1,106 @@
+// AndroidDatabaseBackupPresentationLocalization.swift -- Android backup UI localization helpers
+
+import BibleCore
+import Foundation
+
+/**
+ Adds localized Android backup labels for the SwiftUI settings surface.
+
+ BibleCore keeps Android category and mode display names as stable English fallback labels because
+ it also uses them for sorting and low-level diagnostics. BibleUI resolves localized strings at the
+ presentation boundary so the backup sheet and completion status can participate in the app's
+ localization system without making the core restore service depend on UI resources.
+ */
+extension AndroidDatabaseBackupCategory {
+    /**
+     Localized category label for Android backup section rows and summaries.
+
+     - Returns: Localized category label with the stable Android English category label as the
+       default fallback.
+     - Side effects: reads localization resources through Foundation lookup.
+     - Failure modes: Missing localization keys fall back to `displayName`.
+     */
+    var localizedBackupSectionName: String {
+        NSLocalizedString(
+            "android_backup_category_\(rawValue.lowercased())",
+            value: displayName,
+            comment: "Android backup category label"
+        )
+    }
+}
+
+/**
+ Adds localized operation labels for Android backup Restore/Import controls.
+
+ The raw mode display names remain stable English fallbacks in BibleCore; this extension performs
+ UI localization where the app has access to string resources.
+ */
+extension AndroidDatabaseBackupApplyMode {
+    /**
+     Localized Restore/Import label for segmented pickers and completion summaries.
+
+     - Returns: Localized operation label with the stable Android English operation label as the
+       default fallback.
+     - Side effects: reads localization resources through Foundation lookup.
+     - Failure modes: Missing localization keys fall back to `displayName`.
+     */
+    var localizedBackupModeName: String {
+        switch self {
+        case .restore:
+            return NSLocalizedString(
+                "android_backup_mode_restore",
+                value: displayName,
+                comment: "Android backup Restore mode label"
+            )
+        case .import:
+            return NSLocalizedString(
+                "android_backup_mode_import",
+                value: displayName,
+                comment: "Android backup Import mode label"
+            )
+        }
+    }
+}
+
+/**
+ Adds localized user-facing explanations for Android backup support states.
+
+ BibleCore exposes support state as structured values plus English fallback diagnostics. The
+ settings surface rehydrates those structured values into localized strings so unsupported rows
+ remain visible without leaking core-only English diagnostics into localized UI.
+ */
+extension AndroidDatabaseBackupSectionSupport {
+    /**
+     Localized unsupported-section explanation for the backup section picker.
+
+     - Parameter category: Category whose support state is being explained.
+     - Returns: Localized explanation for unsupported states, or `nil` for supported sections.
+     - Side effects: reads localization resources through Foundation lookup.
+     - Failure modes: Missing localization keys fall back to the built-in English defaults.
+     */
+    func localizedBackupExplanation(for category: AndroidDatabaseBackupCategory) -> String? {
+        switch self {
+        case .supported:
+            return nil
+        case .unsupportedVersion(let version, let supported):
+            return String(
+                format: NSLocalizedString(
+                    "android_backup_unsupported_version_%d_%d",
+                    value: "Requires database version %d; this app supports up to %d.",
+                    comment: "Android backup unsupported database version explanation"
+                ),
+                version,
+                supported
+            )
+        case .unsupportedCategory:
+            return String(
+                format: NSLocalizedString(
+                    "android_backup_unsupported_category_%@",
+                    value: "iOS does not yet have a safe mapper for Android %@ data.",
+                    comment: "Android backup unsupported category explanation"
+                ),
+                category.localizedBackupSectionName
+            )
+        }
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -464,7 +464,7 @@ public struct ImportExportView: View {
             return String(localized: "android_backup_applied", defaultValue: "Android backup applied.")
         }
         let summaries = report.sections.map { section in
-            "\(section.mode.displayName) \(section.category.displayName): \(section.summary)"
+            "\(section.mode.localizedBackupModeName) \(section.category.localizedBackupSectionName): \(section.summary)"
         }
         return String(
             localized: "android_backup_applied_summary",

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -359,7 +359,7 @@ public struct ImportExportView: View {
             isImporting = false
 
         case .failure(let error):
-            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+            statusMessage = localizedErrorMessage(error)
         }
     }
 
@@ -396,15 +396,21 @@ public struct ImportExportView: View {
         do {
             androidBackupArchive = try androidBackupService.loadArchive(from: data)
         } catch {
-            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+            statusMessage = localizedErrorMessage(error)
         }
     }
 
     /**
      Applies selected Android backup sections and reports the completed category summaries.
 
+     This method flips the applying state synchronously, then schedules the restore/import work on
+     the main actor after one yield so SwiftUI can render the disabled controls and progress state
+     before the potentially expensive SwiftData rewrite starts.
+
      - Parameter selections: Supported category/mode pairs emitted by the selection sheet.
      - Side effects:
+       - mutates `isApplyingAndroidBackup` immediately so the sheet disables controls and
+         interactive dismissal
        - mutates selected local SwiftData categories through `AndroidDatabaseBackupService`
        - disables and clears remote-sync state for every applied Android-backed category
        - removes the staged archive directory after success or failure
@@ -418,19 +424,22 @@ public struct ImportExportView: View {
 
         isApplyingAndroidBackup = true
         statusMessage = nil
-        do {
-            let report = try androidBackupService.apply(
-                archive: archive,
-                selections: selections,
-                modelContext: modelContext,
-                settingsStore: SettingsStore(modelContext: modelContext)
-            )
-            statusMessage = androidBackupStatusMessage(for: report)
-        } catch {
-            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+        Task { @MainActor in
+            await Task.yield()
+            do {
+                let report = try androidBackupService.apply(
+                    archive: archive,
+                    selections: selections,
+                    modelContext: modelContext,
+                    settingsStore: SettingsStore(modelContext: modelContext)
+                )
+                statusMessage = androidBackupStatusMessage(for: report)
+            } catch {
+                statusMessage = localizedErrorMessage(error)
+            }
+            isApplyingAndroidBackup = false
+            dismissAndroidBackupArchive()
         }
-        isApplyingAndroidBackup = false
-        dismissAndroidBackupArchive()
     }
 
     /**
@@ -452,6 +461,26 @@ public struct ImportExportView: View {
         return String(
             localized: "android_backup_applied_summary",
             defaultValue: "Android backup applied: \(summaries.joined(separator: "; "))"
+        )
+    }
+
+    /**
+     Formats an import/export error with the localized shared error prefix.
+
+     `String(localized:)` interpolation is easy to misuse for this shared `%@` key. This helper
+     resolves the stable `error_prefix_%@` format first, then applies the concrete error message as
+     an argument so every import/export error path uses the same localized surface.
+
+     - Parameter error: Error whose localized description should be shown to the user.
+     - Returns: Localized status text containing the shared error prefix and error message.
+     - Side effects: none.
+     - Failure modes: Falls back to the key's untranslated format if the app bundle lacks a
+       localization entry.
+     */
+    private func localizedErrorMessage(_ error: Error) -> String {
+        String(
+            format: NSLocalizedString("error_prefix_%@", comment: "Import/export error prefix"),
+            error.localizedDescription
         )
     }
 
@@ -506,13 +535,13 @@ public struct ImportExportView: View {
                 let moduleName = try repo.installFromZip(at: url)
                 statusMessage = String(localized: "installed_module_\(moduleName)")
             } catch {
-                statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+                statusMessage = localizedErrorMessage(error)
             }
 
             isInstallingModule = false
 
         case .failure(let error):
-            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+            statusMessage = localizedErrorMessage(error)
         }
     }
 
@@ -539,13 +568,13 @@ public struct ImportExportView: View {
                     statusMessage = String(localized: "installed_epub_\(identifier)")
                 }
             } catch {
-                statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+                statusMessage = localizedErrorMessage(error)
             }
 
             isInstallingEpub = false
 
         case .failure(let error):
-            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+            statusMessage = localizedErrorMessage(error)
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -59,6 +59,9 @@ public struct ImportExportView: View {
     /// Android database backup archive currently staged for category selection.
     @State private var androidBackupArchive: AndroidDatabaseBackupArchive?
 
+    /// Last archive presented by the sheet, retained until dismissal cleanup runs.
+    @State private var androidBackupArchivePendingCleanup: AndroidDatabaseBackupArchive?
+
     /// Whether selected Android backup sections are currently being applied.
     @State private var isApplyingAndroidBackup = false
 
@@ -218,13 +221,16 @@ public struct ImportExportView: View {
         ) { result in
             handleImport(result)
         }
-        .sheet(item: $androidBackupArchive, onDismiss: cleanupLoadedAndroidBackupArchive) { archive in
+        .sheet(item: $androidBackupArchive, onDismiss: cleanupDismissedAndroidBackupArchive) { archive in
             AndroidDatabaseBackupImportSheet(
                 archive: archive,
                 isApplying: isApplyingAndroidBackup,
                 onCancel: dismissAndroidBackupArchive,
                 onApply: applyAndroidBackupSelections
             )
+            .onAppear {
+                androidBackupArchivePendingCleanup = archive
+            }
         }
         .fileImporter(
             isPresented: $showModuleZipPicker,
@@ -394,7 +400,9 @@ public struct ImportExportView: View {
     private func loadAndroidBackupArchive(from data: Data) {
         cleanupLoadedAndroidBackupArchive()
         do {
-            androidBackupArchive = try androidBackupService.loadArchive(from: data)
+            let archive = try androidBackupService.loadArchive(from: data)
+            androidBackupArchive = archive
+            androidBackupArchivePendingCleanup = archive
         } catch {
             statusMessage = localizedErrorMessage(error)
         }
@@ -490,9 +498,17 @@ public struct ImportExportView: View {
      Side effects:
      - deletes the staged archive directory on a best-effort basis
      - clears `androidBackupArchive`
+     - clears the dismissal cleanup fallback once the archive has been removed
+     - Failure modes: Cleanup errors are swallowed by the service because the files are temporary.
      */
     private func dismissAndroidBackupArchive() {
-        cleanupLoadedAndroidBackupArchive()
+        guard let archive = androidBackupArchive else {
+            androidBackupArchivePendingCleanup = nil
+            return
+        }
+        cleanupAndroidBackupArchive(archive)
+        androidBackupArchive = nil
+        androidBackupArchivePendingCleanup = nil
     }
 
     /**
@@ -501,13 +517,48 @@ public struct ImportExportView: View {
      Side effects:
      - deletes the temporary extracted database directory, if present
      - clears `androidBackupArchive`
+     - clears the dismissal cleanup fallback
+     - Failure modes: Cleanup errors are swallowed by the service because the files are temporary.
      */
     private func cleanupLoadedAndroidBackupArchive() {
         guard let archive = androidBackupArchive else {
+            androidBackupArchivePendingCleanup = nil
             return
         }
-        androidBackupService.cleanup(archive)
+        cleanupAndroidBackupArchive(archive)
         androidBackupArchive = nil
+        androidBackupArchivePendingCleanup = nil
+    }
+
+    /**
+     Cleans up the presented Android backup after SwiftUI dismisses the sheet.
+
+     SwiftUI may clear an item-backed sheet binding before `onDismiss` runs. The pending-cleanup
+     copy preserves the staging directory owner until this dismissal callback removes it.
+
+     Side effects:
+     - deletes the temporary extracted database directory, if present
+     - clears the active archive binding and fallback cleanup copy
+     - Failure modes: Cleanup errors are swallowed by the service because the files are temporary.
+     */
+    private func cleanupDismissedAndroidBackupArchive() {
+        let archive = androidBackupArchive ?? androidBackupArchivePendingCleanup
+        if let archive {
+            cleanupAndroidBackupArchive(archive)
+        }
+        androidBackupArchive = nil
+        androidBackupArchivePendingCleanup = nil
+    }
+
+    /**
+     Removes one staged Android backup archive without mutating presentation state.
+
+     - Parameter archive: Loaded archive whose temporary directory should be deleted.
+     - Side effects: Deletes the archive staging directory on a best-effort basis.
+     - Failure modes: Cleanup errors are swallowed by the service because the files are temporary.
+     */
+    private func cleanupAndroidBackupArchive(_ archive: AndroidDatabaseBackupArchive) {
+        androidBackupService.cleanup(archive)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -56,6 +56,15 @@ public struct ImportExportView: View {
     /// Whether an EPUB installation is currently in progress.
     @State private var isInstallingEpub = false
 
+    /// Android database backup archive currently staged for category selection.
+    @State private var androidBackupArchive: AndroidDatabaseBackupArchive?
+
+    /// Whether selected Android backup sections are currently being applied.
+    @State private var isApplyingAndroidBackup = false
+
+    /// Service used to load, apply, and clean up Android `.abdb.zip` database backups.
+    private let androidBackupService = AndroidDatabaseBackupService()
+
     /**
      Creates the import/export screen.
 
@@ -81,6 +90,9 @@ public struct ImportExportView: View {
         }
         if showEpubPicker {
             return "epubPickerPresented"
+        }
+        if androidBackupArchive != nil {
+            return "androidBackupImportPresented"
         }
         return "idle"
     }
@@ -201,10 +213,18 @@ public struct ImportExportView: View {
         }
         .fileImporter(
             isPresented: $showImportPicker,
-            allowedContentTypes: [.json, .commaSeparatedText, .data],
+            allowedContentTypes: [.json, .commaSeparatedText, .zip, .data],
             allowsMultipleSelection: false
         ) { result in
             handleImport(result)
+        }
+        .sheet(item: $androidBackupArchive, onDismiss: cleanupLoadedAndroidBackupArchive) { archive in
+            AndroidDatabaseBackupImportSheet(
+                archive: archive,
+                isApplying: isApplyingAndroidBackup,
+                onCancel: dismissAndroidBackupArchive,
+                onApply: applyAndroidBackupSelections
+            )
         }
         .fileImporter(
             isPresented: $showModuleZipPicker,
@@ -279,12 +299,14 @@ public struct ImportExportView: View {
      Supported formats:
      - `.json`: full backup import via `BackupService.importFullBackup`
      - `.csv`: bookmark import via `BackupService.importBookmarksCSV`
+     - `.abdb.zip`: Android database backup staging via `AndroidDatabaseBackupService`
      - `.bbl`, `.cmt`, `.dct`: MySword/MyBible hint only; no import is performed
 
      Side effects:
      - starts and stops security-scoped resource access for the chosen file
      - reads the imported file data and updates status text with success or error details
      - mutates persisted app data through `BackupService` for supported formats
+     - stages Android backup SQLite files in a temporary directory before presenting section choice
      */
     private func handleImport(_ result: Result<[URL], Error>) {
         switch result {
@@ -306,6 +328,12 @@ public struct ImportExportView: View {
             }
 
             let ext = url.pathExtension.lowercased()
+            if isAndroidDatabaseBackupFile(url) {
+                loadAndroidBackupArchive(from: data)
+                isImporting = false
+                return
+            }
+
             let service = BackupService(modelContext: modelContext)
 
             switch ext {
@@ -333,6 +361,124 @@ public struct ImportExportView: View {
         case .failure(let error):
             statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
         }
+    }
+
+    /**
+     Determines whether a selected import file should be handled as an Android database backup.
+
+     Android names manual database backups with the compound `.abdb.zip` suffix. The generic
+     import picker is intentionally narrower than the module installer, so any ZIP selected here is
+     treated as an Android backup candidate and validated by `AndroidDatabaseBackupService`.
+
+     - Parameter url: User-selected file URL.
+     - Returns: `true` when the filename has Android's backup suffix or the extension is ZIP.
+     - Side effects: none.
+     - Failure modes: Invalid ZIP contents are rejected later by the backup service.
+     */
+    private func isAndroidDatabaseBackupFile(_ url: URL) -> Bool {
+        let fileName = url.lastPathComponent.lowercased()
+        return fileName.hasSuffix(".abdb.zip") || url.pathExtension.lowercased() == "zip"
+    }
+
+    /**
+     Loads a raw Android database backup archive and presents the section-selection sheet.
+
+     - Parameter data: Raw file bytes read from the user-selected backup.
+     - Side effects:
+       - clears any previously staged Android backup archive
+       - writes validated Android SQLite files into a temporary staging directory
+       - updates `androidBackupArchive` so SwiftUI presents the selection sheet
+       - updates `statusMessage` when validation fails
+     - Failure modes: Surfaces `AndroidDatabaseBackupError` and ZIP/file-system errors as status text.
+     */
+    private func loadAndroidBackupArchive(from data: Data) {
+        cleanupLoadedAndroidBackupArchive()
+        do {
+            androidBackupArchive = try androidBackupService.loadArchive(from: data)
+        } catch {
+            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+        }
+    }
+
+    /**
+     Applies selected Android backup sections and reports the completed category summaries.
+
+     - Parameter selections: Supported category/mode pairs emitted by the selection sheet.
+     - Side effects:
+       - mutates selected local SwiftData categories through `AndroidDatabaseBackupService`
+       - disables and clears remote-sync state for every applied Android-backed category
+       - removes the staged archive directory after success or failure
+       - updates `statusMessage` with the apply result or error
+     - Failure modes: Catches service errors and surfaces them to the settings screen.
+     */
+    private func applyAndroidBackupSelections(_ selections: [AndroidDatabaseBackupSelection]) {
+        guard let archive = androidBackupArchive else {
+            return
+        }
+
+        isApplyingAndroidBackup = true
+        statusMessage = nil
+        do {
+            let report = try androidBackupService.apply(
+                archive: archive,
+                selections: selections,
+                modelContext: modelContext,
+                settingsStore: SettingsStore(modelContext: modelContext)
+            )
+            statusMessage = androidBackupStatusMessage(for: report)
+        } catch {
+            statusMessage = String(localized: "error_prefix_\(error.localizedDescription)")
+        }
+        isApplyingAndroidBackup = false
+        dismissAndroidBackupArchive()
+    }
+
+    /**
+     Builds the user-visible completion summary for an Android backup apply report.
+
+     - Parameter report: Service report containing one row per applied section.
+     - Returns: Concise status message listing category, mode, and row summary.
+     - Side effects: none.
+     - Failure modes: Empty reports return a generic success message, though the sheet normally
+       prevents empty selections.
+     */
+    private func androidBackupStatusMessage(for report: AndroidDatabaseBackupApplyReport) -> String {
+        guard !report.sections.isEmpty else {
+            return String(localized: "android_backup_applied", defaultValue: "Android backup applied.")
+        }
+        let summaries = report.sections.map { section in
+            "\(section.mode.displayName) \(section.category.displayName): \(section.summary)"
+        }
+        return String(
+            localized: "android_backup_applied_summary",
+            defaultValue: "Android backup applied: \(summaries.joined(separator: "; "))"
+        )
+    }
+
+    /**
+     Dismisses the Android backup sheet and removes its temporary extracted files.
+
+     Side effects:
+     - deletes the staged archive directory on a best-effort basis
+     - clears `androidBackupArchive`
+     */
+    private func dismissAndroidBackupArchive() {
+        cleanupLoadedAndroidBackupArchive()
+    }
+
+    /**
+     Removes the currently staged Android backup archive without changing user data.
+
+     Side effects:
+     - deletes the temporary extracted database directory, if present
+     - clears `androidBackupArchive`
+     */
+    private func cleanupLoadedAndroidBackupArchive() {
+        guard let archive = androidBackupArchive else {
+            return
+        }
+        androidBackupService.cleanup(archive)
+        androidBackupArchive = nil
     }
 
     /**

--- a/docs/adr/0003-android-database-backup-restore-parity.md
+++ b/docs/adr/0003-android-database-backup-restore-parity.md
@@ -1,0 +1,119 @@
+# 0003: Android Database Backup Restore Parity
+
+Status: Accepted
+
+Date: 2026-06-04
+
+## Context
+
+#150 adds iOS support for Android manual database backup archives
+(`AndBibleDatabaseBackup.abdb.zip`).
+
+Android's manual backup flow is user-facing behavior, not just an internal
+storage detail. It lets users load a database backup archive, see the contained
+sections, choose section-level Restore or Import behavior, and apply the
+selected data. Restore is destructive for selected categories. Import is
+non-destructive and keeps existing local rows when Android uniqueness keys
+already exist.
+
+iOS cannot honestly implement this by replacing local storage files with
+Android Room SQLite databases. The iOS app stores these categories in SwiftData
+models plus category-specific fidelity side stores. Directly installing Android
+database files would bypass those models, break local invariants, and create a
+data-loss risk.
+
+The repo already has Android SQLite readers and restore engines for several
+remote-sync categories. Those engines are the safest shared implementation
+surface for backup parity because they already know how to map Android database
+rows into iOS SwiftData state.
+
+Some Android backup categories do not yet have safe iOS mappers. Hiding those
+sections would make valid Android backup contents appear absent. Enabling them
+without source-backed mappers would risk corrupt or partial restores.
+
+## Decision
+
+iOS Android database backup support targets Android behavioral parity, not raw
+storage-mechanism parity.
+
+For manual Android database backups, iOS will:
+
+- load `.abdb.zip` archives through the Android backup manifest
+- validate extracted SQLite database sections and schema versions before apply
+- show supported and unsupported sections distinctly
+- allow Restore or Import only for sections that have safe iOS mappers
+- preserve Android's selected-section apply model
+- reset affected remote-sync bookkeeping after a manual apply
+
+Supported sections are limited to categories with safe Android-to-iOS mappers
+and supported schema versions:
+
+- Bookmarks
+- Workspaces
+- Reading Plans
+- My Documents
+
+Unsupported sections remain visible but disabled with a reason. This includes
+Android categories that are present in the archive but do not yet have safe iOS
+mappers, such as Settings, Repositories, Modules, EPUBs, AI Settings, and
+Progress. Future work may enable a category only after adding a source-backed
+mapper, version validation, focused tests, and any required fidelity state.
+
+Restore mode replaces the selected local category data with the Android backup
+section mapped through the existing restore engine.
+
+Import mode preserves the existing local data state first and adds backup rows
+whose Android uniqueness keys are absent. The implementation may build an
+Android-shaped merged snapshot and rewrite the category through the existing
+restore engine. That can recreate SwiftData object instances even when the
+observable data is preserved. This is an accepted storage adaptation, not a
+permission to overwrite local row contents or drift from Android's
+`INSERT OR IGNORE` intent.
+
+After each supported category is applied, iOS disables and clears the
+Android-aligned remote-sync state for that category. Manual backup apply changes
+local data outside the remote patch stream, so leaving remote-sync bookkeeping
+intact would let later sync treat manually restored rows as already reconciled
+remote state.
+
+The category-selection UI may be native SwiftUI because this is an app settings
+and system-file-import workflow, not a reader document/window surface. The UI
+still has to preserve Android's observable flow: archive summary, visible
+sections, disabled unsupported sections, section selection, Restore/Import
+choice, and destructive confirmation for Restore. This native setting-sheet
+decision is not a precedent for reader document surfaces, which are governed by
+ADR 0002.
+
+ZIP extraction should remain explicit and fail-closed. The reader supports the
+stored and deflated central-directory ZIP shapes produced by Android backup
+archives. Unsupported ZIP shapes must fail with an error instead of silently
+skipping entries or treating a partial archive as a valid empty backup.
+
+## Consequences
+
+- Android backup parity is measured by user-observable restore/import behavior
+  and final local data state, not by matching Android's storage files byte for
+  byte.
+- iOS must not enable an unsupported backup category just because the archive
+  contains a valid SQLite file. The category needs a safe mapper and tests first.
+- Unsupported sections should remain visible so users can tell the difference
+  between "not in this backup" and "present but not supported by this iOS
+  build."
+- Import tests must prove local-first behavior and protect against overwriting
+  existing local data.
+- Restore tests must prove selected-category replacement and sync-state reset.
+- Future mapper additions should update this ADR if they change the supported
+  category set or the accepted parity boundary.
+- Native presentation here is acceptable only for this settings/file-import
+  workflow. Reader/document modal decisions still prefer the shared
+  Vue/document pipeline unless a separate ADR records a real platform
+  constraint.
+
+## Related
+
+- [ADR 0001: Gradually Convert Parity Decisions To ADRs](0001-gradually-convert-parity-decisions-to-adrs.md)
+- [ADR 0002: Route Reader Document Modals Through The Shared Document Pipeline](0002-route-reader-document-modals-through-shared-document-pipeline.md)
+- [Android database backup service](../../Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift)
+- [Android database backup import sheet](../../Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift)
+- [Android database backup tests](../../AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift)
+- #150

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,3 +45,4 @@ Use these sections:
 
 - [0001: Gradually Convert Parity Decisions To ADRs](0001-gradually-convert-parity-decisions-to-adrs.md)
 - [0002: Route Reader Document Modals Through The Shared Document Pipeline](0002-route-reader-document-modals-through-shared-document-pipeline.md)
+- [0003: Android Database Backup Restore Parity](0003-android-database-backup-restore-parity.md)


### PR DESCRIPTION
## Summary

- Adds Android .abdb.zip database backup restore/import support on iOS for supported categories.
- Preserves Android section selection, Restore vs Import behavior, destructive Restore confirmation, and sync-state reset semantics.
- Adds ADR 0003 to record the accepted parity compromises directly as a durable decision record.

## Scope

- Android database backup archive loading and validation.
- ZIP central-directory reader for stored and deflated backup entries.
- Section-selection SwiftUI sheet for supported and unsupported archive categories.
- Restore/import mapping for Bookmarks, Workspaces, Reading Plans, and My Documents through existing Android SQLite restore engines.
- Focused unit coverage for archive loading, restore, import, invalid archive handling, unsupported versions, and partial category selection.

## Contract References

- GitHub issue #150: Restore Android database backup archives on iOS.
- ADR 0003: Android Database Backup Restore Parity.
- Android behavior references from #150: BackupControl.kt, DatabaseContainer.kt, and ImportDb.kt.
- iOS mapping surface: existing remote sync Android SQLite restore/snapshot services.

## Change Details

- Adds AndroidDatabaseBackupService to load .abdb.zip archives, validate manifests and SQLite user_version values, expose visible unsupported sections, and apply supported sections.
- Adds local-first Import merging so existing iOS rows are preserved while missing Android rows are added.
- Adds AndroidDatabaseBackupImportSheet with supported-section selection, per-section mode choice, disabled unsupported rows, and destructive Restore confirmation.
- Extends ImportExportView so selected ZIP files are staged as Android database backup candidates.
- Adds ZipArchiveReader so Android backup ZIP files with central-directory sizes and data descriptors are read correctly.
- Adds Android backup tests and registers them in the Xcode test target.
- Adds ADR 0003 and updates the ADR index.

## Validation Evidence

- Ran DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme BibleCore -destination platform=macOS build.
- Ran targeted AndBible iOS simulator tests for Android database backup restore/import coverage.
- Ran DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -derivedDataPath /private/tmp/andbible-issue150-derived build.
- Installed and launched the Debug build in the booted iPhone 16 simulator without erasing simulator data.
- Ran git diff --cached --check before commit.

## Risks / Follow-ups

- Settings, Repositories, Modules, EPUBs, AI Settings, and Progress remain visible but disabled until safe source-backed mappers exist.
- Import may rewrite SwiftData object instances through existing restore engines even when final observable data is preserved; ADR 0003 documents this as a storage adaptation, not a behavior exemption.
- ZIP support is intentionally fail-closed and limited to stored and deflated non-Zip64 archive entries.

## Issue Closure

Closes #150