### PR TITLE
chore(signing): read DEVELOPMENT_TEAM from local xcconfig

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -685,7 +685,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"AndBible/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_PREVIEWS = YES;
 				GOOGLE_DRIVE_CLIENT_ID = "";
 				GOOGLE_DRIVE_REVERSED_CLIENT_ID = "";
@@ -777,7 +777,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"AndBible/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_PREVIEWS = YES;
 				GOOGLE_DRIVE_CLIENT_ID = "";
 				GOOGLE_DRIVE_REVERSED_CLIENT_ID = "";


### PR DESCRIPTION
Why:
The app target hardcoded DEVELOPMENT_TEAM = "" which overrode any value from
Config/Secrets.xcconfig.local, forcing developers to set their team via the
Xcode signing UI — which rewrites the whole project file and bakes a personal
team ID into version control.

What Changed:
Set the app target's DEVELOPMENT_TEAM to "$(inherited)" in Debug and Release so
it resolves from the gitignored Config/Secrets.xcconfig.local. Test targets
unchanged.

Validation:
xcodebuild -showBuildSettings resolves the team from the local xcconfig for both
configs; with no local file present it resolves empty, leaving CI/simulator
builds unchanged.

Impact:
Signing team is now developer-local and never committed.