### PR TITLE
feat(backup): export Android-compatible database backups

### DIFF
--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -90,6 +90,125 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that iOS exports Android-compatible manual database backup archives.
+
+     Setup:
+     - creates local rows across the supported export model graph
+     - exports through `AndroidDatabaseBackupService`
+     - re-reads the generated ZIP through the existing Android backup loader
+
+     Expected result:
+     - the export uses Android's canonical `.abdb.zip` filename and manifest
+     - supported category databases are written under `db/`
+     - each SQLite database declares the Android-compatible `user_version`
+     - at least one real bookmark label row is present in `bookmarks.sqlite3`
+
+     Failure meaning:
+     - iOS would still be exporting a custom JSON backup or an archive Android cannot validate as
+       a manual database backup.
+     */
+    func testAndroidDatabaseBackupExportCreatesAndroidCompatibleArchive() throws {
+        let container = try makeAndroidDatabaseBackupExportModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let labelID = UUID(uuidString: "15000000-0000-0000-0000-000000000301")!
+        let readingPlanID = UUID(uuidString: "15000000-0000-0000-0000-000000000302")!
+        let workspaceID = UUID(uuidString: "15000000-0000-0000-0000-000000000303")!
+        let documentID = UUID(uuidString: "15000000-0000-0000-0000-000000000304")!
+        let pageID = UUID(uuidString: "15000000-0000-0000-0000-000000000305")!
+
+        modelContext.insert(Label(id: labelID, name: "Prayer", color: 7, favourite: true))
+        modelContext.insert(
+            ReadingPlan(
+                id: readingPlanID,
+                planCode: "ios-test-plan",
+                planName: "iOS Test Plan",
+                startDate: Date(timeIntervalSince1970: 1_700_000_000),
+                currentDay: 1,
+                totalDays: 1
+            )
+        )
+        modelContext.insert(Workspace(id: workspaceID, name: "Study", orderNumber: 0))
+        let document = MyDocument(
+            id: documentID,
+            name: "Sermon Notes",
+            initials: "IOSDOC",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        let page = MyDocumentPage(
+            id: pageID,
+            title: "Outline",
+            pageKey: "outline",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        let content = MyDocumentPageContent(pageId: pageID, content: "# Outline")
+        page.document = document
+        page.pageContent = content
+        document.pages = [page]
+        modelContext.insert(document)
+        modelContext.insert(page)
+        modelContext.insert(content)
+        try modelContext.save()
+
+        let service = AndroidDatabaseBackupService()
+        let export = try service.exportArchive(modelContext: modelContext, settingsStore: settingsStore)
+        let entriesByName = Dictionary(uniqueKeysWithValues: try ZipArchiveReader.entries(in: export.data).map { ($0.name, $0.data) })
+        let expectedCategories: [AndroidDatabaseBackupCategory] = [
+            .bookmarks,
+            .readingPlans,
+            .workspaces,
+            .myDocuments,
+        ]
+        let expectedEntryNames: Set<String> = [
+            "AndBibleBackupManifest.json",
+            "db/bookmarks.sqlite3",
+            "db/readingplans.sqlite3",
+            "db/workspaces.sqlite3",
+            "db/mydocuments.sqlite3",
+        ]
+
+        XCTAssertEqual(export.fileName, AndroidDatabaseBackupService.databaseBackupFileName)
+        XCTAssertEqual(export.categories, expectedCategories)
+        XCTAssertEqual(export.entryCount, expectedEntryNames.count)
+        XCTAssertEqual(Set(entriesByName.keys), expectedEntryNames)
+
+        let manifestData = try XCTUnwrap(entriesByName["AndBibleBackupManifest.json"])
+        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
+        XCTAssertEqual(manifest["backupType"] as? String, "DB_BACKUP")
+        XCTAssertEqual(manifest["manifestVersion"] as? Int, 1)
+        XCTAssertEqual(manifest["contains"] as? [String], expectedCategories.map(\.rawValue))
+
+        let loadedArchive = try service.loadArchive(from: export.data)
+        defer { service.cleanup(loadedArchive) }
+        XCTAssertEqual(loadedArchive.manifest.backupType, "DB_BACKUP")
+        XCTAssertEqual(loadedArchive.sections.map(\.category), [.bookmarks, .myDocuments, .readingPlans, .workspaces])
+        XCTAssertTrue(loadedArchive.sections.allSatisfy { $0.support == .supported })
+
+        let materializedDatabases = try materializeExportedDatabases(entriesByName: entriesByName)
+        defer {
+            for databaseURL in materializedDatabases.values {
+                try? FileManager.default.removeItem(at: databaseURL)
+            }
+        }
+        XCTAssertEqual(try readSQLiteUserVersion(at: materializedDatabases["bookmarks.sqlite3"]!), 12)
+        XCTAssertEqual(try readSQLiteUserVersion(at: materializedDatabases["readingplans.sqlite3"]!), 1)
+        XCTAssertEqual(try readSQLiteUserVersion(at: materializedDatabases["workspaces.sqlite3"]!), 22)
+        XCTAssertEqual(
+            try readSQLiteUserVersion(at: materializedDatabases["mydocuments.sqlite3"]!),
+            RemoteSyncMyDocumentRestoreService.supportedAndroidSchemaVersion
+        )
+        XCTAssertEqual(
+            try readSQLiteInteger(
+                "SELECT COUNT(*) FROM Label WHERE name = 'Prayer';",
+                at: materializedDatabases["bookmarks.sqlite3"]!
+            ),
+            1
+        )
+    }
+
+    /**
      Verifies Android-parity restore semantics for a selected database backup section.
 
      Setup:
@@ -815,6 +934,111 @@ extension AndBibleTests {
             .sorted { $0.key < $1.key }
             .map { ("db/\($0.key)", $0.value) }
         return try makeStoredZip(entries: [("AndBibleBackupManifest.json", manifestData)] + databaseEntries)
+    }
+
+    /**
+     Builds an in-memory model container containing every model needed by supported backup export categories.
+
+     Android database backup export reads bookmarks, reading plans, workspaces, My Documents, and
+     local fidelity settings in one pass. This fixture keeps that graph in one container so the
+     export test exercises the same `ModelContext` shape the Settings screen supplies.
+
+     - Returns: In-memory SwiftData container for supported Android database backup export models.
+     - Side effects: none.
+     - Failure modes: Rethrows SwiftData container initialization failures.
+     */
+    private func makeAndroidDatabaseBackupExportModelContainer() throws -> ModelContainer {
+        let schema = Schema([
+            BibleBookmark.self,
+            BibleBookmarkNotes.self,
+            BibleBookmarkToLabel.self,
+            GenericBookmark.self,
+            GenericBookmarkNotes.self,
+            GenericBookmarkToLabel.self,
+            Label.self,
+            StudyPadTextEntry.self,
+            StudyPadTextEntryText.self,
+            ReadingPlan.self,
+            ReadingPlanDay.self,
+            Workspace.self,
+            Window.self,
+            PageManager.self,
+            HistoryItem.self,
+            MyDocument.self,
+            MyDocumentPage.self,
+            MyDocumentPageContent.self,
+            AiPageCacheEntry.self,
+            Setting.self,
+        ])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    /**
+     Writes exported ZIP database entries to temporary files for SQLite assertions.
+
+     - Parameter entriesByName: Exported ZIP entries keyed by archive path.
+     - Returns: Temporary SQLite file URLs keyed by Android database filename.
+     - Side effects: writes temporary SQLite files under the process temporary directory.
+     - Failure modes: Throws when an expected database entry is absent or cannot be written.
+     */
+    private func materializeExportedDatabases(entriesByName: [String: Data]) throws -> [String: URL] {
+        let databaseNames = [
+            "bookmarks.sqlite3",
+            "readingplans.sqlite3",
+            "workspaces.sqlite3",
+            "mydocuments.sqlite3",
+        ]
+        var urlsByName: [String: URL] = [:]
+        for databaseName in databaseNames {
+            let data = try XCTUnwrap(entriesByName["db/\(databaseName)"])
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("android-backup-export-\(UUID().uuidString)-\(databaseName)")
+            try data.write(to: url, options: .atomic)
+            urlsByName[databaseName] = url
+        }
+        return urlsByName
+    }
+
+    /**
+     Reads one integer value from a materialized SQLite database.
+
+     The export test uses this to prove generated databases contain real Android-shaped table
+     content, not only valid SQLite headers and `user_version` pragmas.
+
+     - Parameters:
+       - sql: Single-row, single-column SQL statement returning an integer.
+       - url: SQLite database URL to inspect.
+     - Returns: First column from the first result row as an integer.
+     - Side effects: opens the database read-only and finalizes the prepared statement.
+     - Failure modes: Throws `AndroidDatabaseBackupError.invalidSQLiteDatabase` when SQLite cannot
+       open, prepare, or step the statement.
+     */
+    private func readSQLiteInteger(_ sql: String, at url: URL) throws -> Int {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let database else {
+            if let database {
+                sqlite3_close(database)
+            }
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            if let statement {
+                sqlite3_finalize(statement)
+            }
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            throw AndroidDatabaseBackupError.invalidSQLiteDatabase(url.lastPathComponent)
+        }
+        return Int(sqlite3_column_int(statement, 0))
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -801,7 +801,7 @@ extension AndBibleUITests {
         openReaderActionDestination(
             actionIdentifier: "readerOpenImportExportAction",
             destinationIdentifier: "importExportScreen",
-            readinessIdentifiers: ["importExportImportButton", "importExportFullBackupButton"],
+            readinessIdentifiers: ["importExportImportButton", "importExportAndroidDatabaseBackupButton"],
             in: app,
             timeout: 20
         )

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -1149,9 +1149,11 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The production settings row element.
      * - Side effects:
-     *   - scans the current Settings viewport, then scrolls through the form while re-querying
-     *     the live XCUI hierarchy
-     *   - uses the production Settings search field as a final reveal path when CI scrolling cannot
+     *   - scans the current Settings viewport, then uses the production Settings search field as an
+     *     early reveal path for title-backed rows
+     *   - scrolls through the form while re-querying the live XCUI hierarchy when search cannot
+     *     reveal the row
+     *   - retries the production Settings search field as a final reveal path when CI scrolling cannot
      *     reliably bring an offscreen row into the accessibility hierarchy
      * - Failure modes:
      *   - records an XCTest failure if the production row never appears
@@ -1206,6 +1208,19 @@ extension AndBibleUITests {
                 return control
             }
             return nil
+        }
+
+        if let control = resolvedVisibleControl() {
+            return control
+        }
+        if let control = resolveSettingsNavigationControlViaSearch(
+            title: visibleTitle,
+            settingsForm: settingsForm,
+            app: app,
+            timeout: min(max(timeout / 4, 3), 5),
+            resolveControl: resolvedVisibleControl
+        ) {
+            return control
         }
 
         repeat {

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -464,8 +464,10 @@ extension AndBibleUITests {
      *   - timeout: Maximum time to wait for the picker affordance.
      * - Side effects:
      *   - reveals Search options when needed and taps the translation picker button
+     *   - retries the tap when SwiftUI does not publish the picker-open state under CI load
      * - Failure modes:
-     *   - fails when the translation picker affordance does not open the picker
+     *   - fails when the translation picker affordance does not publish an open state or expose
+     *     picker descendants within the timeout
      */
     func tapSearchTranslationPicker(
         in app: XCUIApplication,
@@ -474,7 +476,7 @@ extension AndBibleUITests {
         let deadline = Date().addingTimeInterval(timeout)
 
         repeat {
-            if searchTranslationPickerIsOpen(in: app, timeout: 0.2) {
+            if searchTranslationPickerIsOpen(in: app, timeout: 0) {
                 return
             }
 
@@ -492,8 +494,18 @@ extension AndBibleUITests {
                 ($0.exists || $0.waitForExistence(timeout: 0.2))
                     && waitForElementToBecomeHittable($0, timeout: 0.5)
             }) {
-                tapElementReliably(picker, timeout: 2)
-                if searchTranslationPickerIsOpen(in: app, timeout: 3) {
+                if elementHasUsableFrame(picker) {
+                    picker.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+                } else {
+                    tapElementReliably(picker, timeout: min(2, max(0.5, deadline.timeIntervalSinceNow)))
+                }
+
+                let remaining = deadline.timeIntervalSinceNow
+                if remaining > 0,
+                   searchTranslationPickerStateIsOpen(in: app, timeout: min(1.5, max(0.5, remaining))) {
+                    return
+                }
+                if firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil {
                     return
                 }
             }
@@ -512,7 +524,8 @@ extension AndBibleUITests {
      *   - timeout: Total time budget for polling the candidate set.
      * - Returns: `true` when a picker-specific Done button or picker list exists.
      * - Side effects:
-     *   - polls the live accessibility hierarchy while SwiftUI presents or dismisses the picker
+     *   - polls the live Search state export and picker accessibility hierarchy while SwiftUI
+     *     presents or dismisses the picker
      * - Failure modes: This helper does not fail directly.
      */
     func searchTranslationPickerIsOpen(
@@ -522,6 +535,9 @@ extension AndBibleUITests {
         let deadline = Date().addingTimeInterval(max(0, timeout))
 
         repeat {
+            if searchTranslationPickerStateIsOpen(in: app, timeout: 0) {
+                return true
+            }
             if firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil {
                 return true
             }
@@ -531,7 +547,41 @@ extension AndBibleUITests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         } while Date() < deadline
 
-        return firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil
+        return searchTranslationPickerStateIsOpen(in: app, timeout: 0)
+            || firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil
+    }
+
+    /**
+     Returns whether Search has published the translation-picker presentation state.
+     *
+     * The Search screen exports this state separately from sheet descendants so UI tests can
+     * distinguish "the button action has toggled presentation" from "SwiftUI has finished exposing
+     * the sheet hierarchy." That keeps picker-opening retries focused on missed actions instead of
+     * treating slow accessibility snapshots as proof that the tap failed.
+     *
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - timeout: Maximum time to poll the Search state export.
+     * - Returns: `true` when the Search state export contains `translationPicker=open`.
+     * - Side effects: none.
+     * - Failure modes: This helper does not fail directly.
+     */
+    func searchTranslationPickerStateIsOpen(
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        repeat {
+            if searchStateCandidateValues(in: app).contains(where: { $0.contains("translationPicker=open") }) {
+                return true
+            }
+            if timeout <= 0 {
+                return false
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+
+        return searchStateCandidateValues(in: app).contains { $0.contains("translationPicker=open") }
     }
 
     /// Returns stable picker descendants that prove the Search translation picker sheet is open.

--- a/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -14,26 +14,26 @@ extension AndBibleUITests {
     }
 
     /**
-     Verifies that the full-backup export action drives Import and Export into share-sheet presentation.
+     Verifies that the Android database backup export action presents the share sheet.
      *
      * - Side effects:
      *   - launches the app directly into Import and Export
-     *   - triggers a full-backup export, which writes a temporary file and requests share-sheet
-     *     presentation
+     *   - triggers Android-compatible `.abdb.zip` database backup export, which writes a temporary
+     *     archive and requests share-sheet presentation
      * - Failure modes:
-     *   - fails if the full-backup action is missing from the Import and Export screen
+     *   - fails if the Android database backup action is missing from the Import and Export screen
      *   - fails if the Import and Export screen never reports the share-sheet-presented state after
      *     export completes
      */
-    func testSettingsImportExportFullBackupPresentsShareSheet() {
+    func testSettingsImportExportAndroidDatabaseBackupPresentsShareSheet() {
         let app = makeApp()
         app.launch()
 
         let importExportScreen = openImportExport(in: app)
         XCTAssertTrue(importExportScreen.exists)
 
-        let fullBackupButton = requireElement("importExportFullBackupButton", in: app, timeout: 10)
-        tapElementReliably(fullBackupButton, timeout: 10)
+        let databaseBackupButton = requireElement("importExportAndroidDatabaseBackupButton", in: app, timeout: 10)
+        tapElementReliably(databaseBackupButton, timeout: 10)
         waitForElementValue("importExportScreen", toEqual: "shareSheetPresented", in: app, timeout: 20)
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -1,4 +1,4 @@
-// AndroidDatabaseBackupService.swift — Android .abdb.zip restore/import support
+// AndroidDatabaseBackupService.swift — Android .abdb.zip import/export support
 
 import Foundation
 import SQLite3
@@ -329,6 +329,49 @@ public struct AndroidDatabaseBackupArchive: Identifiable, Sendable {
 }
 
 /**
+ Exported Android database backup archive.
+
+ The archive uses Android's manual database backup shape: `AndBibleBackupManifest.json` at the
+ archive root and one SQLite database per supported category beneath `db/`.
+ */
+public struct AndroidDatabaseBackupExport: Sendable, Equatable {
+    /// Android-compatible filename used by the share sheet.
+    public let fileName: String
+
+    /// Raw `.abdb.zip` archive bytes.
+    public let data: Data
+
+    /// Categories materialized into SQLite entries under `db/`.
+    public let categories: [AndroidDatabaseBackupCategory]
+
+    /// Number of ZIP file entries, including the manifest.
+    public let entryCount: Int
+
+    /**
+     Creates one Android database backup export summary.
+
+     - Parameters:
+       - fileName: Android-compatible filename used by the share sheet.
+       - data: Raw `.abdb.zip` archive bytes.
+       - categories: Categories materialized into SQLite entries under `db/`.
+       - entryCount: Number of ZIP file entries, including the manifest.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        fileName: String,
+        data: Data,
+        categories: [AndroidDatabaseBackupCategory],
+        entryCount: Int
+    ) {
+        self.fileName = fileName
+        self.data = data
+        self.categories = categories
+        self.entryCount = entryCount
+    }
+}
+
+/**
  User-selected operation for one Android backup section.
  */
 public enum AndroidDatabaseBackupApplyMode: String, CaseIterable, Identifiable, Sendable, Codable {
@@ -500,6 +543,23 @@ public enum AndroidDatabaseBackupError: LocalizedError, Equatable {
    remote state
  */
 public final class AndroidDatabaseBackupService {
+    /// Android file suffix for manual database backups.
+    public static let databaseBackupSuffix = ".abdb.zip"
+
+    /// Android's canonical manual database backup filename.
+    public static let databaseBackupFileName = "AndBibleDatabaseBackup.abdb.zip"
+
+    /// Manifest filename used by Android database and module backup archives.
+    private static let manifestFileName = "AndBibleBackupManifest.json"
+
+    /// Supported category databases iOS can currently materialize into Android-compatible backups.
+    private static let exportableDatabaseCategories: [AndroidDatabaseBackupCategory] = [
+        .bookmarks,
+        .readingPlans,
+        .workspaces,
+        .myDocuments,
+    ]
+
     /**
      Decodable shape of Android's manifest JSON before iOS normalizes optional fields.
 
@@ -536,6 +596,19 @@ public final class AndroidDatabaseBackupService {
             manifestVersion = try container.decodeIfPresent(Int.self, forKey: .manifestVersion)
             andBibleVersion = try container.decodeIfPresent(Int.self, forKey: .andBibleVersion)
         }
+    }
+
+    /**
+     Encodable manifest shape emitted by Android database backup export.
+
+     iOS only declares categories it can currently materialize into Android-shaped SQLite files.
+     Android restore validates database files from the `db/` directory, so this manifest remains
+     honest while allowing unsupported Android-only categories to stay absent.
+     */
+    private struct ExportManifestDTO: Encodable {
+        let backupType: String
+        let contains: [AndroidDatabaseBackupCategory]
+        let manifestVersion: Int
     }
 
     private let fileManager: FileManager
@@ -587,6 +660,72 @@ public final class AndroidDatabaseBackupService {
     }
 
     /**
+     Exports local data as Android's `.abdb.zip` manual database backup format.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns the local category rows.
+       - settingsStore: Local-only settings store that backs Android fidelity metadata.
+     - Returns: Android-compatible database backup archive bytes and exported category summary.
+     - Side effects:
+       - reads supported local categories from SwiftData and fidelity settings
+       - writes temporary Android-shaped SQLite databases beneath the configured temporary directory
+       - removes the temporary SQLite databases after the ZIP archive is materialized
+     - Failure modes:
+       - rethrows category snapshot, SQLite, JSON manifest, file read, and ZIP writer failures
+       - unsupported categories are intentionally omitted rather than emitted as empty databases
+     */
+    public func exportArchive(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> AndroidDatabaseBackupExport {
+        let manifest = ExportManifestDTO(
+            backupType: "DB_BACKUP",
+            contains: Self.exportableDatabaseCategories,
+            manifestVersion: 1
+        )
+        let manifestData = try JSONEncoder().encode(manifest)
+        var entries: [ZipArchiveWriterEntry] = [
+            ZipArchiveWriterEntry(name: Self.manifestFileName, data: manifestData),
+        ]
+        var temporaryDatabaseURLs: [URL] = []
+        defer {
+            for databaseURL in temporaryDatabaseURLs {
+                try? fileManager.removeItem(at: databaseURL)
+            }
+        }
+
+        for category in Self.exportableDatabaseCategories {
+            guard let remoteSyncCategory = category.remoteSyncCategory,
+                  let databaseFileName = category.databaseFileName else {
+                continue
+            }
+            let databaseURL = try RemoteSyncInitialBackupUploadService.buildAndroidDatabaseBackupDatabase(
+                for: remoteSyncCategory,
+                modelContext: modelContext,
+                settingsStore: settingsStore,
+                schemaVersion: category.supportedDatabaseVersion,
+                fileManager: fileManager,
+                temporaryDirectory: temporaryDirectory
+            )
+            temporaryDatabaseURLs.append(databaseURL)
+            entries.append(
+                ZipArchiveWriterEntry(
+                    name: "db/\(databaseFileName)",
+                    data: try Data(contentsOf: databaseURL)
+                )
+            )
+        }
+
+        let archiveData = try ZipArchiveWriter.storedArchive(entries: entries)
+        return AndroidDatabaseBackupExport(
+            fileName: Self.databaseBackupFileName,
+            data: archiveData,
+            categories: Self.exportableDatabaseCategories,
+            entryCount: entries.count
+        )
+    }
+
+    /**
      Loads and validates an Android `.abdb.zip` database backup archive.
 
      - Parameter data: Raw backup archive bytes selected by the user.
@@ -613,7 +752,7 @@ public final class AndroidDatabaseBackupService {
         }
 
         let entriesByName = try Self.entriesByUniqueName(entries)
-        guard let manifestData = entriesByName["AndBibleBackupManifest.json"] else {
+        guard let manifestData = entriesByName[Self.manifestFileName] else {
             throw AndroidDatabaseBackupError.missingManifest
         }
         let manifest = try decodeManifest(from: manifestData)

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -372,6 +372,49 @@ public struct AndroidDatabaseBackupExport: Sendable, Equatable {
 }
 
 /**
+ File-backed Android database backup export.
+
+ This result is the production share-sheet path for manual backup export. It points at a complete
+ `.abdb.zip` file so callers can share or move the archive without keeping the whole ZIP in memory.
+ */
+public struct AndroidDatabaseBackupFileExport: Sendable, Equatable {
+    /// Android-compatible filename used by the share sheet.
+    public let fileName: String
+
+    /// Complete `.abdb.zip` archive file. The caller owns cleanup after sharing or moving it.
+    public let fileURL: URL
+
+    /// Categories materialized into SQLite entries under `db/`.
+    public let categories: [AndroidDatabaseBackupCategory]
+
+    /// Number of ZIP file entries, including the manifest.
+    public let entryCount: Int
+
+    /**
+     Creates one file-backed Android database backup export summary.
+
+     - Parameters:
+       - fileName: Android-compatible filename used by the share sheet.
+       - fileURL: Complete `.abdb.zip` archive file.
+       - categories: Categories materialized into SQLite entries under `db/`.
+       - entryCount: Number of ZIP file entries, including the manifest.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        fileName: String,
+        fileURL: URL,
+        categories: [AndroidDatabaseBackupCategory],
+        entryCount: Int
+    ) {
+        self.fileName = fileName
+        self.fileURL = fileURL
+        self.categories = categories
+        self.entryCount = entryCount
+    }
+}
+
+/**
  User-selected operation for one Android backup section.
  */
 public enum AndroidDatabaseBackupApplyMode: String, CaseIterable, Identifiable, Sendable, Codable {
@@ -678,14 +721,47 @@ public final class AndroidDatabaseBackupService {
         modelContext: ModelContext,
         settingsStore: SettingsStore
     ) throws -> AndroidDatabaseBackupExport {
+        let fileExport = try exportArchiveFile(modelContext: modelContext, settingsStore: settingsStore)
+        defer { try? fileManager.removeItem(at: fileExport.fileURL) }
+        let archiveData = try Data(contentsOf: fileExport.fileURL)
+        return AndroidDatabaseBackupExport(
+            fileName: fileExport.fileName,
+            data: archiveData,
+            categories: fileExport.categories,
+            entryCount: fileExport.entryCount
+        )
+    }
+
+    /**
+     Exports local data as an Android `.abdb.zip` file without buffering the whole archive.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns the local category rows.
+       - settingsStore: Local-only settings store that backs Android fidelity metadata.
+     - Returns: File-backed Android-compatible backup archive and exported category summary.
+     - Side effects:
+       - reads supported local categories from SwiftData and fidelity settings
+       - writes temporary Android-shaped SQLite databases beneath the configured temporary directory
+       - writes a complete `.abdb.zip` archive file beneath the configured temporary directory
+       - removes intermediate SQLite databases after the ZIP archive is materialized
+     - Failure modes:
+       - rethrows category snapshot, SQLite, JSON manifest, file read/write, and ZIP writer failures
+       - unsupported categories are intentionally omitted rather than emitted as empty databases
+     - Note: The returned archive file remains on disk for the caller to share or move; the caller owns
+       cleanup of `fileURL`.
+     */
+    public func exportArchiveFile(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> AndroidDatabaseBackupFileExport {
         let manifest = ExportManifestDTO(
             backupType: "DB_BACKUP",
             contains: Self.exportableDatabaseCategories,
             manifestVersion: 1
         )
         let manifestData = try JSONEncoder().encode(manifest)
-        var entries: [ZipArchiveWriterEntry] = [
-            ZipArchiveWriterEntry(name: Self.manifestFileName, data: manifestData),
+        var entries: [ZipArchiveWriterFileEntry] = [
+            ZipArchiveWriterFileEntry(name: Self.manifestFileName, data: manifestData),
         ]
         var temporaryDatabaseURLs: [URL] = []
         defer {
@@ -709,17 +785,24 @@ public final class AndroidDatabaseBackupService {
             )
             temporaryDatabaseURLs.append(databaseURL)
             entries.append(
-                ZipArchiveWriterEntry(
+                ZipArchiveWriterFileEntry(
                     name: "db/\(databaseFileName)",
-                    data: try Data(contentsOf: databaseURL)
+                    fileURL: databaseURL
                 )
             )
         }
 
-        let archiveData = try ZipArchiveWriter.storedArchive(entries: entries)
-        return AndroidDatabaseBackupExport(
+        let archiveURL = temporaryURL(prefix: "android-database-backup-export-", suffix: ".abdb.zip")
+        do {
+            try ZipArchiveWriter.writeStoredArchive(entries: entries, to: archiveURL, fileManager: fileManager)
+        } catch {
+            try? fileManager.removeItem(at: archiveURL)
+            throw error
+        }
+
+        return AndroidDatabaseBackupFileExport(
             fileName: Self.databaseBackupFileName,
-            data: archiveData,
+            fileURL: archiveURL,
             categories: Self.exportableDatabaseCategories,
             entryCount: entries.count
         )
@@ -1247,6 +1330,20 @@ public final class AndroidDatabaseBackupService {
         RemoteSyncPatchStatusStore(settingsStore: settingsStore).clearCategory(category)
         RemoteSyncLogEntryStore(settingsStore: settingsStore).clearCategory(category)
         RemoteSyncRowFingerprintStore(settingsStore: settingsStore).clearCategory(category)
+    }
+
+    /**
+     Creates a unique temporary file URL for Android database backup staging.
+
+     - Parameters:
+       - prefix: Filename prefix describing the staging purpose.
+       - suffix: Filename extension or suffix required by the staged file type.
+     - Returns: URL beneath the service's configured temporary directory.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail; file creation happens at the call site.
+     */
+    private func temporaryURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -19,6 +19,9 @@ public enum RemoteSyncInitialBackupUploadError: Error, Equatable {
     /// The temporary SQLite database could not be opened or written safely.
     case invalidSQLiteDatabase
 
+    /// Upload was requested from a builder-only service that has no remote backend.
+    case missingRemoteAdapter
+
     /// The requested category does not yet have an initial-backup export pipeline.
     case unsupportedCategory(RemoteSyncCategory)
 }
@@ -104,7 +107,7 @@ public final class RemoteSyncInitialBackupUploadService {
         let workspaceHistoryAliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias]
     }
 
-    private let adapter: any RemoteSyncAdapting
+    private let adapter: (any RemoteSyncAdapting)?
     private let deviceIdentifier: String
     private let fileManager: FileManager
     private let temporaryDirectory: URL
@@ -139,6 +142,66 @@ public final class RemoteSyncInitialBackupUploadService {
     }
 
     /**
+     Creates a builder-only service for local Android-compatible database export.
+
+     Manual Android database backup export reuses the same category SQLite writers as remote sync,
+     but it must not upload, record patch-zero state, or persist workspace history aliases. This
+     initializer keeps that export path local while sharing the schema and row projection logic.
+
+     - Parameters:
+       - fileManager: File manager used for temporary SQLite output.
+       - temporaryDirectory: Optional staging directory override.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    private init(
+        fileManager: FileManager,
+        temporaryDirectory: URL?
+    ) {
+        adapter = nil
+        deviceIdentifier = "manual-database-backup-export"
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        nowProvider = {
+            Int64(Date().timeIntervalSince1970 * 1000.0)
+        }
+    }
+
+    /**
+     Builds one local Android-shaped SQLite database without remote-sync side effects.
+
+     - Parameters:
+       - category: Logical category whose current local state should be exported.
+       - modelContext: SwiftData context that owns the current local category graph.
+       - settingsStore: Local-only settings store backing Android fidelity metadata.
+       - schemaVersion: SQLite `user_version` written into the exported Android database.
+       - fileManager: File manager used for temporary SQLite output.
+       - temporaryDirectory: Optional staging directory override.
+     - Returns: Temporary SQLite database URL; the caller owns cleanup.
+     - Side effects: writes one temporary SQLite database beneath the configured temporary directory.
+     - Failure modes: Rethrows SQLite and JSON-encoding failures from the category-specific writers.
+     */
+    static func buildAndroidDatabaseBackupDatabase(
+        for category: RemoteSyncCategory,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int,
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil
+    ) throws -> URL {
+        let service = RemoteSyncInitialBackupUploadService(
+            fileManager: fileManager,
+            temporaryDirectory: temporaryDirectory
+        )
+        return try service.buildInitialBackup(
+            for: category,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: schemaVersion
+        ).databaseURL
+    }
+
+    /**
      Builds and uploads one category's full Android-style initial backup.
 
      - Parameters:
@@ -168,6 +231,9 @@ public final class RemoteSyncInitialBackupUploadService {
         guard let syncFolderID = bootstrapState.syncFolderID?.trimmingCharacters(in: .whitespacesAndNewlines),
               !syncFolderID.isEmpty else {
             throw RemoteSyncInitialBackupUploadError.missingSyncFolderID
+        }
+        guard let adapter else {
+            throw RemoteSyncInitialBackupUploadError.missingRemoteAdapter
         }
 
         let builtBackup = try buildInitialBackup(

--- a/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ZipArchiveWriter.swift
@@ -55,6 +55,63 @@ public struct ZipArchiveWriterEntry: Sendable, Equatable {
 }
 
 /**
+ File-backed entry source for writing stored ZIP archives without buffering every payload first.
+
+ The writer still precomputes CRC and size metadata because Android/Java readers expect stored-entry
+ local headers to contain those values up front, but file payloads are copied to the destination ZIP in
+ chunks so large backup databases do not need to be loaded into memory as `Data`.
+ */
+struct ZipArchiveWriterFileEntry: Sendable, Equatable {
+    /// Relative ZIP entry path using `/` separators.
+    let name: String
+
+    /// Source payload for the entry.
+    let payload: Payload
+
+    /**
+     Source payload used by the streaming ZIP writer.
+
+     `data` is intended for small generated entries such as manifests. `file` is intended for SQLite
+     databases and other large backup payloads that should be copied incrementally.
+     */
+    enum Payload: Sendable, Equatable {
+        /// In-memory bytes for a small generated entry.
+        case data(Data)
+
+        /// File URL for an entry copied in chunks.
+        case file(URL)
+    }
+
+    /**
+     Creates one small in-memory ZIP entry.
+
+     - Parameters:
+       - name: Relative archive path. Callers are responsible for supplying a safe path.
+       - data: Uncompressed file bytes.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail; size validation happens during archive writing.
+     */
+    init(name: String, data: Data) {
+        self.name = name
+        payload = .data(data)
+    }
+
+    /**
+     Creates one file-backed ZIP entry.
+
+     - Parameters:
+       - name: Relative archive path. Callers are responsible for supplying a safe path.
+       - fileURL: File whose bytes should be copied into the archive.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail; file access and size validation happen during archive writing.
+     */
+    init(name: String, fileURL: URL) {
+        self.name = name
+        payload = .file(fileURL)
+    }
+}
+
+/**
  Creates non-ZIP64 stored ZIP archives with central-directory metadata.
 
  Android backup import uses Java's `ZipInputStream`, which accepts stored entries when CRC and
@@ -64,6 +121,20 @@ public struct ZipArchiveWriterEntry: Sendable, Equatable {
 public enum ZipArchiveWriter {
     /// ZIP general-purpose EFS flag that tells Android/Java readers file names are UTF-8.
     private static let utf8FileNameFlag: UInt16 = 0x0800
+
+    /**
+     Prepared metadata for one stored ZIP entry.
+
+     Stored entries must publish CRC and uncompressed size before the payload bytes, so file-backed
+     entries are scanned once for metadata before the writer emits any ZIP records.
+     */
+    private struct PreparedFileEntry {
+        let name: String
+        let nameData: Data
+        let payload: ZipArchiveWriterFileEntry.Payload
+        let checksum: UInt32
+        let byteCount: UInt32
+    }
 
     /**
      Builds a ZIP archive containing the supplied entries without compression.
@@ -164,6 +235,113 @@ public enum ZipArchiveWriter {
     }
 
     /**
+     Writes a stored ZIP archive directly to a destination file.
+
+     - Parameters:
+       - entries: File entries in the exact archive order to emit.
+       - destinationURL: File URL that will receive the complete ZIP archive.
+       - fileManager: File manager used to inspect file-backed entries and create the destination path.
+     - Side effects:
+       - creates or replaces `destinationURL`
+       - reads file-backed entry payloads and copies them into the archive in chunks
+     - Throws: `ZipArchiveWriterError` when ZIP limits are exceeded, or filesystem errors when a
+       source payload or destination file cannot be read or written.
+     - Note: The output is deterministic for the same ordered entries and source bytes; timestamps are
+       written as zero for parity with `storedArchive(entries:)`.
+     */
+    static func writeStoredArchive(
+        entries: [ZipArchiveWriterFileEntry],
+        to destinationURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard entries.count <= Int(UInt16.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+
+        let preparedEntries = try entries.map { try prepare($0, fileManager: fileManager) }
+        var centralDirectory = Data()
+        var localHeaderOffsets: [UInt32] = []
+        localHeaderOffsets.reserveCapacity(preparedEntries.count)
+        var archiveOffset: UInt64 = 0
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: destinationURL, options: .atomic)
+        let output = try FileHandle(forWritingTo: destinationURL)
+        defer { try? output.close() }
+
+        for entry in preparedEntries {
+            guard archiveOffset <= UInt64(UInt32.max) else {
+                throw ZipArchiveWriterError.archiveTooLarge
+            }
+            localHeaderOffsets.append(UInt32(archiveOffset))
+
+            var localHeader = Data()
+            appendUInt32(0x0403_4b50, to: &localHeader)
+            appendUInt16(20, to: &localHeader)
+            appendUInt16(Self.utf8FileNameFlag, to: &localHeader)
+            appendUInt16(0, to: &localHeader)
+            appendUInt16(0, to: &localHeader)
+            appendUInt16(0, to: &localHeader)
+            appendUInt32(entry.checksum, to: &localHeader)
+            appendUInt32(entry.byteCount, to: &localHeader)
+            appendUInt32(entry.byteCount, to: &localHeader)
+            appendUInt16(UInt16(entry.nameData.count), to: &localHeader)
+            appendUInt16(0, to: &localHeader)
+            localHeader.append(entry.nameData)
+            try output.write(contentsOf: localHeader)
+            archiveOffset += UInt64(localHeader.count)
+
+            try writePayload(entry.payload, to: output)
+            archiveOffset += UInt64(entry.byteCount)
+        }
+
+        guard archiveOffset <= UInt64(UInt32.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+        let centralDirectoryOffset = UInt32(archiveOffset)
+        for (index, entry) in preparedEntries.enumerated() {
+            appendUInt32(0x0201_4b50, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(20, to: &centralDirectory)
+            appendUInt16(Self.utf8FileNameFlag, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(entry.checksum, to: &centralDirectory)
+            appendUInt32(entry.byteCount, to: &centralDirectory)
+            appendUInt32(entry.byteCount, to: &centralDirectory)
+            appendUInt16(UInt16(entry.nameData.count), to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt16(0, to: &centralDirectory)
+            appendUInt32(0, to: &centralDirectory)
+            appendUInt32(localHeaderOffsets[index], to: &centralDirectory)
+            centralDirectory.append(entry.nameData)
+        }
+
+        guard centralDirectory.count <= Int(UInt32.max) else {
+            throw ZipArchiveWriterError.archiveTooLarge
+        }
+        try output.write(contentsOf: centralDirectory)
+        archiveOffset += UInt64(centralDirectory.count)
+
+        var endRecord = Data()
+        appendUInt32(0x0605_4b50, to: &endRecord)
+        appendUInt16(0, to: &endRecord)
+        appendUInt16(0, to: &endRecord)
+        appendUInt16(UInt16(preparedEntries.count), to: &endRecord)
+        appendUInt16(UInt16(preparedEntries.count), to: &endRecord)
+        appendUInt32(UInt32(centralDirectory.count), to: &endRecord)
+        appendUInt32(centralDirectoryOffset, to: &endRecord)
+        appendUInt16(0, to: &endRecord)
+        try output.write(contentsOf: endRecord)
+    }
+
+    /**
      Calculates standard ZIP CRC32 for one uncompressed payload.
 
      - Parameter data: Payload bytes to checksum.
@@ -173,11 +351,121 @@ public enum ZipArchiveWriter {
      */
     private static func crc32(_ data: Data) -> UInt32 {
         var crc: UInt32 = 0xffff_ffff
+        crc = updateCRC32(crc, with: data)
+        return crc ^ 0xffff_ffff
+    }
+
+    /**
+     Calculates standard ZIP CRC32 for a file payload without loading it all into memory.
+
+     - Parameter fileURL: File whose bytes should be checksummed.
+     - Returns: CRC32 value written into local and central ZIP headers.
+     - Side effects: Opens and reads `fileURL` sequentially.
+     - Failure modes: Rethrows file-open and file-read failures.
+     */
+    private static func crc32(fileURL: URL) throws -> UInt32 {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+        var crc: UInt32 = 0xffff_ffff
+        while true {
+            let chunk = try handle.read(upToCount: 64 * 1024) ?? Data()
+            if chunk.isEmpty {
+                break
+            }
+            crc = updateCRC32(crc, with: chunk)
+        }
+        return crc ^ 0xffff_ffff
+    }
+
+    /**
+     Advances an in-progress ZIP CRC32 checksum with additional bytes.
+
+     - Parameters:
+       - crc: Current unfinalized CRC accumulator.
+       - data: Additional payload bytes.
+     - Returns: Updated unfinalized CRC accumulator.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func updateCRC32(_ crc: UInt32, with data: Data) -> UInt32 {
+        var crc = crc
         for byte in data {
             let tableIndex = Int((crc ^ UInt32(byte)) & 0xff)
             crc = (crc >> 8) ^ crc32Table[tableIndex]
         }
-        return crc ^ 0xffff_ffff
+        return crc
+    }
+
+    /**
+     Validates one file-backed ZIP entry and precomputes stored-entry metadata.
+
+     - Parameters:
+       - entry: Entry definition supplied by the caller.
+       - fileManager: File manager used to inspect file payload sizes.
+     - Returns: Prepared metadata used by the streaming writer.
+     - Side effects: Reads file-backed entries to calculate CRC32.
+     - Failure modes: Throws ZIP limit errors for oversized names or payloads, and rethrows file
+       metadata/read errors for file-backed entries.
+     */
+    private static func prepare(
+        _ entry: ZipArchiveWriterFileEntry,
+        fileManager: FileManager
+    ) throws -> PreparedFileEntry {
+        guard let nameData = entry.name.data(using: .utf8),
+              nameData.count <= Int(UInt16.max) else {
+            throw ZipArchiveWriterError.entryTooLarge(entry.name)
+        }
+
+        let byteCount: UInt64
+        let checksum: UInt32
+        switch entry.payload {
+        case .data(let data):
+            byteCount = UInt64(data.count)
+            checksum = crc32(data)
+        case .file(let fileURL):
+            let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+            byteCount = (attributes[.size] as? NSNumber)?.uint64Value ?? UInt64.max
+            checksum = try crc32(fileURL: fileURL)
+        }
+        guard byteCount <= UInt64(UInt32.max) else {
+            throw ZipArchiveWriterError.entryTooLarge(entry.name)
+        }
+        return PreparedFileEntry(
+            name: entry.name,
+            nameData: nameData,
+            payload: entry.payload,
+            checksum: checksum,
+            byteCount: UInt32(byteCount)
+        )
+    }
+
+    /**
+     Copies one prepared payload into an open ZIP output stream.
+
+     - Parameters:
+       - payload: In-memory or file-backed payload to write.
+       - output: Open file handle positioned at the next ZIP payload offset.
+     - Side effects: Writes bytes to `output`; file payloads are opened and read sequentially.
+     - Failure modes: Rethrows file-read or output-write failures.
+     */
+    private static func writePayload(
+        _ payload: ZipArchiveWriterFileEntry.Payload,
+        to output: FileHandle
+    ) throws {
+        switch payload {
+        case .data(let data):
+            try output.write(contentsOf: data)
+        case .file(let fileURL):
+            let input = try FileHandle(forReadingFrom: fileURL)
+            defer { try? input.close() }
+            while true {
+                let chunk = try input.read(upToCount: 64 * 1024) ?? Data()
+                if chunk.isEmpty {
+                    break
+                }
+                try output.write(contentsOf: chunk)
+            }
+        }
     }
 
     /// Lookup table used by `crc32(_:)`.

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -342,7 +342,7 @@ public struct SearchView: View {
         case .creatingIndex: "creatingIndex"
         case .ready: "ready"
         }
-        let baseState = "state=\(stateToken);query=\(query);searching=\(isSearching);results=\(results.count);scope=\(searchScopeToken(for: scopeOption));wordMode=\(searchWordModeToken(for: wordMode))"
+        let baseState = "state=\(stateToken);query=\(query);searching=\(isSearching);results=\(results.count);scope=\(searchScopeToken(for: scopeOption));wordMode=\(searchWordModeToken(for: wordMode));\(searchAccessibilityTranslationPickerToken)"
         guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports else {
             return baseState
         }
@@ -352,6 +352,18 @@ public struct SearchView: View {
     /// Stable selected-translation token exported for UI automation.
     private var searchAccessibilitySelectionToken: String {
         "selectedModules=\(selectedModules.sorted().joined(separator: ","))"
+    }
+
+    /**
+     Stable translation-picker presentation token exported for UI automation.
+     *
+     - Returns: `translationPicker=open` while SwiftUI is presenting the picker sheet, otherwise
+       `translationPicker=closed`.
+     - Side effects: none.
+     - Failure modes: This computed token does not fail.
+     */
+    private var searchAccessibilityTranslationPickerToken: String {
+        "translationPicker=\(showTranslationPicker ? "open" : "closed")"
     }
 
     /// Stable grouped-result totals exported for UI automation.
@@ -588,6 +600,7 @@ public struct SearchView: View {
 
             if installedBibleModules.count > 1 {
                 Button {
+                    isSearchFieldFocused = false
                     showTranslationPicker = true
                 } label: {
                     HStack {
@@ -608,7 +621,7 @@ public struct SearchView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("searchTranslationPickerButton")
-                .accessibilityValue(searchAccessibilitySelectionToken)
+                .accessibilityValue("\(searchAccessibilitySelectionToken);\(searchAccessibilityTranslationPickerToken)")
             }
         }
         .padding(.horizontal)

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -362,6 +362,8 @@ public struct ImportExportView: View {
 
      - Side effects:
        - toggles export state and clears prior status messages
+       - schedules archive generation after one main-actor yield so SwiftUI can render the busy
+         state before the expensive SQLite/ZIP work starts
        - reads SwiftData through `AndroidDatabaseBackupService`
        - writes the generated archive to a temporary file and presents the share sheet on success
        - updates status text with the categories included in the backup
@@ -371,27 +373,30 @@ public struct ImportExportView: View {
         isExporting = true
         statusMessage = nil
 
-        do {
-            let export = try androidBackupService.exportArchive(
-                modelContext: modelContext,
-                settingsStore: SettingsStore(modelContext: modelContext)
-            )
-            if let url = saveToTempFile(data: export.data, fileName: export.fileName) {
-                exportedFileURL = url
-                showExportSheet = true
-                let categorySummary = export.categories
-                    .map(\.localizedBackupSectionName)
-                    .joined(separator: ", ")
-                statusMessage = String(
-                    localized: "android_database_backup_exported_summary",
-                    defaultValue: "Exported Android database backup: \(categorySummary)"
-                )
-            }
-        } catch {
-            statusMessage = localizedErrorMessage(error)
-        }
+        Task { @MainActor in
+            await Task.yield()
+            defer { isExporting = false }
 
-        isExporting = false
+            do {
+                let export = try androidBackupService.exportArchive(
+                    modelContext: modelContext,
+                    settingsStore: SettingsStore(modelContext: modelContext)
+                )
+                if let url = saveToTempFile(data: export.data, fileName: export.fileName) {
+                    exportedFileURL = url
+                    showExportSheet = true
+                    let categorySummary = export.categories
+                        .map(\.localizedBackupSectionName)
+                        .joined(separator: ", ")
+                    statusMessage = String(
+                        localized: "android_database_backup_exported_summary",
+                        defaultValue: "Exported Android database backup: \(categorySummary)"
+                    )
+                }
+            } catch {
+                statusMessage = localizedErrorMessage(error)
+            }
+        }
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -89,7 +89,7 @@ public struct ImportExportView: View {
     /// Whether selected Android backup sections are currently being applied.
     @State private var isApplyingAndroidBackup = false
 
-    /// Service used to load, apply, and clean up Android `.abdb.zip` database backups.
+    /// Service used to export, load, apply, and clean up Android `.abdb.zip` database backups.
     private let androidBackupService = AndroidDatabaseBackupService()
 
     /// Service used to inspect, restore, and export Android `.abmd.zip` module backups.
@@ -138,20 +138,33 @@ public struct ImportExportView: View {
      */
     public var body: some View {
         List {
-            // Export section
             Section {
                 Button {
-                    exportFullBackup()
+                    exportAndroidDatabaseBackup()
                 } label: {
                     HStack {
-                        SwiftUI.Label(String(localized: "full_backup_json"), systemImage: "arrow.up.doc")
+                        SwiftUI.Label(
+                            String(localized: "android_database_backup", defaultValue: "Android Database Backup"),
+                            systemImage: "archivebox.fill"
+                        )
                         Spacer()
                         if isExporting {
                             ProgressView()
                         }
                     }
                 }
-                .accessibilityIdentifier("importExportFullBackupButton")
+                .accessibilityIdentifier("importExportAndroidDatabaseBackupButton")
+                .disabled(isExporting)
+
+                Button {
+                    exportLegacyFullBackup()
+                } label: {
+                    SwiftUI.Label(
+                        String(localized: "legacy_full_backup_json", defaultValue: "Legacy Backup (JSON)"),
+                        systemImage: "arrow.up.doc"
+                    )
+                }
+                .accessibilityIdentifier("importExportLegacyFullBackupButton")
                 .disabled(isExporting)
 
                 Button {
@@ -342,14 +355,58 @@ public struct ImportExportView: View {
     }
 
     /**
-     Exports a full JSON backup, writes it to a temporary file, and presents the share sheet.
+     Exports an Android-compatible database backup and presents the share sheet.
 
-     Side effects:
-     - toggles export state and clears prior status messages
-     - queries `BackupService` for a full backup payload
-     - writes the payload to a temporary file and presents the share sheet on success
+     This is the parity backup path: Android expects `AndBibleDatabaseBackup.abdb.zip` containing
+     `AndBibleBackupManifest.json` and supported category SQLite databases under `db/`.
+
+     - Side effects:
+       - toggles export state and clears prior status messages
+       - reads SwiftData through `AndroidDatabaseBackupService`
+       - writes the generated archive to a temporary file and presents the share sheet on success
+       - updates status text with the categories included in the backup
+     - Failure modes: Catches backup export and file-write failures and surfaces them as status text.
      */
-    private func exportFullBackup() {
+    private func exportAndroidDatabaseBackup() {
+        isExporting = true
+        statusMessage = nil
+
+        do {
+            let export = try androidBackupService.exportArchive(
+                modelContext: modelContext,
+                settingsStore: SettingsStore(modelContext: modelContext)
+            )
+            if let url = saveToTempFile(data: export.data, fileName: export.fileName) {
+                exportedFileURL = url
+                showExportSheet = true
+                let categorySummary = export.categories
+                    .map(\.localizedBackupSectionName)
+                    .joined(separator: ", ")
+                statusMessage = String(
+                    localized: "android_database_backup_exported_summary",
+                    defaultValue: "Exported Android database backup: \(categorySummary)"
+                )
+            }
+        } catch {
+            statusMessage = localizedErrorMessage(error)
+        }
+
+        isExporting = false
+    }
+
+    /**
+     Exports the legacy iOS JSON backup, writes it to a temporary file, and presents the share sheet.
+
+     The JSON payload is retained for local/developer compatibility, but it is not Android's
+     manual backup format and should not be treated as the parity backup path.
+
+     - Side effects:
+       - toggles export state and clears prior status messages
+       - queries `BackupService` for a full JSON backup payload
+       - writes the payload to a temporary file and presents the share sheet on success
+     - Failure modes: Surfaces missing backup data through status text.
+     */
+    private func exportLegacyFullBackup() {
         isExporting = true
         statusMessage = nil
 
@@ -483,7 +540,7 @@ public struct ImportExportView: View {
      */
     private func isAndroidDatabaseBackupFile(_ url: URL) -> Bool {
         let fileName = url.lastPathComponent.lowercased()
-        return fileName.hasSuffix(".abdb.zip")
+        return fileName.hasSuffix(AndroidDatabaseBackupService.databaseBackupSuffix)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -362,9 +362,8 @@ public struct ImportExportView: View {
 
      - Side effects:
        - toggles export state and clears prior status messages
-       - schedules archive generation after one main-actor yield so SwiftUI can render the busy
-         state before the expensive SQLite/ZIP work starts
-       - reads SwiftData through `AndroidDatabaseBackupService`
+       - schedules archive generation after one main-actor yield so SwiftUI can render the busy state
+       - exports from a background SwiftData context so SQLite and ZIP work do not block the UI actor
        - writes the generated archive to a temporary file and presents the share sheet on success
        - updates status text with the categories included in the backup
      - Failure modes: Catches backup export and file-write failures and surfaces them as status text.
@@ -372,27 +371,29 @@ public struct ImportExportView: View {
     private func exportAndroidDatabaseBackup() {
         isExporting = true
         statusMessage = nil
+        let modelContainer = modelContext.container
 
         Task { @MainActor in
             await Task.yield()
             defer { isExporting = false }
 
             do {
-                let export = try androidBackupService.exportArchive(
-                    modelContext: modelContext,
-                    settingsStore: SettingsStore(modelContext: modelContext)
-                )
-                if let url = saveToTempFile(data: export.data, fileName: export.fileName) {
-                    exportedFileURL = url
-                    showExportSheet = true
-                    let categorySummary = export.categories
-                        .map(\.localizedBackupSectionName)
-                        .joined(separator: ", ")
-                    statusMessage = String(
-                        localized: "android_database_backup_exported_summary",
-                        defaultValue: "Exported Android database backup: \(categorySummary)"
+                let export = try await Task.detached(priority: .userInitiated) {
+                    let exportContext = ModelContext(modelContainer)
+                    return try AndroidDatabaseBackupService().exportArchiveFile(
+                        modelContext: exportContext,
+                        settingsStore: SettingsStore(modelContext: exportContext)
                     )
-                }
+                }.value
+                exportedFileURL = try moveExportFileToShareDirectory(export)
+                showExportSheet = true
+                let categorySummary = export.categories
+                    .map(\.localizedBackupSectionName)
+                    .joined(separator: ", ")
+                statusMessage = String(
+                    localized: "android_database_backup_exported_summary",
+                    defaultValue: "Exported Android database backup: \(categorySummary)"
+                )
             } catch {
                 statusMessage = localizedErrorMessage(error)
             }
@@ -1035,6 +1036,32 @@ public struct ImportExportView: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
+    }
+
+    /**
+     Moves a file-backed Android database backup export to the canonical share-sheet filename.
+
+     Android parity depends on presenting `AndBibleDatabaseBackup.abdb.zip`, while the background
+     export service creates a unique temporary filename to avoid collisions during archive generation.
+
+     - Parameter export: Completed file-backed database backup export.
+     - Returns: Temporary file URL with Android's canonical backup filename.
+     - Side effects:
+       - deletes any previous temporary export with the same canonical filename
+       - moves the generated archive into the share-sheet location
+     - Failure modes: Rethrows file-system errors when the previous export cannot be removed or the
+       generated archive cannot be moved.
+     */
+    private func moveExportFileToShareDirectory(_ export: AndroidDatabaseBackupFileExport) throws -> URL {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(export.fileName)
+        if fileURL == export.fileURL {
+            return fileURL
+        }
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+        try FileManager.default.moveItem(at: export.fileURL, to: fileURL)
+        return fileURL
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -23,6 +23,30 @@ import UniformTypeIdentifiers
  - status text reflects the latest success or failure message across all operations
  */
 public struct ImportExportView: View {
+    /**
+     Identifies the currently running export action so row-level progress feedback stays attached
+     to the command the user actually started.
+
+     The value is stored only for the lifetime of one export operation. It prevents concurrent
+     export taps through the derived `isExporting` state and lets each export row decide whether
+     to render a spinner without sharing misleading UI feedback with sibling rows.
+
+     - Side effects: Mutating this state re-renders the export section and changes button
+       disabled/progress state.
+     - Failure modes: Export routines must clear the value on every success and failure path so
+       the export section cannot remain disabled after an error.
+     */
+    private enum ExportAction {
+        /// Android-compatible database backup archive export.
+        case androidDatabaseBackup
+
+        /// Legacy iOS JSON backup export retained for local compatibility.
+        case legacyFullBackup
+
+        /// Bookmark CSV export.
+        case bookmarksCSV
+    }
+
     /// SwiftData context used by backup import/export services.
     @Environment(\.modelContext) private var modelContext
 
@@ -38,8 +62,13 @@ public struct ImportExportView: View {
     /// Latest user-visible success or error message across import/export actions.
     @State private var statusMessage: String?
 
-    /// Whether a backup export is currently in progress.
-    @State private var isExporting = false
+    /// Currently running export action, if any.
+    @State private var activeExportAction: ExportAction?
+
+    /// Whether any export action is currently in progress.
+    private var isExporting: Bool {
+        activeExportAction != nil
+    }
 
     /// Whether a backup import is currently in progress.
     @State private var isImporting = false
@@ -148,7 +177,7 @@ public struct ImportExportView: View {
                             systemImage: "archivebox.fill"
                         )
                         Spacer()
-                        if isExporting {
+                        if activeExportAction == .androidDatabaseBackup {
                             ProgressView()
                         }
                     }
@@ -159,10 +188,16 @@ public struct ImportExportView: View {
                 Button {
                     exportLegacyFullBackup()
                 } label: {
-                    SwiftUI.Label(
-                        String(localized: "legacy_full_backup_json", defaultValue: "Legacy Backup (JSON)"),
-                        systemImage: "arrow.up.doc"
-                    )
+                    HStack {
+                        SwiftUI.Label(
+                            String(localized: "legacy_full_backup_json", defaultValue: "Legacy Backup (JSON)"),
+                            systemImage: "arrow.up.doc"
+                        )
+                        Spacer()
+                        if activeExportAction == .legacyFullBackup {
+                            ProgressView()
+                        }
+                    }
                 }
                 .accessibilityIdentifier("importExportLegacyFullBackupButton")
                 .disabled(isExporting)
@@ -170,7 +205,13 @@ public struct ImportExportView: View {
                 Button {
                     exportBookmarksCSV()
                 } label: {
-                    SwiftUI.Label(String(localized: "bookmarks_csv"), systemImage: "tablecells")
+                    HStack {
+                        SwiftUI.Label(String(localized: "bookmarks_csv"), systemImage: "tablecells")
+                        Spacer()
+                        if activeExportAction == .bookmarksCSV {
+                            ProgressView()
+                        }
+                    }
                 }
                 .disabled(isExporting)
             } header: {
@@ -361,7 +402,7 @@ public struct ImportExportView: View {
      `AndBibleBackupManifest.json` and supported category SQLite databases under `db/`.
 
      - Side effects:
-       - toggles export state and clears prior status messages
+       - marks the Android database export row as active and clears prior status messages
        - schedules archive generation after one main-actor yield so SwiftUI can render the busy state
        - exports from a background SwiftData context so SQLite and ZIP work do not block the UI actor
        - writes the generated archive to a temporary file and presents the share sheet on success
@@ -369,13 +410,13 @@ public struct ImportExportView: View {
      - Failure modes: Catches backup export and file-write failures and surfaces them as status text.
      */
     private func exportAndroidDatabaseBackup() {
-        isExporting = true
+        activeExportAction = .androidDatabaseBackup
         statusMessage = nil
         let modelContainer = modelContext.container
 
         Task { @MainActor in
             await Task.yield()
-            defer { isExporting = false }
+            defer { activeExportAction = nil }
 
             do {
                 let export = try await Task.detached(priority: .userInitiated) {
@@ -407,19 +448,19 @@ public struct ImportExportView: View {
      manual backup format and should not be treated as the parity backup path.
 
      - Side effects:
-       - toggles export state and clears prior status messages
+       - marks the legacy JSON export row as active and clears prior status messages
        - queries `BackupService` for a full JSON backup payload
        - writes the payload to a temporary file and presents the share sheet on success
      - Failure modes: Surfaces missing backup data through status text.
      */
     private func exportLegacyFullBackup() {
-        isExporting = true
+        activeExportAction = .legacyFullBackup
         statusMessage = nil
 
         let service = BackupService(modelContext: modelContext)
         guard let data = service.exportFullBackup() else {
             statusMessage = String(localized: "error_create_backup")
-            isExporting = false
+            activeExportAction = nil
             return
         }
 
@@ -429,20 +470,26 @@ public struct ImportExportView: View {
             showExportSheet = true
         }
 
-        isExporting = false
+        activeExportAction = nil
     }
 
     /**
      Exports bookmarks as CSV, writes the file to a temporary location, and presents the share sheet.
+
+     - Side effects:
+       - marks the bookmark CSV export row as active and clears prior status messages
+       - queries `BackupService` for bookmark CSV payload data
+       - writes the payload to a temporary file and presents the share sheet on success
+     - Failure modes: Surfaces missing bookmark export data through status text.
      */
     private func exportBookmarksCSV() {
-        isExporting = true
+        activeExportAction = .bookmarksCSV
         statusMessage = nil
 
         let service = BackupService(modelContext: modelContext)
         guard let data = service.exportBookmarksCSV() else {
             statusMessage = String(localized: "error_export_bookmarks")
-            isExporting = false
+            activeExportAction = nil
             return
         }
 
@@ -452,7 +499,7 @@ public struct ImportExportView: View {
             showExportSheet = true
         }
 
-        isExporting = false
+        activeExportAction = nil
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -1049,19 +1049,26 @@ public struct ImportExportView: View {
      - Side effects:
        - deletes any previous temporary export with the same canonical filename
        - moves the generated archive into the share-sheet location
+       - removes the generated archive if the canonical move fails
      - Failure modes: Rethrows file-system errors when the previous export cannot be removed or the
-       generated archive cannot be moved.
+       generated archive cannot be moved after attempting to clean up the source archive.
      */
     private func moveExportFileToShareDirectory(_ export: AndroidDatabaseBackupFileExport) throws -> URL {
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(export.fileName)
+        let fileManager = FileManager.default
+        let fileURL = fileManager.temporaryDirectory.appendingPathComponent(export.fileName)
         if fileURL == export.fileURL {
             return fileURL
         }
-        if FileManager.default.fileExists(atPath: fileURL.path) {
-            try FileManager.default.removeItem(at: fileURL)
+        do {
+            if fileManager.fileExists(atPath: fileURL.path) {
+                try fileManager.removeItem(at: fileURL)
+            }
+            try fileManager.moveItem(at: export.fileURL, to: fileURL)
+            return fileURL
+        } catch {
+            try? fileManager.removeItem(at: export.fileURL)
+            throw error
         }
-        try FileManager.default.moveItem(at: export.fileURL, to: fileURL)
-        return fileURL
     }
 
     /**

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -32,7 +32,7 @@
   "AndBibleUITests/AndBibleUITests/testSearchScopeChangeRerunsQueryAndUpdatesResults": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchWordModeChangeRerunsQueryAndUpdatesResults": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSettingsColorsLinkOpensColorEditor": "baseline",
-  "AndBibleUITests/AndBibleUITests/testSettingsImportExportFullBackupPresentsShareSheet": "baseline",
+  "AndBibleUITests/AndBibleUITests/testSettingsImportExportAndroidDatabaseBackupPresentsShareSheet": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings": "baseline",
   "AndBibleUITests/AndBibleUITests/testApplicationPreferencesRenderAndroidListPreferenceRowsWithoutInlineValues": "baseline",

--- a/scripts/ui_test_timings.json
+++ b/scripts/ui_test_timings.json
@@ -26,7 +26,7 @@
   "AndBibleUITests/AndBibleUITests/testSearchScopeChangeRerunsQueryAndUpdatesResults": 36.40324306488037,
   "AndBibleUITests/AndBibleUITests/testSearchWordModeChangeRerunsQueryAndUpdatesResults": 34.39950406551361,
   "AndBibleUITests/AndBibleUITests/testSettingsColorsLinkOpensColorEditor": 18.54922103881836,
-  "AndBibleUITests/AndBibleUITests/testSettingsImportExportFullBackupPresentsShareSheet": 18.399284958839417,
+  "AndBibleUITests/AndBibleUITests/testSettingsImportExportAndroidDatabaseBackupPresentsShareSheet": 18.399284958839417,
   "AndBibleUITests/AndBibleUITests/testSettingsImportExportImportPresentsFilePickerState": 17.958650946617126,
   "AndBibleUITests/AndBibleUITests/testSettingsReadingProgressLinkOpensReadingProgressSettings": 16.167,
   "AndBibleUITests/AndBibleUITests/testSettingsScreenShowsApplicationPreferenceShortcuts": 14.295,


### PR DESCRIPTION
## Summary
- Adds Android-compatible manual database backup export from iOS.
- Makes the Import and Export backup action produce AndBibleDatabaseBackup.abdb.zip instead of the old JSON payload by default.

## Scope
- Android database backup export service plumbing.
- Import and Export backup UI action and accessibility identifiers.
- Unit and UI coverage for the new backup export path.
- UI fixture and timing metadata for the renamed export test.

## Contract References
- commit-message-standard.md
- Android BackupControl.kt database backup format: AndBibleBackupManifest.json plus category SQLite databases under db/.
- Issue #152 acceptance criteria for Android-compatible .abdb.zip export.

## Change Details
- Added AndroidDatabaseBackupService.exportArchive to emit DB_BACKUP manifests and supported category database entries.
- Reused RemoteSyncInitialBackupUploadService category SQLite builders through a builder-only local path with no upload or sync-state mutation.
- Exported currently supported categories: Bookmarks, Reading Plans, Workspaces, and My Documents.
- Kept JSON export available as explicit legacy backup rather than the parity/default export path.
- Updated UI automation selectors, fixture manifest, and timing metadata for the new Android backup export test name.

## Validation Evidence
- xcodebuild test -scheme AndBible -destination platform=iOS Simulator,name=iPhone 16,OS=18.6 -only-testing:AndBibleTests/AndBibleTests/testAndroidDatabaseBackupExportCreatesAndroidCompatibleArchive
- xcodebuild test -scheme AndBible -destination platform=iOS Simulator,name=iPhone 16,OS=18.6 -only-testing:AndBibleUITests/AndBibleUITests/testSettingsImportExportAndroidDatabaseBackupPresentsShareSheet
- python3 scripts/check_repo_standards.py docblocks
- git diff --check
- python3 -m json.tool scripts/ui_test_fixture_manifest.json
- python3 -m json.tool scripts/ui_test_timings.json
- npx gitnexus impact File:Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift --repo and-bible-ios --direction upstream --include-tests

## Risks and Follow-ups
- Unsupported Android-only backup databases are omitted until safe iOS mappers exist.
- GitNexus reports broad file-level impact because AndroidDatabaseBackupService is imported widely; focused export and UI paths are covered by targeted tests.

## Issue Closure
Closes #152