### PR TITLE
feat(backup): support Android module archives

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
 		B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */; };
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
+		A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -85,6 +86,7 @@
 		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
 		D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDocumentDownloadPlannerTests.swift; sourceTree = "<group>"; };
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
+		A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidModuleBackup.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 				D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
+				A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -501,6 +504,7 @@
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
 				B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */,
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
+				A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
@@ -35,6 +35,37 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that archive entry paths are normalized before duplicate detection.
+
+     Setup:
+     - builds an Android module backup containing the same SWORD config path with `\` and `./`
+       spelling variants
+     - includes a valid module data file so the archive would otherwise be restorable
+
+     Expected result:
+     - inspection rejects the normalized duplicate before any restore file writes can occur
+     - the duplicate path reported to users and logs is the normalized archive path
+
+     Failure meaning:
+     - iOS could accept an archive that overwrites one restored file with another spelling of the
+       same path, drifting from Android's collision-safe restore expectations.
+     */
+    func testAndroidModuleBackupRejectsNormalizedDuplicateEntryPaths() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d\\kjv.conf", makeAndroidModuleBackupConf(moduleName: "KJV")),
+            ("./mods.d/kjv.conf", makeAndroidModuleBackupConf(moduleName: "KJV")),
+            ("modules/texts/rawtext/kjv/ot", Data("Genesis content".utf8)),
+        ])
+
+        XCTAssertThrowsError(try service.inspectArchive(from: archiveData)) { error in
+            XCTAssertEqual(error as? AndroidModuleBackupError, .duplicateEntry("mods.d/kjv.conf"))
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: moduleRoot.appendingPathComponent("mods.d/kjv.conf").path))
+    }
+
+    /**
      Verifies that iOS restores the shared SWORD portion of Android module backups and reports
      Android-only manual module payloads as skipped.
 
@@ -202,6 +233,35 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that Android-compatible ZIP exports mark entry names as UTF-8.
+
+     Setup:
+     - writes a minimal stored ZIP archive through `ZipArchiveWriter`
+     - reads the general-purpose bit flag from both local and central-directory headers
+
+     Expected result:
+     - both headers set the ZIP EFS/UTF-8 flag that Android's Java ZIP readers use for path
+       decoding
+
+     Failure meaning:
+     - Android restore could reinterpret iOS-exported module paths with a platform-default
+       encoding, especially for localized module filenames.
+     */
+    func testZipArchiveWriterMarksEntryNamesAsUTF8ForAndroidReaders() throws {
+        let archiveData = try ZipArchiveWriter.storedArchive(entries: [
+            ZipArchiveWriterEntry(name: "mods.d/kjv.conf", data: Data("payload".utf8)),
+        ])
+        let expectedFlag: UInt16 = 0x0800
+        let endOfCentralDirectoryOffset = archiveData.count - 22
+        let centralDirectoryOffset = Int(try readZipUInt32(archiveData, at: endOfCentralDirectoryOffset + 16))
+
+        XCTAssertEqual(try readZipUInt32(archiveData, at: endOfCentralDirectoryOffset), 0x0605_4b50)
+        XCTAssertEqual(try readZipUInt32(archiveData, at: centralDirectoryOffset), 0x0201_4b50)
+        XCTAssertEqual(try readZipUInt16(archiveData, at: 6), expectedFlag)
+        XCTAssertEqual(try readZipUInt16(archiveData, at: centralDirectoryOffset + 8), expectedFlag)
+    }
+
+    /**
      Verifies that Android-compatible module export honors the selected-module list.
 
      Setup:
@@ -327,5 +387,51 @@ extension AndBibleTests {
             withIntermediateDirectories: true
         )
         try data.write(to: dataURL)
+    }
+
+    /**
+     Reads a little-endian UInt16 from a ZIP fixture at an exact byte offset.
+
+     - Parameters:
+       - data: ZIP fixture bytes.
+       - offset: Zero-based byte offset of the two-byte integer.
+     - Returns: Decoded UInt16 value.
+     - Side effects: none.
+     - Failure modes: Throws a test-fixture error if the offset is outside the fixture.
+     */
+    private func readZipUInt16(_ data: Data, at offset: Int) throws -> UInt16 {
+        let bytes = [UInt8](data)
+        guard offset >= 0, offset + 1 < bytes.count else {
+            throw AndroidModuleBackupTestFixtureError.invalidZipOffset
+        }
+        return UInt16(bytes[offset]) | UInt16(bytes[offset + 1]) << 8
+    }
+
+    /**
+     Reads a little-endian UInt32 from a ZIP fixture at an exact byte offset.
+
+     - Parameters:
+       - data: ZIP fixture bytes.
+       - offset: Zero-based byte offset of the four-byte integer.
+     - Returns: Decoded UInt32 value.
+     - Side effects: none.
+     - Failure modes: Throws a test-fixture error if the offset is outside the fixture.
+     */
+    private func readZipUInt32(_ data: Data, at offset: Int) throws -> UInt32 {
+        let bytes = [UInt8](data)
+        guard offset >= 0, offset + 3 < bytes.count else {
+            throw AndroidModuleBackupTestFixtureError.invalidZipOffset
+        }
+        return UInt32(bytes[offset])
+            | UInt32(bytes[offset + 1]) << 8
+            | UInt32(bytes[offset + 2]) << 16
+            | UInt32(bytes[offset + 3]) << 24
+    }
+
+    /**
+     Reports malformed local ZIP fixtures as XCTest failures instead of runtime traps.
+     */
+    private enum AndroidModuleBackupTestFixtureError: Error {
+        case invalidZipOffset
     }
 }

--- a/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
@@ -1,0 +1,331 @@
+import XCTest
+@testable import BibleCore
+
+extension AndBibleTests {
+    /**
+     Verifies that Android module backups are recognized by the `.abmd.zip` suffix and rejected
+     when their manifest declares the database-backup type.
+
+     Setup:
+     - checks Android's module-backup filename suffix
+     - builds a ZIP with `AndBibleBackupManifest.json` declaring `DB_BACKUP`
+
+     Expected result:
+     - `.abmd.zip` recognition is case-insensitive
+     - the module backup service rejects the database manifest before looking for module files
+
+     Failure meaning:
+     - iOS could route Android database and module backups through the wrong restore path, causing
+       confusing UI behavior or unsafe file writes.
+     */
+    func testAndroidModuleBackupRecognizesSuffixAndRejectsDatabaseManifest() throws {
+        XCTAssertTrue(AndroidModuleBackupService.isAndroidModuleBackupFileName("AndBibleModulesBackup.abmd.zip"))
+        XCTAssertTrue(AndroidModuleBackupService.isAndroidModuleBackupFileName("ANDBIBLEMODULESBACKUP.ABMD.ZIP"))
+        XCTAssertFalse(AndroidModuleBackupService.isAndroidModuleBackupFileName("AndBibleDatabaseBackup.abdb.zip"))
+
+        let archiveData = try makeAndroidModuleBackupArchiveData(
+            manifestBackupType: "DB_BACKUP",
+            entries: []
+        )
+        let service = AndroidModuleBackupService(moduleDirectory: try makeTemporaryAndroidModuleBackupRoot())
+
+        XCTAssertThrowsError(try service.inspectArchive(from: archiveData)) { error in
+            XCTAssertEqual(error as? AndroidModuleBackupError, .unsupportedBackupType("DB_BACKUP"))
+        }
+    }
+
+    /**
+     Verifies that iOS restores the shared SWORD portion of Android module backups and reports
+     Android-only manual module payloads as skipped.
+
+     Setup:
+     - builds an Android-shaped `.abmd.zip` with one SWORD config/data pair
+     - includes one `mybible/` payload that Android can install but this iOS path cannot restore
+
+     Expected result:
+     - supported `mods.d/` and `modules/` files are written under the local module root
+     - the manifest and unsupported MyBible payload are not written
+     - the restore report lists the installed SWORD module and skipped Android-only entry
+
+     Failure meaning:
+     - iOS would either skip valid Android SWORD backups or silently pretend unsupported Android
+       formats were restored.
+     */
+    func testAndroidModuleBackupRestoresSwordPayloadAndSkipsUnsupportedEntries() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d/kjv.conf", makeAndroidModuleBackupConf(moduleName: "KJV")),
+            ("modules/texts/rawtext/kjv/ot", Data("Genesis content".utf8)),
+            ("mybible/example.SQLite3", Data("unsupported".utf8)),
+        ])
+
+        let inspection = try service.inspectArchive(from: archiveData)
+        XCTAssertEqual(inspection.supportedModuleNames, ["KJV"])
+        XCTAssertEqual(inspection.supportedEntryCount, 2)
+        XCTAssertEqual(inspection.unsupportedEntryPaths, ["mybible/example.SQLite3"])
+
+        let report = try service.restoreArchive(from: archiveData)
+
+        XCTAssertEqual(report.installedModuleNames, ["KJV"])
+        XCTAssertEqual(report.installedEntryCount, 2)
+        XCTAssertEqual(report.skippedUnsupportedEntryPaths, ["mybible/example.SQLite3"])
+        XCTAssertEqual(
+            try String(contentsOf: moduleRoot.appendingPathComponent("modules/texts/rawtext/kjv/ot"), encoding: .utf8),
+            "Genesis content"
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: moduleRoot.appendingPathComponent("mods.d/kjv.conf").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: moduleRoot.appendingPathComponent("AndBibleBackupManifest.json").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: moduleRoot.appendingPathComponent("mybible/example.SQLite3").path))
+    }
+
+    /**
+     Verifies that overwrite protection matches the UI confirmation contract for Android module
+     backup restore.
+
+     Setup:
+     - creates an existing local module data file
+     - builds an Android backup that would replace that same file
+
+     Expected result:
+     - inspection reports the existing file path for confirmation UI
+     - restore with overwrites disabled fails without changing the local file
+     - restore with overwrites enabled replaces the file
+
+     Failure meaning:
+     - iOS could overwrite installed module data without confirmation or fail to apply the user's
+       confirmed overwrite choice.
+     */
+    func testAndroidModuleBackupReportsAndControlsExistingFileOverwrite() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let existingURL = moduleRoot.appendingPathComponent("modules/texts/rawtext/kjv/ot")
+        try FileManager.default.createDirectory(
+            at: existingURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("local".utf8).write(to: existingURL)
+
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d/kjv.conf", makeAndroidModuleBackupConf(moduleName: "KJV")),
+            ("modules/texts/rawtext/kjv/ot", Data("remote".utf8)),
+        ])
+
+        let inspection = try service.inspectArchive(from: archiveData)
+        XCTAssertEqual(inspection.existingEntryPaths, ["modules/texts/rawtext/kjv/ot"])
+
+        XCTAssertThrowsError(
+            try service.restoreArchive(from: archiveData, allowOverwritingExistingFiles: false)
+        ) { error in
+            XCTAssertEqual(
+                error as? AndroidModuleBackupError,
+                .moduleFilesAlreadyExist(["modules/texts/rawtext/kjv/ot"])
+            )
+        }
+        XCTAssertEqual(try String(contentsOf: existingURL, encoding: .utf8), "local")
+
+        _ = try service.restoreArchive(from: archiveData, allowOverwritingExistingFiles: true)
+        XCTAssertEqual(try String(contentsOf: existingURL, encoding: .utf8), "remote")
+    }
+
+    /**
+     Verifies that archives containing only Android-only module formats fail with a clear
+     unsupported-content error and do not create local files.
+
+     Setup:
+     - builds an Android module backup containing only an optimized Android EPUB payload
+
+     Expected result:
+     - inspection fails with `noSupportedModules`
+     - no `epub/` payload is written into the iOS SWORD module root
+
+     Failure meaning:
+     - iOS would either silently ignore a user-selected backup or install Android-specific files
+       that the iOS module/document pipeline cannot read.
+     */
+    func testAndroidModuleBackupRejectsUnsupportedOnlyContentWithoutWritingFiles() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("epub/Example/book.xhtml", Data("<html></html>".utf8)),
+        ])
+
+        XCTAssertThrowsError(try service.inspectArchive(from: archiveData)) { error in
+            XCTAssertEqual(error as? AndroidModuleBackupError, .noSupportedModules(["epub/Example/book.xhtml"]))
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: moduleRoot.appendingPathComponent("epub/Example/book.xhtml").path))
+    }
+
+    /**
+     Verifies that iOS exports installed SWORD modules in Android's module-backup ZIP shape.
+
+     Setup:
+     - creates a local SWORD config and data file under a temporary module root
+     - exports the module through `AndroidModuleBackupService`
+     - re-reads the ZIP with the production `ZipArchiveReader`
+
+     Expected result:
+     - the archive filename uses Android's `.abmd.zip` name
+     - the manifest declares `MODULE_BACKUP`
+     - the config and data entries are relative to the module root, matching Android's export
+
+     Failure meaning:
+     - Android would be unable to restore an iOS-created module backup, breaking round-trip parity.
+     */
+    func testAndroidModuleBackupExportsInstalledSwordModulesWithAndroidManifest() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        try writeAndroidModuleBackupInstalledModule(
+            moduleRoot: moduleRoot,
+            moduleName: "KJV",
+            data: Data("exported".utf8)
+        )
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+
+        let export = try service.exportArchive(moduleNames: ["KJV"])
+
+        XCTAssertEqual(export.fileName, AndroidModuleBackupService.moduleBackupFileName)
+        XCTAssertEqual(export.moduleNames, ["KJV"])
+        let entries = try ZipArchiveReader.entries(in: export.data)
+        let entriesByName = Dictionary(uniqueKeysWithValues: entries.map { ($0.name, $0.data) })
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(entriesByName["AndBibleBackupManifest.json"]), encoding: .utf8),
+            #"{"backupType":"MODULE_BACKUP","manifestVersion":1}"#
+        )
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(entriesByName["mods.d/kjv.conf"]), encoding: .utf8),
+            String(data: makeAndroidModuleBackupConf(moduleName: "KJV"), encoding: .utf8)
+        )
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(entriesByName["modules/texts/rawtext/kjv/ot"]), encoding: .utf8),
+            "exported"
+        )
+    }
+
+    /**
+     Verifies that Android-compatible module export honors the selected-module list.
+
+     Setup:
+     - creates two installed SWORD modules under a temporary root
+     - requests export of only one module, matching Android's multiselect backup flow
+
+     Expected result:
+     - the generated archive includes the selected module config/data
+     - the unselected module does not appear in the archive
+
+     Failure meaning:
+     - iOS would present a selectable module backup UI but still export unselected documents,
+       breaking Android parity and user intent.
+     */
+    func testAndroidModuleBackupExportsOnlySelectedInstalledModules() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        try writeAndroidModuleBackupInstalledModule(
+            moduleRoot: moduleRoot,
+            moduleName: "KJV",
+            data: Data("selected".utf8)
+        )
+        try writeAndroidModuleBackupInstalledModule(
+            moduleRoot: moduleRoot,
+            moduleName: "ASV",
+            data: Data("unselected".utf8)
+        )
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+
+        let export = try service.exportArchive(moduleNames: ["KJV"])
+
+        XCTAssertEqual(export.moduleNames, ["KJV"])
+        let entryNames = Set(try ZipArchiveReader.entries(in: export.data).map(\.name))
+        XCTAssertTrue(entryNames.contains("mods.d/kjv.conf"))
+        XCTAssertTrue(entryNames.contains("modules/texts/rawtext/kjv/ot"))
+        XCTAssertFalse(entryNames.contains("mods.d/asv.conf"))
+        XCTAssertFalse(entryNames.contains("modules/texts/rawtext/asv/ot"))
+    }
+
+    /**
+     Creates a temporary SWORD module root for Android module-backup tests.
+
+     - Returns: Empty module root URL with `mods.d/` present.
+     - Side effects: Creates a temporary directory and registers it for teardown cleanup.
+     - Failure modes: Rethrows file-system directory creation failures.
+     */
+    private func makeTemporaryAndroidModuleBackupRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("mods.d", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        temporarySwordModulePaths.append(root.path)
+        return root
+    }
+
+    /**
+     Builds an Android-shaped module backup ZIP fixture.
+
+     - Parameters:
+       - manifestBackupType: Manifest `backupType` value to emit.
+       - entries: Additional archive entries after the manifest.
+     - Returns: Stored ZIP data readable by production archive services.
+     - Side effects: none.
+     - Failure modes: Rethrows `ZipArchiveWriter` size failures.
+     */
+    private func makeAndroidModuleBackupArchiveData(
+        manifestBackupType: String = "MODULE_BACKUP",
+        entries: [(String, Data)]
+    ) throws -> Data {
+        let manifest = Data(#"{"backupType":"\#(manifestBackupType)","manifestVersion":1}"#.utf8)
+        let zipEntries = [ZipArchiveWriterEntry(name: "AndBibleBackupManifest.json", data: manifest)]
+            + entries.map { ZipArchiveWriterEntry(name: $0.0, data: $0.1) }
+        return try ZipArchiveWriter.storedArchive(entries: zipEntries)
+    }
+
+    /**
+     Builds a minimal SWORD config for module backup restore/export tests.
+
+     - Parameter moduleName: Module initials to place in the config section.
+     - Returns: UTF-8 SWORD config bytes with `RawText` data under `modules/texts/rawtext`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func makeAndroidModuleBackupConf(moduleName: String) -> Data {
+        Data(
+            """
+            [\(moduleName)]
+            DataPath=./modules/texts/rawtext/\(moduleName.lowercased())/
+            ModDrv=RawText
+            Description=\(moduleName)
+
+            """.utf8
+        )
+    }
+
+    /**
+     Writes a minimal installed SWORD module fixture under a temporary module root.
+
+     - Parameters:
+       - moduleRoot: Temporary SWORD root.
+       - moduleName: Module initials for the config filename and section.
+       - data: Module data payload to write.
+     - Side effects: Creates config and data files under `moduleRoot`.
+     - Failure modes: Rethrows file-system write failures.
+     */
+    private func writeAndroidModuleBackupInstalledModule(
+        moduleRoot: URL,
+        moduleName: String,
+        data: Data
+    ) throws {
+        let confURL = moduleRoot
+            .appendingPathComponent("mods.d", isDirectory: true)
+            .appendingPathComponent("\(moduleName.lowercased()).conf")
+        try makeAndroidModuleBackupConf(moduleName: moduleName).write(to: confURL)
+
+        let dataURL = moduleRoot
+            .appendingPathComponent("modules/texts/rawtext/\(moduleName.lowercased())", isDirectory: true)
+            .appendingPathComponent("ot")
+        try FileManager.default.createDirectory(
+            at: dataURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: dataURL)
+    }
+}

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -333,23 +333,29 @@ extension AndBibleUITests {
         ]
     }
 
-    /// Returns workspace-name prompt text-field candidates without probing arbitrary fields.
+    /**
+     Returns workspace-name prompt text-field candidates without probing arbitrary fields.
+
+     The production workspace prompt exports a text-field identifier. The candidate list therefore
+     stays bounded to that identifier and localized field-title fallbacks; it deliberately avoids
+     prompt-root descendant scans and app-wide focused-field queries because those can wedge XCTest
+     snapshot resolution on hosted simulators.
+     */
     func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
         let identifier = "workspaceNamePromptTextField"
-        let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
-        let customSheetCandidates = ["Name", "name"].flatMap { title in
+        let identifierCandidates = [
+            app.textFields[identifier].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+        let titledCandidates = ["Name", "name"].flatMap { title in
             [
                 app.textFields[title].firstMatch,
                 app.collectionViews.textFields[title].firstMatch,
                 app.tables.textFields[title].firstMatch,
                 app.scrollViews.textFields[title].firstMatch,
             ]
-        } + [
-            app.textFields[identifier].firstMatch,
-            app.otherElements[identifier].firstMatch,
-            app.textFields.matching(focusedPredicate).firstMatch,
-        ]
-        return customSheetCandidates
+        }
+        return identifierCandidates + titledCandidates
     }
 
     /// Returns workspace-name prompt buttons without walking the custom sheet hierarchy.

--- a/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -317,8 +317,8 @@ extension AndBibleUITests {
 
         repeat {
             let button = unresolvedElement("readerMoreMenuButton", in: app)
-            tapReaderMoreMenuChromeCoordinate(in: app)
-            if waitForReaderOverflowMenu(in: app, timeout: min(2, max(1, deadline.timeIntervalSinceNow))) {
+            if tapReaderMoreMenuChromeCoordinate(in: app),
+               waitForReaderOverflowMenu(in: app, timeout: min(2, max(1, deadline.timeIntervalSinceNow))) {
                 return true
             }
             if elementHasUsableFrame(button) {
@@ -509,11 +509,11 @@ extension AndBibleUITests {
 
         repeat {
             let button = unresolvedElement("readerNavigationDrawerButton", in: app)
-            tapReaderNavigationDrawerChromeCoordinate(in: app)
-            if waitForReaderNavigationDrawer(
-                in: app,
-                timeout: min(2, max(1, deadline.timeIntervalSinceNow))
-            ) {
+            if tapReaderNavigationDrawerChromeCoordinate(in: app),
+               waitForReaderNavigationDrawer(
+                   in: app,
+                   timeout: min(2, max(1, deadline.timeIntervalSinceNow))
+               ) {
                 return true
             }
             if elementHasUsableFrame(button) {
@@ -533,14 +533,48 @@ extension AndBibleUITests {
         return false
     }
 
-    /// Taps the reader drawer affordance without forcing XCTest to snapshot its frame first.
-    func tapReaderNavigationDrawerChromeCoordinate(in app: XCUIApplication) {
+    /**
+     Attempts the reader drawer chrome-coordinate tap only when the app frame is safe to sample.
+
+     The coordinate tap preserves coverage for hosted reader chrome that may not expose a stable
+     accessibility button immediately after launch. Hosted XCTest can briefly expose an application
+     frame with infinite coordinates while the reader shell is settling, and creating a coordinate
+     from that frame raises an XCTest exception before the explicit button fallback can run.
+     This helper leaves the app untouched when the sampled frame is unusable so callers can retry
+     through the button path.
+
+     - Parameter app: The launched AndBible application under test.
+     - Returns: `true` when the chrome coordinate was tapped, or `false` when callers should use the
+       explicit drawer button fallback.
+     */
+    @discardableResult
+    func tapReaderNavigationDrawerChromeCoordinate(in app: XCUIApplication) -> Bool {
+        guard elementHasUsableFrame(app) else {
+            return false
+        }
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.06, dy: 0.06)).tap()
+        return true
     }
 
-    /// Taps the reader overflow affordance without forcing XCTest to snapshot its frame first.
-    func tapReaderMoreMenuChromeCoordinate(in app: XCUIApplication) {
+    /**
+     Attempts the reader overflow chrome-coordinate tap only when the app frame is safe to sample.
+
+     The coordinate tap avoids forcing an early snapshot of hosted reader chrome before the overflow
+     button has stabilized. If XCTest reports a non-finite application frame, the helper does not tap
+     and lets the caller fall back to the explicit toolbar button, preventing the infinite-coordinate
+     exception seen in sharded CI.
+
+     - Parameter app: The launched AndBible application under test.
+     - Returns: `true` when the chrome coordinate was tapped, or `false` when callers should use the
+       explicit overflow button fallback.
+     */
+    @discardableResult
+    func tapReaderMoreMenuChromeCoordinate(in app: XCUIApplication) -> Bool {
+        guard elementHasUsableFrame(app) else {
+            return false
+        }
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.94, dy: 0.06)).tap()
+        return true
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -96,6 +96,10 @@ extension AndBibleUITests {
     /**
      Types text into a prompt field and waits for XCTest to observe the committed value.
 
+     Prompt-specific callers pass a field that was already resolved from a known modal/sheet.
+     Those flows intentionally avoid app-wide focused-field probes because hosted XCTest can hang
+     while proving unrelated text fields do not exist.
+
      - Parameters:
        - text: Final text expected in the prompt-owned field.
        - element: Prompt text field resolved by a modal-specific helper.
@@ -127,22 +131,18 @@ extension AndBibleUITests {
         let includeElementMetadata = accessibilityIdentifier == nil
         let deadline = Date().addingTimeInterval(timeout)
 
+        let usesPromptScopedResolvedField = [
+            "labelManagerNewLabelNameField",
+            "workspaceNamePromptTextField",
+        ].contains(resolvedIdentifier)
+
         func promptFocusedTextEntryCandidates() -> [XCUIElement] {
-            switch accessibilityIdentifier {
-            case "labelManagerNewLabelNameField", "workspaceNamePromptTextField":
-                let focusedPredicate = NSPredicate(format: "hasKeyboardFocus == true")
-                return [app.textFields.matching(focusedPredicate).firstMatch]
-            default:
-                return focusedTextEntryCandidates(in: app)
-            }
+            usesPromptScopedResolvedField ? [] : focusedTextEntryCandidates(in: app)
         }
 
         func resolvedPromptTextField() -> XCUIElement {
-            switch accessibilityIdentifier {
-            case "labelManagerNewLabelNameField", "workspaceNamePromptTextField":
+            if usesPromptScopedResolvedField {
                 return element
-            default:
-                break
             }
 
             if let prompt = resolvedModalPrompt(in: app, timeout: 0.2) {
@@ -165,6 +165,10 @@ extension AndBibleUITests {
         }
 
         func promptTextEntryCandidates(preferred preferredCandidates: [XCUIElement]) -> [XCUIElement] {
+            if usesPromptScopedResolvedField {
+                return preferredCandidates.isEmpty ? [element] : preferredCandidates
+            }
+
             var candidates = preferredCandidates
             if preferredCandidates.isEmpty {
                 candidates.append(resolvedPromptTextField())
@@ -177,7 +181,7 @@ extension AndBibleUITests {
         func observedPromptTextValue(preferred preferredCandidates: [XCUIElement] = []) -> String {
             let candidates = promptTextEntryCandidates(preferred: preferredCandidates)
             var fallbackValue = ""
-            for candidate in candidates where candidate.exists {
+            for candidate in candidates where usesPromptScopedResolvedField || candidate.exists {
                 let candidateValue = currentTextEntryValue(
                     in: candidate,
                     placeholderHints: placeholderHints,
@@ -225,10 +229,25 @@ extension AndBibleUITests {
             preferred preferredCandidates: [XCUIElement],
             forceKeyboardDelete: Bool = false
         ) -> Bool {
-            let candidates = promptTextEntryCandidates(preferred: preferredCandidates)
-            for candidate in candidates where candidate.exists {
-                if forceKeyboardDelete {
+            func focusCandidateForKeyboardDelete(_ candidate: XCUIElement) {
+                if usesPromptScopedResolvedField {
+                    focusResolvedPromptTextEntryElement(
+                        candidate,
+                        in: app,
+                        preferTrailingEdge: true,
+                        timeout: 1,
+                        file: file,
+                        line: line
+                    )
+                } else {
                     focusTextEntryElement(candidate, preferTrailingEdge: true, timeout: 1)
+                }
+            }
+
+            let candidates = promptTextEntryCandidates(preferred: preferredCandidates)
+            for candidate in candidates where usesPromptScopedResolvedField || candidate.exists {
+                if forceKeyboardDelete {
+                    focusCandidateForKeyboardDelete(candidate)
                     if waitForElementKeyboardFocus(candidate, timeout: 0.3) {
                         app.typeText(
                             String(repeating: XCUIKeyboardKey.delete.rawValue, count: max(text.count * 2, 32))

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
@@ -448,14 +448,20 @@ public final class AndroidModuleBackupService {
             throw AndroidModuleBackupError.invalidArchive(error.localizedDescription)
         }
 
-        var names: Set<String> = []
-        for entry in entries {
-            guard names.insert(entry.name).inserted else {
+        let normalizedEntries = try entries.map { entry in
+            ZipArchiveEntry(name: try normalizedArchivePath(entry.name), data: entry.data)
+        }
+
+        var normalizedNames: Set<String> = []
+        for entry in normalizedEntries {
+            let collisionKey = entry.name.lowercased()
+            guard normalizedNames.insert(collisionKey).inserted else {
                 throw AndroidModuleBackupError.duplicateEntry(entry.name)
             }
         }
 
-        guard let manifestEntry = entries.first(where: { $0.name == Self.manifestFileName }) else {
+        let manifestName = Self.manifestFileName.lowercased()
+        guard let manifestEntry = normalizedEntries.first(where: { $0.name.lowercased() == manifestName }) else {
             throw AndroidModuleBackupError.missingManifest
         }
         let manifest = try decodeManifest(from: manifestEntry.data)
@@ -468,8 +474,8 @@ public final class AndroidModuleBackupService {
 
         var supportedEntries: [ZipArchiveEntry] = []
         var unsupportedEntryPaths: [String] = []
-        for entry in entries where entry.name != Self.manifestFileName {
-            let normalizedPath = try normalizedArchivePath(entry.name)
+        for entry in normalizedEntries where entry.name.lowercased() != manifestName {
+            let normalizedPath = entry.name
             let lowercasedPath = normalizedPath.lowercased()
             if isSupportedSwordEntry(lowercasedPath) {
                 supportedEntries.append(ZipArchiveEntry(name: normalizedPath, data: entry.data))

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
@@ -1,0 +1,870 @@
+// AndroidModuleBackupService.swift — Android .abmd.zip module backup import/export support
+
+import Foundation
+import SwordKit
+
+/**
+ Android module backup manifest payload read from `AndBibleBackupManifest.json`.
+
+ Android writes this manifest as the first entry in `.abmd.zip` archives. iOS requires the
+ `MODULE_BACKUP` type before installing any files so database backups and module backups cannot be
+ accidentally routed through the wrong restore path.
+ */
+public struct AndroidModuleBackupManifest: Sendable, Equatable {
+    /// Android backup type string, expected to be `MODULE_BACKUP`.
+    public let backupType: String
+
+    /// Manifest schema version. Android currently writes version `1`.
+    public let manifestVersion: Int
+
+    /// Android application version that created the backup, when present.
+    public let andBibleVersion: Int?
+
+    /**
+     Creates one decoded Android module backup manifest.
+
+     - Parameters:
+       - backupType: Android backup type string.
+       - manifestVersion: Manifest schema version.
+       - andBibleVersion: Android application version, when present.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(backupType: String, manifestVersion: Int, andBibleVersion: Int?) {
+        self.backupType = backupType
+        self.manifestVersion = manifestVersion
+        self.andBibleVersion = andBibleVersion
+    }
+}
+
+/**
+ Non-destructive summary of one Android module backup archive.
+
+ The import UI uses this to distinguish supported SWORD payloads from Android-only formats and to
+ decide whether the user should confirm overwriting files that already exist locally.
+ */
+public struct AndroidModuleBackupInspection: Sendable, Equatable {
+    /// Decoded Android backup manifest.
+    public let manifest: AndroidModuleBackupManifest
+
+    /// Module initials derived from supported `mods.d/*.conf` entries.
+    public let supportedModuleNames: [String]
+
+    /// Number of supported SWORD file entries that would be written during restore.
+    public let supportedEntryCount: Int
+
+    /// Android module-backup entries that iOS recognizes but cannot restore through SWORD.
+    public let unsupportedEntryPaths: [String]
+
+    /// Supported SWORD entries whose destination files already exist locally.
+    public let existingEntryPaths: [String]
+
+    /// Whether the archive contains at least one restorable SWORD module.
+    public var hasSupportedModules: Bool { !supportedModuleNames.isEmpty }
+
+    /**
+     Creates one archive inspection summary.
+
+     - Parameters:
+       - manifest: Decoded Android backup manifest.
+       - supportedModuleNames: Restorable SWORD module initials.
+       - supportedEntryCount: Number of supported SWORD file entries.
+       - unsupportedEntryPaths: Recognized Android-only entry paths.
+       - existingEntryPaths: Supported paths that already exist in the local module directory.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        manifest: AndroidModuleBackupManifest,
+        supportedModuleNames: [String],
+        supportedEntryCount: Int,
+        unsupportedEntryPaths: [String],
+        existingEntryPaths: [String]
+    ) {
+        self.manifest = manifest
+        self.supportedModuleNames = supportedModuleNames
+        self.supportedEntryCount = supportedEntryCount
+        self.unsupportedEntryPaths = unsupportedEntryPaths
+        self.existingEntryPaths = existingEntryPaths
+    }
+}
+
+/**
+ Summary returned after installing supported content from an Android module backup.
+ */
+public struct AndroidModuleBackupRestoreReport: Sendable, Equatable {
+    /// Installed SWORD module initials.
+    public let installedModuleNames: [String]
+
+    /// Count of supported SWORD file entries written into the local module directory.
+    public let installedEntryCount: Int
+
+    /// Android-only backup entries skipped because iOS cannot restore them through SWORD.
+    public let skippedUnsupportedEntryPaths: [String]
+
+    /**
+     Creates one restore report.
+
+     - Parameters:
+       - installedModuleNames: Installed SWORD module initials.
+       - installedEntryCount: Number of supported file entries written.
+       - skippedUnsupportedEntryPaths: Recognized Android-only entries that were skipped.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        installedModuleNames: [String],
+        installedEntryCount: Int,
+        skippedUnsupportedEntryPaths: [String]
+    ) {
+        self.installedModuleNames = installedModuleNames
+        self.installedEntryCount = installedEntryCount
+        self.skippedUnsupportedEntryPaths = skippedUnsupportedEntryPaths
+    }
+}
+
+/**
+ Android-compatible module backup archive produced from locally installed SWORD modules.
+ */
+public struct AndroidModuleBackupExport: Sendable, Equatable {
+    /// Android-compatible export filename.
+    public let fileName: String
+
+    /// Raw `.abmd.zip` archive bytes.
+    public let data: Data
+
+    /// Exported SWORD module initials.
+    public let moduleNames: [String]
+
+    /// Number of file entries written into the ZIP, including the manifest.
+    public let entryCount: Int
+
+    /**
+     Creates one module backup export result.
+
+     - Parameters:
+       - fileName: Android-compatible backup filename.
+       - data: Raw ZIP archive bytes.
+       - moduleNames: Exported SWORD module initials.
+       - entryCount: Number of ZIP file entries.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(fileName: String, data: Data, moduleNames: [String], entryCount: Int) {
+        self.fileName = fileName
+        self.data = data
+        self.moduleNames = moduleNames
+        self.entryCount = entryCount
+    }
+}
+
+/**
+ Errors raised while inspecting, restoring, or exporting Android module backups.
+ */
+public enum AndroidModuleBackupError: LocalizedError, Equatable {
+    /// The archive could not be parsed as ZIP.
+    case invalidArchive(String)
+
+    /// The required Android manifest file was missing.
+    case missingManifest
+
+    /// The Android manifest could not be decoded.
+    case invalidManifest
+
+    /// The manifest described a backup type other than `MODULE_BACKUP`.
+    case unsupportedBackupType(String)
+
+    /// The manifest version is newer than this iOS build understands.
+    case unsupportedManifestVersion(Int)
+
+    /// The archive contains only Android module formats that this iOS build cannot restore.
+    case noSupportedModules([String])
+
+    /// The archive's supported SWORD entries are incomplete or inconsistent.
+    case invalidModuleLayout(String)
+
+    /// The archive contains a duplicate file entry.
+    case duplicateEntry(String)
+
+    /// Restore was asked not to overwrite existing files and matching module paths already exist.
+    case moduleFilesAlreadyExist([String])
+
+    /// No installed SWORD modules were available for Android-compatible export.
+    case noExportableModules
+
+    /// An installed module config references data files that are missing locally.
+    case missingExportData(moduleName: String, dataPath: String)
+
+    /// User-visible error description.
+    public var errorDescription: String? {
+        switch self {
+        case .invalidArchive(let message):
+            return "Invalid Android module backup archive: \(message)"
+        case .missingManifest:
+            return "The Android module backup manifest is missing."
+        case .invalidManifest:
+            return "The Android module backup manifest could not be read."
+        case .unsupportedBackupType(let type):
+            return "This archive is \(type), not an Android module backup."
+        case .unsupportedManifestVersion(let version):
+            return "This Android module backup manifest version (\(version)) is newer than iOS supports."
+        case .noSupportedModules(let paths):
+            if paths.isEmpty {
+                return "No supported SWORD modules were found in this Android module backup."
+            }
+            return "This Android module backup only contains formats iOS cannot restore yet: \(paths.prefix(5).joined(separator: ", "))"
+        case .invalidModuleLayout(let message):
+            return "Invalid Android module backup layout: \(message)"
+        case .duplicateEntry(let name):
+            return "Android module backup contains duplicate entry \(name)."
+        case .moduleFilesAlreadyExist(let files):
+            return "Module files already exist: \(files.prefix(5).joined(separator: ", "))"
+        case .noExportableModules:
+            return "No installed SWORD modules are available for Android-compatible export."
+        case .missingExportData(let moduleName, let dataPath):
+            return "Cannot export \(moduleName) because its data files are missing at \(dataPath)."
+        }
+    }
+}
+
+/**
+ Loads Android `.abmd.zip` archives and exports installed SWORD modules in Android's backup shape.
+
+ Android module backups contain a `MODULE_BACKUP` manifest and raw files relative to Android's
+ modules directory. iOS supports the shared SWORD portion of that format (`mods.d/` plus
+ `modules/`) and reports Android-only payloads (`mybible/`, `mysword/`, `esword/`, `epub/`) as
+ skipped instead of pretending they were restored.
+ */
+public final class AndroidModuleBackupService {
+    /// Android module backup suffix used for file recognition.
+    public static let moduleBackupSuffix = ".abmd.zip"
+
+    /// Android's default module backup filename.
+    public static let moduleBackupFileName = "AndBibleModulesBackup.abmd.zip"
+
+    /// Android backup manifest entry name.
+    private static let manifestFileName = "AndBibleBackupManifest.json"
+
+    /// Android-only module backup prefixes that iOS recognizes but cannot restore as SWORD.
+    private static let unsupportedAndroidModulePrefixes = ["mybible/", "mysword/", "esword/", "epub/"]
+
+    /// SWORD drivers whose `DataPath` points at a file stem inside the actual module directory.
+    private static let singleFileDataPathDrivers: Set<String> = ["rawld", "zld", "rawgenbook", "rawfiles"]
+
+    private let fileManager: FileManager
+    private let moduleDirectory: URL
+    private let temporaryDirectory: URL
+
+    /**
+     Creates an Android module backup service.
+
+     - Parameters:
+       - fileManager: File manager used for module file reads/writes and temporary staging.
+       - moduleDirectory: Local SWORD module root. Defaults to `SwordManager.defaultModulePath()`.
+       - temporaryDirectory: Scratch directory for staged restores and rollback backups.
+     - Side effects: Ensures the module root and `mods.d` directory exist.
+     - Failure modes: Directory creation failures are deferred until import/export operations.
+     */
+    public init(
+        fileManager: FileManager = .default,
+        moduleDirectory: URL? = nil,
+        temporaryDirectory: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.moduleDirectory = moduleDirectory
+            ?? URL(fileURLWithPath: SwordManager.defaultModulePath(), isDirectory: true)
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        try? fileManager.createDirectory(at: self.moduleDirectory, withIntermediateDirectories: true)
+        try? fileManager.createDirectory(
+            at: self.moduleDirectory.appendingPathComponent("mods.d", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+    }
+
+    /**
+     Determines whether a filename uses Android's module-backup suffix.
+
+     - Parameter fileName: Display or URL filename to check.
+     - Returns: `true` only for names ending in `.abmd.zip`, case-insensitively.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public static func isAndroidModuleBackupFileName(_ fileName: String) -> Bool {
+        fileName.lowercased().hasSuffix(moduleBackupSuffix)
+    }
+
+    /**
+     Reads an Android module backup without mutating local module files.
+
+     - Parameter data: Raw `.abmd.zip` archive bytes.
+     - Returns: Summary of supported modules, unsupported Android-only entries, and existing files.
+     - Side effects: Reads ZIP data and local file-existence state; no files are written.
+     - Throws: `AndroidModuleBackupError` for malformed archives, wrong backup types, unsupported
+       manifest versions, duplicate entries, or incomplete SWORD module layouts.
+     */
+    public func inspectArchive(from data: Data) throws -> AndroidModuleBackupInspection {
+        let archive = try loadClassifiedArchive(from: data)
+        let existingPaths = existingEntryPaths(in: archive.supportedEntries)
+        return AndroidModuleBackupInspection(
+            manifest: archive.manifest,
+            supportedModuleNames: archive.moduleNames,
+            supportedEntryCount: archive.supportedEntries.count,
+            unsupportedEntryPaths: archive.unsupportedEntryPaths,
+            existingEntryPaths: existingPaths
+        )
+    }
+
+    /**
+     Installs supported SWORD content from an Android module backup.
+
+     - Parameters:
+       - data: Raw `.abmd.zip` archive bytes.
+       - allowOverwritingExistingFiles: Whether existing local module files may be replaced.
+     - Returns: Installed module names and skipped unsupported Android-only entries.
+     - Side effects:
+       - writes supported `mods.d/` and `modules/` entries into the local SWORD module directory
+       - stages files first, then uses rollback backups for overwritten files during publish
+       - deletes SWORD's `modules-conf.cache` so the next manager scan sees restored modules
+     - Throws: `AndroidModuleBackupError` for invalid archives, unsupported-only content, or
+       existing files when overwrite is disabled; rethrows file-system failures during staging or
+       publish after attempting rollback.
+     */
+    public func restoreArchive(
+        from data: Data,
+        allowOverwritingExistingFiles: Bool = true
+    ) throws -> AndroidModuleBackupRestoreReport {
+        let archive = try loadClassifiedArchive(from: data)
+        let existingPaths = existingEntryPaths(in: archive.supportedEntries)
+        if !allowOverwritingExistingFiles, !existingPaths.isEmpty {
+            throw AndroidModuleBackupError.moduleFilesAlreadyExist(existingPaths)
+        }
+
+        let stagingDirectory = temporaryDirectory.appendingPathComponent(
+            "android-module-backup-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let rollbackDirectory = temporaryDirectory.appendingPathComponent(
+            "android-module-backup-rollback-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: rollbackDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: stagingDirectory)
+            try? fileManager.removeItem(at: rollbackDirectory)
+        }
+
+        for entry in archive.supportedEntries {
+            let destinationURL = stagingDirectory.appendingPathComponent(entry.name)
+            try fileManager.createDirectory(
+                at: destinationURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try entry.data.write(to: destinationURL, options: .atomic)
+        }
+
+        try publishStagedEntries(
+            archive.supportedEntries.map(\.name),
+            from: stagingDirectory,
+            rollbackDirectory: rollbackDirectory
+        )
+        invalidateModuleCache()
+
+        return AndroidModuleBackupRestoreReport(
+            installedModuleNames: archive.moduleNames,
+            installedEntryCount: archive.supportedEntries.count,
+            skippedUnsupportedEntryPaths: archive.unsupportedEntryPaths
+        )
+    }
+
+    /**
+     Exports installed SWORD modules using Android's `.abmd.zip` backup layout.
+
+     - Parameter moduleNames: Optional module initials to export. When omitted, all installed SWORD
+       configs under `mods.d/` are exported.
+     - Returns: Android-compatible module backup bytes and exported module names.
+     - Side effects: Reads installed module config/data files from the local SWORD module directory.
+     - Throws: `AndroidModuleBackupError.noExportableModules` when no supported SWORD module files
+       are present; `AndroidModuleBackupError.missingExportData` when a config points at missing
+       data; `ZipArchiveWriterError` when the archive exceeds non-ZIP64 limits.
+     */
+    public func exportArchive(moduleNames: Set<String>? = nil) throws -> AndroidModuleBackupExport {
+        let manifestData = Data(#"{"backupType":"MODULE_BACKUP","manifestVersion":1}"#.utf8)
+        var entries: [ZipArchiveWriterEntry] = [
+            ZipArchiveWriterEntry(name: Self.manifestFileName, data: manifestData),
+        ]
+        var exportedModuleNames: [String] = []
+        var seenEntryNames: Set<String> = [Self.manifestFileName]
+
+        let configs = try installedModuleConfigs(filteredBy: moduleNames)
+        guard !configs.isEmpty else {
+            throw AndroidModuleBackupError.noExportableModules
+        }
+
+        for config in configs {
+            let confArchivePath = try archivePath(for: config.fileURL)
+            if seenEntryNames.insert(confArchivePath).inserted {
+                entries.append(ZipArchiveWriterEntry(name: confArchivePath, data: try Data(contentsOf: config.fileURL)))
+            }
+
+            let dataRoot = dataDirectoryURL(for: config)
+            guard fileManager.fileExists(atPath: dataRoot.path) else {
+                throw AndroidModuleBackupError.missingExportData(
+                    moduleName: config.moduleName,
+                    dataPath: config.dataPath
+                )
+            }
+
+            for fileURL in try regularFiles(under: dataRoot) {
+                let archivePath = try archivePath(for: fileURL)
+                guard seenEntryNames.insert(archivePath).inserted else { continue }
+                entries.append(ZipArchiveWriterEntry(name: archivePath, data: try Data(contentsOf: fileURL)))
+            }
+            exportedModuleNames.append(config.moduleName)
+        }
+
+        guard entries.count > 1 else {
+            throw AndroidModuleBackupError.noExportableModules
+        }
+        let archiveData = try ZipArchiveWriter.storedArchive(entries: entries)
+        return AndroidModuleBackupExport(
+            fileName: Self.moduleBackupFileName,
+            data: archiveData,
+            moduleNames: exportedModuleNames.sorted(),
+            entryCount: entries.count
+        )
+    }
+
+    /**
+     Parses and classifies an Android module backup into supported and unsupported entry groups.
+     */
+    private func loadClassifiedArchive(from data: Data) throws -> ClassifiedArchive {
+        let entries: [ZipArchiveEntry]
+        do {
+            entries = try ZipArchiveReader.entries(in: data)
+        } catch let error as ZipArchiveReaderError {
+            throw AndroidModuleBackupError.invalidArchive(Self.archiveErrorMessage(for: error))
+        } catch {
+            throw AndroidModuleBackupError.invalidArchive(error.localizedDescription)
+        }
+
+        var names: Set<String> = []
+        for entry in entries {
+            guard names.insert(entry.name).inserted else {
+                throw AndroidModuleBackupError.duplicateEntry(entry.name)
+            }
+        }
+
+        guard let manifestEntry = entries.first(where: { $0.name == Self.manifestFileName }) else {
+            throw AndroidModuleBackupError.missingManifest
+        }
+        let manifest = try decodeManifest(from: manifestEntry.data)
+        guard manifest.backupType == "MODULE_BACKUP" else {
+            throw AndroidModuleBackupError.unsupportedBackupType(manifest.backupType)
+        }
+        guard manifest.manifestVersion <= 1 else {
+            throw AndroidModuleBackupError.unsupportedManifestVersion(manifest.manifestVersion)
+        }
+
+        var supportedEntries: [ZipArchiveEntry] = []
+        var unsupportedEntryPaths: [String] = []
+        for entry in entries where entry.name != Self.manifestFileName {
+            let normalizedPath = try normalizedArchivePath(entry.name)
+            let lowercasedPath = normalizedPath.lowercased()
+            if isSupportedSwordEntry(lowercasedPath) {
+                supportedEntries.append(ZipArchiveEntry(name: normalizedPath, data: entry.data))
+            } else if Self.unsupportedAndroidModulePrefixes.contains(where: lowercasedPath.hasPrefix) {
+                unsupportedEntryPaths.append(normalizedPath)
+            } else {
+                throw AndroidModuleBackupError.invalidModuleLayout("Unsupported entry \(normalizedPath).")
+            }
+        }
+
+        let moduleNames = try supportedModuleNames(in: supportedEntries, unsupportedEntryPaths: unsupportedEntryPaths)
+        return ClassifiedArchive(
+            manifest: manifest,
+            supportedEntries: supportedEntries,
+            unsupportedEntryPaths: unsupportedEntryPaths.sorted(),
+            moduleNames: moduleNames
+        )
+    }
+
+    /**
+     Decodes Android's backup manifest while preserving Android defaults for omitted fields.
+     */
+    private func decodeManifest(from data: Data) throws -> AndroidModuleBackupManifest {
+        do {
+            let dto = try JSONDecoder().decode(ManifestDTO.self, from: data)
+            return AndroidModuleBackupManifest(
+                backupType: dto.backupType,
+                manifestVersion: dto.manifestVersion ?? 1,
+                andBibleVersion: dto.andBibleVersion
+            )
+        } catch {
+            throw AndroidModuleBackupError.invalidManifest
+        }
+    }
+
+    /**
+     Converts ZIP parser errors into concise archive messages for user-facing restore failures.
+     */
+    private static func archiveErrorMessage(for error: ZipArchiveReaderError) -> String {
+        switch error {
+        case .missingCentralDirectory:
+            "Missing ZIP central directory."
+        case .invalidArchive(let message):
+            message
+        case .unsupportedCompressionMethod(let method):
+            "Unsupported ZIP compression method \(method)."
+        case .decompressionFailed:
+            "ZIP entry decompression failed."
+        }
+    }
+
+    /**
+     Normalizes and validates one archive entry path before it is used for local file I/O.
+     */
+    private func normalizedArchivePath(_ rawPath: String) throws -> String {
+        var path = rawPath.replacingOccurrences(of: "\\", with: "/")
+        while path.hasPrefix("./") {
+            path = String(path.dropFirst(2))
+        }
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.hasSuffix("/") else {
+            throw AndroidModuleBackupError.invalidModuleLayout("Unsafe entry path \(rawPath).")
+        }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.contains(where: { $0 == ".." || $0.isEmpty }) else {
+            throw AndroidModuleBackupError.invalidModuleLayout("Unsafe entry path \(rawPath).")
+        }
+        return path
+    }
+
+    /**
+     Determines whether a normalized lowercase path belongs to the shared SWORD module layout.
+     */
+    private func isSupportedSwordEntry(_ lowercasedPath: String) -> Bool {
+        if lowercasedPath.hasPrefix("modules/") {
+            return true
+        }
+        return lowercasedPath.hasPrefix("mods.d/") && lowercasedPath.hasSuffix(".conf")
+    }
+
+    /**
+     Validates supported SWORD entries and returns module initials in Android install order.
+     */
+    private func supportedModuleNames(
+        in supportedEntries: [ZipArchiveEntry],
+        unsupportedEntryPaths: [String]
+    ) throws -> [String] {
+        guard !supportedEntries.isEmpty else {
+            throw AndroidModuleBackupError.noSupportedModules(unsupportedEntryPaths.sorted())
+        }
+
+        let confEntries = supportedEntries.filter { entry in
+            let lowercasedPath = entry.name.lowercased()
+            return lowercasedPath.hasPrefix("mods.d/") && lowercasedPath.hasSuffix(".conf")
+        }
+        guard !confEntries.isEmpty else {
+            throw AndroidModuleBackupError.invalidModuleLayout("No module .conf files found in mods.d/.")
+        }
+        let dataEntryNames = Set(
+            supportedEntries.map(\.name).filter { $0.lowercased().hasPrefix("modules/") }
+        )
+        guard !dataEntryNames.isEmpty else {
+            throw AndroidModuleBackupError.invalidModuleLayout("No module data files found in modules/.")
+        }
+
+        var moduleNames: [String] = []
+        for entry in confEntries {
+            let config = try parseModuleConfig(data: entry.data, fallbackPath: entry.name)
+            let expectedDataRoot = dataDirectoryPath(for: config)
+            let hasData = dataEntryNames.contains { entryName in
+                entryName == expectedDataRoot || entryName.hasPrefix("\(expectedDataRoot)/")
+            }
+            guard hasData else {
+                throw AndroidModuleBackupError.invalidModuleLayout(
+                    "\(config.moduleName) references missing data path \(expectedDataRoot)."
+                )
+            }
+            moduleNames.append(config.moduleName)
+        }
+        return moduleNames
+    }
+
+    /**
+     Finds supported archive paths that would overwrite existing local module files.
+     */
+    private func existingEntryPaths(in supportedEntries: [ZipArchiveEntry]) -> [String] {
+        supportedEntries.map(\.name)
+            .filter { fileManager.fileExists(atPath: moduleDirectory.appendingPathComponent($0).path) }
+            .sorted()
+    }
+
+    /**
+     Atomically publishes staged module files with rollback protection for overwritten paths.
+     */
+    private func publishStagedEntries(
+        _ relativePaths: [String],
+        from stagingDirectory: URL,
+        rollbackDirectory: URL
+    ) throws {
+        var movedExistingPaths: [String] = []
+        var createdPaths: [String] = []
+
+        do {
+            for relativePath in relativePaths {
+                let finalURL = moduleDirectory.appendingPathComponent(relativePath)
+                let stagedURL = stagingDirectory.appendingPathComponent(relativePath)
+                let rollbackURL = rollbackDirectory.appendingPathComponent(relativePath)
+                try fileManager.createDirectory(
+                    at: finalURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+
+                if fileManager.fileExists(atPath: finalURL.path) {
+                    try fileManager.createDirectory(
+                        at: rollbackURL.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    try fileManager.moveItem(at: finalURL, to: rollbackURL)
+                    movedExistingPaths.append(relativePath)
+                }
+
+                try fileManager.copyItem(at: stagedURL, to: finalURL)
+                createdPaths.append(relativePath)
+            }
+        } catch {
+            for relativePath in createdPaths.reversed() {
+                try? fileManager.removeItem(at: moduleDirectory.appendingPathComponent(relativePath))
+            }
+            for relativePath in movedExistingPaths.reversed() {
+                let finalURL = moduleDirectory.appendingPathComponent(relativePath)
+                let rollbackURL = rollbackDirectory.appendingPathComponent(relativePath)
+                try? fileManager.createDirectory(
+                    at: finalURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try? fileManager.moveItem(at: rollbackURL, to: finalURL)
+            }
+            throw error
+        }
+    }
+
+    /**
+     Removes SWORD's module cache after installing files outside `ModuleRepository`.
+     */
+    private func invalidateModuleCache() {
+        let cacheURL = moduleDirectory
+            .appendingPathComponent("mods.d", isDirectory: true)
+            .appendingPathComponent("modules-conf.cache")
+        try? fileManager.removeItem(at: cacheURL)
+    }
+
+    /**
+     Loads installed SWORD config files and filters them by optional module initials.
+     */
+    private func installedModuleConfigs(filteredBy moduleNames: Set<String>?) throws -> [ModuleConfig] {
+        let requestedNames = moduleNames.map { Set($0.map { $0.uppercased() }) }
+        let modsDirectory = moduleDirectory.appendingPathComponent("mods.d", isDirectory: true)
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: modsDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return try files
+            .filter { $0.pathExtension.lowercased() == "conf" }
+            .compactMap { url -> ModuleConfig? in
+                let data = try Data(contentsOf: url)
+                let config = try parseModuleConfig(data: data, fallbackPath: url.path)
+                guard requestedNames?.contains(config.moduleName.uppercased()) ?? true else {
+                    return nil
+                }
+                return ModuleConfig(
+                    moduleName: config.moduleName,
+                    dataPath: config.dataPath,
+                    modDrv: config.modDrv,
+                    fileURL: url
+                )
+            }
+            .sorted { $0.moduleName.localizedCaseInsensitiveCompare($1.moduleName) == .orderedAscending }
+    }
+
+    /**
+     Parses the SWORD config fields needed for Android backup restore/export validation.
+     */
+    private func parseModuleConfig(data: Data, fallbackPath: String) throws -> ModuleConfig {
+        guard let content = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .isoLatin1) else {
+            throw AndroidModuleBackupError.invalidModuleLayout("\(fallbackPath) is not a readable SWORD config.")
+        }
+
+        var sectionName: String?
+        var dataPath: String?
+        var modDrv: String?
+        for rawLine in content.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("["),
+               line.hasSuffix("]"),
+               line.count > 2,
+               sectionName == nil {
+                sectionName = String(line.dropFirst().dropLast())
+                continue
+            }
+            guard let equalsIndex = line.firstIndex(of: "=") else { continue }
+            let key = line[..<equalsIndex].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = line[line.index(after: equalsIndex)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            if key == "datapath" {
+                dataPath = value
+            } else if key == "moddrv" {
+                modDrv = value
+            }
+        }
+
+        let fallbackName = ((fallbackPath as NSString).lastPathComponent as NSString).deletingPathExtension
+        let moduleName = (sectionName?.isEmpty == false ? sectionName : fallbackName) ?? fallbackName
+        guard let dataPath, !dataPath.isEmpty else {
+            throw AndroidModuleBackupError.invalidModuleLayout("\(moduleName) is missing DataPath.")
+        }
+        let normalizedDataPath = try normalizedDataPath(dataPath, moduleName: moduleName)
+        return ModuleConfig(
+            moduleName: moduleName.uppercased(),
+            dataPath: normalizedDataPath,
+            modDrv: modDrv?.lowercased() ?? "",
+            fileURL: URL(fileURLWithPath: fallbackPath)
+        )
+    }
+
+    /**
+     Normalizes a SWORD `DataPath` value to an archive-relative path.
+     */
+    private func normalizedDataPath(_ rawDataPath: String, moduleName: String) throws -> String {
+        var path = rawDataPath.replacingOccurrences(of: "\\", with: "/")
+        while path.hasPrefix("./") {
+            path = String(path.dropFirst(2))
+        }
+        while path.hasPrefix("/") {
+            path = String(path.dropFirst())
+        }
+        while path.hasSuffix("/") {
+            path = String(path.dropLast())
+        }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !path.isEmpty,
+              !components.contains(where: { $0 == ".." || $0.isEmpty }),
+              path.lowercased().hasPrefix("modules/") else {
+            throw AndroidModuleBackupError.invalidModuleLayout("\(moduleName) has unsupported DataPath \(rawDataPath).")
+        }
+        return path
+    }
+
+    /**
+     Returns the archive data directory path for a parsed module config.
+     */
+    private func dataDirectoryPath(for config: ModuleConfig) -> String {
+        guard Self.singleFileDataPathDrivers.contains(config.modDrv),
+              let slashIndex = config.dataPath.lastIndex(of: "/") else {
+            return config.dataPath
+        }
+        return String(config.dataPath[..<slashIndex])
+    }
+
+    /**
+     Returns the local data directory URL for a parsed module config.
+     */
+    private func dataDirectoryURL(for config: ModuleConfig) -> URL {
+        moduleDirectory.appendingPathComponent(dataDirectoryPath(for: config), isDirectory: true)
+    }
+
+    /**
+     Lists regular files below one local file or directory in deterministic archive order.
+     */
+    private func regularFiles(under url: URL) throws -> [URL] {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return []
+        }
+        if !isDirectory.boolValue {
+            return [url]
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: []
+        ) else {
+            return []
+        }
+        var files: [URL] = []
+        for case let fileURL as URL in enumerator {
+            let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            if values.isRegularFile == true {
+                files.append(fileURL)
+            }
+        }
+        return files.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+    }
+
+    /**
+     Converts a local module file URL into an Android module-backup archive path.
+     */
+    private func archivePath(for fileURL: URL) throws -> String {
+        let rootPath = moduleDirectory.standardizedFileURL.path
+        let filePath = fileURL.standardizedFileURL.path
+        guard filePath.hasPrefix("\(rootPath)/") else {
+            throw AndroidModuleBackupError.invalidModuleLayout("\(fileURL.path) is outside the module directory.")
+        }
+        return String(filePath.dropFirst(rootPath.count + 1))
+    }
+
+    /**
+     Private DTO for Android's manifest JSON.
+     */
+    private struct ManifestDTO: Decodable {
+        /// Required backup type string.
+        let backupType: String
+
+        /// Optional manifest version; Android defaults to `1`.
+        let manifestVersion: Int?
+
+        /// Optional Android app version.
+        let andBibleVersion: Int?
+    }
+
+    /**
+     Parsed SWORD module config fields used by backup restore/export.
+     */
+    private struct ModuleConfig {
+        /// Module initials from the config section or config filename.
+        let moduleName: String
+
+        /// Normalized archive-relative `DataPath`.
+        let dataPath: String
+
+        /// Lowercased SWORD driver name.
+        let modDrv: String
+
+        /// Local config file URL for export, or fallback URL used during archive validation.
+        let fileURL: URL
+    }
+
+    /**
+     Classified, validated archive entries used internally by inspection and restore.
+     */
+    private struct ClassifiedArchive {
+        /// Decoded Android manifest.
+        let manifest: AndroidModuleBackupManifest
+
+        /// Supported SWORD entries safe to write under the local module directory.
+        let supportedEntries: [ZipArchiveEntry]
+
+        /// Recognized Android-only entries that iOS skips.
+        let unsupportedEntryPaths: [String]
+
+        /// Module initials derived from supported config entries.
+        let moduleNames: [String]
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
@@ -1,0 +1,218 @@
+// ZipArchiveWriter.swift — ZIP archive writer for Android-compatible backup exports
+
+import Foundation
+
+/**
+ Errors raised while creating ZIP archives for backup export.
+
+ The writer intentionally supports the small stored-entry ZIP shape needed by Android backup
+ parity instead of becoming a general-purpose archive library.
+ */
+public enum ZipArchiveWriterError: Error, LocalizedError, Equatable {
+    /// One entry path or payload exceeds the non-ZIP64 limits supported by this writer.
+    case entryTooLarge(String)
+
+    /// The number of entries or central-directory byte count exceeds the non-ZIP64 ZIP shape.
+    case archiveTooLarge
+
+    /// User-visible error description.
+    public var errorDescription: String? {
+        switch self {
+        case .entryTooLarge(let name):
+            return "ZIP entry is too large for Android-compatible export: \(name)"
+        case .archiveTooLarge:
+            return "ZIP archive is too large for Android-compatible export."
+        }
+    }
+}
+
+/**
+ One file entry to be written into a stored ZIP archive.
+
+ Directory entries are intentionally omitted. Android's module backup reader only needs regular
+ file entries and resolves directories from the file paths while extracting.
+ */
+public struct ZipArchiveWriterEntry: Sendable, Equatable {
+    /// Relative ZIP entry path using `/` separators.
+    public let name: String
+
+    /// Uncompressed file bytes for the entry.
+    public let data: Data
+
+    /**
+     Creates one ZIP writer entry.
+
+     - Parameters:
+       - name: Relative archive path. Callers are responsible for supplying a safe path.
+       - data: Uncompressed file bytes.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail; size validation happens during archive writing.
+     */
+    public init(name: String, data: Data) {
+        self.name = name
+        self.data = data
+    }
+}
+
+/**
+ Creates non-ZIP64 stored ZIP archives with central-directory metadata.
+
+ Android backup import uses Java's `ZipInputStream`, which accepts stored entries when CRC and
+ size metadata are present. This writer calculates CRC32 and writes central-directory records so
+ exported iOS module backups can be restored by Android and re-read by `ZipArchiveReader`.
+ */
+public enum ZipArchiveWriter {
+    /**
+     Builds a ZIP archive containing the supplied entries without compression.
+
+     - Parameter entries: File entries in the exact archive order to emit.
+     - Returns: Raw ZIP archive bytes.
+     - Side effects: none.
+     - Throws: `ZipArchiveWriterError` when the entry count, path length, payload size, or central
+       directory exceeds the non-ZIP64 ZIP limits supported by Android-compatible backup export.
+     - Note: The output is deterministic for the same ordered entries; timestamps are written as
+       zero because Android's module backup contract does not depend on ZIP entry dates.
+     */
+    public static func storedArchive(entries: [ZipArchiveWriterEntry]) throws -> Data {
+        guard entries.count <= Int(UInt16.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+
+        var archive = Data()
+        var centralDirectory = Data()
+        var localHeaderOffsets: [UInt32] = []
+        localHeaderOffsets.reserveCapacity(entries.count)
+
+        for entry in entries {
+            guard let nameData = entry.name.data(using: .utf8),
+                  nameData.count <= Int(UInt16.max),
+                  entry.data.count <= Int(UInt32.max),
+                  archive.count <= Int(UInt32.max) else {
+                throw ZipArchiveWriterError.entryTooLarge(entry.name)
+            }
+
+            localHeaderOffsets.append(UInt32(archive.count))
+            let checksum = crc32(entry.data)
+            appendUInt32(0x0403_4b50, to: &archive)
+            appendUInt16(20, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt16(0, to: &archive)
+            appendUInt32(checksum, to: &archive)
+            appendUInt32(UInt32(entry.data.count), to: &archive)
+            appendUInt32(UInt32(entry.data.count), to: &archive)
+            appendUInt16(UInt16(nameData.count), to: &archive)
+            appendUInt16(0, to: &archive)
+            archive.append(nameData)
+            archive.append(entry.data)
+        }
+
+        guard archive.count <= Int(UInt32.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+        let centralDirectoryOffset = UInt32(archive.count)
+        for (index, entry) in entries.enumerated() {
+            guard let nameData = entry.name.data(using: .utf8),
+                  nameData.count <= Int(UInt16.max) else {
+                throw ZipArchiveWriterError.entryTooLarge(entry.name)
+            }
+
+            let checksum = crc32(entry.data)
+            appendUInt32(0x0201_4b50, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(checksum, to: &centralDirectory)
+            appendUInt32(UInt32(entry.data.count), to: &centralDirectory)
+            appendUInt32(UInt32(entry.data.count), to: &centralDirectory)
+            appendUInt16(UInt16(nameData.count), to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(0, to: &centralDirectory)
+            appendUInt32(localHeaderOffsets[index], to: &centralDirectory)
+            centralDirectory.append(nameData)
+        }
+
+        guard centralDirectory.count <= Int(UInt32.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+        archive.append(centralDirectory)
+        appendUInt32(0x0605_4b50, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(0, to: &archive)
+        appendUInt16(UInt16(entries.count), to: &archive)
+        appendUInt16(UInt16(entries.count), to: &archive)
+        appendUInt32(UInt32(centralDirectory.count), to: &archive)
+        appendUInt32(centralDirectoryOffset, to: &archive)
+        appendUInt16(0, to: &archive)
+        return archive
+    }
+
+    /**
+     Calculates standard ZIP CRC32 for one uncompressed payload.
+
+     - Parameter data: Payload bytes to checksum.
+     - Returns: CRC32 value written into local and central ZIP headers.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xffff_ffff
+        for byte in data {
+            let tableIndex = Int((crc ^ UInt32(byte)) & 0xff)
+            crc = (crc >> 8) ^ crc32Table[tableIndex]
+        }
+        return crc ^ 0xffff_ffff
+    }
+
+    /// Lookup table used by `crc32(_:)`.
+    private static let crc32Table: [UInt32] = {
+        (0..<256).map { value in
+            var crc = UInt32(value)
+            for _ in 0..<8 {
+                if crc & 1 == 1 {
+                    crc = 0xedb8_8320 ^ (crc >> 1)
+                } else {
+                    crc >>= 1
+                }
+            }
+            return crc
+        }
+    }()
+
+    /**
+     Appends a little-endian 16-bit integer to ZIP output.
+
+     - Parameters:
+       - value: Unsigned value to append.
+       - data: Mutable archive buffer.
+     - Side effects: Appends two bytes to `data`.
+     - Failure modes: none.
+     */
+    private static func appendUInt16(_ value: UInt16, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+    }
+
+    /**
+     Appends a little-endian 32-bit integer to ZIP output.
+
+     - Parameters:
+       - value: Unsigned value to append.
+       - data: Mutable archive buffer.
+     - Side effects: Appends four bytes to `data`.
+     - Failure modes: none.
+     */
+    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        data.append(UInt8(value & 0xff))
+        data.append(UInt8((value >> 8) & 0xff))
+        data.append(UInt8((value >> 16) & 0xff))
+        data.append(UInt8((value >> 24) & 0xff))
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
@@ -62,6 +62,9 @@ public struct ZipArchiveWriterEntry: Sendable, Equatable {
  exported iOS module backups can be restored by Android and re-read by `ZipArchiveReader`.
  */
 public enum ZipArchiveWriter {
+    /// ZIP general-purpose EFS flag that tells Android/Java readers file names are UTF-8.
+    private static let utf8FileNameFlag: UInt16 = 0x0800
+
     /**
      Builds a ZIP archive containing the supplied entries without compression.
 
@@ -71,7 +74,9 @@ public enum ZipArchiveWriter {
      - Throws: `ZipArchiveWriterError` when the entry count, path length, payload size, or central
        directory exceeds the non-ZIP64 ZIP limits supported by Android-compatible backup export.
      - Note: The output is deterministic for the same ordered entries; timestamps are written as
-       zero because Android's module backup contract does not depend on ZIP entry dates.
+       zero because Android's module backup contract does not depend on ZIP entry dates. File-name
+       headers set the ZIP UTF-8 flag so Android's Java ZIP readers do not reinterpret paths with
+       platform-default encodings.
      */
     public static func storedArchive(entries: [ZipArchiveWriterEntry]) throws -> Data {
         guard entries.count <= Int(UInt16.max) else {
@@ -85,17 +90,21 @@ public enum ZipArchiveWriter {
 
         for entry in entries {
             guard let nameData = entry.name.data(using: .utf8),
-                  nameData.count <= Int(UInt16.max),
-                  entry.data.count <= Int(UInt32.max),
-                  archive.count <= Int(UInt32.max) else {
+                  nameData.count <= Int(UInt16.max) else {
                 throw ZipArchiveWriterError.entryTooLarge(entry.name)
+            }
+            guard entry.data.count <= Int(UInt32.max) else {
+                throw ZipArchiveWriterError.entryTooLarge(entry.name)
+            }
+            guard archive.count <= Int(UInt32.max) else {
+                throw ZipArchiveWriterError.archiveTooLarge
             }
 
             localHeaderOffsets.append(UInt32(archive.count))
             let checksum = crc32(entry.data)
             appendUInt32(0x0403_4b50, to: &archive)
             appendUInt16(20, to: &archive)
-            appendUInt16(0, to: &archive)
+            appendUInt16(Self.utf8FileNameFlag, to: &archive)
             appendUInt16(0, to: &archive)
             appendUInt16(0, to: &archive)
             appendUInt16(0, to: &archive)
@@ -122,7 +131,7 @@ public enum ZipArchiveWriter {
             appendUInt32(0x0201_4b50, to: &centralDirectory)
             appendUInt16(20, to: &centralDirectory)
             appendUInt16(20, to: &centralDirectory)
-            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(Self.utf8FileNameFlag, to: &centralDirectory)
             appendUInt16(0, to: &centralDirectory)
             appendUInt16(0, to: &centralDirectory)
             appendUInt16(0, to: &centralDirectory)

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidModuleBackupExportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidModuleBackupExportSheet.swift
@@ -91,7 +91,7 @@ struct AndroidModuleBackupExportSheet: View {
                             }
                         }
                         .disabled(isExporting)
-                        .accessibilityIdentifier("androidModuleBackupExportRow")
+                        .accessibilityIdentifier("androidModuleBackupExportRow::\(module.name)")
                     }
                 } header: {
                     Text(String(localized: "android_module_backup_export_modules", defaultValue: "Select modules"))

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidModuleBackupExportSheet.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidModuleBackupExportSheet.swift
@@ -1,0 +1,212 @@
+// AndroidModuleBackupExportSheet.swift -- Android module backup export selection UI
+
+import SwiftUI
+import SwordKit
+
+/**
+ Presents installed SWORD modules for Android-compatible module backup export.
+
+ Android asks the user which installed documents to include before creating
+ `AndBibleModulesBackup.abmd.zip`. This sheet mirrors that behavior for the SWORD-backed module
+ types iOS can export, defaulting to every listed module selected and allowing the user to switch
+ between all and none before exporting.
+
+ Data dependencies:
+ - `modules` is the installed SWORD module list gathered by the parent from `SwordManager`
+ - `onExport` receives selected module initials in display order
+
+ Side effects:
+ - mutates local selection state as the user toggles modules
+ - invokes `onCancel` or `onExport` in response to toolbar actions
+
+ Failure modes:
+ - empty selections disable the Export command so the parent never receives an invalid request
+ - unsupported Android-only module formats are not listed because they are not represented by
+   SWORD `ModuleInfo` entries on iOS
+ */
+struct AndroidModuleBackupExportSheet: View {
+    /// Installed SWORD modules eligible for Android-compatible export.
+    let modules: [ModuleInfo]
+
+    /// Whether the parent is currently writing the backup archive.
+    let isExporting: Bool
+
+    /// Callback used to dismiss without exporting.
+    let onCancel: () -> Void
+
+    /// Callback receiving selected module initials in display order.
+    let onExport: ([String]) -> Void
+
+    /// Current selected module initials.
+    @State private var selectedModuleNames: Set<String>
+
+    /**
+     Creates one export-selection sheet.
+
+     - Parameters:
+       - modules: Installed SWORD modules eligible for export.
+       - isExporting: Parent-owned progress state that disables controls while archive writing runs.
+       - onCancel: Dismiss callback.
+       - onExport: Export callback receiving selected initials.
+     - Side effects: Initializes local selection state with every module selected, matching
+       Android's selected-by-default backup dialog.
+     - Failure modes: This initializer cannot fail.
+     */
+    init(
+        modules: [ModuleInfo],
+        isExporting: Bool,
+        onCancel: @escaping () -> Void,
+        onExport: @escaping ([String]) -> Void
+    ) {
+        self.modules = modules
+        self.isExporting = isExporting
+        self.onCancel = onCancel
+        self.onExport = onExport
+        _selectedModuleNames = State(initialValue: Set(modules.map(\.name)))
+    }
+
+    /**
+     Builds the selectable module list and export/cancel toolbar actions.
+     */
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Button(selectionToggleTitle) {
+                        toggleAllSelections()
+                    }
+                    .disabled(isExporting || modules.isEmpty)
+                    .accessibilityIdentifier("androidModuleBackupExportSelectToggleButton")
+                }
+
+                Section {
+                    ForEach(modules, id: \.name) { module in
+                        Toggle(isOn: binding(for: module.name)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(module.description.isEmpty ? module.name : module.description)
+                                    .font(.body)
+                                Text(moduleDetail(for: module))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .disabled(isExporting)
+                        .accessibilityIdentifier("androidModuleBackupExportRow")
+                    }
+                } header: {
+                    Text(String(localized: "android_module_backup_export_modules", defaultValue: "Select modules"))
+                } footer: {
+                    Text(
+                        String(
+                            localized: "android_module_backup_export_footer",
+                            defaultValue: "Only SWORD-backed modules can be exported in an Android-compatible module backup on iOS."
+                        )
+                    )
+                }
+            }
+            .accessibilityIdentifier("androidModuleBackupExportSheet")
+            .navigationTitle(String(localized: "android_module_backup_export_title", defaultValue: "Module Backup"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "cancel")) {
+                        onCancel()
+                    }
+                    .disabled(isExporting)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        onExport(selectedModuleNamesInDisplayOrder)
+                    } label: {
+                        if isExporting {
+                            ProgressView()
+                        } else {
+                            Text(String(localized: "export"))
+                        }
+                    }
+                    .accessibilityIdentifier("androidModuleBackupExportApplyButton")
+                    .disabled(isExporting || selectedModuleNamesInDisplayOrder.isEmpty)
+                }
+            }
+        }
+        .interactiveDismissDisabled(isExporting)
+    }
+
+    /**
+     Selected module initials in the same order shown to the user.
+
+     - Returns: Selected initials filtered through `modules` display order.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private var selectedModuleNamesInDisplayOrder: [String] {
+        modules.map(\.name).filter(selectedModuleNames.contains)
+    }
+
+    /**
+     Title for the Android-style select-all/select-none control.
+
+     - Returns: "Select none" when all modules are selected, otherwise "Select all".
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private var selectionToggleTitle: String {
+        if selectedModuleNames.count == modules.count {
+            return String(localized: "select_none", defaultValue: "Select none")
+        }
+        return String(localized: "select_all", defaultValue: "Select all")
+    }
+
+    /**
+     Produces a mutable selection binding for one module row.
+
+     - Parameter moduleName: Module initials whose selected state should be exposed.
+     - Returns: Binding that adds or removes the module from `selectedModuleNames`.
+     - Side effects: Writes local sheet selection state when the user toggles a row.
+     - Failure modes: none.
+     */
+    private func binding(for moduleName: String) -> Binding<Bool> {
+        Binding(
+            get: { selectedModuleNames.contains(moduleName) },
+            set: { isSelected in
+                if isSelected {
+                    selectedModuleNames.insert(moduleName)
+                } else {
+                    selectedModuleNames.remove(moduleName)
+                }
+            }
+        )
+    }
+
+    /**
+     Toggles between all modules selected and no modules selected.
+
+     Side effects:
+     - mutates `selectedModuleNames`
+
+     Failure modes:
+     - empty module lists remain empty; the toolbar button is disabled for that state.
+     */
+    private func toggleAllSelections() {
+        if selectedModuleNames.count == modules.count {
+            selectedModuleNames.removeAll()
+        } else {
+            selectedModuleNames = Set(modules.map(\.name))
+        }
+    }
+
+    /**
+     Builds Android-like row detail text from module initials, category, and language.
+
+     - Parameter module: Installed module shown in the export sheet.
+     - Returns: Compact detail text that distinguishes similarly named modules.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func moduleDetail(for module: ModuleInfo) -> String {
+        let language = module.language.isEmpty ? "?" : module.language
+        return "\(module.name), \(language), \(module.category.rawValue)"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -50,6 +50,30 @@ public struct ImportExportView: View {
     /// Whether a SWORD module installation is currently in progress.
     @State private var isInstallingModule = false
 
+    /// Controls presentation of the Android module backup picker.
+    @State private var showAndroidModuleBackupPicker = false
+
+    /// Whether an Android module backup restore is currently in progress.
+    @State private var isRestoringAndroidModuleBackup = false
+
+    /// Whether an Android module backup export is currently in progress.
+    @State private var isExportingAndroidModuleBackup = false
+
+    /// Controls presentation of Android module backup export module selection.
+    @State private var showAndroidModuleBackupExportSheet = false
+
+    /// Installed SWORD modules shown in the Android module backup export selection sheet.
+    @State private var androidModuleBackupExportModules: [ModuleInfo] = []
+
+    /// Selected Android module backup bytes retained while the overwrite confirmation is visible.
+    @State private var pendingAndroidModuleBackupData: Data?
+
+    /// Existing module file paths reported for the pending Android module backup confirmation.
+    @State private var pendingAndroidModuleBackupExistingFiles: [String] = []
+
+    /// Controls the Android module backup overwrite confirmation prompt.
+    @State private var showAndroidModuleBackupOverwriteAlert = false
+
     /// Controls presentation of the EPUB picker.
     @State private var showEpubPicker = false
 
@@ -67,6 +91,9 @@ public struct ImportExportView: View {
 
     /// Service used to load, apply, and clean up Android `.abdb.zip` database backups.
     private let androidBackupService = AndroidDatabaseBackupService()
+
+    /// Service used to inspect, restore, and export Android `.abmd.zip` module backups.
+    private let androidModuleBackupService = AndroidModuleBackupService()
 
     /**
      Creates the import/export screen.
@@ -90,6 +117,12 @@ public struct ImportExportView: View {
         }
         if showModuleZipPicker {
             return "moduleZipPickerPresented"
+        }
+        if showAndroidModuleBackupPicker {
+            return "androidModuleBackupPickerPresented"
+        }
+        if showAndroidModuleBackupExportSheet {
+            return "androidModuleBackupExportPresented"
         }
         if showEpubPicker {
             return "epubPickerPresented"
@@ -168,6 +201,38 @@ public struct ImportExportView: View {
                     }
                 }
                 .disabled(isInstallingModule)
+
+                Button {
+                    showAndroidModuleBackupPicker = true
+                } label: {
+                    HStack {
+                        SwiftUI.Label(
+                            String(localized: "restore_android_module_backup", defaultValue: "Restore Android Module Backup"),
+                            systemImage: "archivebox"
+                        )
+                        Spacer()
+                        if isRestoringAndroidModuleBackup {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isRestoringAndroidModuleBackup)
+
+                Button {
+                    presentAndroidModuleBackupExportSelection()
+                } label: {
+                    HStack {
+                        SwiftUI.Label(
+                            String(localized: "export_android_module_backup", defaultValue: "Export Android Module Backup"),
+                            systemImage: "archivebox.fill"
+                        )
+                        Spacer()
+                        if isExportingAndroidModuleBackup {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isExportingAndroidModuleBackup)
             } header: {
                 Text(String(localized: "modules"))
             } footer: {
@@ -240,11 +305,39 @@ public struct ImportExportView: View {
             handleModuleZipImport(result)
         }
         .fileImporter(
+            isPresented: $showAndroidModuleBackupPicker,
+            allowedContentTypes: [.zip, .data],
+            allowsMultipleSelection: false
+        ) { result in
+            handleAndroidModuleBackupImport(result)
+        }
+        .sheet(isPresented: $showAndroidModuleBackupExportSheet) {
+            AndroidModuleBackupExportSheet(
+                modules: androidModuleBackupExportModules,
+                isExporting: isExportingAndroidModuleBackup,
+                onCancel: dismissAndroidModuleBackupExportSelection,
+                onExport: exportAndroidModuleBackup(moduleNames:)
+            )
+        }
+        .fileImporter(
             isPresented: $showEpubPicker,
             allowedContentTypes: [.epub, .data],
             allowsMultipleSelection: false
         ) { result in
             handleEpubImport(result)
+        }
+        .alert(
+            String(localized: "android_module_backup_overwrite_title", defaultValue: "Overwrite existing module files?"),
+            isPresented: $showAndroidModuleBackupOverwriteAlert
+        ) {
+            Button(String(localized: "cancel"), role: .cancel) {
+                clearPendingAndroidModuleBackup()
+            }
+            Button(String(localized: "overwrite", defaultValue: "Overwrite"), role: .destructive) {
+                restorePendingAndroidModuleBackup()
+            }
+        } message: {
+            Text(androidModuleBackupOverwriteMessage())
         }
     }
 
@@ -306,6 +399,7 @@ public struct ImportExportView: View {
      - `.json`: full backup import via `BackupService.importFullBackup`
      - `.csv`: bookmark import via `BackupService.importBookmarksCSV`
      - `.abdb.zip`: Android database backup staging via `AndroidDatabaseBackupService`
+     - `.abmd.zip`: Android module backup restore via `AndroidModuleBackupService`
      - `.bbl`, `.cmt`, `.dct`: MySword/MyBible hint only; no import is performed
 
      Side effects:
@@ -336,6 +430,11 @@ public struct ImportExportView: View {
             let ext = url.pathExtension.lowercased()
             if isAndroidDatabaseBackupFile(url) {
                 loadAndroidBackupArchive(from: data)
+                isImporting = false
+                return
+            }
+            if AndroidModuleBackupService.isAndroidModuleBackupFileName(url.lastPathComponent) {
+                prepareAndroidModuleBackupRestore(from: data)
                 isImporting = false
                 return
             }
@@ -373,17 +472,18 @@ public struct ImportExportView: View {
      Determines whether a selected import file should be handled as an Android database backup.
 
      Android names manual database backups with the compound `.abdb.zip` suffix. The generic
-     import picker is intentionally narrower than the module installer, so any ZIP selected here is
-     treated as an Android backup candidate and validated by `AndroidDatabaseBackupService`.
+     import picker no longer treats arbitrary ZIP files as database backups because Android module
+     backups use the sibling `.abmd.zip` suffix and ordinary SWORD ZIP packages are handled by the
+     module installer.
 
      - Parameter url: User-selected file URL.
-     - Returns: `true` when the filename has Android's backup suffix or the extension is ZIP.
+     - Returns: `true` when the filename has Android's database-backup suffix.
      - Side effects: none.
      - Failure modes: Invalid ZIP contents are rejected later by the backup service.
      */
     private func isAndroidDatabaseBackupFile(_ url: URL) -> Bool {
         let fileName = url.lastPathComponent.lowercased()
-        return fileName.hasSuffix(".abdb.zip") || url.pathExtension.lowercased() == "zip"
+        return fileName.hasSuffix(".abdb.zip")
     }
 
     /**
@@ -594,6 +694,243 @@ public struct ImportExportView: View {
         case .failure(let error):
             statusMessage = localizedErrorMessage(error)
         }
+    }
+
+    /**
+     Presents installed SWORD modules for Android-compatible backup export selection.
+
+     Android asks the user which installed documents/modules to include before writing
+     `AndBibleModulesBackup.abmd.zip`. iOS mirrors that behavior for SWORD-backed modules by
+     collecting the current installed-module list from `SwordManager`, sorting it in Android's
+     language-first order, and presenting a multiselect sheet before export.
+
+     Side effects:
+     - reads installed modules through `SwordManager`
+     - updates `androidModuleBackupExportModules`
+     - presents the export selection sheet or surfaces a no-modules error
+     */
+    private func presentAndroidModuleBackupExportSelection() {
+        statusMessage = nil
+        guard let manager = SwordManager() else {
+            statusMessage = localizedErrorMessage(AndroidModuleBackupError.noExportableModules)
+            return
+        }
+        let modules = manager.installedModules().sorted { lhs, rhs in
+            let languageOrder = lhs.language.localizedCaseInsensitiveCompare(rhs.language)
+            if languageOrder != .orderedSame {
+                return languageOrder == .orderedAscending
+            }
+            let descriptionOrder = lhs.description.localizedCaseInsensitiveCompare(rhs.description)
+            if descriptionOrder != .orderedSame {
+                return descriptionOrder == .orderedAscending
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        guard !modules.isEmpty else {
+            statusMessage = localizedErrorMessage(AndroidModuleBackupError.noExportableModules)
+            return
+        }
+        androidModuleBackupExportModules = modules
+        showAndroidModuleBackupExportSheet = true
+    }
+
+    /**
+     Dismisses Android module backup export selection without writing files.
+
+     Side effects:
+     - clears export selection state
+     - dismisses the export selection sheet
+     */
+    private func dismissAndroidModuleBackupExportSelection() {
+        showAndroidModuleBackupExportSheet = false
+        androidModuleBackupExportModules = []
+        isExportingAndroidModuleBackup = false
+    }
+
+    /**
+     Exports selected SWORD modules as Android's `.abmd.zip` module backup archive.
+
+     - Parameter moduleNames: Selected module initials emitted by the export selection sheet.
+     - Side effects:
+       - reads local SWORD module config and data files
+       - writes the generated backup to a temporary file
+       - dismisses the selection sheet and schedules the share sheet after SwiftUI processes
+         dismissal, avoiding two active sheet presentations at once
+       - updates status text with export success or failure details
+     */
+    private func exportAndroidModuleBackup(moduleNames: [String]) {
+        guard !moduleNames.isEmpty else {
+            statusMessage = localizedErrorMessage(AndroidModuleBackupError.noExportableModules)
+            return
+        }
+        isExportingAndroidModuleBackup = true
+        statusMessage = nil
+        do {
+            let export = try androidModuleBackupService.exportArchive(moduleNames: Set(moduleNames))
+            if let url = saveToTempFile(data: export.data, fileName: export.fileName) {
+                exportedFileURL = url
+                showAndroidModuleBackupExportSheet = false
+                androidModuleBackupExportModules = []
+                Task { @MainActor in
+                    await Task.yield()
+                    showExportSheet = true
+                }
+                statusMessage = String(
+                    localized: "android_module_backup_exported_summary",
+                    defaultValue: "Exported Android module backup: \(export.moduleNames.joined(separator: ", "))"
+                )
+            }
+        } catch {
+            statusMessage = localizedErrorMessage(error)
+        }
+        isExportingAndroidModuleBackup = false
+    }
+
+    /**
+     Handles Android module backup import results from the module-backup file picker.
+
+     Side effects:
+     - starts and stops security-scoped resource access for the chosen archive
+     - inspects the archive before writing files
+     - either restores immediately or shows an overwrite confirmation for existing module files
+     - updates status text with success or failure details
+     */
+    private func handleAndroidModuleBackupImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            isRestoringAndroidModuleBackup = true
+            statusMessage = nil
+
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessing { url.stopAccessingSecurityScopedResource() }
+            }
+
+            do {
+                let data = try Data(contentsOf: url)
+                prepareAndroidModuleBackupRestore(from: data)
+            } catch {
+                statusMessage = localizedErrorMessage(error)
+            }
+            if !showAndroidModuleBackupOverwriteAlert {
+                isRestoringAndroidModuleBackup = false
+            }
+
+        case .failure(let error):
+            statusMessage = localizedErrorMessage(error)
+        }
+    }
+
+    /**
+     Inspects an Android module backup and either restores it or queues overwrite confirmation.
+
+     - Parameter data: Raw `.abmd.zip` archive bytes selected by the user.
+     - Side effects:
+     - may write supported module files when no overwrite confirmation is required
+     - may retain `data` and existing paths in state for a later confirmation action
+     - updates status text with restore success or failure details
+     - Failure modes: Catches service errors and surfaces them to the settings screen.
+     */
+    private func prepareAndroidModuleBackupRestore(from data: Data) {
+        do {
+            let inspection = try androidModuleBackupService.inspectArchive(from: data)
+            guard inspection.existingEntryPaths.isEmpty else {
+                pendingAndroidModuleBackupData = data
+                pendingAndroidModuleBackupExistingFiles = inspection.existingEntryPaths
+                showAndroidModuleBackupOverwriteAlert = true
+                return
+            }
+            let report = try androidModuleBackupService.restoreArchive(
+                from: data,
+                allowOverwritingExistingFiles: true
+            )
+            statusMessage = androidModuleBackupRestoreStatusMessage(for: report)
+        } catch {
+            statusMessage = localizedErrorMessage(error)
+        }
+    }
+
+    /**
+     Restores the pending Android module backup after the user confirms overwriting files.
+
+     Side effects:
+     - writes supported SWORD module files into the local module directory
+     - clears pending confirmation state
+     - updates status text with success or failure details
+     */
+    private func restorePendingAndroidModuleBackup() {
+        guard let data = pendingAndroidModuleBackupData else {
+            clearPendingAndroidModuleBackup()
+            return
+        }
+        do {
+            let report = try androidModuleBackupService.restoreArchive(
+                from: data,
+                allowOverwritingExistingFiles: true
+            )
+            statusMessage = androidModuleBackupRestoreStatusMessage(for: report)
+        } catch {
+            statusMessage = localizedErrorMessage(error)
+        }
+        clearPendingAndroidModuleBackup()
+        isRestoringAndroidModuleBackup = false
+    }
+
+    /**
+     Clears retained Android module backup confirmation state without mutating user files.
+     */
+    private func clearPendingAndroidModuleBackup() {
+        pendingAndroidModuleBackupData = nil
+        pendingAndroidModuleBackupExistingFiles = []
+        showAndroidModuleBackupOverwriteAlert = false
+        isRestoringAndroidModuleBackup = false
+    }
+
+    /**
+     Builds the overwrite-confirmation message for Android module backup restore.
+
+     - Returns: User-visible explanation listing the first few paths that would be overwritten.
+     - Side effects: none.
+     - Failure modes: Empty pending state returns a generic overwrite warning.
+     */
+    private func androidModuleBackupOverwriteMessage() -> String {
+        guard !pendingAndroidModuleBackupExistingFiles.isEmpty else {
+            return String(
+                localized: "android_module_backup_overwrite_generic",
+                defaultValue: "This backup will replace existing module files."
+            )
+        }
+        let preview = pendingAndroidModuleBackupExistingFiles.prefix(5).joined(separator: "\n")
+        return String(
+            localized: "android_module_backup_overwrite_message",
+            defaultValue: "This backup will replace existing module files:\n\(preview)"
+        )
+    }
+
+    /**
+     Builds the user-visible completion summary for Android module backup restore.
+
+     - Parameter report: Restore report from `AndroidModuleBackupService`.
+     - Returns: Concise status message listing installed modules and skipped unsupported content.
+     - Side effects: none.
+     - Failure modes: Empty module names produce a generic success message, though the service
+       normally rejects archives without supported SWORD modules.
+     */
+    private func androidModuleBackupRestoreStatusMessage(for report: AndroidModuleBackupRestoreReport) -> String {
+        let modules = report.installedModuleNames.isEmpty
+            ? String(localized: "android_module_backup_modules_unknown", defaultValue: "modules")
+            : report.installedModuleNames.joined(separator: ", ")
+        if report.skippedUnsupportedEntryPaths.isEmpty {
+            return String(
+                localized: "android_module_backup_restored_summary",
+                defaultValue: "Restored Android module backup: \(modules)"
+            )
+        }
+        return String(
+            localized: "android_module_backup_restored_with_skips_summary",
+            defaultValue: "Restored Android module backup: \(modules). Skipped \(report.skippedUnsupportedEntryPaths.count) Android-only files."
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds Android-compatible .abmd.zip module backup support on iOS for the shared SWORD module archive contract.

## Scope

- Recognizes Android module backup archives by .abmd.zip suffix and MODULE_BACKUP manifest.
- Restores supported SWORD module config/data entries from Android module backups.
- Exports selected installed SWORD modules as AndBibleModulesBackup.abmd.zip.
- Keeps Android database backup routing separate from module backup and ordinary SWORD ZIP install.
- Reports Android-only module payloads as unsupported instead of silently treating them as restored.

## Contract references

- GitHub issue: #151.
- Android source: app/src/main/java/net/bible/android/control/backup/BackupControl.kt.
- Android install path: app/src/main/java/net/bible/android/view/activity/installzip/InstallZip.kt.
- iOS source: Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift.

## Change details

- Added AndroidModuleBackupService for archive inspection, restore, overwrite detection, rollback-safe publishing, cache invalidation, and export.
- Added ZipArchiveWriter for deterministic non-ZIP64 stored ZIP export.
- Added AndroidModuleBackupExportSheet so iOS matches Android selected-module backup behavior.
- Updated ImportExportView with Android module backup restore/export actions and .abdb.zip versus .abmd.zip routing.
- Added Android module backup tests for recognition, manifest rejection, restore, unsupported-only archives, overwrite behavior, Android-shaped export, and selected export filtering.

## Validation evidence

- xcodebuild focused Android module backup tests: 6 passed.
- xcodebuild Android database backup regression tests: 8 passed.
- xcodebuild selected export compile/test pass: 2 passed.
- git diff --check: clean.

## Risks/follow-ups

- iOS restores the shared SWORD portion of Android module backups. Android-only formats under mybible, mysword, esword, and epub are recognized and reported as unsupported because this iOS path cannot restore those Android-specific layouts through SWORD.
- Risk is concentrated in backup/import UI routing and SWORD module file import/export.

Closes #151