### PR TITLE
fix(reader): align SWORD semantics with JSword

### DIFF
--- a/AndBibleTests/AndBibleTestSupport.swift
+++ b/AndBibleTests/AndBibleTestSupport.swift
@@ -353,6 +353,58 @@ extension AndBibleTests {
         return tempRoot.path
     }
 
+    /**
+     Seeds a deterministic empty SWORD commentary module into a temporary module directory.
+
+     The bundled test fixture intentionally carries only KJV, but commentary parity tests need an
+     installed verse-key commentary category so `BibleReaderController` exercises its commentary
+     loading path. The module uses SWORD's `RawCom` driver with empty testament data files, which
+     is enough for category discovery and missing-entry behavior without redistributing another
+     module.
+
+     - Parameters:
+       - moduleName: SWORD module initials to publish in `mods.d`.
+       - modulePath: Temporary SWORD root returned by `makeTemporaryBundledSwordPath()`.
+     - Side effects: Writes a `.conf` file and empty `RawCom` data files under `modulePath`.
+     - Failure modes: Propagates filesystem write errors.
+     */
+    func seedEmptyRawCommentaryModule(named moduleName: String = "UITestComm", in modulePath: String) throws {
+        let fm = FileManager.default
+        let moduleRoot = URL(fileURLWithPath: modulePath, isDirectory: true)
+        let modsDURL = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let dataURL = moduleRoot
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("comments", isDirectory: true)
+            .appendingPathComponent("rawcom", isDirectory: true)
+            .appendingPathComponent(moduleName.lowercased(), isDirectory: true)
+
+        try fm.createDirectory(at: modsDURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: dataURL, withIntermediateDirectories: true)
+        for fileName in ["ot", "ot.vss", "nt", "nt.vss"] {
+            let fileURL = dataURL.appendingPathComponent(fileName, isDirectory: false)
+            if !fm.fileExists(atPath: fileURL.path) {
+                try Data().write(to: fileURL)
+            }
+        }
+
+        let conf = """
+        [\(moduleName)]
+        Description=UI Test Commentary
+        DataPath=./modules/comments/rawcom/\(moduleName.lowercased())/
+        ModDrv=RawCom
+        SourceType=OSIS
+        Encoding=UTF-8
+        Lang=en
+        Versification=KJV
+        About=Deterministic empty commentary module for iOS parity tests.
+        """
+        try conf.write(
+            to: modsDURL.appendingPathComponent("\(moduleName.lowercased()).conf", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
     func copyDirectoryContents(from source: URL, to destination: URL) throws {
         let fm = FileManager.default
         try fm.createDirectory(at: destination, withIntermediateDirectories: true)

--- a/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import BibleCore
+import SwordKit
 
 extension AndBibleTests {
     /**
@@ -143,6 +144,40 @@ extension AndBibleTests {
             try String(contentsOf: moduleRoot.appendingPathComponent("modules/texts/rawtext/kjv/ot"), encoding: .utf8),
             "Genesis content"
         )
+    }
+
+    /**
+     Verifies that file-backed Android module backup restore announces the installed-module store
+     change immediately after publishing SWORD files.
+
+     Setup:
+     - writes a valid Android `.abmd.zip` fixture to disk
+     - observes the module-store change notification that open reader and downloads views use to
+       rebuild stale `SwordManager` snapshots
+
+     Expected result:
+     - restore posts a visible module-store change after successful file publication
+
+     Failure meaning:
+     - restored modules can remain hidden in already-open UI surfaces until app restart, because
+       SWORD's disk cache was invalidated without notifying long-lived in-memory module caches.
+     */
+    func testAndroidModuleBackupRestoreFromFileURLNotifiesModuleStoreChange() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d/esv.conf", makeAndroidModuleBackupConf(moduleName: "ESV")),
+            ("modules/texts/rawtext/esv/ot", Data("Genesis content".utf8)),
+        ])
+        let archiveURL = try writeTemporaryAndroidModuleBackupArchive(archiveData)
+        let notificationExpectation = expectation(
+            forNotification: SwordModuleStore.modulesDidChangeNotification,
+            object: nil
+        )
+
+        _ = try service.restoreArchive(fromArchiveAt: archiveURL)
+
+        wait(for: [notificationExpectation], timeout: 0.2)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -80,6 +80,61 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Verifies bookmark-list range text keeps JSword's same-chapter shorthand.
+     *
+     Android reconstructs a JSword `VerseRange` from stored ordinals and displays the range name.
+     For a range within one chapter, JSword emits `Book chapter:start-end`, so the iOS bookmark
+     list should not expand the repeated chapter or collapse a real multi-verse range.
+     */
+    func testBookmarkListVerseReferenceFormatsSameChapterRangeLikeJSword() {
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: 5,
+            kjvOrdinalEnd: 7,
+            ordinalStart: 5,
+            ordinalEnd: 7,
+            v11n: "KJVA"
+        )
+        bookmark.book = "Genesis"
+
+        let reference = BookmarkListView.verseReference(for: bookmark) { _, ordinal in
+            [
+                5: BookmarkListVerseReference(chapter: 1, verse: 5),
+                7: BookmarkListVerseReference(chapter: 1, verse: 7),
+            ][ordinal]
+        }
+
+        XCTAssertEqual(reference, "Genesis 1:5-7")
+    }
+
+    /**
+     Verifies bookmark-list range text preserves the end chapter when a stored ordinal range crosses
+     a chapter boundary.
+     *
+     JSword `VerseRange` names same-book cross-chapter ranges as `Book startChapter:startVerse-
+     endChapter:endVerse`. A failure here means two different ranges such as `Genesis 1:5-2:5` and
+     `Genesis 1:5` can be rendered ambiguously or collapsed in the iOS bookmark list.
+     */
+    func testBookmarkListVerseReferenceKeepsCrossChapterEndChapterLikeJSword() {
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: 5,
+            kjvOrdinalEnd: 45,
+            ordinalStart: 5,
+            ordinalEnd: 45,
+            v11n: "KJVA"
+        )
+        bookmark.book = "Genesis"
+
+        let reference = BookmarkListView.verseReference(for: bookmark) { _, ordinal in
+            [
+                5: BookmarkListVerseReference(chapter: 1, verse: 5),
+                45: BookmarkListVerseReference(chapter: 2, verse: 5),
+            ][ordinal]
+        }
+
+        XCTAssertEqual(reference, "Genesis 1:5-2:5")
+    }
+
     #if os(iOS)
     @MainActor
     func testReaderBookmarkBridgeUpdateEmitsTypedPayloadShape() throws {
@@ -131,6 +186,103 @@ extension AndBibleTests {
         XCTAssertEqual(relation["type"] as? String, "BibleBookmarkToLabel")
         XCTAssertEqual(relation["bookmarkId"] as? String, bookmark.id.uuidString)
         XCTAssertEqual(relation["labelId"] as? String, Label.unlabeledId.uuidString)
+    }
+
+    /**
+     Verifies bookmark bridge payloads derive range fields from the same ordinal-backed
+     JSword-style verse range Android serializes through `ClientBibleBookmark`.
+     *
+     Data dependencies:
+     * - copies the bundled KJV SWORD module into a temporary module path
+     * - creates one Bible bookmark that spans Genesis 1:31 through Genesis 2:2
+     *
+     * Failure modes:
+     * - throws if bundled KJV cannot be loaded or its ordinals cannot be resolved
+     * - fails if iOS collapses cross-chapter ranges to the start chapter, emits a non-JSword OSIS
+     *   ref, or omits verse text from the end chapter
+     */
+    @MainActor
+    func testReaderBookmarkBridgeUpdateEmitsJSwordCrossChapterRangePayload() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkStore = BookmarkStore(modelContext: modelContext)
+        let bookmarkService = BookmarkService(store: bookmarkStore)
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        controller.bookmarkService = bookmarkService
+        let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
+        let startOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 31))
+        let endOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 2))
+
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            wholeVerse: true
+        )
+        bookmark.book = "Genesis"
+
+        controller.refreshBookmarkInVueJS(bookmarkId: bookmark.id)
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: recordedScripts(), event: "add_or_update_bookmarks") as? [[String: Any]]
+        )
+        let bookmarkObject = try XCTUnwrap(payload.first)
+        XCTAssertEqual(bookmarkObject["osisRef"] as? String, "Gen.1.31-Gen.2.2")
+        XCTAssertEqual(bookmarkObject["verseRange"] as? String, "Genesis 1:31-2:2")
+        XCTAssertEqual(bookmarkObject["verseRangeOnlyNumber"] as? String, "31-2")
+        XCTAssertEqual(bookmarkObject["verseRangeAbbreviated"] as? String, "Gen 1:31-2:2")
+
+        let fullText = try XCTUnwrap(bookmarkObject["fullText"] as? String)
+        XCTAssertTrue(
+            fullText.contains("the heavens and the earth were finished"),
+            "Expected bridge payload text to include Genesis 2:1 content; got: \(fullText)"
+        )
+    }
+
+    /**
+     Verifies StudyPad bookmark payloads use the same JSword-style cross-chapter range projection
+     as live bookmark update events.
+     *
+     Android serializes Study Pad bookmarks through the same `ClientBibleBookmark` DTO as bookmark
+     update events. A failure means iOS has reintroduced drift between equivalent bridge payloads.
+     */
+    @MainActor
+    func testReaderStudyPadDocumentBridgeEmissionUsesJSwordCrossChapterRangePayload() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkStore = BookmarkStore(modelContext: modelContext)
+        let bookmarkService = BookmarkService(store: bookmarkStore)
+        let controller = BibleReaderController(bridge: bridge)
+        controller.bookmarkService = bookmarkService
+
+        let label = bookmarkService.createLabel(name: "Cross Chapter", color: Label.defaultColor)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 31,
+            endOrdinal: 42,
+            wholeVerse: true
+        )
+        bookmark.book = "Genesis"
+        _ = bookmarkService.toggleLabel(bookmarkId: bookmark.id, labelId: label.id)
+
+        controller.bridgeDidSetClientReady(bridge)
+        let scriptCount = recordedScripts().count
+        controller.loadStudyPadDocument(labelId: label.id, bookmarkId: bookmark.id)
+        let studyPadScripts = Array(recordedScripts().dropFirst(scriptCount))
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: studyPadScripts, event: "add_documents") as? [String: Any]
+        )
+        let bookmarks = try XCTUnwrap(payload["bookmarks"] as? [[String: Any]])
+        let bookmarkObject = try XCTUnwrap(bookmarks.first)
+        XCTAssertEqual(bookmarkObject["osisRef"] as? String, "Gen.1.31-Gen.2.2")
+        XCTAssertEqual(bookmarkObject["verseRange"] as? String, "Genesis 1:31-2:2")
+        XCTAssertEqual(bookmarkObject["verseRangeOnlyNumber"] as? String, "31-2")
+        XCTAssertEqual(bookmarkObject["verseRangeAbbreviated"] as? String, "Gen 1:31-2:2")
     }
 
     @MainActor

--- a/AndBibleTests/AndBibleTests+Downloads.swift
+++ b/AndBibleTests/AndBibleTests+Downloads.swift
@@ -1876,10 +1876,10 @@ extension AndBibleTests {
     private func seedSearchIndexFixture(moduleName: String, db: OpaquePointer?) throws {
         let escapedModuleName = moduleName.replacingOccurrences(of: "'", with: "''")
         let sql = """
-        INSERT INTO verse_fts (verse_key, plain_text, module_name)
-        VALUES ('Genesis 1:1', 'created', '\(escapedModuleName)');
+        INSERT INTO verse_fts (verse_key, plain_text, module_name, entry_order)
+        VALUES ('Genesis 1:1', 'created', '\(escapedModuleName)', 0);
         INSERT INTO indexed_modules (module_name, verse_count, indexed_at, schema_version)
-        VALUES ('\(escapedModuleName)', 1, datetime('now'), 1);
+        VALUES ('\(escapedModuleName)', 1, datetime('now'), \(SearchIndexService.currentSchemaVersion));
         """
         guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
             throw SearchIndexFixtureError.writeFailed

--- a/AndBibleTests/AndBibleTests+Downloads.swift
+++ b/AndBibleTests/AndBibleTests+Downloads.swift
@@ -267,6 +267,21 @@ extension AndBibleTests {
         XCTAssertEqual(modules.first?.sourceName, "Example MyBible")
     }
 
+    /**
+     Verifies that MyBible package installs and uninstalls publish installed-module mutations.
+
+     Setup:
+     - installs a real fixture MyBible SQLite package through the repository download path
+     - removes the same module through the shared uninstall API
+     - observes the module-store notification consumed by open reader and Downloads snapshots
+
+     Expected result:
+     - both the successful install and successful uninstall announce that installed modules changed
+
+     Failure meaning:
+     - MyBible modules can appear or disappear on disk while already-open UI lists keep stale module
+       state until app restart or an unrelated refresh.
+     */
     func testModuleRepositoryInstallsAndUninstallsMyBiblePackage() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -351,6 +366,21 @@ extension AndBibleTests {
         )
 
         _ = try await repository.refreshCatalog(for: source)
+        let notificationExpectation = expectation(
+            description: "MyBible install and uninstall publish module-store changes"
+        )
+        notificationExpectation.expectedFulfillmentCount = 2
+        let notificationObserver = NotificationCenter.default.addObserver(
+            forName: SwordModuleStore.modulesDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationExpectation.fulfill()
+        }
+        defer {
+            NotificationCenter.default.removeObserver(notificationObserver)
+        }
+
         try await repository.installModule(named: "MyBible-finrk_SQLite3", from: source)
 
         let installed = repository.loadInstalledMyBibleModules()
@@ -375,6 +405,7 @@ extension AndBibleTests {
         try repository.uninstallModule(named: "MyBible-finrk_SQLite3")
         XCTAssertFalse(FileManager.default.fileExists(atPath: moduleDir.path))
         XCTAssertTrue(repository.loadInstalledMyBibleModules().isEmpty)
+        await fulfillment(of: [notificationExpectation], timeout: 0.2)
     }
 
     func testModuleRepositoryInstallsDeflatedMyBiblePackage() async throws {
@@ -535,6 +566,67 @@ extension AndBibleTests {
             try Data(contentsOf: swordDir.appendingPathComponent("modules/texts/rawtext/finrk/ot")),
             moduleData
         )
+    }
+
+    /**
+     Verifies that local SWORD ZIP installation announces the installed-module store mutation.
+
+     Setup:
+     - builds an Android-compatible data-descriptor ZIP package
+     - installs it through `ModuleRepository.installFromZip(at:)`, the same storage path used by
+       Files/Settings SWORD ZIP imports
+     - observes the shared module-store notification consumed by open reader and Downloads views
+
+     Expected result:
+     - a successful ZIP install posts the module-store change notification once files are published
+
+     Failure meaning:
+     - newly imported modules can remain absent from already-open UI caches until app restart or a
+       coincidental Downloads sheet refresh.
+     */
+    func testModuleRepositoryInstallFromZipNotifiesModuleStoreChange() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let conf = Data(
+            """
+            [FINRK]
+            Description=Finnish RK
+            Category=Biblical Texts
+            Lang=fi
+            ModDrv=RawText
+            DataPath=./modules/texts/rawtext/finrk/
+            Version=1.0
+            InstallSize=1
+            """.utf8
+        )
+        let moduleData = Data("genesis-through-revelation".utf8)
+        let zipData = try makeModuleRepositoryZipWithDataDescriptors([
+            (
+                name: "mods.d/finrk.conf",
+                body: conf,
+                compressedBody: makeModuleRepositoryRawDeflateData(conf)
+            ),
+            (
+                name: "modules/texts/rawtext/finrk/ot",
+                body: moduleData,
+                compressedBody: makeModuleRepositoryRawDeflateData(moduleData)
+            ),
+        ])
+        let archiveURL = tempDir.appendingPathComponent("FinRK.zip")
+        try zipData.write(to: archiveURL)
+        let repository = ModuleRepository(basePath: tempDir.path, swordPath: swordDir.path)
+        let notificationExpectation = expectation(
+            forNotification: SwordModuleStore.modulesDidChangeNotification,
+            object: nil
+        )
+
+        _ = try repository.installFromZip(at: archiveURL)
+
+        wait(for: [notificationExpectation], timeout: 0.2)
     }
 
     func testModuleRepositoryDownloadFailsWithoutInstalledMarkerWhenRequiredFileFails() async throws {

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -18,6 +18,15 @@ import struct SwiftUI.Color
 #endif
 
 extension AndBibleTests {
+    /**
+     Protects Android/JSword ordinal parity for compare links.
+
+     The web client sends verse ordinals into the native compare bridge. Android resolves those
+     ordinals through JSword's active versification, whose values include intro slots and therefore
+     are not `(chapter - 1) * 40 + verse`. The bundled KJV module supplies the same SWORD
+     versification data here; a failure means compare links have drifted back toward synthetic
+     ordinals and can open the wrong verse range.
+     */
     func testReaderCompareBridgeRequestEmitsVueCompareDocument() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()
         let modulePath = try makeTemporaryBundledSwordPath()
@@ -30,9 +39,12 @@ extension AndBibleTests {
         let startVerse = 5
         let endVerse = 7
         let activeModuleName = controller.activeModuleName
+        let activeModule = try XCTUnwrap(manager.module(named: activeModuleName))
 
-        func ordinal(for verse: Int) -> Int {
-            (chapter - 1) * 40 + verse
+        func ordinal(for verse: Int) throws -> Int {
+            try XCTUnwrap(
+                activeModule.verseOrdinal(osisBookId: "2Cor", chapter: chapter, verse: verse)
+            )
         }
 
         controller.navigateTo(book: secondCorinthians, chapter: chapter, verse: 1)
@@ -40,7 +52,11 @@ extension AndBibleTests {
         XCTAssertEqual(
             bridge.dispatchMessage(
                 method: "compare",
-                args: [activeModuleName, ordinal(for: startVerse), ordinal(for: endVerse)]
+                args: [
+                    activeModuleName,
+                    try ordinal(for: startVerse),
+                    try ordinal(for: endVerse),
+                ]
             ),
             .handled
         )
@@ -660,11 +676,22 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Verifies explicit verse navigation highlights the JSword/SWORD ordinal for the selected verse.
+
+     Android stores the navigation target as the active versification's verse ordinal, including
+     intro slots. The bundled KJV module supplies the expected ordinal here so this test fails if
+     iOS reverts to literal verse numbers while still emitting an `originalOrdinalRange` field.
+     */
     @MainActor
     func testLoadCurrentContentHighlightsExplicitVerseNavigationTarget() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()
         let modulePath = try makeTemporaryBundledSwordPath()
         let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let module = try XCTUnwrap(manager.module(named: "KJV"))
+        let expectedOrdinal = try XCTUnwrap(
+            module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 5)
+        )
 
         let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
 
@@ -677,8 +704,67 @@ extension AndBibleTests {
         )
 
         XCTAssertTrue(
-            addDocumentsScript.contains("\"originalOrdinalRange\":[5,5]"),
+            addDocumentsScript.contains("\"originalOrdinalRange\":[\(expectedOrdinal),\(expectedOrdinal)]"),
             "Expected explicit verse navigation to preserve the original highlighted target. Script: \(addDocumentsScript)"
+        )
+    }
+
+    /**
+     Protects commentary rendering against chapter-shaped fallbacks.
+
+     Android's `CurrentCommentaryPage` is a single-key page: when the current Bible verse is
+     Genesis 1:5, the commentary document is keyed to that verse even if the selected commentary
+     module has no entry there. The test uses a minimal empty `RawCom` module so the controller
+     enters the real commentary path while the missing-entry branch stays deterministic. A failure
+     means iOS has drifted back to whole-chapter commentary semantics or verse-1 placeholder ranges.
+     */
+    @MainActor
+    func testCommentaryMissingEntryUsesSelectedVerseKeyAndOrdinalRange() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawCommentaryModule(in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let bibleModule = try XCTUnwrap(manager.module(named: "KJV"))
+        let expectedOrdinal = try XCTUnwrap(
+            bibleModule.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 5)
+        )
+        XCTAssertTrue(
+            manager.installedModules(category: .commentary).contains { $0.name == "UITestComm" },
+            "Expected the temporary RawCom fixture to be discovered as a commentary module."
+        )
+
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+
+        controller.navigateTo(book: "Genesis", chapter: 1, verse: 5)
+        controller.switchCategory(to: .commentary)
+        let baselineScriptCount = recordedScripts().count
+        controller.loadCurrentContent()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(
+                from: Array(recordedScripts().dropFirst(baselineScriptCount)),
+                event: "add_documents"
+            ) as? [String: Any]
+        )
+        let fragment = try XCTUnwrap(payload["osisFragment"] as? [String: Any])
+        let xml = try XCTUnwrap(fragment["xml"] as? String)
+
+        XCTAssertEqual(payload["bookCategory"] as? String, "COMMENTARY")
+        XCTAssertEqual(payload["bookInitials"] as? String, "UITestComm")
+        XCTAssertEqual(payload["key"] as? String, "Gen.1.5")
+        XCTAssertEqual(payload["osisRef"] as? String, "Gen.1.5")
+        XCTAssertEqual(payload["ordinalRange"] as? [Int], [expectedOrdinal, expectedOrdinal])
+        XCTAssertEqual(fragment["key"] as? String, "Gen.1.5")
+        XCTAssertEqual(fragment["osisRef"] as? String, "Gen.1.5")
+        XCTAssertEqual(fragment["ordinalRange"] as? [Int], [expectedOrdinal, expectedOrdinal])
+        XCTAssertTrue(
+            xml.contains("No commentary available for this verse"),
+            "Expected missing commentary text to describe the selected verse. XML: \(xml)"
+        )
+        XCTAssertFalse(
+            xml.contains("No commentary available for this chapter"),
+            "Commentary is a single-key document on Android and must not report chapter-level absence. XML: \(xml)"
         )
     }
 
@@ -728,6 +814,72 @@ extension AndBibleTests {
             "Expected multi-reference osis:// to render a Vue MultiDocument. Script: \(addDocumentsScript)"
         )
         XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.1""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Exod.2.1""#))
+    }
+
+    /**
+     Verifies OSIS range links use JSword/SWORD passage semantics instead of endpoint splitting.
+
+     Android parses `osis://` references with JSword `PassageKeyFactory`, so
+     `Gen.1.1-Gen.1.3` opens a multi-document containing verses 1, 2, and 3. The test drives the
+     native link handler with the bundled KJV module and inspects the emitted Vue `MultiDocument`;
+     a failure means cross-reference links can omit middle verses while appearing to open normally.
+     */
+    @MainActor
+    func testOsisRangeLinkExpandsEveryVerseInVueMultiDocument() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        var showedCrossReferences = false
+        controller.onShowCrossReferences = { _ in showedCrossReferences = true }
+
+        controller.bridge(bridge, openExternalLink: "osis://?osis=Gen.1.1-Gen.1.3&v11n=KJVA")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        XCTAssertFalse(showedCrossReferences)
+        let addDocumentsScript = try XCTUnwrap(
+            recordedScripts().first(where: { $0.contains("emit('add_documents'") })
+        )
+        XCTAssertTrue(
+            addDocumentsScript.contains(#""type":"multi""#),
+            "Expected OSIS range link to render a Vue MultiDocument. Script: \(addDocumentsScript)"
+        )
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.1""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.2""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.3""#))
+    }
+
+    /**
+     Verifies OSIS list separators and range expansion compose through the SWORD parser boundary.
+
+     JSword `PassageKeyFactory` accepts comma-separated passage lists and expands each range against
+     the active versification. iOS must preserve both semantics instead of sending the whole comma
+     string to SWORD, whose flat parser only reliably expands individual segments here. A failure
+     means mixed cross-reference links can silently drop later list entries or range members.
+     */
+    @MainActor
+    func testOsisMixedListAndRangeLinkEmitsEveryParsedVerse() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        var showedCrossReferences = false
+        controller.onShowCrossReferences = { _ in showedCrossReferences = true }
+
+        controller.bridge(bridge, openExternalLink: "osis://?osis=Gen.1.1-Gen.1.2,Exod.2.1&v11n=KJVA")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        XCTAssertFalse(showedCrossReferences)
+        let addDocumentsScript = try XCTUnwrap(
+            recordedScripts().first(where: { $0.contains("emit('add_documents'") })
+        )
+        XCTAssertTrue(
+            addDocumentsScript.contains(#""type":"multi""#),
+            "Expected mixed OSIS list/range link to render a Vue MultiDocument. Script: \(addDocumentsScript)"
+        )
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.1""#))
+        XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Gen.1.2""#))
         XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"Exod.2.1""#))
     }
 
@@ -1164,13 +1316,87 @@ extension AndBibleTests {
     }
 
     @MainActor
-    func testParseRefSendsResponseWithOriginalCallId() {
+    func testParseRefSendsResponseWithOriginalCallId() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()
-        let controller = BibleReaderController(bridge: bridge)
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
 
         controller.bridge(bridge, parseRef: 3703, text: "Genesis 1:1")
 
         XCTAssertEqual(recordedScripts().last, #"bibleView.response(3703, "Gen.1.1");"#)
+
+        controller.bridge(bridge, parseRef: 3705, text: "III John 1:2")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            #"bibleView.response(3705, "3John.1.2");"#,
+            "parseRef should delegate to the active module parser so JSword-compatible book names are accepted."
+        )
+
+        controller.bridge(bridge, parseRef: 3706, text: "Genesis 1:1, Exodus 2:1")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            #"bibleView.response(3706, "Gen.1.1 Exod.2.1");"#,
+            "parseRef should preserve JSword PassageKeyFactory semantics for multi-reference passage lists."
+        )
+
+        controller.bridge(bridge, parseRef: 3707, text: "Genesis 1:1, 2")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            #"bibleView.response(3707, "Gen.1.1-Gen.1.2");"#,
+            "parseRef should preserve JSword basis semantics for verse lists."
+        )
+
+        controller.bridge(bridge, parseRef: 3708, text: "Genesis 1")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            #"bibleView.response(3708, "Gen.1");"#,
+            "parseRef should serialize whole chapters using JSword getOsisRef semantics."
+        )
+
+        controller.bridge(bridge, parseRef: 3709, text: "Genesis 1-2")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            #"bibleView.response(3709, "Gen.1-Gen.2");"#,
+            "parseRef should serialize chapter ranges using JSword getOsisRef semantics."
+        )
+
+        controller.bridge(bridge, parseRef: 3704, text: "Gen.1.99")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            "bibleView.response(3704, null);",
+            "parseRef must reject out-of-range references through the active module parser instead of accepting any OSIS-looking string."
+        )
+
+        controller.bridge(bridge, parseRef: 3710, text: "Genesis 1:1, 99")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            "bibleView.response(3710, null);",
+            "parseRef must reject invalid shorthand verse-list entries the same way JSword validates VerseRange parts."
+        )
+
+        controller.bridge(bridge, parseRef: 3711, text: "Genesis 1:1-99")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            "bibleView.response(3711, null);",
+            "parseRef must reject invalid range endpoints before SWORD normalizes them."
+        )
+
+        controller.bridge(bridge, parseRef: 3712, text: "Genesis 2-1")
+
+        XCTAssertEqual(
+            recordedScripts().last,
+            "bibleView.response(3712, null);",
+            "parseRef must reject reverse ranges using active module ordinals instead of accepting fabricated ordering values."
+        )
     }
 
     @MainActor
@@ -1401,9 +1627,21 @@ extension AndBibleTests {
         XCTAssertEqual(pageManager.bibleVerseNo, 5)
     }
 
-    func testDidScrollToOrdinalDebouncesPersistenceWithinCurrentChapter() {
+    /**
+     Protects visible-verse persistence against synthetic ordinal arithmetic.
+
+     Android receives scroll ordinals that belong to the active JSword versification. This test
+     uses the bundled KJV SWORD module to derive the ordinal for Genesis 1:5, then expects the
+     native reader to reverse-map that ordinal back to verse 5 before debouncing persistence. A
+     failure means reader state is deriving verses from fixed 40-verse chapter math.
+     */
+    func testDidScrollToOrdinalDebouncesPersistenceWithinCurrentChapter() throws {
         let bridge = BibleBridge()
-        let controller = BibleReaderController(bridge: bridge)
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
+        let ordinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 5))
         let window = Window()
         let pageManager = PageManager(id: window.id)
         window.pageManager = pageManager
@@ -1417,7 +1655,7 @@ extension AndBibleTests {
             persisted.fulfill()
         }
 
-        controller.bridge(bridge, didScrollToOrdinal: 5, key: "Gen.1", atChapterTop: false)
+        controller.bridge(bridge, didScrollToOrdinal: ordinal, key: "Gen.1", atChapterTop: false)
 
         XCTAssertEqual(persistCount, 0)
         XCTAssertEqual(controller.currentVerse, 5)
@@ -1428,9 +1666,21 @@ extension AndBibleTests {
         XCTAssertEqual(persistCount, 1)
     }
 
-    func testDidScrollToOrdinalPersistsImmediatelyWhenChapterChanges() {
+    /**
+     Protects chapter-change scroll persistence against synthetic ordinal arithmetic.
+
+     The document key tells the native reader which chapter is visible, but the verse number must
+     still be reverse-mapped from the JSword/SWORD ordinal. Genesis 2:5 is intentionally chosen
+     because SWORD's ordinal is not the legacy `45`; a failure means infinite-scroll persistence
+     can store the wrong visible verse after a chapter boundary.
+     */
+    func testDidScrollToOrdinalPersistsImmediatelyWhenChapterChanges() throws {
         let bridge = BibleBridge()
-        let controller = BibleReaderController(bridge: bridge)
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
+        let ordinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 5))
         let window = Window()
         let pageManager = PageManager(id: window.id)
         window.pageManager = pageManager
@@ -1440,7 +1690,7 @@ extension AndBibleTests {
         var persistCount = 0
         controller.onPersistState = { persistCount += 1 }
 
-        controller.bridge(bridge, didScrollToOrdinal: 45, key: "Gen.2", atChapterTop: false)
+        controller.bridge(bridge, didScrollToOrdinal: ordinal, key: "Gen.2", atChapterTop: false)
 
         XCTAssertEqual(persistCount, 1)
         XCTAssertEqual(controller.currentChapter, 2)

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -28,6 +28,7 @@ extension AndBibleTests {
 
     func testStrongsQueryNormalizationHandlesLeadingZeroes() {
         let options = StrongsSearchSupport.normalizedQueryOptions(for: "H02022")
+        XCTAssertEqual(options?.canonicalStrongTokens, ["H2022"])
         XCTAssertEqual(
             options?.entryAttributeQueries,
             ["Word//Lemma./H02022", "Word//Lemma./H2022"]
@@ -36,6 +37,7 @@ extension AndBibleTests {
 
     func testStrongsQueryNormalizationAcceptsDecoratedInput() {
         let options = StrongsSearchSupport.normalizedQueryOptions(for: "lemma:strong:g00123")
+        XCTAssertEqual(options?.canonicalStrongTokens, ["G0123"])
         XCTAssertEqual(
             options?.entryAttributeQueries,
             ["Word//Lemma./G00123", "Word//Lemma./G0123", "Word//Lemma./G123"]
@@ -44,9 +46,37 @@ extension AndBibleTests {
 
     func testStrongsQueryNormalizationIncludesIntermediateZeroTrimVariants() {
         let options = StrongsSearchSupport.normalizedQueryOptions(for: "H00430")
+        XCTAssertEqual(options?.canonicalStrongTokens, ["H0430"])
         XCTAssertEqual(
             options?.entryAttributeQueries,
             ["Word//Lemma./H00430", "Word//Lemma./H0430", "Word//Lemma./H430"]
+        )
+    }
+
+    /**
+     Verifies iOS tokenizes Strong's OSIS lemma values the same way JSword populates the Lucene
+     `strong` field.
+
+     JSword `OSISUtil.getStrongsNumbers` extracts `strong:` lemma values from `<w>` elements, and
+     `StrongsNumberFilter` normalizes each number to four digits. Part-suffixed values are indexed
+     twice: once as the base number and once as the full part token. A failure means iOS "find all
+     occurrences" can disagree with Android even when both apps read the same SWORD verse content.
+     */
+    func testStrongsRawLemmaExtractionUsesJSwordCanonicalTokens() {
+        let rawEntry = """
+        <verse osisID="Gen.1.1">
+          <w lemma="strong:H00430 strong:H01234!b">God</w>
+          <w lemma="lemma:noise strong:g00123a">made</w>
+        </verse>
+        """
+
+        XCTAssertEqual(
+            StrongsSearchSupport.canonicalStrongTokens(
+                rawEntry: rawEntry,
+                renderedText: "",
+                book: "Genesis"
+            ),
+            ["H0430", "H1234", "H1234b", "G0123", "G0123a"]
         )
     }
 
@@ -125,6 +155,132 @@ extension AndBibleTests {
             hits.isEmpty,
             "Expected the bundled KJV Strong's search for H00430 to return at least one verse"
         )
+        XCTAssertTrue(
+            hits.contains { $0.book == "Genesis" && $0.chapter == 1 && $0.verse == 1 },
+            "Expected JSword-style Strong's token search for H00430/H0430 to find Genesis 1:1"
+        )
+    }
+
+    /**
+     Verifies SWORD Bible book discovery exposes the full Protestant canon for a complete module.
+
+     The bundled KJV fixture contains content for all 66 books and exercises the same
+     `SwordModule.getBookList()` path used by restored Android `.abmd.zip` Bible modules such as
+     ESV. A failure means the reader's dynamic book picker can hide valid restored content even
+     though the module files and verse entries are present. The test copies bundled SWORD resources
+     into a temporary directory and relies on the shared test cleanup to remove those files.
+     */
+    func testBundledKJVBookListIncludesAllCanonicalBooks() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for book-list regression testing"
+        )
+
+        let discoveredBookIds = module.getBookList().map(\.osisId)
+
+        XCTAssertEqual(discoveredBookIds.count, 66)
+        XCTAssertEqual(
+            discoveredBookIds,
+            [
+                "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Ruth",
+                "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh",
+                "Esth", "Job", "Ps", "Prov", "Eccl", "Song", "Isa", "Jer",
+                "Lam", "Ezek", "Dan", "Hos", "Joel", "Amos", "Obad", "Jonah",
+                "Mic", "Nah", "Hab", "Zeph", "Hag", "Zech", "Mal", "Matt",
+                "Mark", "Luke", "John", "Acts", "Rom", "1Cor", "2Cor", "Gal",
+                "Eph", "Phil", "Col", "1Thess", "2Thess", "1Tim", "2Tim", "Titus",
+                "Phlm", "Heb", "Jas", "1Pet", "2Pet", "1John", "2John", "3John",
+                "Jude", "Rev",
+            ]
+        )
+    }
+
+    /**
+     Verifies iOS expands OSIS reference ranges through the same SWORD key parser boundary that
+     backs JSword-style passage semantics.
+
+     Android uses JSword `PassageKeyFactory` for OSIS references, so a range such as
+     `Gen.1.1-Gen.1.3` resolves to every verse in the range rather than only the textual endpoints.
+     The setup loads the bundled KJV fixture and asks the active SWORD module to parse the range;
+     a failure means reader cross-reference links can silently omit middle verses.
+     */
+    func testBundledKJVParseKeyListExpandsOsisRanges() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for key-list parsing parity testing"
+        )
+
+        XCTAssertEqual(
+            module.parseKeyList("Gen.1.1-Gen.1.3"),
+            ["Gen.1.1", "Gen.1.2", "Gen.1.3"]
+        )
+    }
+
+    /**
+     Verifies iOS obtains chapter verse counts from the active module's SWORD `VerseKey` metadata.
+
+     Android's passage chooser uses JSword `Versification.getLastVerse(book, chapterNo)`, not a
+     partial hard-coded table. The KJV fixture exercises common and uncommon chapter counts; Ruth 4
+     is intentionally included because the previous fallback returned `30` for unknown chapters.
+     A failure means the native verse picker can offer invalid verses or hide valid verses.
+     */
+    func testBundledKJVVerseCountUsesModuleVersification() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for verse-count parity testing"
+        )
+
+        XCTAssertEqual(module.verseCount(osisBookId: "Gen", chapter: 1), 31)
+        XCTAssertEqual(module.verseCount(osisBookId: "Ruth", chapter: 4), 22)
+        XCTAssertEqual(module.verseCount(osisBookId: "Ps", chapter: 119), 176)
+        XCTAssertEqual(module.verseCount(osisBookId: "Rev", chapter: 22), 21)
+        XCTAssertNil(module.verseCount(osisBookId: "Bogus", chapter: 1))
+    }
+
+    /**
+     Verifies iOS uses SWORD/JSword-style verse ordinals instead of per-chapter arithmetic.
+
+     JSword `Versification.getOrdinal(Verse)` includes Bible, testament, book, and chapter intro
+     slots before the first normal verse. SWORD's `VerseKey.getIndex()` follows the same convention,
+     so `Gen.1.1` is ordinal 4 and `Gen.2.1` is ordinal 36, not ordinals 1 and 41. The reverse
+     lookup assertion protects bookmark, memorization, and bridge code that must map persisted
+     Android ordinals back to exact verse references.
+     */
+    func testBundledKJVVerseOrdinalsUseIntroInclusiveVersification() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for ordinal parity testing"
+        )
+
+        XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 1), 4)
+        XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 31), 34)
+        XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 1), 36)
+        XCTAssertEqual(
+            module.verseReference(osisBookId: "Gen", ordinal: 36),
+            VerseKeyReference(osisBookId: "Gen", chapter: 2, verse: 1, ordinal: 36)
+        )
+        XCTAssertNil(module.verseReference(osisBookId: "Exod", ordinal: 36))
+        XCTAssertNil(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 99))
     }
 
     func testBibleChapterDocumentBuilderPreservesSecondCorinthiansIntroAndChapterMarker() throws {

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -17,6 +17,45 @@ import WebKit
 import struct SwiftUI.Color
 #endif
 
+/**
+ Thread-safe recorder for SWORD concurrency regression failures.
+
+ The stress test below intentionally runs native SWORD reads from multiple Dispatch worker threads.
+ XCTest assertions are collected here and asserted after `concurrentPerform` returns so failures are
+ deterministic and reported from the test method rather than from racing background closures.
+
+ - Side effects: Stores failure messages in memory behind an `NSLock`.
+ - Failure modes: None expected; lock contention only serializes recorder access, not SWORD access.
+ */
+private final class SwordConcurrencyFailureRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    /**
+     Records one validation failure from a concurrent worker.
+
+     - Parameter message: Human-readable failure evidence including the worker index.
+     - Side effects: Appends to the protected message list.
+     */
+    func record(_ message: String) {
+        lock.lock()
+        messages.append(message)
+        lock.unlock()
+    }
+
+    /**
+     Returns all collected failures in insertion order.
+
+     - Returns: A copied array so XCTest can inspect it after worker execution completes.
+     - Side effects: Acquires the recorder lock while copying.
+     */
+    var all: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return messages
+    }
+}
+
 extension AndBibleTests {
     func testCSVSetEncodingAndDecodingRoundTrip() {
         let encoded = AppPreferenceRegistry.encodeCSVSet(["  KJV  ", "", "ESV", "KJV", "  "])
@@ -290,6 +329,65 @@ extension AndBibleTests {
         XCTAssertNil(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 99))
         XCTAssertNil(module.verseOrdinal(osisBookId: "Gen", chapter: 99, verse: 1))
         XCTAssertNil(module.verseCount(osisBookId: "Gen", chapter: 99))
+    }
+
+    /**
+     Verifies concurrent Swift SWORD wrappers cannot interleave native libsword state.
+
+     The app can create fresh `SwordManager` instances after imports, restores, and module-store
+     refreshes while other reader/search code is still reading existing modules. The local C bridge
+     and libsword hold process-global pointer caches, so per-instance queues leave a race that can
+     surface as the CI-only `SIGSEGV` seen in the ordinal test. This regression runs many managers
+     against the same bundled KJV fixture in parallel; success means every worker received stable
+     JSword-parity verse ordinals, reverse references, verse counts, and parsed ranges.
+
+     - Setup: Copies the bundled SWORD fixture into one temporary module path shared by all workers.
+     - Expected result: No worker records a missing manager/module or inconsistent SWORD result.
+     - Failure meaning: Native SWORD access is not serialized at the process boundary, risking app
+       crashes during restore/import refreshes or parallel reader/search activity.
+     - Side effects: Creates temporary SWORD fixture files that shared test cleanup removes.
+     */
+    func testBundledKJVNativeAccessSerializesAcrossConcurrentManagers() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let failures = SwordConcurrencyFailureRecorder()
+
+        DispatchQueue.concurrentPerform(iterations: 48) { index in
+            autoreleasepool {
+                guard let manager = SwordManager(modulePath: modulePath) else {
+                    failures.record("worker \(index): missing SwordManager")
+                    return
+                }
+                guard let module = manager.module(named: "KJV") else {
+                    failures.record("worker \(index): missing KJV module")
+                    return
+                }
+
+                let target = index.isMultiple(of: 2)
+                    ? (osisBookId: "Gen", chapter: 1, verse: 1, ordinal: 4)
+                    : (osisBookId: "Gen", chapter: 2, verse: 1, ordinal: 36)
+                let ordinal = module.verseOrdinal(
+                    osisBookId: target.osisBookId,
+                    chapter: target.chapter,
+                    verse: target.verse
+                )
+                let reference = module.verseReference(ordinal: target.ordinal)
+
+                if ordinal != target.ordinal {
+                    failures.record("worker \(index): expected ordinal \(target.ordinal), got \(String(describing: ordinal))")
+                }
+                if reference?.osisRef != "\(target.osisBookId).\(target.chapter).\(target.verse)" {
+                    failures.record("worker \(index): expected reference for ordinal \(target.ordinal), got \(String(describing: reference))")
+                }
+                if module.verseCount(osisBookId: "Gen", chapter: 1) != 31 {
+                    failures.record("worker \(index): unexpected Genesis 1 verse count")
+                }
+                if module.parseKeyList("Gen.1.1-Gen.1.3") != ["Gen.1.1", "Gen.1.2", "Gen.1.3"] {
+                    failures.record("worker \(index): OSIS range did not expand deterministically")
+                }
+            }
+        }
+
+        XCTAssertEqual(failures.all, [])
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -119,6 +119,56 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Verifies Strong's token extraction keeps the JSword raw-OSIS path primary and does not render
+     verse text when raw lexical tokens are already present.
+
+     JSword builds its `strong` field from parsed OSIS `<w lemma="strong:...">` values. Rendering a
+     verse to recover `showStrong` links is an iOS compatibility fallback for modules that do not
+     expose usable raw OSIS, not part of Android's primary search path. A failure means "find all
+     occurrences" may pay unnecessary render cost or merge fallback tokens into a verse whose raw
+     lexical data is already authoritative.
+     */
+    func testStrongsCanonicalExtractionSkipsRenderedFallbackWhenRawOSISHasLexicalTokens() {
+        var renderCount = 0
+
+        let tokens = StrongsSearchSupport.canonicalStrongTokens(
+            rawEntry: #"<w lemma="strong:H00430">God</w>"#,
+            renderedTextProvider: {
+                renderCount += 1
+                return #"<a href="passagestudy.jsp?action=showStrong=01234#cv">unexpected</a>"#
+            },
+            book: "Genesis"
+        )
+
+        XCTAssertEqual(tokens, ["H0430"])
+        XCTAssertEqual(renderCount, 0)
+    }
+
+    /**
+     Verifies the rendered-text fallback remains reachable for modules whose raw entries do not
+     expose JSword-style lexical tokens.
+
+     Some SWORD modules only expose Strong's links after rendering. iOS should still recover those
+     `showStrong` links when raw OSIS extraction finds no tokens, while keeping the same canonical
+     four-digit token shape used by JSword's Strong's index.
+     */
+    func testStrongsCanonicalExtractionUsesRenderedFallbackWhenRawOSISHasNoLexicalTokens() {
+        var renderCount = 0
+
+        let tokens = StrongsSearchSupport.canonicalStrongTokens(
+            rawEntry: "<p>God created.</p>",
+            renderedTextProvider: {
+                renderCount += 1
+                return #"<a href="passagestudy.jsp?action=showStrong=0430#cv">God</a>"#
+            },
+            book: "Genesis"
+        )
+
+        XCTAssertEqual(tokens, ["H0430"])
+        XCTAssertEqual(renderCount, 1)
+    }
+
     func testParseVerseKeySupportsHumanReadableFormat() {
         let parsed = StrongsSearchSupport.parseVerseKey("I Samuel 2:3")
         XCTAssertEqual(parsed?.book, "I Samuel")

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -272,15 +272,62 @@ extension AndBibleTests {
             "Expected bundled KJV module to be available for ordinal parity testing"
         )
 
+        module.setKey("=Gen.1.1")
+        XCTAssertEqual(module.currentVerseKeyIndex(), 4)
         XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 1), 4)
         XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 31), 34)
         XCTAssertEqual(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 1), 36)
         XCTAssertEqual(
+            module.verseReference(ordinal: 4),
+            VerseKeyReference(osisBookId: "Gen", chapter: 1, verse: 1, ordinal: 4)
+        )
+        XCTAssertEqual(
             module.verseReference(osisBookId: "Gen", ordinal: 36),
             VerseKeyReference(osisBookId: "Gen", chapter: 2, verse: 1, ordinal: 36)
         )
+        XCTAssertNil(module.verseReference(ordinal: 1))
         XCTAssertNil(module.verseReference(osisBookId: "Exod", ordinal: 36))
         XCTAssertNil(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 99))
+        XCTAssertNil(module.verseOrdinal(osisBookId: "Gen", chapter: 99, verse: 1))
+        XCTAssertNil(module.verseCount(osisBookId: "Gen", chapter: 99))
+    }
+
+    /**
+     Verifies the Swift VerseKey parser preserves SWORD-provided metadata while accepting the
+     flat API's documented 8-field minimum.
+
+     `SWModule_getKeyChildren` has shipped with both an 8-field comment and 11 named VerseKey
+     constants. iOS must not collapse all text fields to the OSIS reference when the richer fields
+     are present, because book discovery, chapter rendering, and reference validation consume the
+     copied book name, abbreviation, and OSIS book fields. The bundled KJV fixture exercises the
+     same SWORD bridge used by imported Android backup modules.
+     */
+    func testBundledKJVVerseKeyChildrenExposeBookMetadata() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for VerseKey metadata parity testing"
+        )
+
+        module.setKey("=Gen.1.1")
+        let children = try XCTUnwrap(module.currentVerseKeyChildren())
+
+        XCTAssertEqual(children.testament, 1)
+        XCTAssertEqual(children.book, 1)
+        XCTAssertEqual(children.chapter, 1)
+        XCTAssertEqual(children.verse, 1)
+        XCTAssertEqual(children.index, 4)
+        XCTAssertEqual(children.chapterMax, 50)
+        XCTAssertEqual(children.verseMax, 31)
+        XCTAssertEqual(children.bookName, "Genesis")
+        XCTAssertEqual(children.osisRef, "Gen.1.1")
+        XCTAssertFalse(children.shortText.isEmpty)
+        XCTAssertEqual(children.bookAbbreviation, "Gen")
+        XCTAssertEqual(children.osisBookName, "Gen")
     }
 
     func testBibleChapterDocumentBuilderPreservesSecondCorinthiansIntroAndChapterMarker() throws {

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -251,6 +251,56 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the app's reusable search index stores and queries canonical Strong's tokens.
+
+     Android routes "find all occurrences" through JSword's Lucene index rather than walking every
+     verse during the visible search. The iOS index must therefore preserve the same canonical
+     Strong's token contract while keeping normal text snippets available for result rows. A failure
+     means Search can regress to a long SWORD scan for common numbers such as H00430, which is the
+     production behavior that made the UI shard sit in `searching=true`.
+
+     - Setup: Builds an isolated SQLite search index from the bundled KJV SWORD fixture.
+     - Expected result: Searching the canonical H00430/H0430 token finds Genesis 1:1 through the
+       index with cleaned preview text.
+     - Failure meaning: Strong's searches are not backed by the same indexed semantics Android uses.
+     - Side effects: Creates temporary SWORD and SQLite files removed by shared test cleanup/defer.
+     */
+    func testSearchIndexFindsCanonicalStrongsTokens() async throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for Strong's index regression testing"
+        )
+        let queryOptions = try XCTUnwrap(
+            StrongsSearchSupport.normalizedQueryOptions(for: "H00430"),
+            "Expected H00430 to normalize into canonical Strong's search tokens"
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("search-index-strongs-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        let service = SearchIndexService(databasePath: databaseURL.path)
+
+        await service.createIndex(module: module)
+        let hits = service.searchStrongs(
+            canonicalTokens: queryOptions.canonicalStrongTokens,
+            moduleName: "KJV"
+        )
+
+        XCTAssertTrue(
+            hits.contains { $0.key == "Genesis 1:1" },
+            "Expected indexed Strong's search for H00430/H0430 to find Genesis 1:1"
+        )
+        XCTAssertTrue(
+            hits.allSatisfy { !$0.snippet.contains("<H") && !$0.snippet.contains("<G") },
+            "Expected indexed Strong's previews to use cleaned verse text rather than raw Strong's tags"
+        )
+    }
+
+    /**
      Verifies the Strong's search path can use SWORD entry-attribute results as a candidate index
      without trusting them as the semantic result source.
 

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -301,6 +301,59 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies indexed text search emits hits in Android-style canonical verse order.
+
+     Android groups Lucene hits by verse and sorts scripture results by book, chapter, and verse
+     before rendering them. The iOS FTS index must therefore preserve module entry order instead of
+     exposing SQLite's rank ordering for broad queries such as `earth`, `jesus`, and `noah`. A
+     failure means users can see search results jump to later books even though earlier canonical
+     matches exist.
+
+     - Setup: Builds an isolated SQLite search index from the bundled KJV SWORD fixture.
+     - Expected result: Broad searches return early canonical KJV hits before later-book relevance
+       matches.
+     - Failure meaning: Indexed search result ordering has drifted from Android's visible search
+       result contract.
+     - Side effects: Creates temporary SWORD and SQLite files removed by shared test cleanup/defer.
+     */
+    func testSearchIndexReturnsTextHitsInCanonicalEntryOrder() async throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for text index ordering regression testing"
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("search-index-order-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        let service = SearchIndexService(databasePath: databaseURL.path)
+
+        await service.createIndex(module: module)
+        let earthHits = service.search(query: "earth", moduleName: "KJV", wordMode: .allWords)
+        let jesusHits = service.search(query: "jesus", moduleName: "KJV", wordMode: .allWords)
+        let noahHits = service.search(query: "noah", moduleName: "KJV", wordMode: .allWords)
+
+        XCTAssertGreaterThanOrEqual(earthHits.count, 2, "Expected broad KJV search for earth to return multiple hits")
+        XCTAssertEqual(
+            Array(earthHits.prefix(2).map(\.key)),
+            ["Genesis 1:1", "Genesis 1:2"],
+            "Expected indexed search hits to follow canonical module order, not SQLite rank order"
+        )
+        XCTAssertEqual(
+            jesusHits.first?.key,
+            "Matthew 1:1",
+            "Expected broad New Testament hits to start at the first canonical KJV match"
+        )
+        XCTAssertTrue(
+            noahHits.prefix(5).map(\.key).contains("Genesis 6:8"),
+            "Expected early canonical Noah hits to remain visible in the first rendered results"
+        )
+    }
+
+    /**
      Verifies the Strong's search path can use SWORD entry-attribute results as a candidate index
      without trusting them as the semantic result source.
 

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -251,6 +251,45 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the Strong's search path can use SWORD entry-attribute results as a candidate index
+     without trusting them as the semantic result source.
+
+     Android's find-all path reads JSword's canonical `strong` field, so iOS must still validate
+     candidate verses against parsed Strong's lemma tokens. A failure means the UI search path may
+     either fall back to an expensive full-module scan when SWORD already has candidate verses, or
+     return entry-attribute hits that do not match JSword token semantics.
+     */
+    func testStrongsSearchEntryAttributeCandidatesAreCanonicallyValidated() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(
+            SwordManager(modulePath: modulePath),
+            "Expected SwordManager to initialize against a temporary bundled sword module path"
+        )
+        let module = try XCTUnwrap(
+            manager.module(named: "KJV"),
+            "Expected bundled KJV module to be available for Strong's candidate regression testing"
+        )
+        let queryOptions = try XCTUnwrap(
+            StrongsSearchSupport.normalizedQueryOptions(for: "H00430"),
+            "Expected H00430 to normalize into Strong's search queries"
+        )
+
+        let candidateResult = StrongsSearchSupport.searchVerseHitsByEntryAttributeCandidates(
+            in: module,
+            queryOptions: queryOptions
+        )
+
+        XCTAssertTrue(
+            candidateResult.sawLexicalTokens,
+            "Expected SWORD candidate verses to expose JSword-style lexical Strong's tokens"
+        )
+        XCTAssertTrue(
+            candidateResult.hits.contains { $0.book == "Genesis" && $0.chapter == 1 && $0.verse == 1 },
+            "Expected candidate-index search to validate Genesis 1:1 against canonical H0430 tokens"
+        )
+    }
+
+    /**
      Verifies SWORD Bible book discovery exposes the full Protestant canon for a complete module.
 
      The bundled KJV fixture contains content for all 66 books and exercises the same

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -301,6 +301,80 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies text-index readiness is not treated as Strong's-index readiness.
+
+     Android's JSword index has distinct fields for normal verse text and Strong's tokens. A
+     text-only SQLite fixture or stale partial index must therefore remain usable for ordinary text
+     search while being rejected as an indexed Strong's source. The fallback/index-creation decision
+     in Search depends on this distinction; otherwise a Strong's query can short-circuit to an empty
+     `verse_strongs` table and report zero hits.
+
+     - Setup: Creates an isolated search database with KJV `verse_fts` rows and current metadata,
+       then adds a matching `verse_strongs` row in a second serialized mutation.
+     - Expected result: `hasIndex` is true for the text facet, `hasStrongsIndex` is false until the
+       lexical row exists, and indexed Strong's search returns the seeded row only after that point.
+     - Failure meaning: Search can confuse text-only indexes with Android/JSword-style Strong's
+       indexes, recreating the UI failure where `H00430` settles with zero results.
+     - Side effects: Creates and removes one temporary SQLite database.
+     */
+    func testSearchIndexDistinguishesTextAndStrongsReadiness() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("search-index-text-only-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = SearchIndexService(databasePath: databaseURL.path)
+        try await service.performIndexMutationForTesting { db in
+            let sql = """
+            INSERT INTO verse_fts (verse_key, plain_text, module_name, entry_order)
+            VALUES ('Genesis 1:2', 'And the Spirit of God moved upon the face of the waters.', 'KJV', 0);
+            INSERT INTO indexed_modules (module_name, verse_count, indexed_at, schema_version)
+            VALUES ('KJV', 1, datetime('now'), \(SearchIndexService.currentSchemaVersion));
+            """
+            guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+                let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "SQLite write failed"
+                throw NSError(domain: "SearchIndexFixture", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: message
+                ])
+            }
+        }
+
+        let queryOptions = try XCTUnwrap(
+            StrongsSearchSupport.normalizedQueryOptions(for: "H00430"),
+            "Expected H00430 to normalize into canonical Strong's tokens"
+        )
+
+        XCTAssertTrue(service.hasIndex(for: "KJV"))
+        XCTAssertFalse(
+            service.hasStrongsIndex(for: "KJV"),
+            "A text-only index must not satisfy the Strong's index facet."
+        )
+        XCTAssertTrue(
+            service.searchStrongs(canonicalTokens: queryOptions.canonicalStrongTokens, moduleName: "KJV").isEmpty,
+            "Strong's search must not synthesize hits from text-only FTS rows."
+        )
+
+        try await service.performIndexMutationForTesting { db in
+            let sql = """
+            INSERT INTO verse_strongs (module_name, token, verse_key, entry_order)
+            VALUES ('KJV', 'H0430', 'Genesis 1:2', 0);
+            """
+            guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+                let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "SQLite write failed"
+                throw NSError(domain: "SearchIndexFixture", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: message
+                ])
+            }
+        }
+
+        XCTAssertTrue(service.hasStrongsIndex(for: "KJV"))
+        let hits = service.searchStrongs(
+            canonicalTokens: queryOptions.canonicalStrongTokens,
+            moduleName: "KJV"
+        )
+        XCTAssertEqual(hits.map(\.key), ["Genesis 1:2"])
+    }
+
+    /**
      Verifies indexed text search emits hits in Android-style canonical verse order.
 
      Android groups Lucene hits by verse and sorts scripture results by book, chapter, and verse

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -391,14 +391,12 @@ extension AndBibleTests {
     }
 
     /**
-     Verifies the Swift VerseKey parser preserves SWORD-provided metadata while accepting the
-     flat API's documented 8-field minimum.
+     Verifies the Swift VerseKey parser preserves SWORD-provided metadata from the native adapter.
 
-     `SWModule_getKeyChildren` has shipped with both an 8-field comment and 11 named VerseKey
-     constants. iOS must not collapse all text fields to the OSIS reference when the richer fields
-     are present, because book discovery, chapter rendering, and reference validation consume the
-     copied book name, abbreviation, and OSIS book fields. The bundled KJV fixture exercises the
-     same SWORD bridge used by imported Android backup modules.
+     iOS must not collapse all text fields to the OSIS reference, because book discovery, chapter
+     rendering, and reference validation consume the copied book name, abbreviation, and OSIS book
+     fields. The bundled KJV fixture exercises the same SWORD bridge used by imported Android
+     backup modules.
      */
     func testBundledKJVVerseKeyChildrenExposeBookMetadata() throws {
         let modulePath = try makeTemporaryBundledSwordPath()

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -336,17 +336,13 @@ extension AndBibleUITests {
     /**
      Returns workspace-name prompt text-field candidates without probing arbitrary fields.
 
-     The production workspace prompt exports a text-field identifier. The candidate list therefore
-     stays bounded to that identifier and localized field-title fallbacks; it deliberately avoids
-     prompt-root descendant scans and app-wide focused-field queries because those can wedge XCTest
-     snapshot resolution on hosted simulators.
+     SwiftUI can expose the workspace prompt field by its visible title while custom identifier
+     text-field queries intermittently wedge XCTest snapshot resolution on hosted simulators. The
+     candidate list therefore stays bounded to title lookups and scoped title fallbacks; it
+     deliberately avoids prompt-root descendant scans, app-wide focused-field queries, and the
+     custom-id text-field lookup that can stall before the prompt has fully settled.
      */
     func workspaceNamePromptTextFieldCandidates(in app: XCUIApplication) -> [XCUIElement] {
-        let identifier = "workspaceNamePromptTextField"
-        let identifierCandidates = [
-            app.textFields[identifier].firstMatch,
-            app.otherElements[identifier].firstMatch,
-        ]
         let titledCandidates = ["Name", "name"].flatMap { title in
             [
                 app.textFields[title].firstMatch,
@@ -355,7 +351,7 @@ extension AndBibleUITests {
                 app.scrollViews.textFields[title].firstMatch,
             ]
         }
-        return identifierCandidates + titledCandidates
+        return titledCandidates
     }
 
     /// Returns workspace-name prompt buttons without walking the custom sheet hierarchy.

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -35,10 +35,10 @@ extension AndBibleUITests {
         )
         if let promptElement = waitForAnyElement(
             [
-                "workspaceNamePromptTextField",
                 "workspaceNamePromptConfirmButton",
                 "workspaceNamePromptCancelButton",
                 "workspaceNamePromptScreen",
+                "workspaceNamePromptTextField",
             ],
             in: app,
             timeout: timeout

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -525,7 +525,8 @@ extension AndBibleUITests {
      Returns the visible native prompt container used by the create-label flow.
 
      - Parameter app: Running application under test.
-     - Returns: The title-matched alert/sheet used by the create-label prompt.
+     - Returns: The title-matched alert/sheet used by the create-label prompt, or the current
+       native prompt surface when SwiftUI has exposed the text field but not the alert title.
      - Side effects: none.
      - Failure modes: returns `nil` when XCTest cannot observe a presented prompt.
      */
@@ -534,6 +535,8 @@ extension AndBibleUITests {
             [
                 app.alerts["New Label"].firstMatch,
                 app.sheets["New Label"].firstMatch,
+                app.alerts.firstMatch,
+                app.sheets.firstMatch,
             ],
             timeout: 0.2
         )

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -526,14 +526,14 @@ extension AndBibleUITests {
     }
 
     /**
-     Verifies that a bundled Strong's query reaches the direct lemma-search path and returns hits.
+     Verifies that a bundled Strong's query reaches the indexed lexical-token path and returns hits.
      *
      * - Side effects:
      *   - launches the app directly into Search with one deterministic Strong's query
-     *   - waits for Search to bypass any FTS index prompt and settle with non-zero results
+     *   - lets Search create the bundled KJV index when missing, then waits for non-zero results
      * - Failure modes:
-     *   - fails if Search never reaches the ready state for the Strong's query
-     *   - fails if the bundled Strong's-capable Bible still reports zero matches
+     *   - fails if Search never reaches the ready state for the Strong's query after index setup
+     *   - fails if the bundled Strong's-capable Bible still reports zero indexed lexical matches
      */
     func testSearchDirectLaunchStrongsQueryReturnsBundledResults() {
         let app = makeApp(searchQuery: "H00430")

--- a/Package.swift
+++ b/Package.swift
@@ -105,7 +105,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "UITestFixtureTool",
-            dependencies: ["BibleCore"],
+            dependencies: ["BibleCore", "SwordKit"],
             path: "Tools/UITestFixtureTool"
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
             cSettings: [
                 .define("USE_REAL_SWORD"),
             ],
+            cxxSettings: [
+                .headerSearchPath("../../../libsword/libsword.xcframework/ios-arm64_x86_64-simulator/Headers/sword"),
+            ],
             linkerSettings: [
                 .linkedLibrary("z"),
                 .linkedLibrary("bz2"),

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
@@ -890,12 +890,22 @@ public final class AndroidModuleBackupService {
 
     /**
      Removes SWORD's module cache after installing files outside `ModuleRepository`.
+
+     Side effects:
+     - deletes `mods.d/modules-conf.cache` on a best-effort basis
+     - posts `SwordModuleStore.modulesDidChangeNotification` so open readers and Downloads can
+       rebuild stale `SwordManager` snapshots
+
+     Failure modes:
+     - cache deletion errors are intentionally ignored because the module files have already been
+       published and SWORD can recreate the cache on the next manager scan.
      */
     private func invalidateModuleCache() {
         let cacheURL = moduleDirectory
             .appendingPathComponent("mods.d", isDirectory: true)
             .appendingPathComponent("modules-conf.cache")
         try? fileManager.removeItem(at: cacheURL)
+        SwordModuleStore.notifyModulesDidChange()
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
@@ -23,6 +23,9 @@ import Observation
  */
 @Observable
 public final class SearchIndexService: @unchecked Sendable {
+    /// Current search-index schema version. Increment to force re-indexing when text processing changes.
+    public static let currentSchemaVersion = 4
+
     private var db: OpaquePointer?
     @ObservationIgnored
     private let dbPath: String
@@ -118,11 +121,18 @@ public final class SearchIndexService: @unchecked Sendable {
 
         sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil)
 
+        if Self.searchSchemaNeedsRebuild(db: db) {
+            sqlite3_exec(db, "DROP TABLE IF EXISTS verse_strongs", nil, nil, nil)
+            sqlite3_exec(db, "DROP TABLE IF EXISTS verse_fts", nil, nil, nil)
+            sqlite3_exec(db, "DROP TABLE IF EXISTS indexed_modules", nil, nil, nil)
+        }
+
         sqlite3_exec(db, """
             CREATE VIRTUAL TABLE IF NOT EXISTS verse_fts USING fts5(
                 verse_key,
                 plain_text,
                 module_name UNINDEXED,
+                entry_order UNINDEXED,
                 tokenize='unicode61'
             )
         """, nil, nil, nil)
@@ -157,6 +167,42 @@ public final class SearchIndexService: @unchecked Sendable {
             DELETE FROM indexed_modules WHERE schema_version < \(Self.schemaVersion)
                 OR schema_version IS NULL
         """, nil, nil, nil)
+    }
+
+    /**
+     Detects whether the persisted FTS schema predates canonical entry ordering.
+
+     The app stores search indexes in a durable SQLite database. `CREATE VIRTUAL TABLE IF NOT
+     EXISTS` cannot add a new FTS5 column to an existing table, so schema upgrades that change FTS
+     columns must drop the generated index tables and let callers rebuild modules on demand.
+     Android displays scripture search hits in canonical verse order; retaining a rank-only legacy
+     table would preserve the user-visible ordering bug after app upgrade.
+
+     - Parameter db: Open SQLite handle for the search-index database.
+     - Returns: `true` when `verse_fts` exists without the required `entry_order` column.
+     - Side effects: Reads SQLite table metadata only.
+     - Failure modes: Returns `false` when SQLite cannot prepare metadata, allowing the normal
+       create path to handle a missing or corrupt table.
+     */
+    private static func searchSchemaNeedsRebuild(db: OpaquePointer?) -> Bool {
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+
+        guard sqlite3_prepare_v2(db, "PRAGMA table_info(verse_fts)", -1, &stmt, nil) == SQLITE_OK else {
+            return false
+        }
+
+        var sawColumn = false
+        var hasEntryOrder = false
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            sawColumn = true
+            guard let namePtr = sqlite3_column_text(stmt, 1) else { continue }
+            if String(cString: namePtr) == "entry_order" {
+                hasEntryOrder = true
+            }
+        }
+
+        return sawColumn && !hasEntryOrder
     }
 
     /**
@@ -232,7 +278,10 @@ public final class SearchIndexService: @unchecked Sendable {
                 // Begin bulk insert transaction
                 sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil)
 
-                let insertSql = "INSERT INTO verse_fts (verse_key, plain_text, module_name) VALUES (?, ?, ?)"
+                let insertSql = """
+                    INSERT INTO verse_fts (verse_key, plain_text, module_name, entry_order)
+                    VALUES (?, ?, ?, ?)
+                """
                 var insertStmt: OpaquePointer?
                 guard sqlite3_prepare_v2(db, insertSql, -1, &insertStmt, nil) == SQLITE_OK else {
                     sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
@@ -280,6 +329,7 @@ public final class SearchIndexService: @unchecked Sendable {
                     sqlite3_bind_text(insertStmt, 1, key, -1, self.sqliteTransient)
                     sqlite3_bind_text(insertStmt, 2, cleaned, -1, self.sqliteTransient)
                     sqlite3_bind_text(insertStmt, 3, moduleName, -1, self.sqliteTransient)
+                    sqlite3_bind_int(insertStmt, 4, Int32(index))
                     sqlite3_step(insertStmt)
 
                     for token in strongTokens {
@@ -471,7 +521,7 @@ public final class SearchIndexService: @unchecked Sendable {
             SELECT verse_key, snippet(verse_fts, 1, '', '', '...', 64), module_name
             FROM verse_fts
             WHERE verse_fts MATCH ? AND module_name = ?
-            ORDER BY rank
+            ORDER BY CAST(entry_order AS INTEGER)
             LIMIT 5000
         """
 
@@ -679,8 +729,7 @@ public final class SearchIndexService: @unchecked Sendable {
 
     // MARK: - SQLite Helpers
 
-    /// Current schema version. Increment to force re-indexing when text processing changes.
-    private static let schemaVersion = 3
+    private static let schemaVersion = currentSchemaVersion
 
     /// SQLITE_TRANSIENT equivalent — tells SQLite to make a copy of the bound string.
     private var sqliteTransient: sqlite3_destructor_type {

--- a/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
@@ -128,6 +128,21 @@ public final class SearchIndexService: @unchecked Sendable {
         """, nil, nil, nil)
 
         sqlite3_exec(db, """
+            CREATE TABLE IF NOT EXISTS verse_strongs (
+                module_name TEXT NOT NULL,
+                token TEXT NOT NULL,
+                verse_key TEXT NOT NULL,
+                entry_order INTEGER NOT NULL,
+                PRIMARY KEY (module_name, token, verse_key)
+            )
+        """, nil, nil, nil)
+
+        sqlite3_exec(db, """
+            CREATE INDEX IF NOT EXISTS idx_verse_strongs_module_token
+            ON verse_strongs (module_name, token, entry_order)
+        """, nil, nil, nil)
+
+        sqlite3_exec(db, """
             CREATE TABLE IF NOT EXISTS indexed_modules (
                 module_name TEXT PRIMARY KEY,
                 verse_count INTEGER DEFAULT 0,
@@ -227,11 +242,25 @@ public final class SearchIndexService: @unchecked Sendable {
                     }
                     return
                 }
+                let insertStrongsSql = """
+                    INSERT OR IGNORE INTO verse_strongs (module_name, token, verse_key, entry_order)
+                    VALUES (?, ?, ?, ?)
+                """
+                var insertStrongsStmt: OpaquePointer?
+                guard sqlite3_prepare_v2(db, insertStrongsSql, -1, &insertStrongsStmt, nil) == SQLITE_OK else {
+                    sqlite3_finalize(insertStmt)
+                    sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+                    DispatchQueue.main.async {
+                        self.isIndexing = false
+                        continuation.resume()
+                    }
+                    return
+                }
 
                 var totalCount = 0
                 let estimatedTotal = 31102.0 // standard Bible verse count
 
-                module.iterateAllEntries { key, text, index in
+                module.iterateAllEntriesWithRaw { key, text, rawEntry, index in
                     // Skip empty entries
                     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                     guard !trimmed.isEmpty else { return true }
@@ -239,12 +268,29 @@ public final class SearchIndexService: @unchecked Sendable {
                     // Strip Strong's numbers and other inline markup
                     let cleaned = Self.cleanText(trimmed)
                     guard !cleaned.isEmpty else { return true }
+                    let rawTokens = StrongsTokenNormalizer.canonicalTokens(
+                        rawEntry: rawEntry,
+                        renderedTextProvider: { "" },
+                        isNewTestamentBook: false
+                    )
+                    let taggedTextTokens = StrongsTokenNormalizer.canonicalTokens(taggedText: trimmed)
+                    let strongTokens = Self.orderedUnique(rawTokens + taggedTextTokens)
 
                     sqlite3_reset(insertStmt)
                     sqlite3_bind_text(insertStmt, 1, key, -1, self.sqliteTransient)
                     sqlite3_bind_text(insertStmt, 2, cleaned, -1, self.sqliteTransient)
                     sqlite3_bind_text(insertStmt, 3, moduleName, -1, self.sqliteTransient)
                     sqlite3_step(insertStmt)
+
+                    for token in strongTokens {
+                        sqlite3_reset(insertStrongsStmt)
+                        sqlite3_clear_bindings(insertStrongsStmt)
+                        sqlite3_bind_text(insertStrongsStmt, 1, moduleName, -1, self.sqliteTransient)
+                        sqlite3_bind_text(insertStrongsStmt, 2, token, -1, self.sqliteTransient)
+                        sqlite3_bind_text(insertStrongsStmt, 3, key, -1, self.sqliteTransient)
+                        sqlite3_bind_int(insertStrongsStmt, 4, Int32(index))
+                        sqlite3_step(insertStrongsStmt)
+                    }
 
                     totalCount = index + 1
 
@@ -261,6 +307,7 @@ public final class SearchIndexService: @unchecked Sendable {
                 }
 
                 sqlite3_finalize(insertStmt)
+                sqlite3_finalize(insertStrongsStmt)
                 sqlite3_exec(db, "COMMIT", nil, nil, nil)
 
                 // Record completion
@@ -377,6 +424,13 @@ public final class SearchIndexService: @unchecked Sendable {
     private func deleteIndexData(db: OpaquePointer, moduleName: String) {
         var stmt: OpaquePointer?
 
+        if sqlite3_prepare_v2(db, "DELETE FROM verse_strongs WHERE module_name = ?", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, moduleName, -1, sqliteTransient)
+            sqlite3_step(stmt)
+        }
+        sqlite3_finalize(stmt)
+        stmt = nil
+
         if sqlite3_prepare_v2(db, "DELETE FROM verse_fts WHERE module_name = ?", -1, &stmt, nil) == SQLITE_OK {
             sqlite3_bind_text(stmt, 1, moduleName, -1, sqliteTransient)
             sqlite3_step(stmt)
@@ -445,6 +499,87 @@ public final class SearchIndexService: @unchecked Sendable {
             }
 
             results.append(IndexSearchResult(key: key, snippet: snippet, moduleName: modName))
+        }
+
+        return results
+    }
+
+    /**
+     Searches the Strong's-token index for verses containing all requested canonical tokens.
+
+     Android stores Strong's numbers in JSword's Lucene `strong` field and queries that field for
+     "find all occurrences". iOS mirrors that architecture by keeping lexical Strong's tokens in a
+     separate SQLite table linked to the normal verse-text index. This keeps plain text search free
+     of Strong's tags while avoiding per-search SWORD scans for common numbers.
+
+     - Parameters:
+       - canonicalTokens: JSword-style canonical tokens such as `H0430` or `G0123a`; every token
+         must be present in a returned verse.
+       - moduleName: SWORD module initials whose completed index should be searched.
+       - scopeBookName: Optional human-readable book-name prefix for current-book searches.
+       - scopeTestament: Optional `OT` or `NT` testament filter.
+     - Returns: Matching verse keys with cleaned preview snippets in canonical module order.
+     - Side effects: Reads the SQLite search-index database.
+     - Failure modes:
+       - returns an empty array when the database is unavailable, tokens are empty, or SQLite
+         statement preparation fails
+     */
+    public func searchStrongs(
+        canonicalTokens: [String],
+        moduleName: String,
+        scopeBookName: String? = nil,
+        scopeTestament: String? = nil
+    ) -> [IndexSearchResult] {
+        guard let db else { return [] }
+        let tokens = Self.orderedUnique(canonicalTokens).filter { !$0.isEmpty }
+        guard !tokens.isEmpty else { return [] }
+
+        let placeholders = Array(repeating: "?", count: tokens.count).joined(separator: ",")
+        let sql = """
+            SELECT s.verse_key, f.plain_text, s.module_name, MIN(s.entry_order) AS sort_order
+            FROM verse_strongs s
+            JOIN verse_fts f
+                ON f.verse_key = s.verse_key
+                AND f.module_name = s.module_name
+            WHERE s.module_name = ?
+                AND s.token IN (\(placeholders))
+            GROUP BY s.module_name, s.verse_key
+            HAVING COUNT(DISTINCT s.token) = ?
+            ORDER BY sort_order
+            LIMIT 5000
+        """
+
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+
+        sqlite3_bind_text(stmt, 1, moduleName, -1, sqliteTransient)
+        for (offset, token) in tokens.enumerated() {
+            sqlite3_bind_text(stmt, Int32(offset + 2), token, -1, sqliteTransient)
+        }
+        sqlite3_bind_int(stmt, Int32(tokens.count + 2), Int32(tokens.count))
+
+        var results: [IndexSearchResult] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let keyPtr = sqlite3_column_text(stmt, 0),
+                  let snippetPtr = sqlite3_column_text(stmt, 1),
+                  let modPtr = sqlite3_column_text(stmt, 2) else { continue }
+
+            let key = String(cString: keyPtr)
+            let snippet = String(cString: snippetPtr)
+            let modName = String(cString: modPtr)
+
+            if let bookName = scopeBookName, !key.hasPrefix(bookName + " ") { continue }
+            if let testament = scopeTestament {
+                if testament == "OT" && Self.isNewTestament(key) { continue }
+                if testament == "NT" && !Self.isNewTestament(key) { continue }
+            }
+
+            results.append(IndexSearchResult(
+                key: key,
+                snippet: String(snippet.prefix(200)),
+                moduleName: modName
+            ))
         }
 
         return results
@@ -545,10 +680,19 @@ public final class SearchIndexService: @unchecked Sendable {
     // MARK: - SQLite Helpers
 
     /// Current schema version. Increment to force re-indexing when text processing changes.
-    private static let schemaVersion = 2
+    private static let schemaVersion = 3
 
     /// SQLITE_TRANSIENT equivalent — tells SQLite to make a copy of the bound string.
     private var sqliteTransient: sqlite3_destructor_type {
         unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    }
+
+    private static func orderedUnique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values where seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
@@ -239,6 +239,33 @@ public final class SearchIndexService: @unchecked Sendable {
         return sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_int(stmt, 0) > 0
     }
 
+    /**
+     Checks whether a module has the lexical Strong's facet required for indexed Strong's search.
+
+     Text FTS and Strong's lookup are separate Android/JSword index facets: a module can have
+     `verse_fts` rows that satisfy ordinary text search while still lacking `verse_strongs` rows
+     needed by "find all occurrences" for Strong's numbers. This method deliberately validates the
+     real token table, not only `indexed_modules`, so stale or partial text-only indexes cannot be
+     mistaken for Strong's-capable indexes.
+
+     - Parameter moduleName: SWORD module initials to inspect.
+     - Returns: `true` only when module metadata exists and at least one lexical Strong's token row
+       is present for the module.
+     - Side effects: Reads the SQLite search-index database.
+     - Failure modes: Returns `false` when the database handle is unavailable, metadata is missing,
+       the Strong's token table is absent/empty, or SQLite statement preparation fails.
+     */
+    public func hasStrongsIndex(for moduleName: String) -> Bool {
+        guard hasIndex(for: moduleName), let db else { return false }
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+
+        let sql = "SELECT 1 FROM verse_strongs WHERE module_name = ? LIMIT 1"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return false }
+        sqlite3_bind_text(stmt, 1, moduleName, -1, sqliteTransient)
+        return sqlite3_step(stmt) == SQLITE_ROW
+    }
+
     /// Return module names from the given list that don't have an index yet.
     public func modulesNeedingIndex(from moduleNames: [String]) -> [String] {
         moduleNames.filter { !hasIndex(for: $0) }

--- a/Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+/**
+ Normalized Strong's query variants shared by indexed and direct SWORD search paths.
+
+ Android's JSword search indexes canonical `strong` field tokens while SWORD entry-attribute
+ fallback searches need the original zero-padded lookup forms. Keeping both representations in one
+ shared value prevents iOS search, dictionary, and index code from drifting in how they interpret
+ the same Strong's number.
+ */
+public struct NormalizedStrongsQueryOptions: Equatable, Sendable {
+    /// Canonical JSword/Lucene Strong's tokens to match in parsed verse lexical data.
+    public let canonicalStrongTokens: [String]
+
+    /// Ordered SWORD entry-attribute query strings to try against modules without an index.
+    public let entryAttributeQueries: [String]
+
+    /**
+     Creates a normalized Strong's query option set.
+
+     - Parameters:
+       - canonicalStrongTokens: JSword-style tokens such as `H0430` or `G0123a`.
+       - entryAttributeQueries: SWORD entry-attribute lookup strings such as
+         `Word//Lemma./H00430`.
+     - Side effects: none.
+     - Failure modes: none; callers are responsible for supplying already-normalized values.
+     */
+    public init(canonicalStrongTokens: [String], entryAttributeQueries: [String]) {
+        self.canonicalStrongTokens = canonicalStrongTokens
+        self.entryAttributeQueries = entryAttributeQueries
+    }
+}
+
+/**
+ Shared Strong's normalization utilities matching Android's JSword indexing behavior.
+
+ JSword extracts `strong:` lemma values from OSIS `<w>` elements and normalizes numbers through
+ `StrongsNumberFilter` before adding them to the Lucene `strong` field. This type centralizes the
+ same token rules for iOS FTS indexing, Search UI routing, and SWORD fallback validation.
+ */
+public enum StrongsTokenNormalizer {
+    /**
+     Normalizes a user-entered Strong's query into JSword canonical tokens and SWORD fallback
+     entry-attribute queries.
+
+     - Parameter query: User-entered query such as `H02022`, `strong:g00123`, or
+       `lemma:strong:h08414`.
+     - Returns: Ordered query variants, or `nil` when the input does not contain a Strong's
+       prefix-plus-number form.
+     - Side effects: none.
+     - Failure modes:
+       - returns `nil` for empty input or unsupported prefixes
+       - returns an options value with no canonical tokens for syntactically Strong's-shaped but
+         JSword-invalid values so callers do not fall through to plain full-text search
+     */
+    public static func normalizedQueryOptions(for query: String) -> NormalizedStrongsQueryOptions? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var candidate = trimmed.uppercased()
+        if candidate.hasPrefix("LEMMA:STRONG:") {
+            candidate = String(candidate.dropFirst("LEMMA:STRONG:".count))
+        } else if candidate.hasPrefix("STRONG:") {
+            candidate = String(candidate.dropFirst("STRONG:".count))
+        } else if candidate.hasPrefix("LEMMA:") {
+            candidate = String(candidate.dropFirst("LEMMA:".count))
+        }
+
+        guard let parsedQuery = parseStrongNumber(candidate) else { return nil }
+        let prefix = parsedQuery.language
+        let digitsRaw = parsedQuery.digits
+
+        var digitVariants: [String] = [digitsRaw]
+        var currentDigits = digitsRaw
+        while currentDigits.hasPrefix("0"), currentDigits.count > 1 {
+            currentDigits.removeFirst()
+            digitVariants.append(currentDigits)
+        }
+
+        let entryAttributeQueries = orderedUnique(
+            digitVariants.map { "Word//Lemma./\(prefix)\($0)" }
+        )
+
+        return NormalizedStrongsQueryOptions(
+            canonicalStrongTokens: canonicalStrongNumberTokens(from: parsedQuery).queryTokens,
+            entryAttributeQueries: entryAttributeQueries
+        )
+    }
+
+    /**
+     Extracts JSword/Lucene Strong's index tokens while preserving Android's raw-OSIS-first
+     behavior.
+
+     - Parameters:
+       - rawEntry: Raw SWORD entry, usually OSIS with `<w lemma="strong:...">` values.
+       - renderedTextProvider: Lazy rendered HTML provider used only when raw extraction finds no
+         lexical tokens.
+       - isNewTestamentBook: Whether unprefixed rendered Strong's links should receive a Greek
+         prefix.
+     - Returns: Ordered unique canonical tokens matching JSword `StrongsNumberFilter` output.
+     - Side effects: Calls `renderedTextProvider` only when raw OSIS exposes no Strong's tokens.
+     - Failure modes: Malformed token fragments are ignored.
+     */
+    public static func canonicalTokens(
+        rawEntry: String,
+        renderedTextProvider: () -> String,
+        isNewTestamentBook: Bool
+    ) -> [String] {
+        let rawTokens = canonicalTokensFromRawOSIS(rawEntry)
+        if !rawTokens.isEmpty {
+            return orderedUnique(rawTokens)
+        }
+
+        return orderedUnique(canonicalTokensFromRenderedText(
+            renderedTextProvider(),
+            isNewTestamentBook: isNewTestamentBook
+        ))
+    }
+
+    /**
+     Extracts canonical Strong's tokens from SWORD stripped text tags such as `<H0430>`.
+
+     The FTS index receives stripped verse text from SWORD. Some Strong's modules preserve lexical
+     numbers as inline angle-bracket tags in that stripped text. Indexing those tags into a separate
+     Strong's table gives iOS the same query shape Android gets from JSword's Lucene `strong` field
+     without polluting normal full-text searches.
+
+     - Parameter taggedText: SWORD stripped text before normal text cleanup removes lexical tags.
+     - Returns: Ordered unique canonical Strong's tokens found in the text.
+     - Side effects: none.
+     - Failure modes: Malformed or out-of-range Strong's values are ignored.
+     */
+    public static func canonicalTokens(taggedText: String) -> [String] {
+        let pattern = #"<\s*([GgHh][0-9]+!?[A-Za-z]*)\s*>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let matches = regex.matches(in: taggedText, range: NSRange(taggedText.startIndex..., in: taggedText))
+        return orderedUnique(matches.flatMap { match -> [String] in
+            guard let range = Range(match.range(at: 1), in: taggedText),
+                  let parsed = parseStrongNumber(String(taggedText[range])) else {
+                return []
+            }
+            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
+        })
+    }
+
+    private struct ParsedStrongNumber: Equatable {
+        let language: Character
+        let digits: String
+        let part: String?
+
+        var numericValue: Int {
+            Int(digits) ?? 0
+        }
+    }
+
+    private struct CanonicalStrongNumberTokens: Equatable {
+        let baseToken: String
+        let fullToken: String?
+
+        var indexTokens: [String] {
+            guard !baseToken.isEmpty else { return [] }
+            if let fullToken {
+                return [baseToken, fullToken]
+            }
+            return [baseToken]
+        }
+
+        var queryTokens: [String] {
+            guard !baseToken.isEmpty else { return [] }
+            if let fullToken {
+                return [fullToken]
+            }
+            return [baseToken]
+        }
+    }
+
+    private static func canonicalTokensFromRawOSIS(_ rawEntry: String) -> [String] {
+        let pattern = #"strong:([GgHh][0-9]+!?[A-Za-z]*)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let matches = regex.matches(in: rawEntry, range: NSRange(rawEntry.startIndex..., in: rawEntry))
+        return matches.flatMap { match -> [String] in
+            guard let range = Range(match.range(at: 1), in: rawEntry),
+                  let parsed = parseStrongNumber(String(rawEntry[range])) else {
+                return []
+            }
+            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
+        }
+    }
+
+    private static func canonicalTokensFromRenderedText(
+        _ renderedText: String,
+        isNewTestamentBook: Bool
+    ) -> [String] {
+        let pattern = #"showStrong=([0-9]+!?[A-Za-z]*)#cv"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let prefix = isNewTestamentBook ? "G" : "H"
+
+        let matches = regex.matches(in: renderedText, range: NSRange(renderedText.startIndex..., in: renderedText))
+        return matches.flatMap { match -> [String] in
+            guard let range = Range(match.range(at: 1), in: renderedText),
+                  let parsed = parseStrongNumber(prefix + String(renderedText[range])) else {
+                return []
+            }
+            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
+        }
+    }
+
+    private static func parseStrongNumber(_ text: String) -> ParsedStrongNumber? {
+        let pattern = #"^([GgHh])([0-9]+)!?([A-Za-z]+)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let languageRange = Range(match.range(at: 1), in: text),
+              let digitsRange = Range(match.range(at: 2), in: text) else {
+            return nil
+        }
+
+        let language = Character(String(text[languageRange]).uppercased())
+        let digits = String(text[digitsRange])
+        let part: String?
+        if match.range(at: 3).location != NSNotFound,
+           let partRange = Range(match.range(at: 3), in: text) {
+            part = String(text[partRange])
+        } else {
+            part = nil
+        }
+
+        return ParsedStrongNumber(language: language, digits: digits, part: part)
+    }
+
+    private static func canonicalStrongNumberTokens(
+        from parsed: ParsedStrongNumber
+    ) -> CanonicalStrongNumberTokens {
+        guard isValidStrongsNumber(parsed) else {
+            return CanonicalStrongNumberTokens(baseToken: "", fullToken: nil)
+        }
+
+        let base = "\(parsed.language)\(String(format: "%04d", parsed.numericValue))"
+        let part = parsed.part?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let full = part?.isEmpty == false ? base + (part ?? "") : nil
+        return CanonicalStrongNumberTokens(baseToken: base, fullToken: full)
+    }
+
+    private static func isValidStrongsNumber(_ parsed: ParsedStrongNumber) -> Bool {
+        let number = parsed.numericValue
+        switch parsed.language {
+        case "H":
+            return (1...8674).contains(number)
+        case "G":
+            return (number >= 1 && number < 1418)
+                || (number > 1418 && number < 2717)
+                || (number > 2717 && number < 3203)
+                || (number > 3302 && number < 5624)
+                || (number > 5999 && number < 10000)
+        default:
+            return false
+        }
+    }
+
+    private static func orderedUnique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values where seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleChapterDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleChapterDocumentBuilder.swift
@@ -83,9 +83,13 @@ struct BibleChapterDocumentBuilder {
 
             let text = module.rawEntry()
             if !text.isEmpty {
+                guard let ordinal = ordinal(osisBookId: osisBookId, chapter: chapter, verse: parsedVerse) else {
+                    chapterBuilderLogger.warning("SWORD: Could not resolve ordinal for \(osisBookId) \(chapter):\(parsedVerse)")
+                    return nil
+                }
                 let verseEntry = VerseEntry(
                     verse: parsedVerse,
-                    ordinal: Self.ordinal(chapter: chapter, verse: parsedVerse),
+                    ordinal: ordinal,
                     xml: text
                 )
                 verseCount += 1
@@ -115,6 +119,27 @@ struct BibleChapterDocumentBuilder {
 
     static func ordinal(chapter: Int, verse: Int) -> Int {
         (chapter - 1) * 40 + max(1, verse)
+    }
+
+    /**
+     Resolves the verse ordinal used in reader OSIS output.
+
+     Android receives verse ordinals from JSword's active `Versification`; SWORD exposes the same
+     concept through `VerseKey.getIndex()`. The fallback exists only for placeholder/unavailable
+     module paths and preserves historical rendering when the bridge cannot resolve a real
+     `VerseKey`.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier for the verse being rendered.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: The active module's versification ordinal, or `nil` if the exact verse cannot be
+       resolved through the module.
+     - Side effects: May temporarily move the SWORD module cursor through `SwordModule`; the module
+       restores its previous key before returning.
+     */
+    private func ordinal(osisBookId: String, chapter: Int, verse: Int) -> Int? {
+        module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse)
     }
 
     private func normalizedOsisSegment(_ xml: String) -> String {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
@@ -75,6 +75,9 @@ struct BibleReaderActiveSheetContent: View {
                     },
                     onOpenStudyPad: { labelId in
                         controller?.loadStudyPadDocument(labelId: labelId)
+                    },
+                    bibleOrdinalResolver: { book, ordinal in
+                        controller?.bookmarkListVerseReference(book: book, ordinal: ordinal)
                     }
                 )
             }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -156,13 +156,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /**
      Dynamic book list from the active module's versification.
-     Populated when a Bible module is loaded. Falls back to `Self.defaultBooks` if empty.
+     Populated when a Bible module is loaded. Empty means either no module is active or the active
+     module could not expose a safe module-specific book list.
      */
     private(set) var moduleBookList: [BookInfo] = []
 
-    /// The active book list: uses the module's versification when available, otherwise the 66-book default.
+    /// The active book list: uses the module's versification, or the 66-book default only with no module.
     var bookList: [BookInfo] {
-        moduleBookList.isEmpty ? Self.defaultBooks : moduleBookList
+        if !moduleBookList.isEmpty {
+            return moduleBookList
+        }
+        return activeModule == nil ? Self.defaultBooks : []
     }
 
     /// Commentary module support
@@ -256,18 +260,130 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             .replacingOccurrences(of: "\n", with: " ")
     }
 
-    /// Ordinal range for the current chapter using the app's KJVA-compatible ordinal scheme.
-    private func currentChapterOrdinalRange() -> (start: Int, end: Int, verseCount: Int) {
-        let verseCount = Self.verseCount(for: currentBook, chapter: currentChapter)
-        let ordinalStart = (currentChapter - 1) * 40 + 1
-        let ordinalEnd = (currentChapter - 1) * 40 + verseCount
-        return (ordinalStart, ordinalEnd, verseCount)
+    /**
+     Legacy ordinal fallback used only when no SWORD verse-key module can resolve the reference.
+
+     Real Bible, commentary, cross-reference, bookmark, and memorization paths should use
+     `verseOrdinal(...)` so ordinals come from the active SWORD/JSword-style versification. This
+     fallback preserves placeholder rendering for startup and no-module states where there is no
+     module cursor to query.
+     */
+    private func compatibilityOrdinal(chapter: Int, verse: Int) -> Int {
+        BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: verse)
+    }
+
+    /**
+     Resolves a verse ordinal through the active module's SWORD versification.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier for the verse.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: The SWORD/JSword-style ordinal when available, the legacy placeholder ordinal when
+       no module is present, or `nil` when the active module rejects the reference.
+     - Side effects: May temporarily move the active SWORD module cursor; `SwordModule` restores it
+       before returning.
+     */
+    private func verseOrdinal(osisBookId: String, chapter: Int, verse: Int) -> Int? {
+        if let activeModule {
+            return activeModule.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse)
+        }
+        return compatibilityOrdinal(chapter: chapter, verse: verse)
+    }
+
+    /**
+     Resolves a persisted ordinal back to a verse reference for a book.
+
+     Android resolves these values through JSword's versification when building bookmark,
+     memorization, and note payloads. iOS mirrors that by asking the active SWORD module to position
+     a `VerseKey` by index, falling back to the historical placeholder calculation only when there
+     is no active module available.
+
+     - Parameters:
+       - book: User-facing book name used to derive the OSIS identifier.
+       - ordinal: Persisted verse ordinal.
+     - Returns: A verse reference in the requested book, or `nil` for invalid ordinals.
+     - Side effects: May temporarily move the active SWORD module cursor; `SwordModule` restores it
+       before returning.
+     */
+    private func verseReference(book: String, ordinal: Int) -> VerseKeyReference? {
+        guard ordinal > 0 else { return nil }
+        let osisBookId = osisBookId(for: book)
+        if let activeModule {
+            return activeModule.verseReference(osisBookId: osisBookId, ordinal: ordinal)
+        }
+
+        let chapter = max(1, ((ordinal - 1) / 40) + 1)
+        let verse = ordinal - ((chapter - 1) * 40)
+        guard verse > 0 else { return nil }
+        return VerseKeyReference(
+            osisBookId: osisBookId,
+            chapter: chapter,
+            verse: verse,
+            ordinal: ordinal
+        )
+    }
+
+    /**
+     Resolves a Bible bookmark ordinal for bookmark-list display and navigation.
+
+     `BookmarkListView` does not own a SWORD manager. The active reader supplies this closure so the
+     list uses the same SWORD/JSword-style versification semantics as rendered Bible content while
+     keeping the view independent from module lifecycle concerns.
+
+     - Parameters:
+       - book: User-facing book name stored with the bookmark.
+       - ordinal: Persisted verse ordinal.
+     - Returns: A chapter/verse DTO for the bookmark list, or `nil` if the ordinal is invalid.
+     - Side effects: May temporarily move the active SWORD module cursor; the module restores it
+       before returning.
+     */
+    func bookmarkListVerseReference(book: String, ordinal: Int) -> BookmarkListVerseReference? {
+        guard let reference = verseReference(book: book, ordinal: ordinal) else { return nil }
+        return BookmarkListVerseReference(chapter: reference.chapter, verse: reference.verse)
+    }
+
+    /**
+     Resolves the ordinal range for a chapter in the active module's versification.
+
+     - Parameters:
+       - book: User-facing book name.
+       - chapter: One-based chapter number.
+       - verseCount: Optional known last verse count; when omitted, the method asks the active
+         module, or uses the static compatibility table only when there is no active module.
+     - Returns: Start/end ordinals and the verse count used to compute the end, or `nil` when an
+       active module cannot resolve the chapter exactly.
+     - Side effects: May query the active SWORD module for verse counts and ordinals.
+     */
+    private func chapterOrdinalRange(book: String, chapter: Int, verseCount: Int? = nil) -> (start: Int, end: Int, verseCount: Int)? {
+        let osisBookId = osisBookId(for: book)
+        let resolvedVerseCount: Int
+        if let verseCount {
+            resolvedVerseCount = verseCount
+        } else if let activeModule {
+            guard let moduleVerseCount = activeModule.verseCount(osisBookId: osisBookId, chapter: chapter) else {
+                return nil
+            }
+            resolvedVerseCount = moduleVerseCount
+        } else {
+            resolvedVerseCount = Self.verseCount(for: book, chapter: chapter)
+        }
+        guard let ordinalStart = verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: 1),
+              let ordinalEnd = verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: resolvedVerseCount) else {
+            return nil
+        }
+        return (ordinalStart, ordinalEnd, resolvedVerseCount)
+    }
+
+    /// Ordinal range for the current chapter using the active module's SWORD versification.
+    private func currentChapterOrdinalRange() -> (start: Int, end: Int, verseCount: Int)? {
+        chapterOrdinalRange(book: currentBook, chapter: currentChapter)
     }
 
     /// Notes with non-empty payloads that belong to the currently visible chapter.
     private func currentChapterMyNotesBookmarks() -> [BibleBookmark] {
-        guard let service = bookmarkService else { return [] }
-        let range = currentChapterOrdinalRange()
+        guard let service = bookmarkService,
+              let range = currentChapterOrdinalRange() else { return [] }
         return service.bookmarks(for: range.start, endOrdinal: range.end, book: currentBook)
             .filter { bookmark in
                 guard let note = bookmark.notes?.notes else { return false }
@@ -283,11 +399,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Stable row token for the My Notes accessibility export.
     private func myNotesReferenceToken(for bookmark: BibleBookmark) -> String {
-        let chapterBase = (currentChapter - 1) * 40
-        let startVerse = max(1, bookmark.ordinalStart - chapterBase)
-        let endVerse = max(startVerse, bookmark.ordinalEnd - chapterBase)
+        let startReference = verseReference(book: currentBook, ordinal: bookmark.ordinalStart)
+        let endReference = verseReference(book: currentBook, ordinal: bookmark.ordinalEnd)
+        let startVerse = startReference?.verse ?? 1
+        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
         let verseToken = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)_\(endVerse)"
-        return "\(Self.contentStateToken(currentBook))_\(currentChapter)_\(verseToken)"
+        let chapter = startReference?.chapter ?? currentChapter
+        return "\(Self.contentStateToken(currentBook))_\(chapter)_\(verseToken)"
     }
 
     /// Typed My Notes state used to produce compact UI-test accessibility exports.
@@ -636,7 +754,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                 text += trimmed
                 let endOffset = text.utf16.count
                 let osisID = "\(osisBookId).\(chapter).\(parsedVerse)"
-                let ordinal = (chapter - 1) * 40 + parsedVerse
+                guard let ordinal = verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: parsedVerse) else {
+                    break
+                }
                 offsets.append((osisID: osisID, ordinal: ordinal, startOffset: startOffset, endOffset: endOffset))
             }
             if !module.next() { break }
@@ -693,7 +813,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             guard let (_, parsedChapter, parsedVerse) = parseVerseKey(key) else { break }
             if parsedChapter != chapter { break }
 
-            let ordinal = (chapter - 1) * 40 + parsedVerse
+            guard let ordinal = verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: parsedVerse) else {
+                break
+            }
             if ordinal >= startOrdinal && ordinal <= endOrdinal {
                 let verseText = module.stripText()
                 if !verseText.isEmpty {
@@ -1132,7 +1254,24 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         applyNightModeBackground()
     }
 
-    /// Load commentary text for the current chapter using the active commentary module.
+    /**
+     Loads commentary for the currently selected Bible verse.
+
+     Android's `CurrentCommentaryPage` is a single-key page backed by JSword `BookData(book, key)`;
+     it does not walk the current chapter when the user switches to a commentary. iOS mirrors that
+     contract by resolving the selected verse once, reading exactly that SWORD key, and emitting a
+     verse-level document key and ordinal range. Missing commentary entries are still represented as
+     the selected verse so tabs, highlights, and restored state stay tied to the same passage.
+
+     Side effects:
+     - clears the current Vue document, emits labels and a commentary document, updates rendered
+       content state, emits active-window state, clears selection, and reapplies the reader
+       background.
+
+     Failure modes:
+     - when no commentary module is selected or the selected module has no exact entry for the
+       current verse, emits a deterministic no-content commentary document for the selected verse.
+     */
     private func loadCommentaryForCurrentVerse() {
         showingMyNotes = false
         showingStudyPad = false
@@ -1142,22 +1281,53 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         hasActiveSelection = false
         selectedText = ""
 
+        let osisBookId = osisBookId(for: currentBook)
+        let chapter = currentChapter
+        let verse = max(1, currentVerse)
+        let verseKey = "\(osisBookId).\(chapter).\(verse)"
+        let verseTitle = "\(currentBook) \(chapter):\(verse)"
+        guard let selectedOrdinal = activeCommentaryModule?.verseOrdinal(
+            osisBookId: osisBookId,
+            chapter: chapter,
+            verse: verse
+        ) ?? verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse) else {
+            logger.error("Failed to resolve commentary ordinal for \(osisBookId, privacy: .public).\(chapter).\(verse)")
+            return
+        }
+        let selectedOrdinalRange = [selectedOrdinal, selectedOrdinal]
+        let selectedVerseBookmarks = bookmarkService?.bookmarks(
+            for: selectedOrdinal,
+            endOrdinal: selectedOrdinal,
+            book: currentBook
+        ) ?? []
+
         guard let module = activeCommentaryModule else {
             // No commentary module selected — show a message
             bridge.emit(event: "clear_document")
-            let xml = "<div><title type=\"x-gen\">No Commentary</title><div type=\"paragraph\"><p>No commentary module is installed. Download one from the module browser.</p></div></div>"
-            let osisBookId = osisBookId(for: currentBook)
-            let document = buildDocumentJSON(
+            let xml = buildCommentaryVerseXML(
                 osisBookId: osisBookId,
                 bookName: currentBook,
-                chapter: currentChapter,
+                chapter: chapter,
+                verse: verse,
+                ordinal: selectedOrdinal,
+                bodyXML: "<p>No commentary module is installed. Download one from the module browser.</p>",
+                title: "No Commentary"
+            )
+            guard let document = buildDocumentJSON(
+                osisBookId: osisBookId,
+                bookName: currentBook,
+                chapter: chapter,
                 verseCount: 1,
                 isNT: isNewTestament(currentBook),
                 xml: xml,
                 bookmarks: [],
                 bookCategory: "COMMENTARY",
-                bookInitials: "none"
-            )
+                bookInitials: "none",
+                addChapter: false,
+                documentKey: verseKey,
+                keyName: verseTitle,
+                ordinalRangeOverride: selectedOrdinalRange
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: """
             {"jumpToOrdinal":null,"jumpToAnchor":null,"jumpToId":null,"topOffset":0,"bottomOffset":0}
@@ -1166,64 +1336,55 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                 category: .commentary,
                 moduleName: activeCommentaryModuleName,
                 book: currentBook,
-                chapter: currentChapter,
-                key: "\(osisBookId).\(currentChapter)"
+                chapter: chapter,
+                key: verseKey
             )
             applyNightModeBackground()
             return
         }
 
-        let osisBookId = osisBookId(for: currentBook)
-        let chapter = currentChapter
         let isNT = isNewTestament(currentBook)
-
-        // Use the same setKey/rawEntry/next pattern as loadChapterFromSword
-        let startKey = "\(osisBookId) \(chapter):1"
-        module.setKey(startKey)
-
-        var verses: [(Int, String)] = []
-        while true {
-            let key = module.currentKey()
-            guard let (_, parsedChapter, parsedVerse) = parseVerseKey(key) else { break }
-            if parsedChapter != chapter { break }
-
-            let text = module.rawEntry()
-            if !text.isEmpty {
-                verses.append((parsedVerse, text))
-            }
-            if !module.next() { break }
-        }
-
         let moduleName = activeCommentaryModuleName ?? "Commentary"
-        let xml: String
-        let verseCount: Int
-
-        if verses.isEmpty {
-            // Commentary may not have entries for every chapter
-            xml = "<div><title type=\"x-gen\">\(currentBook) \(chapter)</title><div type=\"paragraph\"><p>No commentary available for this chapter in \(moduleName).</p></div></div>"
-            verseCount = 1
-        } else {
-            xml = buildSwordChapterXML(osisBookId: osisBookId, bookName: currentBook, chapter: chapter, verses: verses)
-            verseCount = verses.count
+        let inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious("=\(verseKey)")
+        let rawText = inspection.verseKey.flatMap { key -> String? in
+            guard key.osisBookName == osisBookId,
+                  key.chapter == chapter,
+                  key.verse == verse else {
+                return nil
+            }
+            let trimmed = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
         }
-
-        // Query bookmarks for this chapter
-        let chapterBookmarks = bookmarksForCurrentChapter(verseCount: verseCount)
+        let bodyXML = rawText.map(Self.commentaryVerseBodyXML(from:))
+            ?? "<p>No commentary available for this verse in \(moduleName).</p>"
+        let xml = buildCommentaryVerseXML(
+            osisBookId: osisBookId,
+            bookName: currentBook,
+            chapter: chapter,
+            verse: verse,
+            ordinal: selectedOrdinal,
+            bodyXML: bodyXML,
+            title: verseTitle
+        )
 
         bridge.emit(event: "clear_document")
         sendLabelsToVueJS()
 
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: osisBookId,
             bookName: currentBook,
             chapter: chapter,
-            verseCount: verseCount,
+            verseCount: 1,
             isNT: isNT,
             xml: xml,
-            bookmarks: chapterBookmarks,
+            bookmarks: selectedVerseBookmarks,
             bookCategory: "COMMENTARY",
-            bookInitials: moduleName
-        )
+            bookInitials: moduleName,
+            addChapter: false,
+            documentKey: verseKey,
+            keyName: verseTitle,
+            ordinalRangeOverride: selectedOrdinalRange
+        ) else { return }
         bridge.emit(event: "add_documents", data: document)
 
         bridge.emit(event: "setup_content", data: """
@@ -1233,13 +1394,74 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             category: .commentary,
             moduleName: moduleName,
             book: currentBook,
-            chapter: currentChapter,
-            key: "\(osisBookId).\(currentChapter)"
+            chapter: chapter,
+            key: verseKey
         )
         emitActiveState()
 
         bridge.clearSelection()
         applyNightModeBackground()
+    }
+
+    /**
+     Builds a verse-scoped commentary OSIS fragment for the Vue reader.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier for the selected Bible verse.
+       - bookName: Display book name for titles.
+       - chapter: Selected chapter.
+       - verse: Selected verse.
+       - ordinal: JSword/SWORD ordinal for the selected verse.
+       - bodyXML: Commentary body XML or no-content message already prepared for the verse body.
+       - title: Title to display above the commentary content.
+     - Returns: A small OSIS fragment with one verse wrapper and paragraph milestones.
+     - Side effects: None.
+     - Failure modes: None; callers supply XML that the reader already accepts.
+     */
+    private func buildCommentaryVerseXML(
+        osisBookId: String,
+        bookName: String,
+        chapter: Int,
+        verse: Int,
+        ordinal: Int,
+        bodyXML: String,
+        title: String
+    ) -> String {
+        let osisRef = "\(osisBookId).\(chapter).\(verse)"
+        let body = bodyXML.trimmingCharacters(in: .whitespacesAndNewlines)
+        return """
+        <div><title type="x-gen">\(title)</title><div sID="p1" type="paragraph"/><verse osisID="\(osisRef)" verseOrdinal="\(ordinal)">\(body) </verse><div eID="p1" type="paragraph"/></div>
+        """
+    }
+
+    /**
+     Mirrors JSword's single-key commentary unwrap behavior.
+
+     Android removes the outer `<verse>` element returned by `BookData(book, key)` for a
+     single-key commentary, then renders that verse's children. SWORD raw entries may already be
+     verse-wrapped, while no-content messages are not; this helper strips exactly one whole outer
+     verse wrapper and otherwise preserves the raw body unchanged.
+
+     - Parameter rawEntry: Raw SWORD OSIS entry for one exact commentary verse key.
+     - Returns: The verse body XML to embed in the reader's own verse wrapper.
+     - Side effects: None.
+     - Failure modes: If the raw entry is not a single outer `<verse>`, returns it unchanged.
+     */
+    private static func commentaryVerseBodyXML(from rawEntry: String) -> String {
+        let trimmed = rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let regex = try? NSRegularExpression(
+            pattern: #"^<verse\b[^>]*>([\s\S]*)</verse>$"#,
+            options: []
+        ) else {
+            return trimmed
+        }
+        let range = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
+        guard let match = regex.firstMatch(in: trimmed, range: range),
+              match.numberOfRanges == 2,
+              let bodyRange = Range(match.range(at: 1), in: trimmed) else {
+            return trimmed
+        }
+        return String(trimmed[bodyRange]).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Dictionary/GenBook/Map Content Loading
@@ -1260,10 +1482,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard let module = activeDictionaryModule else {
             bridge.emit(event: "clear_document")
             let xml = "<div><title type=\"x-gen\">No Dictionary</title><div type=\"paragraph\"><p>No dictionary module is selected. Download one from the module browser.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Dict", bookName: "Dictionary", chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: "none"
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1282,10 +1504,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.emit(event: "clear_document")
             let moduleName = activeDictionaryModuleName ?? "Dictionary"
             let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view its definition.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Dict", bookName: moduleName, chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: moduleName
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1318,10 +1540,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
 
         bridge.emit(event: "clear_document")
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: "Dict", bookName: entryKey, chapter: 1, verseCount: 1,
             isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: moduleName
-        )
+        ) else { return }
         bridge.emit(event: "add_documents", data: document)
         bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
         setRenderedContentState(
@@ -1346,10 +1568,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard let module = activeGeneralBookModule else {
             bridge.emit(event: "clear_document")
             let xml = "<div><title type=\"x-gen\">No General Book</title><div type=\"paragraph\"><p>No general book module is selected. Download one from the module browser.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "GenBook", bookName: "General Book", chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: "none"
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1367,10 +1589,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.emit(event: "clear_document")
             let moduleName = activeGeneralBookModuleName ?? "General Book"
             let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view its content.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "GenBook", bookName: moduleName, chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: moduleName
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1401,10 +1623,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
 
         bridge.emit(event: "clear_document")
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: "GenBook", bookName: entryKey, chapter: 1, verseCount: 1,
             isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: moduleName
-        )
+        ) else { return }
         bridge.emit(event: "add_documents", data: document)
         bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
         setRenderedContentState(
@@ -1429,10 +1651,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard let module = activeMapModule else {
             bridge.emit(event: "clear_document")
             let xml = "<div><title type=\"x-gen\">No Map</title><div type=\"paragraph\"><p>No map module is selected. Download one from the module browser.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Map", bookName: "Map", chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "MAP", bookInitials: "none"
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1450,10 +1672,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.emit(event: "clear_document")
             let moduleName = activeMapModuleName ?? "Map"
             let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view the map.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Map", bookName: moduleName, chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "MAP", bookInitials: moduleName
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1484,10 +1706,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
 
         bridge.emit(event: "clear_document")
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: "Map", bookName: entryKey, chapter: 1, verseCount: 1,
             isNT: false, xml: xml, bookCategory: "MAP", bookInitials: moduleName
-        )
+        ) else { return }
         bridge.emit(event: "add_documents", data: document)
         bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
         setRenderedContentState(
@@ -1533,10 +1755,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard let reader = activeEpubReader else {
             bridge.emit(event: "clear_document")
             let xml = "<div><title type=\"x-gen\">No EPUB</title><div type=\"paragraph\"><p>No EPUB is selected. Import one from the Import &amp; Export screen, then open it from the EPUB Library.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Epub", bookName: "EPUB", chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: "none"
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1555,10 +1777,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.emit(event: "clear_document")
             let title = activeEpubTitle ?? "EPUB"
             let xml = "<div><title type=\"x-gen\">\(title)</title><div type=\"paragraph\"><p>Select a section from the Table of Contents to begin reading.</p></div></div>"
-            let document = buildDocumentJSON(
+            guard let document = buildDocumentJSON(
                 osisBookId: "Epub", bookName: title, chapter: 1, verseCount: 1,
                 isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: title
-            )
+            ) else { return }
             bridge.emit(event: "add_documents", data: document)
             bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
             setRenderedContentState(
@@ -1950,9 +2172,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             currentVerse = 1
         }
         originalNavigationOrdinalRange = nil
-        lastScrollTarget = currentVerse > 1
-            ? .ordinal(ordinal(forChapter: currentChapter, verse: currentVerse))
-            : .chapterTop
+        if currentVerse > 1,
+           let ordinal = ordinal(forChapter: currentChapter, verse: currentVerse) {
+            lastScrollTarget = .ordinal(ordinal)
+        } else {
+            lastScrollTarget = .chapterTop
+        }
         logger.info("Restored position: \(self.currentBook) \(self.currentChapter):\(self.currentVerse)")
     }
 
@@ -1979,13 +2204,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         let resolvedVerse = max(1, verse ?? 1)
         currentVerse = resolvedVerse
         if let explicitVerse = verse {
-            let ordinal = ordinal(forChapter: chapter, verse: max(1, explicitVerse))
-            originalNavigationOrdinalRange = [ordinal, ordinal]
+            if let ordinal = ordinal(forChapter: chapter, verse: max(1, explicitVerse)) {
+                originalNavigationOrdinalRange = [ordinal, ordinal]
+            } else {
+                originalNavigationOrdinalRange = nil
+            }
         } else {
             originalNavigationOrdinalRange = nil
         }
-        if resolvedVerse > 1 {
-            lastScrollTarget = .ordinal(ordinal(forChapter: chapter, verse: resolvedVerse))
+        if resolvedVerse > 1,
+           let ordinal = ordinal(forChapter: chapter, verse: resolvedVerse) {
+            lastScrollTarget = .ordinal(ordinal)
             shouldRestoreScroll = true
         } else {
             lastScrollTarget = .chapterTop
@@ -2306,9 +2535,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                     if let bookIdx = bookList.firstIndex(where: { $0.name == currentBook }) {
                         pm.bibleBibleBook = bookIdx
                     }
-                    let verse = max(1, ordinal - (chapter - 1) * 40)
-                    currentVerse = verse
-                    pm.bibleVerseNo = verse
+                    if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
+                        currentVerse = verse
+                        pm.bibleVerseNo = verse
+                    }
                     persistVisibleVerseState(immediate: true)
                 }
             } else if let name = bookName(forOsisId: osisId), name != currentBook {
@@ -2317,15 +2547,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                     if let bookIdx = bookList.firstIndex(where: { $0.name == currentBook }) {
                         pm.bibleBibleBook = bookIdx
                     }
-                    let verse = max(1, ordinal - (currentChapter - 1) * 40)
-                    currentVerse = verse
-                    pm.bibleVerseNo = verse
+                    if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
+                        currentVerse = verse
+                        pm.bibleVerseNo = verse
+                    }
                     persistVisibleVerseState(immediate: true)
                 }
             } else if let pm = activeWindow?.pageManager {
-                let verse = max(1, ordinal - (currentChapter - 1) * 40)
-                currentVerse = verse
-                pm.bibleVerseNo = verse
+                if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
+                    currentVerse = verse
+                    pm.bibleVerseNo = verse
+                }
                 persistVisibleVerseState(immediate: false)
             }
         }
@@ -3178,7 +3410,15 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     func bookmarkSelection(wholeVerse: Bool = false) {
         Task { @MainActor in
             guard let sel = await querySelectionDetails() else { return }
-            let startOrd = sel.startOrdinal ?? ((currentChapter - 1) * 40 + 1)
+            let startOrd = sel.startOrdinal ?? verseOrdinal(
+                osisBookId: osisBookId(for: currentBook),
+                chapter: currentChapter,
+                verse: 1
+            )
+            guard let startOrd else {
+                logger.error("Failed to resolve selection bookmark start ordinal for \(self.currentBook, privacy: .public) \(self.currentChapter)")
+                return
+            }
             let endOrd = sel.endOrdinal ?? startOrd
 
             let selectionStartOffset = wholeVerse ? nil : sel.startOffset
@@ -3854,7 +4094,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         selectedText = ""
 
         let osisBookId = osisBookId(for: currentBook)
-        let range = currentChapterOrdinalRange()
+        guard let range = currentChapterOrdinalRange() else {
+            logger.error("Failed to resolve My Notes chapter range for \(self.currentBook, privacy: .public) \(self.currentChapter)")
+            return
+        }
         let verseCount = range.verseCount
 
         // Get bookmarks with notes for this chapter
@@ -4963,6 +5206,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         var verseXML: [String] = []
 
         for verse in normalizedStart...normalizedEnd {
+            guard let ordinal = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse) else {
+                return nil
+            }
             let inspection: (actualKey: String, verseKey: VerseKeyChildren?, rawEntry: String)
             if verse == normalizedStart {
                 inspection = firstInspection
@@ -4983,7 +5229,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             guard !rawText.isEmpty else { continue }
 
             let osisRef = "\(osisBookId).\(chapter).\(verse)"
-            let ordinal = BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: verse)
             verseXML.append(
                 "<verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(rawText) </verse>"
             )
@@ -5003,8 +5248,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             startVerse: normalizedStart,
             endVerse: normalizedEnd
         )
-        let ordinalStart = BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: normalizedStart)
-        let ordinalEnd = BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: normalizedEnd)
+        guard let ordinalStart = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedStart),
+              let ordinalEnd = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedEnd) else {
+            return nil
+        }
 
         return [
             "xml": "<div>\(verseXML.joined())</div>",
@@ -5079,11 +5326,23 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard !refs.isEmpty else { return nil }
 
         let moduleName = activeModuleName
-        let fragments: [[String: Any]] = refs.map { ref in
+        let fragments: [[String: Any]] = refs.compactMap { ref in
             let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
-            let ordinal = BibleChapterDocumentBuilder.ordinal(chapter: ref.chapter, verse: ref.verse)
+            let ordinal: Int
+            if let activeModule {
+                guard let moduleOrdinal = activeModule.verseOrdinal(
+                    osisBookId: ref.osisId,
+                    chapter: ref.chapter,
+                    verse: ref.verse
+                ) else {
+                    return nil
+                }
+                ordinal = moduleOrdinal
+            } else {
+                ordinal = compatibilityOrdinal(chapter: ref.chapter, verse: ref.verse)
+            }
             return [
-                "xml": buildBibleMultiReferenceXML(ref: ref, module: activeModule),
+                "xml": buildBibleMultiReferenceXML(ref: ref, module: activeModule, ordinal: ordinal),
                 "key": "\(moduleName)--\(osisRef)",
                 "keyName": ref.displayName,
                 "v11n": "KJVA",
@@ -5099,6 +5358,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                 "direction": "ltr",
             ]
         }
+        guard fragments.count == refs.count else { return nil }
 
         let document: [String: Any] = [
             "id": "multi-\(UUID().uuidString)",
@@ -5121,16 +5381,15 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Parameters:
        - ref: Parsed Bible reference to render.
        - module: Active Bible module to read from. A missing module yields a fallback fragment.
-     - Returns: A `<div>` containing one `<verse>` element with the same approximate ordinal scheme
-       used by chapter rendering.
+     - Returns: A `<div>` containing one `<verse>` element with the caller-supplied module or
+       placeholder ordinal.
      - Side effects: when `module` is present, temporarily moves its SWORD key cursor inside one
        serialized inspection call and restores the previous cursor before returning.
      - Failure modes: if the module cannot resolve the exact verse or returns empty raw OSIS, the
        fragment contains an escaped display label rather than throwing.
      */
-    private func buildBibleMultiReferenceXML(ref: OsisRef, module: SwordModule?) -> String {
+    private func buildBibleMultiReferenceXML(ref: OsisRef, module: SwordModule?, ordinal: Int) -> String {
         let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
-        let ordinal = BibleChapterDocumentBuilder.ordinal(chapter: ref.chapter, verse: ref.verse)
         let rawText: String
 
         if let module {
@@ -5908,16 +6167,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         468: "2Esd",
     ]
 
-    /// Parse an OSIS reference string like "Matt.1.1" or "Gen.1.1-Gen.1.3" into structured refs.
+    /**
+     Parses an OSIS reference string into structured verse references.
+
+     Android resolves cross-reference passages through JSword `PassageKeyFactory`, which expands
+     ranges and lists against the active document versification. For range/list inputs iOS now
+     delegates to the active SWORD module's key parser and uses the previous string splitter only
+     as a no-module fallback.
+
+     - Parameter osisString: OSIS reference text such as `Matt.1.1`, `Gen.1.1-Gen.1.3`, or a
+       comma-separated list.
+     - Returns: Parsed references in module/parser order. Invalid or unknown keys are omitted.
+     - Side effects: May temporarily move the active module cursor through `SwordModule`; that
+       method restores the previous key before returning.
+     */
     private func parseOsisReferences(_ osisString: String) -> [OsisRef] {
-        // Split on "-" for ranges, but also handle comma-separated
-        let parts = osisString.components(separatedBy: CharacterSet(charactersIn: ",-"))
+        let trimmed = osisString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let activeModule {
+            let parsedKeys = trimmed.components(separatedBy: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .flatMap { activeModule.parseKeyList($0) }
+            if !parsedKeys.isEmpty {
+                return parsedKeys.compactMap { key in
+                    guard let ref = parseOsisRef(key),
+                          isValidResolvedReference(osisBookId: ref.osisId, chapter: ref.chapter, verse: ref.verse) else {
+                        return nil
+                    }
+                    return ref
+                }
+            }
+        }
+
+        // Fallback for no-module startup paths and parser failures.
+        let parts = trimmed.components(separatedBy: CharacterSet(charactersIn: ",-"))
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
 
         var refs: [OsisRef] = []
         for part in parts {
-            if let ref = parseOsisRef(part) {
+            if let ref = parseOsisRef(part),
+               isValidResolvedReference(osisBookId: ref.osisId, chapter: ref.chapter, verse: ref.verse) {
                 refs.append(ref)
             }
         }
@@ -6016,6 +6306,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return
         }
 
+        if let osisRef = resolveReferenceWithActiveModuleParser(trimmed) {
+            let escaped = osisRef.replacingOccurrences(of: "\"", with: "\\\"")
+            bridge.sendResponse(callId: callId, value: "\"\(escaped)\"")
+            return
+        }
+
         // If already OSIS format (e.g. "Gen.1.1"), validate and return
         if let osisRef = resolveOsisRef(trimmed) {
             let escaped = osisRef.replacingOccurrences(of: "\"", with: "\\\"")
@@ -6034,14 +6330,542 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         bridge.sendResponse(callId: callId, value: "null")
     }
 
+    /**
+     Resolves reference text through the active SWORD parser and serializes it like JSword.
+
+     Android's text editor calls `LinkControl.resolveRef`, which delegates to JSword
+     `PassageKeyFactory` and returns `key.osisRef`. This helper mirrors that path for iOS by
+     asking the active module to parse each comma-separated passage item, then joining normalized
+     OSIS range strings with JSword's space delimiter.
+
+     - Parameter text: Human-readable or OSIS passage text supplied by the web client.
+     - Returns: JSword-style `osisRef` text, or `nil` when no active module can parse it.
+     - Side effects: Temporarily moves the active SWORD module cursor through `parseKeyList` and
+       verse-count checks; `SwordModule` restores the cursor around those calls.
+     - Failure modes: Returns `nil` if any parsed key is not a valid verse reference in the active
+       module's versification.
+     */
+    private func resolveReferenceWithActiveModuleParser(_ text: String) -> String? {
+        guard let activeModule else { return nil }
+        let explicitValidation = validateExplicitReferenceText(text, module: activeModule)
+        if case .invalid = explicitValidation {
+            return nil
+        }
+
+        let parsedKeys = activeModule.parseKeyList(text)
+        guard !parsedKeys.isEmpty else { return nil }
+
+        if case let .parsed(ranges) = explicitValidation,
+           let osisRef = moduleParsedOsisRef(ranges: ranges, module: activeModule) {
+            return osisRef
+        }
+
+        let refs = parsedKeys.compactMap { key -> OsisRef? in
+            guard let ref = parseOsisRef(key),
+                  isValidResolvedReference(
+                    osisBookId: ref.osisId,
+                    chapter: ref.chapter,
+                    verse: ref.verse
+                  ) else {
+                return nil
+            }
+            return ref
+        }
+        guard refs.count == parsedKeys.count else { return nil }
+        return moduleParsedOsisRef(refs, module: activeModule)
+    }
+
+    /**
+     Validates and parses explicit numeric coordinates before trusting SWORD's parser output.
+
+     JSword's `PassageKeyFactory` validates every constructed `VerseRange` through
+     `Versification.validate(...)`. SWORD's `SWModule_parseKeyList` instead normalizes references
+     such as `Gen.1.99` to a later valid verse. This helper preserves JSword semantics by checking
+     user-supplied chapter/verse numbers that iOS can unambiguously identify. When the whole string
+     is parsed, the resulting ranges also preserve list/range structure that SWORD may otherwise
+     flatten into separate chapter keys.
+     */
+    private func validateExplicitReferenceText(
+        _ text: String,
+        module: SwordModule
+    ) -> ExplicitReferenceValidation {
+        let normalized = text.replacingOccurrences(
+            of: #"\p{Pd}"#,
+            with: "-",
+            options: .regularExpression
+        )
+        var basis: ReferenceCoordinate?
+        var ranges: [ReferenceRange] = []
+        for segment in normalized.components(separatedBy: CharacterSet(charactersIn: ",;")) {
+            let trimmedSegment = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedSegment.isEmpty else { continue }
+            let rangeParts = trimmedSegment.components(separatedBy: "-")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
+            guard rangeParts.count <= 2 else { return .invalid }
+            guard let firstPart = rangeParts.first,
+                  let start = parseReferenceCoordinate(firstPart, basis: basis) else {
+                return .unknown
+            }
+            guard isValidReferenceCoordinate(start, module: module) else { return .invalid }
+
+            var end = start
+            if rangeParts.count > 1 {
+                guard let parsedEnd = parseReferenceCoordinate(
+                    rangeParts[1],
+                    basis: start,
+                    rangeEndUsesChapterWhenStartIsChapterOnly: start.verse == nil
+                ),
+                      isValidReferenceCoordinate(parsedEnd, module: module),
+                      let startOrdinal = referenceOrdinal(start, module: module),
+                      let endOrdinal = referenceOrdinal(parsedEnd, module: module),
+                      endOrdinal >= startOrdinal else {
+                    return .invalid
+                }
+                end = parsedEnd
+            }
+
+            ranges.append(ReferenceRange(start: start, end: end))
+            basis = end
+        }
+
+        return ranges.isEmpty ? .unknown : .parsed(ranges)
+    }
+
+    /**
+     Serializes one parser result segment into the compact OSIS form JSword would expose.
+
+     `SWModule_parseKeyList` returns expanded verse keys. JSword's `Passage.getOsisRef()` reports
+     a single verse as `Book.Chapter.Verse`, a same-chapter range as
+     `Book.Chapter.Start-Book.Chapter.End`, and a whole chapter as `Book.Chapter`. This helper
+     reconstructs those compact forms for the common verse-list and range cases accepted by the
+     editor bridge.
+     */
+    private func moduleParsedOsisRef(_ refs: [OsisRef], module: SwordModule) -> String? {
+        guard !refs.isEmpty else { return nil }
+
+        let references = refs.compactMap { ref -> VerseKeyReference? in
+            guard let ordinal = module.verseOrdinal(
+                osisBookId: ref.osisId,
+                chapter: ref.chapter,
+                verse: ref.verse
+            ) else {
+                return nil
+            }
+            return module.verseReference(osisBookId: ref.osisId, ordinal: ordinal)
+        }
+        guard references.count == refs.count else { return nil }
+
+        var ranges: [(start: VerseKeyReference, end: VerseKeyReference)] = []
+        var rangeStart = references[0]
+        var rangeEnd = references[0]
+
+        for reference in references.dropFirst() {
+            if reference.ordinal == rangeEnd.ordinal + 1 {
+                rangeEnd = reference
+            } else {
+                ranges.append((rangeStart, rangeEnd))
+                rangeStart = reference
+                rangeEnd = reference
+            }
+        }
+        ranges.append((rangeStart, rangeEnd))
+
+        return ranges
+            .map { moduleParsedOsisRange(start: $0.start, end: $0.end, module: module) }
+            .joined(separator: " ")
+    }
+
+    /**
+     Serializes parsed explicit ranges using the same contiguous-range normalization as JSword.
+
+     JSword normalizes adjacent range/list entries before `getOsisRef()`. This converts
+     chapter-level coordinates into their real verse endpoints, merges adjacent ranges by active
+     module ordinal, and then delegates to the same range formatter used for SWORD-expanded keys.
+     */
+    private func moduleParsedOsisRef(ranges: [ReferenceRange], module: SwordModule) -> String? {
+        let resolvedRanges = ranges.compactMap { range -> (start: VerseKeyReference, end: VerseKeyReference)? in
+            guard let start = verseKeyReference(forStartOf: range.start, module: module),
+                  let end = verseKeyReference(forEndOf: range.end, module: module) else {
+                return nil
+            }
+            return (start, end)
+        }
+        guard resolvedRanges.count == ranges.count, !resolvedRanges.isEmpty else { return nil }
+
+        var merged: [(start: VerseKeyReference, end: VerseKeyReference)] = []
+        var current = resolvedRanges[0]
+        for range in resolvedRanges.dropFirst() {
+            if range.start.ordinal == current.end.ordinal + 1 {
+                current.end = range.end
+            } else {
+                merged.append(current)
+                current = range
+            }
+        }
+        merged.append(current)
+
+        return merged
+            .map { moduleParsedOsisRange(start: $0.start, end: $0.end, module: module) }
+            .joined(separator: " ")
+    }
+
+    /**
+     Formats one contiguous verse run using JSword `VerseRange.getOsisRef()` semantics.
+
+     - Returns: A single verse, same-chapter range, whole-chapter reference, or multi-chapter range
+       with whole-chapter endpoints compacted where the active module confirms the endpoint starts
+       or ends a chapter.
+     */
+    private func moduleParsedOsisRange(
+        start: VerseKeyReference,
+        end: VerseKeyReference,
+        module: SwordModule
+    ) -> String {
+        if start == end {
+            return start.osisRef
+        }
+
+        if start.osisBookId == end.osisBookId,
+           start.chapter == 1,
+           start.verse == 1,
+           let bookName = bookName(forOsisId: start.osisBookId),
+           end.chapter == chapterCount(for: bookName),
+           module.verseCount(osisBookId: end.osisBookId, chapter: end.chapter) == end.verse {
+            return start.osisBookId
+        }
+
+        if start.osisBookId == end.osisBookId, start.chapter == end.chapter {
+            if start.verse == 1,
+               module.verseCount(osisBookId: start.osisBookId, chapter: start.chapter) == end.verse {
+                return "\(start.osisBookId).\(start.chapter)"
+            }
+            return "\(start.osisRef)-\(end.osisRef)"
+        }
+
+        let startText = start.verse == 1
+            ? "\(start.osisBookId).\(start.chapter)"
+            : start.osisRef
+        let endText = module.verseCount(osisBookId: end.osisBookId, chapter: end.chapter) == end.verse
+            ? "\(end.osisBookId).\(end.chapter)"
+            : end.osisRef
+        return "\(startText)-\(endText)"
+    }
+
+    private func osisRefString(_ ref: OsisRef) -> String {
+        "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+    }
+
+    /**
+     Parsed coordinate from user reference text.
+
+     `verse == nil` represents a chapter-level coordinate. That distinction is required because
+     JSword interprets `Gen 1-2` as a chapter range but `Gen 1:1-2` as a verse range.
+     */
+    private enum ExplicitReferenceValidation {
+        case parsed([ReferenceRange])
+        case unknown
+        case invalid
+    }
+
+    private struct ReferenceRange {
+        let start: ReferenceCoordinate
+        let end: ReferenceCoordinate
+    }
+
+    private struct ReferenceCoordinate {
+        let osisBookId: String
+        let chapter: Int
+        let verse: Int?
+    }
+
+    private func parseReferenceCoordinate(
+        _ text: String,
+        basis: ReferenceCoordinate?,
+        rangeEndUsesChapterWhenStartIsChapterOnly: Bool = false
+    ) -> ReferenceCoordinate? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let osis = parseOsisCoordinate(trimmed) {
+            return osis
+        }
+
+        if let human = parseHumanCoordinate(trimmed) {
+            return human
+        }
+
+        if let chapterVerse = parseRelativeChapterVerseCoordinate(trimmed, basis: basis) {
+            return chapterVerse
+        }
+
+        if let number = Int(trimmed), let basis {
+            if rangeEndUsesChapterWhenStartIsChapterOnly || basis.verse == nil {
+                return ReferenceCoordinate(osisBookId: basis.osisBookId, chapter: number, verse: nil)
+            }
+            return ReferenceCoordinate(osisBookId: basis.osisBookId, chapter: basis.chapter, verse: number)
+        }
+
+        return nil
+    }
+
+    private func parseOsisCoordinate(_ text: String) -> ReferenceCoordinate? {
+        let parts = text.components(separatedBy: ".")
+        guard parts.count == 2 || parts.count == 3,
+              bookName(forOsisId: parts[0]) != nil,
+              let chapter = Int(parts[1]) else {
+            return nil
+        }
+        let verse = parts.count == 3 ? Int(parts[2]) : nil
+        if parts.count == 3, verse == nil { return nil }
+        return ReferenceCoordinate(osisBookId: parts[0], chapter: chapter, verse: verse)
+    }
+
+    private func parseHumanCoordinate(_ text: String) -> ReferenceCoordinate? {
+        let aliases = referenceBookAliases()
+            .sorted { $0.alias.count > $1.alias.count }
+            .map { NSRegularExpression.escapedPattern(for: $0.alias) }
+            .joined(separator: "|")
+        guard !aliases.isEmpty,
+              let regex = try? NSRegularExpression(
+                pattern: #"(?i)^(\#(aliases))\s+(\d+)(?::(\d+))?$"#
+              ),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let aliasRange = Range(match.range(at: 1), in: text),
+              let chapterRange = Range(match.range(at: 2), in: text),
+              let chapter = Int(text[chapterRange]) else {
+            return nil
+        }
+
+        let alias = canonicalReferenceAlias(String(text[aliasRange]))
+        guard let osisBookId = referenceBookAliasMap()[alias] else { return nil }
+        let verse: Int?
+        if match.range(at: 3).location != NSNotFound,
+           let verseRange = Range(match.range(at: 3), in: text) {
+            verse = Int(text[verseRange])
+            if verse == nil { return nil }
+        } else {
+            verse = nil
+        }
+
+        return ReferenceCoordinate(osisBookId: osisBookId, chapter: chapter, verse: verse)
+    }
+
+    private func parseRelativeChapterVerseCoordinate(
+        _ text: String,
+        basis: ReferenceCoordinate?
+    ) -> ReferenceCoordinate? {
+        guard let basis else { return nil }
+        let parts = text.components(separatedBy: ":")
+        guard parts.count == 2,
+              let chapter = Int(parts[0]),
+              let verse = Int(parts[1]) else {
+            return nil
+        }
+        return ReferenceCoordinate(osisBookId: basis.osisBookId, chapter: chapter, verse: verse)
+    }
+
+    private func isValidReferenceCoordinate(_ coordinate: ReferenceCoordinate, module: SwordModule) -> Bool {
+        if let verse = coordinate.verse {
+            return module.verseOrdinal(
+                osisBookId: coordinate.osisBookId,
+                chapter: coordinate.chapter,
+                verse: verse
+            ) != nil
+        }
+        return module.verseCount(osisBookId: coordinate.osisBookId, chapter: coordinate.chapter) != nil
+    }
+
+    private func referenceOrdinal(_ coordinate: ReferenceCoordinate, module: SwordModule) -> Int? {
+        if let verse = coordinate.verse {
+            return module.verseOrdinal(
+                osisBookId: coordinate.osisBookId,
+                chapter: coordinate.chapter,
+                verse: verse
+            )
+        }
+        return module.verseOrdinal(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter,
+            verse: 1
+        )
+    }
+
+    private func verseKeyReference(
+        forStartOf coordinate: ReferenceCoordinate,
+        module: SwordModule
+    ) -> VerseKeyReference? {
+        let verse = coordinate.verse ?? 1
+        guard let ordinal = module.verseOrdinal(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter,
+            verse: verse
+        ) else {
+            return nil
+        }
+        return VerseKeyReference(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter,
+            verse: verse,
+            ordinal: ordinal
+        )
+    }
+
+    private func verseKeyReference(
+        forEndOf coordinate: ReferenceCoordinate,
+        module: SwordModule
+    ) -> VerseKeyReference? {
+        let verse: Int
+        if let coordinateVerse = coordinate.verse {
+            verse = coordinateVerse
+        } else if let chapterVerseCount = module.verseCount(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter
+        ) {
+            verse = chapterVerseCount
+        } else {
+            return nil
+        }
+
+        guard let ordinal = module.verseOrdinal(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter,
+            verse: verse
+        ) else {
+            return nil
+        }
+        return VerseKeyReference(
+            osisBookId: coordinate.osisBookId,
+            chapter: coordinate.chapter,
+            verse: verse,
+            ordinal: ordinal
+        )
+    }
+
+    private func referenceBookAliasMap() -> [String: String] {
+        var map: [String: String] = [:]
+        for alias in referenceBookAliases() {
+            map[alias.alias] = alias.osisBookId
+        }
+        return map
+    }
+
+    private func referenceBookAliases() -> [(alias: String, osisBookId: String)] {
+        var aliases: [(alias: String, osisBookId: String)] = []
+        let books = (bookList.isEmpty ? Self.defaultBooks : bookList)
+        for book in books {
+            appendReferenceAlias(book.name, osisBookId: book.osisId, to: &aliases)
+            appendReferenceAlias(book.abbreviation, osisBookId: book.osisId, to: &aliases)
+            appendReferenceAlias(book.osisId, osisBookId: book.osisId, to: &aliases)
+            appendNumberedBookReferenceAliases(for: book, to: &aliases)
+        }
+        for (alias, osisBookId) in Self.commonReferenceAliasOsisIds {
+            appendReferenceAlias(alias, osisBookId: osisBookId, to: &aliases)
+        }
+        return aliases
+    }
+
+    private static let commonReferenceAliasOsisIds: [String: String] = [
+        "gen": "Gen", "ex": "Exod", "exo": "Exod", "lev": "Lev",
+        "num": "Num", "deut": "Deut", "deu": "Deut", "dt": "Deut",
+        "josh": "Josh", "judg": "Judg", "jdg": "Judg",
+        "1 sam": "1Sam", "2 sam": "2Sam", "1 ki": "1Kgs", "2 ki": "2Kgs",
+        "1 chr": "1Chr", "2 chr": "2Chr", "neh": "Neh", "est": "Esth",
+        "ps": "Ps", "psa": "Ps", "prov": "Prov", "pro": "Prov",
+        "eccl": "Eccl", "ecc": "Eccl", "song": "Song", "sos": "Song",
+        "isa": "Isa", "jer": "Jer", "lam": "Lam", "ezek": "Ezek", "eze": "Ezek",
+        "dan": "Dan", "hos": "Hos", "joe": "Joel", "amo": "Amos",
+        "oba": "Obad", "jon": "Jonah", "mic": "Mic", "nah": "Nah",
+        "hab": "Hab", "zeph": "Zeph", "zep": "Zeph",
+        "hag": "Hag", "zech": "Zech", "zec": "Zech", "mal": "Mal",
+        "matt": "Matt", "mat": "Matt", "mk": "Mark", "luk": "Luke", "lk": "Luke",
+        "jn": "John", "joh": "John", "act": "Acts",
+        "rom": "Rom", "1 cor": "1Cor", "2 cor": "2Cor",
+        "gal": "Gal", "eph": "Eph", "phil": "Phil", "php": "Phil",
+        "col": "Col", "1 thess": "1Thess", "2 thess": "2Thess",
+        "1 th": "1Thess", "2 th": "2Thess",
+        "1 tim": "1Tim", "2 tim": "2Tim", "tit": "Titus", "phm": "Phlm", "philem": "Phlm",
+        "heb": "Heb", "jas": "Jas", "jam": "Jas",
+        "1 pet": "1Pet", "2 pet": "2Pet", "1 pe": "1Pet", "2 pe": "2Pet",
+        "1 jn": "1John", "2 jn": "2John", "3 jn": "3John",
+        "1 john": "1John", "2 john": "2John", "3 john": "3John",
+        "jude": "Jude", "jud": "Jude",
+        "rev": "Rev", "reve": "Rev",
+    ]
+
+    private func appendNumberedBookReferenceAliases(
+        for book: BookInfo,
+        to aliases: inout [(alias: String, osisBookId: String)]
+    ) {
+        let numberedPrefixes: [(numeric: String, roman: String, word: String)] = [
+            ("1", "I", "First"),
+            ("2", "II", "Second"),
+            ("3", "III", "Third"),
+            ("4", "IV", "Fourth"),
+        ]
+        for prefix in numberedPrefixes where book.name.hasPrefix("\(prefix.numeric) ") {
+            let baseName = String(book.name.dropFirst(2))
+            appendReferenceAlias("\(prefix.roman) \(baseName)", osisBookId: book.osisId, to: &aliases)
+            appendReferenceAlias("\(prefix.word) \(baseName)", osisBookId: book.osisId, to: &aliases)
+            appendReferenceAlias("\(prefix.numeric)\(baseName)", osisBookId: book.osisId, to: &aliases)
+        }
+    }
+
+    private func appendReferenceAlias(
+        _ alias: String,
+        osisBookId: String,
+        to aliases: inout [(alias: String, osisBookId: String)]
+    ) {
+        let canonical = canonicalReferenceAlias(alias)
+        guard !canonical.isEmpty else { return }
+        aliases.append((canonical, osisBookId))
+    }
+
+    private func canonicalReferenceAlias(_ alias: String) -> String {
+        alias
+            .replacingOccurrences(of: ".", with: " ")
+            .replacingOccurrences(of: #"[\s_]+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
     /// Try to validate/resolve an OSIS-format reference like "Gen.1.1"
     private func resolveOsisRef(_ text: String) -> String? {
         let parts = text.components(separatedBy: ".")
         guard parts.count >= 2 else { return nil }
         // Check if first part is a valid OSIS book ID
         guard bookName(forOsisId: parts[0]) != nil else { return nil }
-        guard Int(parts[1]) != nil else { return nil }
+        guard let chapter = Int(parts[1]) else { return nil }
+        let verse = parts.count >= 3 ? Int(parts[2]) : nil
+        guard isValidResolvedReference(osisBookId: parts[0], chapter: chapter, verse: verse) else {
+            return nil
+        }
         return text
+    }
+
+    /**
+     Validates a resolved OSIS reference against the active module when one exists.
+
+     Android delegates parsed references to JSword's `PassageKeyFactory`, which rejects invalid
+     chapter and verse coordinates instead of accepting text that merely looks like OSIS. This
+     helper gives iOS the same contract through SWORD's exact verse/versification APIs, with the
+     static compatibility table used only when no module is available.
+     */
+    private func isValidResolvedReference(osisBookId: String, chapter: Int, verse: Int?) -> Bool {
+        guard chapter > 0, let book = bookName(forOsisId: osisBookId) else { return false }
+        if let activeModule {
+            if let verse {
+                return activeModule.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse) != nil
+            }
+            return activeModule.verseCount(osisBookId: osisBookId, chapter: chapter) != nil
+        }
+
+        guard chapter <= Self.chapterCount(for: book) else { return false }
+        if let verse {
+            return verse > 0 && verse <= Self.verseCount(for: book, chapter: chapter)
+        }
+        return true
     }
 
     /// Try to resolve a human-readable reference like "Genesis 1:1" or "Gen 1:1"
@@ -6066,9 +6890,19 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         if match.range(at: 3).location != NSNotFound,
            let verseRange = Range(match.range(at: 3), in: text),
            let verse = Int(text[verseRange]) {
-            return "\(osisId).\(chapter).\(verse)"
+            let startRef = "\(osisId).\(chapter).\(verse)"
+            guard resolveOsisRef(startRef) != nil else { return nil }
+            if match.range(at: 4).location != NSNotFound,
+               let endRange = Range(match.range(at: 4), in: text),
+               let endVerse = Int(text[endRange]) {
+                let endRef = "\(osisId).\(chapter).\(endVerse)"
+                guard endVerse >= verse, resolveOsisRef(endRef) != nil else { return nil }
+                return "\(startRef)-\(endRef)"
+            }
+            return startRef
         }
-        return "\(osisId).\(chapter)"
+        let chapterRef = "\(osisId).\(chapter)"
+        return resolveOsisRef(chapterRef)
     }
 
     /// Look up OSIS ID from a human-readable book name or abbreviation.
@@ -6281,11 +7115,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /**
      Convert an ordinal back to a verse number within the current chapter.
-     Ordinals use the formula: (chapter - 1) * 40 + verse.
      */
     private func ordinalToVerse(_ ordinal: Int) -> Int? {
-        let verse = ordinal - (currentChapter - 1) * 40
-        return verse >= 1 ? verse : nil
+        guard let reference = verseReference(book: currentBook, ordinal: ordinal),
+              reference.chapter == currentChapter else {
+            return nil
+        }
+        return reference.verse
     }
 
     /// Get plain text for a verse range using SWORD stripText.
@@ -6302,7 +7138,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             guard let (_, parsedChapter, parsedVerse) = parseVerseKey(key) else { break }
             if parsedChapter != chapter { break }
 
-            let ordinal = (chapter - 1) * 40 + parsedVerse
+            guard let ordinal = verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: parsedVerse) else {
+                break
+            }
             if ordinal >= startOrdinal && ordinal <= endOrdinal {
                 let verseText = module.stripText()
                 if !verseText.isEmpty {
@@ -6454,9 +7292,22 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             osisBookId: osisBookId,
             chapter: currentChapter
         )
-        let fallbackChapter = loadPlaceholderChapter(osisBookId: osisBookId, bookName: currentBook)
-        let xml = loadedChapter?.xml ?? fallbackChapter.0
-        let verseCount = loadedChapter?.verseCount ?? fallbackChapter.1
+        let xml: String
+        let verseCount: Int
+        let addChapter: Bool
+        if let loadedChapter {
+            xml = loadedChapter.xml
+            verseCount = loadedChapter.verseCount
+            addChapter = loadedChapter.addChapter
+        } else if activeModule == nil {
+            let fallbackChapter = loadPlaceholderChapter(osisBookId: osisBookId, bookName: currentBook)
+            xml = fallbackChapter.0
+            verseCount = fallbackChapter.1
+            addChapter = true
+        } else {
+            logger.error("Failed to load SWORD chapter for \(osisBookId, privacy: .public).\(self.currentChapter)")
+            return
+        }
 
         // Query bookmarks for this chapter
         let chapterBookmarks = bookmarksForCurrentChapter(verseCount: verseCount)
@@ -6467,7 +7318,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         // Send bookmark labels before the document (Vue.js needs labels to render bookmark highlights)
         sendLabelsToVueJS()
 
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: osisBookId,
             bookName: currentBook,
             chapter: currentChapter,
@@ -6475,9 +7326,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             isNT: isNT,
             xml: xml,
             bookmarks: chapterBookmarks,
-            addChapter: loadedChapter?.addChapter ?? true,
+            addChapter: addChapter,
             originalOrdinalRange: originalNavigationOrdinalRange
-        )
+        ) else { return }
         bridge.emit(event: "add_documents", data: document)
 
         // Track loaded chapter/book range for infinite scroll
@@ -6490,8 +7341,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         let restoreTarget: ScrollRestoreTarget
         if shouldRestoreScroll {
             restoreTarget = lastScrollTarget
-        } else if currentVerse > 1 {
-            restoreTarget = .ordinal(ordinal(forChapter: currentChapter, verse: currentVerse))
+        } else if currentVerse > 1,
+                  let ordinal = ordinal(forChapter: currentChapter, verse: currentVerse) {
+            restoreTarget = .ordinal(ordinal)
         } else {
             restoreTarget = .chapterTop
         }
@@ -6546,6 +7398,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
         let osisBookId = osisBookId(for: book)
         let isNT = isNewTestament(book)
+        let restoreKey = "\(self.osisBookId(for: currentBook)) \(currentChapter):1"
+        defer {
+            module.setKey(restoreKey)
+        }
 
         guard let loadedChapter = loadChapterFromSword(
             osisBookId: osisBookId,
@@ -6555,11 +7411,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
 
         // Query bookmarks for this chapter's ordinal range
-        let ordinalStart = (chapter - 1) * 40 + 1
-        let ordinalEnd = (chapter - 1) * 40 + loadedChapter.verseCount
-        let chapterBookmarks = bookmarkService?.bookmarks(for: ordinalStart, endOrdinal: ordinalEnd, book: book) ?? []
+        guard let range = chapterOrdinalRange(book: book, chapter: chapter, verseCount: loadedChapter.verseCount) else {
+            logger.error("Failed to resolve SWORD chapter range for \(osisBookId, privacy: .public).\(chapter)")
+            return nil
+        }
+        let chapterBookmarks = bookmarkService?.bookmarks(for: range.start, endOrdinal: range.end, book: book) ?? []
 
-        let document = buildDocumentJSON(
+        guard let document = buildDocumentJSON(
             osisBookId: osisBookId,
             bookName: book,
             chapter: chapter,
@@ -6569,11 +7427,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bookmarks: chapterBookmarks,
             addChapter: loadedChapter.addChapter,
             originalOrdinalRange: nil
-        )
-
-        // Restore module position to current chapter so other operations aren't affected
-        let restoreKey = "\(self.osisBookId(for: currentBook)) \(currentChapter):1"
-        module.setKey(restoreKey)
+        ) else { return nil }
 
         return document
     }
@@ -6598,8 +7452,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         displaySettings.showSectionTitles ?? TextDisplaySettings.appDefaults.showSectionTitles ?? true
     }
 
-    private func ordinal(forChapter chapter: Int, verse: Int) -> Int {
-        BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: verse)
+    private func ordinal(forChapter chapter: Int, verse: Int) -> Int? {
+        verseOrdinal(osisBookId: osisBookId(for: currentBook), chapter: chapter, verse: verse)
     }
 
     private func buildSwordChapterXML(osisBookId: String, bookName: String, chapter: Int, verses: [(Int, String)]) -> String {
@@ -6609,7 +7463,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
         for (verseNum, text) in verses {
             let cleanText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            xml += "<verse osisID=\"\(osisBookId).\(chapter).\(verseNum)\" verseOrdinal=\"\(ordinal(forChapter: chapter, verse: verseNum))\">"
+            guard let ordinal = ordinal(forChapter: chapter, verse: verseNum) else { continue }
+            xml += "<verse osisID=\"\(osisBookId).\(chapter).\(verseNum)\" verseOrdinal=\"\(ordinal)\">"
             xml += "\(cleanText) "
             xml += "</verse>"
         }
@@ -6674,9 +7529,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Query bookmarks for the current chapter's ordinal range, filtered by current book.
     private func bookmarksForCurrentChapter(verseCount: Int) -> [BibleBookmark] {
         guard let service = bookmarkService else { return [] }
-        let ordinalStart = (currentChapter - 1) * 40 + 1
-        let ordinalEnd = (currentChapter - 1) * 40 + verseCount
-        return service.bookmarks(for: ordinalStart, endOrdinal: ordinalEnd, book: currentBook)
+        guard let range = chapterOrdinalRange(book: currentBook, chapter: currentChapter, verseCount: verseCount) else {
+            logger.error("Failed to resolve bookmark range for \(self.currentBook, privacy: .public) \(self.currentChapter)")
+            return []
+        }
+        return service.bookmarks(for: range.start, endOrdinal: range.end, book: currentBook)
     }
 
     // MARK: - Default Labels
@@ -6765,30 +7622,33 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             validLabelIDs: labelPayload.labelIDs
         )
 
-        // Compute verse references from ordinals
-        let osisBookId = osisBookId(for: currentBook)
-        let chapterBase = (currentChapter - 1) * 40
-        let startVerse = max(1, bookmark.ordinalStart - chapterBase)
-        let endVerse = max(startVerse, bookmark.ordinalEnd - chapterBase)
+        // Compute verse references from ordinals using the active versification.
+        let bookmarkBook = bookmark.book ?? currentBook
+        let osisBookId = osisBookId(for: bookmarkBook)
+        let startReference = verseReference(book: bookmarkBook, ordinal: bookmark.ordinalStart)
+        let endReference = verseReference(book: bookmarkBook, ordinal: bookmark.ordinalEnd)
+        let chapter = startReference?.chapter ?? currentChapter
+        let startVerse = startReference?.verse ?? 1
+        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
 
         let osisRef: String
         let verseRange: String
         let verseRangeOnlyNumber: String
         let verseRangeAbbreviated: String
         if startVerse == endVerse {
-            osisRef = "\(osisBookId).\(currentChapter).\(startVerse)"
-            verseRange = "\(currentBook) \(currentChapter):\(startVerse)"
+            osisRef = "\(osisBookId).\(chapter).\(startVerse)"
+            verseRange = "\(bookmarkBook) \(chapter):\(startVerse)"
             verseRangeOnlyNumber = "\(startVerse)"
-            verseRangeAbbreviated = "\(osisBookId) \(currentChapter):\(startVerse)"
+            verseRangeAbbreviated = "\(osisBookId) \(chapter):\(startVerse)"
         } else {
-            osisRef = "\(osisBookId).\(currentChapter).\(startVerse)-\(osisBookId).\(currentChapter).\(endVerse)"
-            verseRange = "\(currentBook) \(currentChapter):\(startVerse)-\(endVerse)"
+            osisRef = "\(osisBookId).\(chapter).\(startVerse)-\(osisBookId).\(chapter).\(endVerse)"
+            verseRange = "\(bookmarkBook) \(chapter):\(startVerse)-\(endVerse)"
             verseRangeOnlyNumber = "\(startVerse)-\(endVerse)"
-            verseRangeAbbreviated = "\(osisBookId) \(currentChapter):\(startVerse)-\(endVerse)"
+            verseRangeAbbreviated = "\(osisBookId) \(chapter):\(startVerse)-\(endVerse)"
         }
 
         // Load verse text from SWORD if available
-        let fullText = loadVerseText(osisBookId: osisBookId, chapter: currentChapter, startVerse: startVerse, endVerse: endVerse)
+        let fullText = loadVerseText(osisBookId: osisBookId, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
 
         return BibleBookmarkData(
             id: id,
@@ -6977,10 +7837,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bookOsisId = osisBookId(for: currentBook)
             bookName = currentBook
         }
-        let chapterBase = bookmark.ordinalStart / 40
-        let chapter = chapterBase + 1
-        let startVerse = max(1, bookmark.ordinalStart - chapterBase * 40)
-        let endVerse = max(startVerse, bookmark.ordinalEnd - chapterBase * 40)
+        let startReference = verseReference(book: bookName, ordinal: bookmark.ordinalStart)
+        let endReference = verseReference(book: bookName, ordinal: bookmark.ordinalEnd)
+        let chapter = startReference?.chapter ?? currentChapter
+        let startVerse = startReference?.verse ?? 1
+        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
 
         let osisRef = startVerse == endVerse
             ? "\(bookOsisId).\(chapter).\(startVerse)"
@@ -7815,7 +8676,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         xml += "<div sID=\"p1\" type=\"paragraph\"/>"
 
         for verse in 1...verseCount {
-            let ordinal = (chapter - 1) * 40 + verse // approximate ordinal
+            let ordinal = compatibilityOrdinal(chapter: chapter, verse: verse)
             let text = Self.placeholderVerseText(book: bookName, chapter: chapter, verse: verse)
             xml += "<verse osisID=\"\(osisBookId).\(chapter).\(verse)\" verseOrdinal=\"\(ordinal)\">"
             xml += "\(text) "
@@ -7841,8 +8702,16 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        - bookmarks: Chapter bookmarks to serialize alongside the document.
        - bookCategory: Document category string consumed by the frontend.
        - bookInitials: Optional module initials override for compare/nonstandard documents.
+       - addChapter: Whether Vue should inject a chapter marker for this document.
+       - originalOrdinalRange: Optional source navigation target used for highlight restoration.
+       - documentKey: Optional exact document key. Bible chapters use `Book.Chapter`; commentary
+         single-key documents use `Book.Chapter.Verse`.
+       - keyName: Optional display label for the fragment key.
+       - ordinalRangeOverride: Optional exact ordinal range for single-key or non-chapter
+         documents.
 
-     - Returns: JSON string for one Vue.js document record.
+     - Returns: JSON string for one Vue.js document record, or `nil` when a Bible document cannot
+       resolve its active-module ordinal range.
      */
     private func buildDocumentJSON(osisBookId: String,
                                    bookName: String,
@@ -7854,10 +8723,26 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                                    bookCategory: String = "BIBLE",
                                    bookInitials: String? = nil,
                                    addChapter: Bool = true,
-                                   originalOrdinalRange: [Int]? = nil) -> String {
-        let key = "\(osisBookId).\(chapter)"
-        let ordinalStart = (chapter - 1) * 40 + 1
-        let ordinalEnd = (chapter - 1) * 40 + verseCount
+                                   originalOrdinalRange: [Int]? = nil,
+                                   documentKey: String? = nil,
+                                   keyName: String? = nil,
+                                   ordinalRangeOverride: [Int]? = nil) -> String? {
+        let key = documentKey ?? "\(osisBookId).\(chapter)"
+        let displayKeyName = keyName ?? "\(bookName) \(chapter)"
+        let documentOrdinalRange: [Int]
+        if let ordinalRangeOverride {
+            documentOrdinalRange = ordinalRangeOverride
+        } else if bookCategory == DocumentCategory.bible.rawValue {
+            guard let range = chapterOrdinalRange(book: bookName, chapter: chapter, verseCount: verseCount) else {
+                logger.error("Failed to resolve Bible document range for \(osisBookId, privacy: .public).\(chapter)")
+                return nil
+            }
+            documentOrdinalRange = [range.start, range.end]
+        } else {
+            documentOrdinalRange = [0, 0]
+        }
+        let ordinalStart = documentOrdinalRange.first ?? 0
+        let ordinalEnd = documentOrdinalRange.last ?? ordinalStart
         let initials = bookInitials ?? activeModuleName
 
         func jsonObject<T: Encodable>(from value: T) -> Any? {
@@ -7869,7 +8754,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             [
                 "xml": xml,
                 "key": keySuffix,
-                "keyName": "\(bookName) \(chapter)",
+                "keyName": displayKeyName,
                 "v11n": "KJVA",
                 "bookCategory": bookCategory,
                 "bookInitials": initials,
@@ -7896,7 +8781,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         var doc: [String: Any] = [
             "id": "doc-1",
             "type": "bible",
-            "osisFragment": osisFragmentObject(xml: xml, ordinalRange: [ordinalStart, ordinalEnd], keySuffix: key),
+            "osisFragment": osisFragmentObject(xml: xml, ordinalRange: documentOrdinalRange, keySuffix: key),
             "bookInitials": initials,
             "bookCategory": bookCategory,
             "bookAbbreviation": osisBookId,
@@ -7906,7 +8791,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             "osisRef": key,
             "annotateRef": "",
             "genericBookmarks": [Any](),
-            "ordinalRange": [ordinalStart, ordinalEnd],
+            "ordinalRange": documentOrdinalRange,
             "isNativeHtml": false,
             "bookmarks": bookmarkObjects,
             "bibleBookName": bookName,
@@ -7931,7 +8816,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard let data = try? JSONSerialization.data(withJSONObject: doc, options: [.sortedKeys]),
               let json = String(data: data, encoding: .utf8) else {
             logger.error("Failed to serialize document JSON for \(osisBookId, privacy: .public) \(chapter)")
-            return "{}"
+            return nil
         }
 
         return json
@@ -8024,7 +8909,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
         let books = mod.getBookList()
         if books.isEmpty {
-            logger.info("Module \(mod.info.name) returned no books — using default 66-book list")
+            logger.error("Module \(mod.info.name, privacy: .public) returned no books; refusing static canon fallback while active")
             moduleBookList = []
         } else {
             logger.info("Module \(mod.info.name) has \(books.count) books (versification: \(mod.configEntry("Versification") ?? "KJV"))")
@@ -8034,7 +8919,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Chapter count for a book, using the active module's versification.
     func chapterCount(for book: String) -> Int {
-        bookList.first(where: { $0.name == book })?.chapterCount ?? 1
+        if let chapterCount = bookList.first(where: { $0.name == book })?.chapterCount {
+            return chapterCount
+        }
+        return activeModule == nil ? Self.chapterCount(for: book) : 0
     }
 
     /// Static chapter count using the default 66-book list.
@@ -8058,7 +8946,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// OSIS book ID lookup, using the active module's versification.
     func osisBookId(for bookName: String) -> String {
-        bookList.first(where: { $0.name == bookName })?.osisId ?? bookName.prefix(3).description
+        if let osisId = bookList.first(where: { $0.name == bookName })?.osisId {
+            return osisId
+        }
+        return activeModule == nil ? Self.osisBookId(for: bookName) : ""
     }
 
     /// KJVA-compatible ordinal for the canonical book position used by local reading progress.
@@ -8077,8 +8968,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         startOrdinal: Int,
         chapter: Int
     ) -> ReadingProgressBridgeTarget? {
-        let chapterRange = currentChapterOrdinalRange()
-        guard currentCategory == .bible,
+        guard let chapterRange = currentChapterOrdinalRange(),
+              currentCategory == .bible,
               !bookInitials.isEmpty,
               bookInitials == activeModuleName,
               startOrdinal >= chapterRange.start,
@@ -8134,6 +9025,34 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Static NT check using the default list.
     static func isNewTestament(_ bookName: String) -> Bool {
         defaultBooks.first(where: { $0.name == bookName })?.isNewTestament ?? false
+    }
+
+    /**
+     Returns the verse count for a book/chapter using the active Bible module when available.
+
+     Android's passage chooser asks the current document versification for
+     `getLastVerse(book, chapterNo)`. The iOS reader obtains the same value from the active SWORD
+     module's `VerseKey` metadata and falls back to the legacy static table only when no module is
+     active.
+
+     - Parameters:
+       - book: Display book name from the active module book list.
+       - chapter: One-based chapter number selected in the chooser.
+     - Returns: The last selectable verse number for the chapter, or `nil` when the active module
+       cannot resolve the chapter exactly.
+     - Side effects: May temporarily move the active module cursor through `SwordModule`; that
+       method restores the previous key before returning.
+     */
+    func verseCountForActiveModule(book: String, chapter: Int) -> Int? {
+        let osisId = osisBookId(for: book)
+        if let activeModule {
+            guard let count = activeModule.verseCount(osisBookId: osisId, chapter: chapter),
+                  count > 0 else {
+                return nil
+            }
+            return count
+        }
+        return Self.verseCount(for: book, chapter: chapter)
     }
 
     /// Returns the verse count for a book/chapter. Defaults to 30 if unknown.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -7597,6 +7597,115 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
+     Ordinal-backed Bible bookmark range projected into the bridge fields used by Vue.js.
+
+     Android serializes bookmark ranges from a JSword `VerseRange`; this projection is the iOS
+     equivalent. It keeps `osisRef`, display names, abbreviated names, and number-only labels
+     derived from one resolved start/end pair instead of repeating range formatting at each bridge
+     call site.
+     */
+    private struct BookmarkBridgeVerseRangeProjection {
+        let startBookName: String
+        let startBookAbbreviation: String
+        let start: VerseKeyReference
+        let endBookName: String
+        let endBookAbbreviation: String
+        let end: VerseKeyReference
+
+        private var isSingleVerse: Bool {
+            start.osisBookId == end.osisBookId
+                && start.chapter == end.chapter
+                && start.verse == end.verse
+        }
+
+        var osisRef: String {
+            let startRef = "\(start.osisBookId).\(start.chapter).\(start.verse)"
+            guard !isSingleVerse else { return startRef }
+            return "\(startRef)-\(end.osisBookId).\(end.chapter).\(end.verse)"
+        }
+
+        var verseRange: String {
+            formattedRange(startBook: startBookName, endBook: endBookName)
+        }
+
+        var verseRangeOnlyNumber: String {
+            isSingleVerse ? "\(start.verse)" : "\(start.verse)-\(end.verse)"
+        }
+
+        var verseRangeAbbreviated: String {
+            formattedRange(startBook: startBookAbbreviation, endBook: endBookAbbreviation)
+        }
+
+        private func formattedRange(startBook: String, endBook: String) -> String {
+            if isSingleVerse {
+                return "\(startBook) \(start.chapter):\(start.verse)"
+            }
+            if start.osisBookId == end.osisBookId {
+                if start.chapter == end.chapter {
+                    return "\(startBook) \(start.chapter):\(start.verse)-\(end.verse)"
+                }
+                return "\(startBook) \(start.chapter):\(start.verse)-\(end.chapter):\(end.verse)"
+            }
+            return "\(startBook) \(start.chapter):\(start.verse)-\(endBook) \(end.chapter):\(end.verse)"
+        }
+    }
+
+    /**
+     Resolves a bookmark's stored ordinals into the bridge range projection used by Android's
+     `ClientBibleBookmark` fields.
+
+     - Parameters:
+       - bookName: Stored or current start book name.
+       - startOrdinal: Stored start ordinal in the bookmark versification.
+       - endOrdinal: Stored end ordinal in the bookmark versification.
+     - Returns: A normalized range projection. Invalid or reversed end ordinals collapse to the
+       start verse, matching existing single-verse normalization.
+     */
+    private func bibleBookmarkRangeProjection(
+        bookName: String,
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) -> BookmarkBridgeVerseRangeProjection {
+        let startReference = verseReference(book: bookName, ordinal: startOrdinal)
+            ?? activeModule?.verseReference(ordinal: startOrdinal)
+            ?? fallbackVerseReference(bookName: bookName, ordinal: startOrdinal)
+        let effectiveEndOrdinal = endOrdinal > startOrdinal ? endOrdinal : startOrdinal
+        let endReference = verseReference(book: bookName, ordinal: effectiveEndOrdinal)
+            ?? activeModule?.verseReference(ordinal: effectiveEndOrdinal)
+            ?? startReference
+
+        return BookmarkBridgeVerseRangeProjection(
+            startBookName: bridgeBookName(for: startReference, fallback: bookName),
+            startBookAbbreviation: bridgeBookAbbreviation(for: startReference),
+            start: startReference,
+            endBookName: bridgeBookName(for: endReference, fallback: bookName),
+            endBookAbbreviation: bridgeBookAbbreviation(for: endReference),
+            end: endReference
+        )
+    }
+
+    private func fallbackVerseReference(bookName: String, ordinal: Int) -> VerseKeyReference {
+        let safeOrdinal = max(1, ordinal)
+        let chapter = max(1, ((safeOrdinal - 1) / 40) + 1)
+        let verse = max(1, safeOrdinal - ((chapter - 1) * 40))
+        return VerseKeyReference(
+            osisBookId: osisBookId(for: bookName),
+            chapter: chapter,
+            verse: verse,
+            ordinal: safeOrdinal
+        )
+    }
+
+    private func bridgeBookName(for reference: VerseKeyReference, fallback: String) -> String {
+        Self.bookName(forOsisId: reference.osisBookId) ?? fallback
+    }
+
+    private func bridgeBookAbbreviation(for reference: VerseKeyReference) -> String {
+        Self.defaultBooks.first(where: { $0.osisId == reference.osisBookId })?.abbreviation
+            ?? reference.osisBookId
+    }
+
+    /**
      Builds the typed Bible bookmark bridge payload consumed by Vue.js.
 
      - Parameter bookmark: SwiftData Bible bookmark model to project.
@@ -7624,31 +7733,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
         // Compute verse references from ordinals using the active versification.
         let bookmarkBook = bookmark.book ?? currentBook
-        let osisBookId = osisBookId(for: bookmarkBook)
-        let startReference = verseReference(book: bookmarkBook, ordinal: bookmark.ordinalStart)
-        let endReference = verseReference(book: bookmarkBook, ordinal: bookmark.ordinalEnd)
-        let chapter = startReference?.chapter ?? currentChapter
-        let startVerse = startReference?.verse ?? 1
-        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
-
-        let osisRef: String
-        let verseRange: String
-        let verseRangeOnlyNumber: String
-        let verseRangeAbbreviated: String
-        if startVerse == endVerse {
-            osisRef = "\(osisBookId).\(chapter).\(startVerse)"
-            verseRange = "\(bookmarkBook) \(chapter):\(startVerse)"
-            verseRangeOnlyNumber = "\(startVerse)"
-            verseRangeAbbreviated = "\(osisBookId) \(chapter):\(startVerse)"
-        } else {
-            osisRef = "\(osisBookId).\(chapter).\(startVerse)-\(osisBookId).\(chapter).\(endVerse)"
-            verseRange = "\(bookmarkBook) \(chapter):\(startVerse)-\(endVerse)"
-            verseRangeOnlyNumber = "\(startVerse)-\(endVerse)"
-            verseRangeAbbreviated = "\(osisBookId) \(chapter):\(startVerse)-\(endVerse)"
-        }
+        let rangeProjection = bibleBookmarkRangeProjection(
+            bookName: bookmarkBook,
+            startOrdinal: bookmark.ordinalStart,
+            endOrdinal: bookmark.ordinalEnd
+        )
 
         // Load verse text from SWORD if available
-        let fullText = loadVerseText(osisBookId: osisBookId, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
+        let fullText = loadVerseText(for: rangeProjection)
 
         return BibleBookmarkData(
             id: id,
@@ -7659,7 +7751,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             labels: labelPayload.labelIDs,
             bookInitials: activeModuleName,
             bookName: activeModuleName,
-            bookAbbreviation: osisBookId,
+            bookAbbreviation: rangeProjection.start.osisBookId,
             createdAt: createdAt,
             text: fullText,
             fullText: fullText,
@@ -7671,11 +7763,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             wholeVerse: bookmark.wholeVerse,
             customIcon: bookmark.customIcon,
             editAction: EditActionData(),
-            osisRef: osisRef,
+            osisRef: rangeProjection.osisRef,
             originalOrdinalRange: [bookmark.kjvOrdinalStart, bookmark.kjvOrdinalEnd],
-            verseRange: verseRange,
-            verseRangeOnlyNumber: verseRangeOnlyNumber,
-            verseRangeAbbreviated: verseRangeAbbreviated,
+            verseRange: rangeProjection.verseRange,
+            verseRangeOnlyNumber: rangeProjection.verseRangeOnlyNumber,
+            verseRangeAbbreviated: rangeProjection.verseRangeAbbreviated,
             v11n: bookmark.v11n,
             osisFragment: nil
         )
@@ -7688,12 +7780,24 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         buildBookmarkJSON(bookmark)
     }
 
-    /// Load plain text for a verse range from the active SWORD module.
-    private func loadVerseText(osisBookId: String, chapter: Int, startVerse: Int, endVerse: Int) -> String {
+    /**
+     Load plain text for an ordinal-backed verse range from the active SWORD module.
+
+     Android's bookmark DTO uses a JSword `VerseRange`, so text extraction can span chapter
+     boundaries. Iterating the resolved SWORD ordinals keeps iOS aligned with that behavior instead
+     of assuming the start chapter applies to every verse in the bookmark.
+     */
+    private func loadVerseText(for range: BookmarkBridgeVerseRangeProjection) -> String {
         guard let module = activeModule else { return "" }
         var parts: [String] = []
-        for verse in startVerse...endVerse {
-            let key = "\(osisBookId) \(chapter):\(verse)"
+
+        let lowerOrdinal = min(range.start.ordinal, range.end.ordinal)
+        let upperOrdinal = max(range.start.ordinal, range.end.ordinal)
+        for ordinal in lowerOrdinal...upperOrdinal {
+            guard let reference = module.verseReference(ordinal: ordinal) else {
+                continue
+            }
+            let key = "\(reference.osisBookId) \(reference.chapter):\(reference.verse)"
             module.setKey(key)
             let raw = module.rawEntry()
             // Strip XML tags to get plain text
@@ -7828,33 +7932,19 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         )
 
         // Compute verse references
-        let bookOsisId: String
         let bookName: String
         if let book = bookmark.book {
-            bookOsisId = osisBookId(for: book)
             bookName = book
         } else {
-            bookOsisId = osisBookId(for: currentBook)
             bookName = currentBook
         }
-        let startReference = verseReference(book: bookName, ordinal: bookmark.ordinalStart)
-        let endReference = verseReference(book: bookName, ordinal: bookmark.ordinalEnd)
-        let chapter = startReference?.chapter ?? currentChapter
-        let startVerse = startReference?.verse ?? 1
-        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
+        let rangeProjection = bibleBookmarkRangeProjection(
+            bookName: bookName,
+            startOrdinal: bookmark.ordinalStart,
+            endOrdinal: bookmark.ordinalEnd
+        )
 
-        let osisRef = startVerse == endVerse
-            ? "\(bookOsisId).\(chapter).\(startVerse)"
-            : "\(bookOsisId).\(chapter).\(startVerse)-\(bookOsisId).\(chapter).\(endVerse)"
-        let verseRange = startVerse == endVerse
-            ? "\(bookName) \(chapter):\(startVerse)"
-            : "\(bookName) \(chapter):\(startVerse)-\(endVerse)"
-        let verseRangeOnlyNumber = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)-\(endVerse)"
-        let verseRangeAbbreviated = startVerse == endVerse
-            ? "\(bookOsisId) \(chapter):\(startVerse)"
-            : "\(bookOsisId) \(chapter):\(startVerse)-\(endVerse)"
-
-        let fullText = loadVerseText(osisBookId: bookOsisId, chapter: chapter, startVerse: startVerse, endVerse: endVerse)
+        let fullText = loadVerseText(for: rangeProjection)
 
         return BibleBookmarkData(
             id: id,
@@ -7865,7 +7955,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             labels: labelPayload.labelIDs,
             bookInitials: activeModuleName,
             bookName: activeModuleName,
-            bookAbbreviation: bookOsisId,
+            bookAbbreviation: rangeProjection.start.osisBookId,
             createdAt: createdAt,
             text: fullText,
             fullText: fullText,
@@ -7877,11 +7967,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             wholeVerse: bookmark.wholeVerse,
             customIcon: bookmark.customIcon,
             editAction: editActionData(bookmark.editAction),
-            osisRef: osisRef,
+            osisRef: rangeProjection.osisRef,
             originalOrdinalRange: [bookmark.kjvOrdinalStart, bookmark.kjvOrdinalEnd],
-            verseRange: verseRange,
-            verseRangeOnlyNumber: verseRangeOnlyNumber,
-            verseRangeAbbreviated: verseRangeAbbreviated,
+            verseRange: rangeProjection.verseRange,
+            verseRangeOnlyNumber: rangeProjection.verseRangeOnlyNumber,
+            verseRangeAbbreviated: rangeProjection.verseRangeAbbreviated,
             v11n: bookmark.v11n,
             osisFragment: nil
         )

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -675,6 +675,11 @@ public struct BibleReaderView: View {
         .onChange(of: activeReaderDestination) { oldValue, newValue in
             handleActiveReaderDestinationChange(from: oldValue, to: newValue)
         }
+        .onReceive(NotificationCenter.default.publisher(for: SwordModuleStore.modulesDidChangeNotification)) { _ in
+            Task { @MainActor in
+                handleModuleStoreDidChange()
+            }
+        }
         .onChange(of: showReaderOverflowMenu) { oldValue, newValue in
             guard oldValue, !newValue else {
                 return
@@ -1274,6 +1279,29 @@ public struct BibleReaderView: View {
             return
         }
         reloadBehaviorPreferences()
+    }
+
+    /**
+     Refreshes open reader controllers after the installed SWORD module store changes.
+
+     Settings restores, external ZIP opens, and Downloads installs mutate module files outside the
+     reader controllers that own visible picker state. Those controllers must rebuild their
+     `SwordManager` instances because SWORD and the C bridge cache module lists per manager.
+
+     Side effects:
+     - recreates SWORD managers inside every open `BibleReaderController`
+     - hides the no-Bible startup prompt when a newly restored or installed Bible is now available
+
+     Failure modes:
+     - controllers that cannot create a replacement `SwordManager` retain their existing state.
+     */
+    private func handleModuleStoreDidChange() {
+        for (_, ctrl) in windowManager.controllers {
+            (ctrl as? BibleReaderController)?.refreshInstalledModules()
+        }
+        if showStartupDownloadPrompt, !startupHasNoBibleModules() {
+            showStartupDownloadPrompt = false
+        }
     }
 
     /// Presents a follow-up top-level sheet after another flow already captured the pane target.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -805,7 +805,16 @@ public struct BibleReaderView: View {
         NavigationStack {
             BookChooserView(
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
-                navigateToVerse: navigateToVersePref
+                navigateToVerse: navigateToVersePref,
+                verseCountProvider: { book, chapter in
+                    guard let panePresentationController else {
+                        return BibleReaderController.verseCount(for: book.name, chapter: chapter)
+                    }
+                    return panePresentationController.verseCountForActiveModule(
+                        book: book.name,
+                        chapter: chapter
+                    )
+                }
             ) { book, chapter, verse in
                 dismissBookChooser()
                 panePresentationController?.navigateTo(book: book, chapter: chapter, verse: verse)

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -420,7 +420,7 @@ public struct BookmarkListView: View {
      Converts bookmark ordinals into a human-readable verse reference string.
 
      - Parameter bookmark: Bookmark whose ordinals should be rendered for the list UI.
-     - Returns: Reference text like `Genesis 1:1` or `Genesis 1:1-3`.
+     - Returns: Reference text like `Genesis 1:1`, `Genesis 1:1-3`, or `Genesis 1:31-2:1`.
      */
     static func verseReference(
         for bookmark: BibleBookmark,
@@ -434,10 +434,12 @@ public struct BookmarkListView: View {
         let endReference = ordinalResolver?(bookName, effectiveEnd)
             ?? compatibilityVerseReference(ordinal: effectiveEnd)
 
-        if effectiveEnd == bookmark.ordinalStart || endReference.verse == startReference.verse {
+        if effectiveEnd == bookmark.ordinalStart || endReference == startReference {
             return "\(bookName) \(startReference.chapter):\(startReference.verse)"
-        } else {
+        } else if endReference.chapter == startReference.chapter {
             return "\(bookName) \(startReference.chapter):\(startReference.verse)-\(endReference.verse)"
+        } else {
+            return "\(bookName) \(startReference.chapter):\(startReference.verse)-\(endReference.chapter):\(endReference.verse)"
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -5,6 +5,34 @@ import SwiftData
 import BibleCore
 
 /**
+ Verse reference resolved from an Android/JSword-style bookmark ordinal.
+
+ Bookmark rows are built from persisted SwiftData records, but those records store ordinals in the
+ source versification rather than chapter/verse text. The reader injects a resolver backed by
+ SWORD's `VerseKey` so the list can display and navigate bookmarks without reintroducing local
+ ordinal arithmetic.
+ */
+public struct BookmarkListVerseReference: Sendable, Equatable {
+    /// One-based chapter number.
+    public let chapter: Int
+
+    /// One-based verse number.
+    public let verse: Int
+
+    /**
+     Creates a resolved bookmark verse reference.
+
+     - Parameters:
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     */
+    public init(chapter: Int, verse: Int) {
+        self.chapter = chapter
+        self.verse = verse
+    }
+}
+
+/**
  Displays a searchable, filterable, and sortable list of Bible and generic bookmarks from SwiftData.
 
  `BookmarkListView` is the main bookmark-browser surface. It excludes note-bearing bookmarks that
@@ -60,19 +88,26 @@ public struct BookmarkListView: View {
     /// Optional callback used to open a study pad for a selected label.
     var onOpenStudyPad: ((UUID) -> Void)?
 
+    /// Optional SWORD-backed resolver for Bible bookmark ordinals.
+    var bibleOrdinalResolver: ((String, Int) -> BookmarkListVerseReference?)?
+
     /**
      Creates the bookmark list view.
 
      - Parameters:
        - onNavigate: Callback invoked when the user opens a bookmark from the list.
        - onOpenStudyPad: Callback invoked when the user wants to open a selected label's study pad.
+       - bibleOrdinalResolver: Optional resolver that maps `(bookName, ordinal)` to a concrete
+         chapter/verse using the active Bible versification.
      */
     public init(
         onNavigate: ((String, Int) -> Void)? = nil,
-        onOpenStudyPad: ((UUID) -> Void)? = nil
+        onOpenStudyPad: ((UUID) -> Void)? = nil,
+        bibleOrdinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
     ) {
         self.onNavigate = onNavigate
         self.onOpenStudyPad = onOpenStudyPad
+        self.bibleOrdinalResolver = bibleOrdinalResolver
     }
 
     /**
@@ -114,7 +149,7 @@ public struct BookmarkListView: View {
     private var bookmarkListItems: [BookmarkListItem] {
         let bibleItems = bibleBookmarks
             .filter { ($0.notes?.notes ?? "").isEmpty }
-            .map(BookmarkListItem.init(bibleBookmark:))
+            .map { BookmarkListItem(bibleBookmark: $0, ordinalResolver: bibleOrdinalResolver) }
         let genericItems = genericBookmarks
             .filter { ($0.notes?.notes ?? "").isEmpty }
             .map(BookmarkListItem.init(genericBookmark:))
@@ -387,19 +422,36 @@ public struct BookmarkListView: View {
      - Parameter bookmark: Bookmark whose ordinals should be rendered for the list UI.
      - Returns: Reference text like `Genesis 1:1` or `Genesis 1:1-3`.
      */
-    static func verseReference(for bookmark: BibleBookmark) -> String {
+    static func verseReference(
+        for bookmark: BibleBookmark,
+        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
+    ) -> String {
         let bookName = bookmark.book ?? "Unknown"
-        let startChapter = bookmark.ordinalStart / 40 + 1
-        let startVerse = max(bookmark.ordinalStart % 40, 1)
+        let startReference = ordinalResolver?(bookName, bookmark.ordinalStart)
+            ?? compatibilityVerseReference(ordinal: bookmark.ordinalStart)
         // Normalize: treat endOrdinal <= 0 or <= startOrdinal as single verse
         let effectiveEnd = bookmark.ordinalEnd > bookmark.ordinalStart ? bookmark.ordinalEnd : bookmark.ordinalStart
-        let endVerse = max(effectiveEnd % 40, 1)
+        let endReference = ordinalResolver?(bookName, effectiveEnd)
+            ?? compatibilityVerseReference(ordinal: effectiveEnd)
 
-        if effectiveEnd == bookmark.ordinalStart || endVerse == startVerse {
-            return "\(bookName) \(startChapter):\(startVerse)"
+        if effectiveEnd == bookmark.ordinalStart || endReference.verse == startReference.verse {
+            return "\(bookName) \(startReference.chapter):\(startReference.verse)"
         } else {
-            return "\(bookName) \(startChapter):\(startVerse)-\(endVerse)"
+            return "\(bookName) \(startReference.chapter):\(startReference.verse)-\(endReference.verse)"
         }
+    }
+
+    /**
+     Compatibility fallback for no-module bookmark list previews.
+
+     Real reader-owned bookmark lists should inject `bibleOrdinalResolver` so ordinals are decoded
+     through SWORD's versification. The fallback keeps design previews and isolated unit tests
+     functional when no reader/controller exists.
+     */
+    fileprivate static func compatibilityVerseReference(ordinal: Int) -> BookmarkListVerseReference {
+        let chapter = max(1, ((ordinal - 1) / 40) + 1)
+        let verse = max(1, ordinal - ((chapter - 1) * 40))
+        return BookmarkListVerseReference(chapter: chapter, verse: verse)
     }
 
     /**
@@ -496,8 +548,11 @@ private struct BookmarkListItem: Identifiable {
     }
 
     /// Creates a normalized row for one Bible bookmark.
-    init(bibleBookmark bookmark: BibleBookmark) {
-        let reference = BookmarkListView.verseReference(for: bookmark)
+    init(
+        bibleBookmark bookmark: BibleBookmark,
+        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
+    ) {
+        let reference = BookmarkListView.verseReference(for: bookmark, ordinalResolver: ordinalResolver)
         let noteText = bookmark.notes?.notes ?? ""
         self.id = bookmark.id
         self.source = .bible(bookmark)
@@ -509,9 +564,12 @@ private struct BookmarkListItem: Identifiable {
         self.customIcon = bookmark.customIcon
         self.noteText = noteText
         self.labels = bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
+        let bookName = bookmark.book ?? "Genesis"
+        let resolvedStart = ordinalResolver?(bookName, bookmark.ordinalStart)
+            ?? BookmarkListView.compatibilityVerseReference(ordinal: bookmark.ordinalStart)
         self.navigationTarget = (
-            bookName: bookmark.book ?? "Genesis",
-            chapter: bookmark.ordinalStart / 40 + 1
+            bookName: bookName,
+            chapter: resolvedStart.chapter
         )
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -542,6 +542,11 @@ public struct ModuleBrowserView: View {
                 reloadRepositorySources()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: SwordModuleStore.modulesDidChangeNotification)) { _ in
+            Task { @MainActor in
+                refreshInstalledList()
+            }
+        }
     }
 
     // MARK: - Row Views
@@ -1407,15 +1412,20 @@ public struct ModuleBrowserView: View {
     }
 
     /**
-     Reloads locally installed modules from the active `SwordManager`.
+     Reloads locally installed modules from a fresh `SwordManager`.
 
      Side effects:
+     - rebuilds `swordManager` so SWORD rescans module files after installs, restores, or uninstalls
      - replaces the local `installedModules` array when a manager is available
 
      Failure modes:
-     - returns without mutating state when `swordManager` has not been initialized yet
+     - returns without mutating state when a new `SwordManager` cannot be created and no previous
+       manager is available
      */
     private func refreshInstalledList() {
+        if let mgr = SwordManager() {
+            swordManager = mgr
+        }
         guard let mgr = swordManager else { return }
         installedModules = mgr.installedModules() + repository.loadInstalledMyBibleModules()
     }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -12,6 +12,9 @@ import SwordKit
 
  Data dependencies:
  - `books` is the module-specific canon and chapter metadata provided by the caller
+ - `verseCountProvider` supplies module-specific `Versification.getLastVerse` equivalents when
+   the chooser drills into verse selection; `nil` means the active module could not resolve the
+   selected chapter and no synthetic verse list should be shown
  - `dismiss` closes the chooser when the user cancels the flow
 
  Side effects:
@@ -25,6 +28,9 @@ public struct BookChooserView: View {
 
     /// Whether the flow should include a verse chooser after chapter selection.
     let navigateToVerse: Bool
+
+    /// Provides the last verse number for a selected book/chapter.
+    let verseCountProvider: (BookInfo, Int) -> Int?
 
     /// Callback invoked when the user has completed the selection flow.
     let onSelect: (String, Int, Int?) -> Void
@@ -44,15 +50,22 @@ public struct BookChooserView: View {
      - Parameters:
        - books: Book list from the active module's versification.
        - navigateToVerse: Whether the flow should include verse selection.
+       - verseCountProvider: Optional provider for module-specific chapter verse counts. A missing
+         provider keeps existing no-module callers functional by falling back to the static
+         compatibility table.
        - onSelect: Callback receiving `(bookName, chapter, verse?)` when selection completes.
      */
     public init(
         books: [BookInfo],
         navigateToVerse: Bool = false,
+        verseCountProvider: ((BookInfo, Int) -> Int?)? = nil,
         onSelect: @escaping (String, Int, Int?) -> Void
     ) {
         self.books = books
         self.navigateToVerse = navigateToVerse
+        self.verseCountProvider = verseCountProvider ?? { book, chapter in
+            BibleReaderController.verseCount(for: book.name, chapter: chapter)
+        }
         self.onSelect = onSelect
     }
 
@@ -76,7 +89,7 @@ public struct BookChooserView: View {
                     VerseChooserView(
                         bookName: book.name,
                         chapter: chapter,
-                        verseCount: BibleReaderController.verseCount(for: book.name, chapter: chapter)
+                        verseCount: verseCountProvider(book, chapter) ?? 0
                     ) { verse in
                         onSelect(book.name, chapter, verse)
                     }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
@@ -12,7 +12,7 @@ public struct ChapterChooserView: View {
     /// User-visible book name shown in the navigation title.
     let bookName: String
 
-    /// Number of chapters available for this book in the active module.
+    /// Number of chapters available for this book in the active module; zero renders no choices.
     let chapterCount: Int
 
     /// Callback invoked with the chosen one-based chapter number.
@@ -37,16 +37,18 @@ public struct ChapterChooserView: View {
         ScrollView {
             let columns = [GridItem(.adaptive(minimum: 50), spacing: 8)]
             LazyVGrid(columns: columns, spacing: 8) {
-                ForEach(1...max(chapterCount, 1), id: \.self) { chapter in
-                    Button(action: { onSelect(chapter) }) {
-                        Text("\(chapter)")
-                            .font(.body.monospacedDigit())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(.quaternary)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                if chapterCount > 0 {
+                    ForEach(1...chapterCount, id: \.self) { chapter in
+                        Button(action: { onSelect(chapter) }) {
+                            Text("\(chapter)")
+                                .font(.body.monospacedDigit())
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(.quaternary)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .padding()

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
@@ -15,7 +15,7 @@ public struct VerseChooserView: View {
     /// One-based chapter number currently being selected within.
     let chapter: Int
 
-    /// Number of verses available for this chapter in the active module.
+    /// Number of verses available for this chapter in the active module; zero renders no choices.
     let verseCount: Int
 
     /// Callback invoked with the chosen one-based verse number.
@@ -42,16 +42,18 @@ public struct VerseChooserView: View {
         ScrollView {
             let columns = [GridItem(.adaptive(minimum: 44), spacing: 6)]
             LazyVGrid(columns: columns, spacing: 6) {
-                ForEach(1...max(verseCount, 1), id: \.self) { verse in
-                    Button(action: { onSelect(verse) }) {
-                        Text("\(verse)")
-                            .font(.callout.monospacedDigit())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
-                            .background(.quaternary)
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                if verseCount > 0 {
+                    ForEach(1...verseCount, id: \.self) { verse in
+                        Button(action: { onSelect(verse) }) {
+                            Text("\(verse)")
+                                .font(.callout.monospacedDigit())
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                                .background(.quaternary)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .padding()

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -1047,7 +1047,7 @@ public struct SearchView: View {
                 return
             }
 
-            if let missingModule = strongsModules.first(where: { !service.hasIndex(for: $0.info.name) }) {
+            if let missingModule = strongsModules.first(where: { !service.hasStrongsIndex(for: $0.info.name) }) {
                 viewState = .needsIndex(
                     moduleName: missingModule.info.name,
                     moduleDescription: moduleDescription(for: missingModule.info.name)
@@ -1165,7 +1165,7 @@ public struct SearchView: View {
                     swordManager: swordManager,
                     searchIndexService: service
                 )
-                for mod in strongsModules where !service.hasIndex(for: mod.info.name) {
+                for mod in strongsModules where !service.hasStrongsIndex(for: mod.info.name) {
                     list.append((mod, mod.info.name))
                 }
                 return list
@@ -1258,7 +1258,7 @@ public struct SearchView: View {
                     var hits: [SearchHit] = []
                     for strongsModule in strongsModules {
                         if let service = currentSearchIndexService,
-                           service.hasIndex(for: strongsModule.info.name) {
+                           service.hasStrongsIndex(for: strongsModule.info.name) {
                             hits = Self.convertIndexResults(service.searchStrongs(
                                 canonicalTokens: strongsQueryOptions.canonicalStrongTokens,
                                 moduleName: strongsModule.info.name,

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -1008,7 +1008,12 @@ public struct SearchView: View {
     // MARK: - Index Management
 
     /**
-     Checks whether the selected modules already have indexes and updates `viewState` accordingly.
+     Checks whether the selected search target modules already have indexes.
+
+     Android checks JSword index readiness before launching indexed searches, including Strong's
+     "find all occurrences" queries. iOS mirrors that behavior by resolving Strong's-capable Bible
+     modules for Strong's input and ordinary selected modules for text input, then prompting for
+     the first missing index before allowing the search to auto-run.
 
      Side effects:
      - mutates `viewState` to `.ready`, `.needsIndex`, or `.creatingIndex`
@@ -1016,11 +1021,40 @@ public struct SearchView: View {
      - reads index availability from `SearchIndexService`
 
      Failure modes:
-     - if either `searchIndexService` or `swordModule` is unavailable, the method intentionally
-       skips index inspection, marks the view ready, and continues without indexed search setup
+     - if `searchIndexService` is unavailable, the method intentionally skips index inspection,
+       marks the view ready, and leaves `performSearch()` to use its non-indexed SWORD fallback
+     - if no Strong's-capable module can be resolved for a Strong's query, the method marks the
+       view ready so the search can finish with zero results rather than blocking on an index that
+       cannot be built
      */
     private func checkIndex() {
         if StrongsSearchSupport.normalizedQueryOptions(for: query) != nil {
+            guard let service = searchIndexService else {
+                viewState = .ready
+                autoSearchIfNeeded()
+                return
+            }
+
+            let strongsModules = Self.resolveStrongsSearchModules(
+                currentModule: swordModule,
+                installedModules: installedBibleModules,
+                swordManager: swordManager,
+                searchIndexService: service
+            )
+            guard !strongsModules.isEmpty else {
+                viewState = .ready
+                autoSearchIfNeeded()
+                return
+            }
+
+            if let missingModule = strongsModules.first(where: { !service.hasIndex(for: $0.info.name) }) {
+                viewState = .needsIndex(
+                    moduleName: missingModule.info.name,
+                    moduleDescription: moduleDescription(for: missingModule.info.name)
+                )
+                return
+            }
+
             viewState = .ready
             autoSearchIfNeeded()
             return
@@ -1094,9 +1128,12 @@ public struct SearchView: View {
     }
 
     /**
-     Starts asynchronous index creation for the primary and any selected unindexed modules.
+     Starts asynchronous index creation for the modules required by the current query.
 
-     Once all requested indexes are built, the view transitions back to `.ready`.
+     Ordinary text searches index the primary and selected translation modules. Strong's searches
+     index Strong's-capable Bible modules so the later query can use the same indexed lexical-token
+     architecture Android gets from JSword. Once all requested indexes are built, the view
+     transitions back to `.ready`.
 
      Side effects:
      - mutates `viewState` to `.creatingIndex` and later back to `.ready`
@@ -1121,6 +1158,19 @@ public struct SearchView: View {
         // Collect all modules that need indexing
         let modulesToIndex: [(SwordModule, String)] = {
             var list: [(SwordModule, String)] = []
+            if StrongsSearchSupport.normalizedQueryOptions(for: query) != nil {
+                let strongsModules = Self.resolveStrongsSearchModules(
+                    currentModule: swordModule,
+                    installedModules: installedBibleModules,
+                    swordManager: swordManager,
+                    searchIndexService: service
+                )
+                for mod in strongsModules where !service.hasIndex(for: mod.info.name) {
+                    list.append((mod, mod.info.name))
+                }
+                return list
+            }
+
             // Always index the primary module
             if let mod = swordModule, !service.hasIndex(for: mod.info.name) {
                 list.append((mod, mod.info.name))
@@ -1150,7 +1200,7 @@ public struct SearchView: View {
     // MARK: - Search Execution
 
     /**
-     Executes the current search query using Strong's lookup, indexed FTS, or SWORD fallback.
+     Executes the current search query using indexed Strong's lookup, indexed FTS, or SWORD fallback.
 
      The method snapshots current view state, then performs the potentially expensive work in a
      detached task so UI updates remain responsive. Results are marshalled back to the main actor.
@@ -1192,7 +1242,8 @@ public struct SearchView: View {
             Self.resolveStrongsSearchModules(
                 currentModule: currentSwordModule,
                 installedModules: currentInstalledBibleModules,
-                swordManager: currentSwordManager
+                swordManager: currentSwordManager,
+                searchIndexService: currentSearchIndexService
             )
         } else {
             []
@@ -1200,24 +1251,34 @@ public struct SearchView: View {
         let singleModuleName = currentSelectedModules.first ?? currentSwordModule?.info.name ?? ""
 
         Task.detached(priority: .userInitiated) {
-            // Android parity: find-all occurrences uses "strong:<key>" query syntax and
-            // a Strong's-capable Bible module, not plain-text FTS.
+            // Android parity: find-all occurrences uses canonical Strong's tokens from the
+            // module index and a Strong's-capable Bible module, not plain-text FTS.
             if let strongsQueryOptions {
                 if !strongsModules.isEmpty {
                     var hits: [SearchHit] = []
                     for strongsModule in strongsModules {
-                        hits = StrongsSearchSupport.searchVerseHits(
-                            in: strongsModule,
-                            queryOptions: strongsQueryOptions,
-                            scope: swordScope
-                        ).map {
-                            SearchHit(
-                                book: $0.book,
-                                chapter: $0.chapter,
-                                verse: $0.verse,
-                                text: $0.previewText,
-                                moduleName: nil
-                            )
+                        if let service = currentSearchIndexService,
+                           service.hasIndex(for: strongsModule.info.name) {
+                            hits = Self.convertIndexResults(service.searchStrongs(
+                                canonicalTokens: strongsQueryOptions.canonicalStrongTokens,
+                                moduleName: strongsModule.info.name,
+                                scopeBookName: scopeBookName,
+                                scopeTestament: scopeTestament
+                            ))
+                        } else {
+                            hits = StrongsSearchSupport.searchVerseHits(
+                                in: strongsModule,
+                                queryOptions: strongsQueryOptions,
+                                scope: swordScope
+                            ).map {
+                                SearchHit(
+                                    book: $0.book,
+                                    chapter: $0.chapter,
+                                    verse: $0.verse,
+                                    text: $0.previewText,
+                                    moduleName: nil
+                                )
+                            }
                         }
                         if !hits.isEmpty { break }
                     }
@@ -1386,48 +1447,50 @@ public struct SearchView: View {
     }
 
     /**
-     Resolves the best modules to use for Strong's "find all occurrences" searches.
+     Resolves the effective module for Strong's "find all occurrences" searches.
+
+     Android uses the current Bible when it has Strong's data; otherwise it chooses a default
+     Strong's Bible, preferring one that already has a completed index. This resolver returns at
+     most one module so iOS does not require indexing unrelated Strong's translations before a
+     single find-all search can run.
 
      - Parameters:
        - currentModule: Currently open Bible module, preferred when it advertises Strong's support.
        - installedModules: Installed Bible modules available to the reader.
-       - swordManager: Module manager used to resolve additional Strong's-capable modules.
-     - Returns: Ordered modules to try for Strong's search, without duplicates.
+       - swordManager: Module manager used to resolve the fallback Strong's-capable module.
+       - searchIndexService: Optional index service used to prefer an already-indexed fallback
+         module when the current module is not Strong's-capable.
+     - Returns: A single Strong's-capable module when one can be resolved, otherwise an empty list.
      */
     nonisolated private static func resolveStrongsSearchModules(
         currentModule: SwordModule?,
         installedModules: [ModuleInfo],
-        swordManager: SwordManager?
+        swordManager: SwordManager?,
+        searchIndexService: SearchIndexService?
     ) -> [SwordModule] {
-        var modules: [SwordModule] = []
-        var seenNames = Set<String>()
-
-        func appendUnique(_ module: SwordModule?) {
-            guard let module else { return }
-            if seenNames.insert(module.info.name).inserted {
-                modules.append(module)
-            }
-        }
-
-        // Prefer the currently-open module when it already has Strong's data.
         if let currentModule, currentModule.info.features.contains(.strongsNumbers) {
-            appendUnique(currentModule)
+            return [currentModule]
         }
 
-        // Then try every installed Strong's-capable Bible module.
-        if let swordManager {
-            let strongsBibleNames = installedModules
-                .filter { $0.features.contains(.strongsNumbers) }
-                .map(\.name)
-                .sorted()
-            for moduleName in strongsBibleNames {
-                appendUnique(swordManager.module(named: moduleName))
+        guard let swordManager else { return [] }
+        let strongsBibleInfos = installedModules
+            .enumerated()
+            .filter { $0.element.features.contains(.strongsNumbers) }
+            .sorted { lhs, rhs in
+                let leftIndexed = searchIndexService?.hasIndex(for: lhs.element.name) ?? false
+                let rightIndexed = searchIndexService?.hasIndex(for: rhs.element.name) ?? false
+                if leftIndexed != rightIndexed {
+                    return leftIndexed && !rightIndexed
+                }
+                return lhs.offset < rhs.offset
             }
-        }
+            .map(\.element)
 
-        // Final fallback to current module even if feature metadata is missing/stale.
-        appendUnique(currentModule)
-        return modules
+        guard let defaultInfo = strongsBibleInfos.first,
+              let defaultModule = swordManager.module(named: defaultInfo.name) else {
+            return []
+        }
+        return [defaultModule]
     }
 
 }

--- a/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
@@ -1,19 +1,6 @@
 import Foundation
+import BibleCore
 import SwordKit
-
-/**
- Normalized Strong's query variants used for SWORD entry-attribute searches.
-
- The search flow may need more than one query because SWORD lemma values can be stored with or
- without leading zeroes.
- */
-struct NormalizedStrongsQueryOptions: Equatable, Sendable {
-    /// Canonical JSword/Lucene Strong's tokens to match in parsed verse lexical data.
-    let canonicalStrongTokens: [String]
-
-    /// Ordered set of entry-attribute query strings to try against SWORD.
-    let entryAttributeQueries: [String]
-}
 
 /**
  One Strong's search hit mapped into verse coordinates and preview text.
@@ -57,40 +44,7 @@ enum StrongsSearchSupport {
        JSword-invalid values so callers do not fall through to plain full-text search
      */
     static func normalizedQueryOptions(for query: String) -> NormalizedStrongsQueryOptions? {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        var candidate = trimmed.uppercased()
-        if candidate.hasPrefix("LEMMA:STRONG:") {
-            candidate = String(candidate.dropFirst("LEMMA:STRONG:".count))
-        } else if candidate.hasPrefix("STRONG:") {
-            candidate = String(candidate.dropFirst("STRONG:".count))
-        } else if candidate.hasPrefix("LEMMA:") {
-            candidate = String(candidate.dropFirst("LEMMA:".count))
-        }
-
-        guard let parsedQuery = parseStrongNumber(candidate) else { return nil }
-        let prefix = parsedQuery.language
-        let digitsRaw = parsedQuery.digits
-
-        // SWORD lemma storage is inconsistent about zero padding. Some modules use
-        // the fully padded key, some use a partially trimmed key (for example
-        // H00430 -> H0430), and some use the fully stripped form.
-        var digitVariants: [String] = [digitsRaw]
-        var currentDigits = digitsRaw
-        while currentDigits.hasPrefix("0"), currentDigits.count > 1 {
-            currentDigits.removeFirst()
-            digitVariants.append(currentDigits)
-        }
-
-        let entryAttributeQueries = orderedUnique(
-            digitVariants.map { "Word//Lemma./\(prefix)\($0)" }
-        )
-
-        return NormalizedStrongsQueryOptions(
-            canonicalStrongTokens: canonicalStrongNumberTokens(from: parsedQuery).queryTokens,
-            entryAttributeQueries: entryAttributeQueries
-        )
+        StrongsTokenNormalizer.normalizedQueryOptions(for: query)
     }
 
     /**
@@ -201,12 +155,11 @@ enum StrongsSearchSupport {
         renderedTextProvider: () -> String,
         book: String
     ) -> [String] {
-        let rawTokens = canonicalStrongTokensFromRawOSIS(rawEntry)
-        if !rawTokens.isEmpty {
-            return orderedUnique(rawTokens)
-        }
-
-        return orderedUnique(canonicalStrongTokensFromRenderedText(renderedTextProvider(), book: book))
+        StrongsTokenNormalizer.canonicalTokens(
+            rawEntry: rawEntry,
+            renderedTextProvider: renderedTextProvider,
+            isNewTestamentBook: BibleReaderController.isNewTestament(normalizedBookName(book))
+        )
     }
 
     /**
@@ -428,117 +381,6 @@ enum StrongsSearchSupport {
             return nil
         }
         return rawEntry[osisRange].split(separator: " ").first.map(String.init)
-    }
-
-    private struct ParsedStrongNumber: Equatable {
-        let language: Character
-        let digits: String
-        let part: String?
-
-        var numericValue: Int {
-            Int(digits) ?? 0
-        }
-    }
-
-    private struct CanonicalStrongNumberTokens: Equatable {
-        let baseToken: String
-        let fullToken: String?
-
-        var indexTokens: [String] {
-            guard !baseToken.isEmpty else { return [] }
-            if let fullToken {
-                return [baseToken, fullToken]
-            }
-            return [baseToken]
-        }
-
-        var queryTokens: [String] {
-            guard !baseToken.isEmpty else { return [] }
-            if let fullToken {
-                return [fullToken]
-            }
-            return [baseToken]
-        }
-    }
-
-    private static func parseStrongNumber(_ text: String) -> ParsedStrongNumber? {
-        let pattern = #"^([GgHh])([0-9]+)!?([A-Za-z]+)?"#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
-              let languageRange = Range(match.range(at: 1), in: text),
-              let digitsRange = Range(match.range(at: 2), in: text) else {
-            return nil
-        }
-
-        let language = Character(String(text[languageRange]).uppercased())
-        let digits = String(text[digitsRange])
-        let part: String?
-        if match.range(at: 3).location != NSNotFound,
-           let partRange = Range(match.range(at: 3), in: text) {
-            part = String(text[partRange])
-        } else {
-            part = nil
-        }
-
-        return ParsedStrongNumber(language: language, digits: digits, part: part)
-    }
-
-    private static func canonicalStrongNumberTokens(
-        from parsed: ParsedStrongNumber
-    ) -> CanonicalStrongNumberTokens {
-        guard isValidStrongsNumber(parsed) else {
-            return CanonicalStrongNumberTokens(baseToken: "", fullToken: nil)
-        }
-
-        let base = "\(parsed.language)\(String(format: "%04d", parsed.numericValue))"
-        let part = parsed.part?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let full = part?.isEmpty == false ? base + (part ?? "") : nil
-        return CanonicalStrongNumberTokens(baseToken: base, fullToken: full)
-    }
-
-    private static func isValidStrongsNumber(_ parsed: ParsedStrongNumber) -> Bool {
-        let number = parsed.numericValue
-        switch parsed.language {
-        case "H":
-            return (1...8674).contains(number)
-        case "G":
-            return (number >= 1 && number < 1418)
-                || (number > 1418 && number < 2717)
-                || (number > 2717 && number < 3203)
-                || (number > 3302 && number < 5624)
-                || (number > 5999 && number < 10000)
-        default:
-            return false
-        }
-    }
-
-    private static func canonicalStrongTokensFromRawOSIS(_ rawEntry: String) -> [String] {
-        let pattern = #"strong:([GgHh][0-9]+!?[A-Za-z]*)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-
-        let matches = regex.matches(in: rawEntry, range: NSRange(rawEntry.startIndex..., in: rawEntry))
-        return matches.flatMap { match -> [String] in
-            guard let range = Range(match.range(at: 1), in: rawEntry),
-                  let parsed = parseStrongNumber(String(rawEntry[range])) else {
-                return []
-            }
-            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
-        }
-    }
-
-    private static func canonicalStrongTokensFromRenderedText(_ renderedText: String, book: String) -> [String] {
-        let pattern = #"showStrong=([0-9]+!?[A-Za-z]*)#cv"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-        let prefix = BibleReaderController.isNewTestament(normalizedBookName(book)) ? "G" : "H"
-
-        let matches = regex.matches(in: renderedText, range: NSRange(renderedText.startIndex..., in: renderedText))
-        return matches.flatMap { match -> [String] in
-            guard let range = Range(match.range(at: 1), in: renderedText),
-                  let parsed = parseStrongNumber(prefix + String(renderedText[range])) else {
-                return []
-            }
-            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
-        }
     }
 
     private static func scopeAllows(book: String, scope: String?) -> Bool {

--- a/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
@@ -154,7 +154,7 @@ enum StrongsSearchSupport {
     }
 
     /**
-     Extracts JSword/Lucene Strong's index tokens from raw OSIS and rendered SWORD entry text.
+     Extracts JSword/Lucene Strong's index tokens from raw OSIS, with rendered SWORD text fallback.
 
      - Parameters:
        - rawEntry: Raw SWORD entry, usually OSIS with `<w lemma="strong:...">` values.
@@ -164,10 +164,40 @@ enum StrongsSearchSupport {
      - Returns: Ordered unique canonical tokens matching JSword `StrongsNumberFilter` output.
      */
     static func canonicalStrongTokens(rawEntry: String, renderedText: String, book: String) -> [String] {
-        var tokens: [String] = []
-        tokens.append(contentsOf: canonicalStrongTokensFromRawOSIS(rawEntry))
-        tokens.append(contentsOf: canonicalStrongTokensFromRenderedText(renderedText, book: book))
-        return orderedUnique(tokens)
+        canonicalStrongTokens(
+            rawEntry: rawEntry,
+            renderedTextProvider: { renderedText },
+            book: book
+        )
+    }
+
+    /**
+     Extracts JSword/Lucene Strong's index tokens while preserving Android's raw-OSIS-first
+     behavior.
+
+     Android's JSword index reads Strong's numbers from parsed OSIS. Rendering is an iOS fallback
+     for modules whose raw entries do not expose lexical tokens; the provider keeps that fallback
+     lazy so normal OSIS-backed modules do not render every verse during "find all occurrences".
+
+     - Parameters:
+       - rawEntry: Raw SWORD entry, usually OSIS with `<w lemma="strong:...">` values.
+       - renderedTextProvider: Lazy rendered HTML provider used only when raw extraction finds no
+         lexical tokens.
+       - book: Human-readable book name used to infer Hebrew/Greek prefix for rendered SWORD
+         Strong's links that carry only digits.
+     - Returns: Ordered unique canonical tokens matching JSword `StrongsNumberFilter` output.
+     */
+    static func canonicalStrongTokens(
+        rawEntry: String,
+        renderedTextProvider: () -> String,
+        book: String
+    ) -> [String] {
+        let rawTokens = canonicalStrongTokensFromRawOSIS(rawEntry)
+        if !rawTokens.isEmpty {
+            return orderedUnique(rawTokens)
+        }
+
+        return orderedUnique(canonicalStrongTokensFromRenderedText(renderedTextProvider(), book: book))
     }
 
     private static func searchVerseHitsByEntryAttributes(
@@ -226,7 +256,13 @@ enum StrongsSearchSupport {
 
             let tokens = canonicalStrongTokens(
                 rawEntry: inspection.rawEntry,
-                renderedText: inspection.renderedText,
+                renderedTextProvider: {
+                    module.setKeyAndInspect(
+                        key,
+                        includeRenderedText: true,
+                        includeStrippedText: false
+                    ).renderedText
+                },
                 book: normalizedBook
             )
             if !tokens.isEmpty {

--- a/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
@@ -7,7 +7,10 @@ import SwordKit
  The search flow may need more than one query because SWORD lemma values can be stored with or
  without leading zeroes.
  */
-struct NormalizedStrongsQueryOptions: Equatable {
+struct NormalizedStrongsQueryOptions: Equatable, Sendable {
+    /// Canonical JSword/Lucene Strong's tokens to match in parsed verse lexical data.
+    let canonicalStrongTokens: [String]
+
     /// Ordered set of entry-attribute query strings to try against SWORD.
     let entryAttributeQueries: [String]
 }
@@ -40,15 +43,18 @@ struct StrongsSearchVerseHit: Equatable {
  */
 enum StrongsSearchSupport {
     /**
-     Normalizes a user-entered Strong's query into one or more SWORD entry-attribute queries.
+     Normalizes a user-entered Strong's query into JSword canonical tokens and SWORD fallback
+     entry-attribute queries.
 
      - Parameter query: User-entered query such as `H02022`, `strong:g00123`, or
        `lemma:strong:h08414`.
-     - Returns: Ordered query variants to try, or `nil` when the input does not contain a valid
-       Strong's prefix-plus-number form.
+     - Returns: Ordered query variants, or `nil` when the input does not contain a Strong's
+       prefix-plus-number form.
 
      Failure modes:
-     - returns `nil` for empty input, unsupported prefixes, or non-numeric suffixes
+     - returns `nil` for empty input or unsupported prefixes
+     - returns an options value with no canonical tokens for syntactically Strong's-shaped but
+       JSword-invalid values so callers do not fall through to plain full-text search
      */
     static func normalizedQueryOptions(for query: String) -> NormalizedStrongsQueryOptions? {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -63,9 +69,9 @@ enum StrongsSearchSupport {
             candidate = String(candidate.dropFirst("LEMMA:".count))
         }
 
-        guard let prefix = candidate.first, prefix == "H" || prefix == "G" else { return nil }
-        let digitsRaw = String(candidate.dropFirst())
-        guard !digitsRaw.isEmpty, digitsRaw.allSatisfy(\.isNumber) else { return nil }
+        guard let parsedQuery = parseStrongNumber(candidate) else { return nil }
+        let prefix = parsedQuery.language
+        let digitsRaw = parsedQuery.digits
 
         // SWORD lemma storage is inconsistent about zero padding. Some modules use
         // the fully padded key, some use a partially trimmed key (for example
@@ -82,6 +88,7 @@ enum StrongsSearchSupport {
         )
 
         return NormalizedStrongsQueryOptions(
+            canonicalStrongTokens: canonicalStrongNumberTokens(from: parsedQuery).queryTokens,
             entryAttributeQueries: entryAttributeQueries
         )
     }
@@ -103,23 +110,70 @@ enum StrongsSearchSupport {
     }
 
     /**
-     Searches one module for verse hits matching the normalized Strong's query options.
+     Searches one module for verse hits matching normalized Strong's query options.
+
+     Android's "find all occurrences" path searches JSword's Lucene `strong` field. JSword builds
+     that field by extracting `strong:` lemma values from parsed OSIS `<w>` elements and normalizing
+     them with `StrongsNumberFilter`; part-suffixed values are indexed as both their base token and
+     their full token. iOS mirrors that semantic path by scanning the module's verse entries for the
+     same lexical tokens before falling back to SWORD entry-attribute search only when no lexical
+     tokens are exposed by raw/rendered entries.
 
      - Parameters:
        - module: Module to search.
        - queryOptions: Normalized Strong's query variants to try in order.
        - scope: Optional SWORD search scope string.
      - Returns: Verse hits from the first query variant that produces matches, capped to the first
-       5000 raw SWORD results.
+       5000 verse results.
 
      Failure modes:
-     - returns an empty array when no query variant produces parseable verse hits
-     - ignores raw SWORD results whose keys cannot be mapped into verse coordinates
+     - returns an empty array when no JSword-valid canonical tokens are present
+     - ignores raw SWORD entries whose keys cannot be mapped into verse coordinates
      */
     static func searchVerseHits(
         in module: SwordModule,
         queryOptions: NormalizedStrongsQueryOptions,
         scope: String? = nil
+    ) -> [StrongsSearchVerseHit] {
+        guard !queryOptions.canonicalStrongTokens.isEmpty else { return [] }
+
+        let canonicalResult = searchVerseHitsByCanonicalTokens(
+            in: module,
+            queryOptions: queryOptions,
+            scope: scope
+        )
+        if canonicalResult.sawLexicalTokens || !canonicalResult.hits.isEmpty {
+            return canonicalResult.hits
+        }
+
+        return searchVerseHitsByEntryAttributes(
+            in: module,
+            queryOptions: queryOptions,
+            scope: scope
+        )
+    }
+
+    /**
+     Extracts JSword/Lucene Strong's index tokens from raw OSIS and rendered SWORD entry text.
+
+     - Parameters:
+       - rawEntry: Raw SWORD entry, usually OSIS with `<w lemma="strong:...">` values.
+       - renderedText: Rendered SWORD HTML fallback for modules whose raw markup is not OSIS.
+       - book: Human-readable book name used to infer Hebrew/Greek prefix for rendered SWORD
+         Strong's links that carry only digits.
+     - Returns: Ordered unique canonical tokens matching JSword `StrongsNumberFilter` output.
+     */
+    static func canonicalStrongTokens(rawEntry: String, renderedText: String, book: String) -> [String] {
+        var tokens: [String] = []
+        tokens.append(contentsOf: canonicalStrongTokensFromRawOSIS(rawEntry))
+        tokens.append(contentsOf: canonicalStrongTokensFromRenderedText(renderedText, book: book))
+        return orderedUnique(tokens)
+    }
+
+    private static func searchVerseHitsByEntryAttributes(
+        in module: SwordModule,
+        queryOptions: NormalizedStrongsQueryOptions,
+        scope: String?
     ) -> [StrongsSearchVerseHit] {
         for query in queryOptions.entryAttributeQueries {
             let options = SearchOptions(
@@ -143,6 +197,68 @@ enum StrongsSearchSupport {
             }
         }
         return []
+    }
+
+    private static func searchVerseHitsByCanonicalTokens(
+        in module: SwordModule,
+        queryOptions: NormalizedStrongsQueryOptions,
+        scope: String?
+    ) -> (hits: [StrongsSearchVerseHit], sawLexicalTokens: Bool) {
+        var hits: [StrongsSearchVerseHit] = []
+        var seenReferences = Set<String>()
+        var sawLexicalTokens = false
+
+        for key in module.allKeys() {
+            let inspection = module.setKeyAndInspect(
+                key,
+                includeRenderedText: false,
+                includeStrippedText: false
+            )
+            guard let parsed = parseVerseReference(
+                actualKey: inspection.actualKey,
+                rawEntry: inspection.rawEntry
+            ) else {
+                continue
+            }
+
+            let normalizedBook = normalizedBookName(parsed.book)
+            guard scopeAllows(book: normalizedBook, scope: scope) else { continue }
+
+            let tokens = canonicalStrongTokens(
+                rawEntry: inspection.rawEntry,
+                renderedText: inspection.renderedText,
+                book: normalizedBook
+            )
+            if !tokens.isEmpty {
+                sawLexicalTokens = true
+            }
+
+            guard queryOptions.canonicalStrongTokens.allSatisfy({ tokens.contains($0) }) else {
+                continue
+            }
+
+            let referenceKey = "\(normalizedBook)|\(parsed.chapter)|\(parsed.verse)"
+            guard seenReferences.insert(referenceKey).inserted else { continue }
+
+            let preview = module.setKeyAndInspect(
+                key,
+                includeRenderedText: false,
+                includeStrippedText: true
+            ).strippedText
+
+            hits.append(StrongsSearchVerseHit(
+                book: normalizedBook,
+                chapter: parsed.chapter,
+                verse: parsed.verse,
+                previewText: String(preview.prefix(200))
+            ))
+
+            if hits.count >= 5000 {
+                break
+            }
+        }
+
+        return (hits, sawLexicalTokens)
     }
 
     /**
@@ -182,6 +298,182 @@ enum StrongsSearchSupport {
         let osisId = String(parts[parts.count - 3])
         let bookName = BibleReaderController.bookName(forOsisId: osisId) ?? osisId
         return (bookName, chapter, verse)
+    }
+
+    private static func parseVerseReference(
+        actualKey: String,
+        rawEntry: String
+    ) -> (book: String, chapter: Int, verse: Int)? {
+        if let osisID = firstVerseOsisID(in: rawEntry),
+           let parsed = parseOsisVerseKey(osisID) {
+            return parsed
+        }
+        return parseVerseKey(actualKey)
+    }
+
+    private static func firstVerseOsisID(in rawEntry: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: #"osisID\s*=\s*["']([^"']+)["']"#) else {
+            return nil
+        }
+        let range = NSRange(rawEntry.startIndex..., in: rawEntry)
+        guard let match = regex.firstMatch(in: rawEntry, range: range),
+              let osisRange = Range(match.range(at: 1), in: rawEntry) else {
+            return nil
+        }
+        return rawEntry[osisRange].split(separator: " ").first.map(String.init)
+    }
+
+    private struct ParsedStrongNumber: Equatable {
+        let language: Character
+        let digits: String
+        let part: String?
+
+        var numericValue: Int {
+            Int(digits) ?? 0
+        }
+    }
+
+    private struct CanonicalStrongNumberTokens: Equatable {
+        let baseToken: String
+        let fullToken: String?
+
+        var indexTokens: [String] {
+            guard !baseToken.isEmpty else { return [] }
+            if let fullToken {
+                return [baseToken, fullToken]
+            }
+            return [baseToken]
+        }
+
+        var queryTokens: [String] {
+            guard !baseToken.isEmpty else { return [] }
+            if let fullToken {
+                return [fullToken]
+            }
+            return [baseToken]
+        }
+    }
+
+    private static func parseStrongNumber(_ text: String) -> ParsedStrongNumber? {
+        let pattern = #"^([GgHh])([0-9]+)!?([A-Za-z]+)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let languageRange = Range(match.range(at: 1), in: text),
+              let digitsRange = Range(match.range(at: 2), in: text) else {
+            return nil
+        }
+
+        let language = Character(String(text[languageRange]).uppercased())
+        let digits = String(text[digitsRange])
+        let part: String?
+        if match.range(at: 3).location != NSNotFound,
+           let partRange = Range(match.range(at: 3), in: text) {
+            part = String(text[partRange])
+        } else {
+            part = nil
+        }
+
+        return ParsedStrongNumber(language: language, digits: digits, part: part)
+    }
+
+    private static func canonicalStrongNumberTokens(
+        from parsed: ParsedStrongNumber
+    ) -> CanonicalStrongNumberTokens {
+        guard isValidStrongsNumber(parsed) else {
+            return CanonicalStrongNumberTokens(baseToken: "", fullToken: nil)
+        }
+
+        let base = "\(parsed.language)\(String(format: "%04d", parsed.numericValue))"
+        let part = parsed.part?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let full = part?.isEmpty == false ? base + (part ?? "") : nil
+        return CanonicalStrongNumberTokens(baseToken: base, fullToken: full)
+    }
+
+    private static func isValidStrongsNumber(_ parsed: ParsedStrongNumber) -> Bool {
+        let number = parsed.numericValue
+        switch parsed.language {
+        case "H":
+            return (1...8674).contains(number)
+        case "G":
+            return (number >= 1 && number < 1418)
+                || (number > 1418 && number < 2717)
+                || (number > 2717 && number < 3203)
+                || (number > 3302 && number < 5624)
+                || (number > 5999 && number < 10000)
+        default:
+            return false
+        }
+    }
+
+    private static func canonicalStrongTokensFromRawOSIS(_ rawEntry: String) -> [String] {
+        let pattern = #"strong:([GgHh][0-9]+!?[A-Za-z]*)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let matches = regex.matches(in: rawEntry, range: NSRange(rawEntry.startIndex..., in: rawEntry))
+        return matches.flatMap { match -> [String] in
+            guard let range = Range(match.range(at: 1), in: rawEntry),
+                  let parsed = parseStrongNumber(String(rawEntry[range])) else {
+                return []
+            }
+            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
+        }
+    }
+
+    private static func canonicalStrongTokensFromRenderedText(_ renderedText: String, book: String) -> [String] {
+        let pattern = #"showStrong=([0-9]+!?[A-Za-z]*)#cv"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let prefix = BibleReaderController.isNewTestament(normalizedBookName(book)) ? "G" : "H"
+
+        let matches = regex.matches(in: renderedText, range: NSRange(renderedText.startIndex..., in: renderedText))
+        return matches.flatMap { match -> [String] in
+            guard let range = Range(match.range(at: 1), in: renderedText),
+                  let parsed = parseStrongNumber(prefix + String(renderedText[range])) else {
+                return []
+            }
+            return canonicalStrongNumberTokens(from: parsed).indexTokens.filter { !$0.isEmpty }
+        }
+    }
+
+    private static func scopeAllows(book: String, scope: String?) -> Bool {
+        guard let scope, !scope.isEmpty else { return true }
+        let normalizedBook = normalizedBookName(book)
+        switch scope {
+        case "Gen-Mal":
+            return !BibleReaderController.isNewTestament(normalizedBook)
+        case "Matt-Rev":
+            return BibleReaderController.isNewTestament(normalizedBook)
+        default:
+            return BibleReaderController.osisBookId(for: normalizedBook) == scope
+                || normalizedBook.caseInsensitiveCompare(scope) == .orderedSame
+        }
+    }
+
+    private static func normalizedBookName(_ book: String) -> String {
+        let trimmed = book.trimmingCharacters(in: .whitespacesAndNewlines)
+        if BibleReaderController.defaultBooks.contains(where: { $0.name == trimmed }) {
+            return trimmed
+        }
+
+        let aliases = [
+            "I Samuel": "1 Samuel",
+            "II Samuel": "2 Samuel",
+            "I Kings": "1 Kings",
+            "II Kings": "2 Kings",
+            "I Chronicles": "1 Chronicles",
+            "II Chronicles": "2 Chronicles",
+            "I Corinthians": "1 Corinthians",
+            "II Corinthians": "2 Corinthians",
+            "I Thessalonians": "1 Thessalonians",
+            "II Thessalonians": "2 Thessalonians",
+            "I Timothy": "1 Timothy",
+            "II Timothy": "2 Timothy",
+            "I Peter": "1 Peter",
+            "II Peter": "2 Peter",
+            "I John": "1 John",
+            "II John": "2 John",
+            "III John": "3 John",
+        ]
+        return aliases[trimmed] ?? trimmed
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
@@ -137,6 +137,15 @@ enum StrongsSearchSupport {
     ) -> [StrongsSearchVerseHit] {
         guard !queryOptions.canonicalStrongTokens.isEmpty else { return [] }
 
+        let indexedCandidateResult = searchVerseHitsByEntryAttributeCandidates(
+            in: module,
+            queryOptions: queryOptions,
+            scope: scope
+        )
+        if !indexedCandidateResult.hits.isEmpty {
+            return indexedCandidateResult.hits
+        }
+
         let canonicalResult = searchVerseHitsByCanonicalTokens(
             in: module,
             queryOptions: queryOptions,
@@ -200,6 +209,44 @@ enum StrongsSearchSupport {
         return orderedUnique(canonicalStrongTokensFromRenderedText(renderedTextProvider(), book: book))
     }
 
+    /**
+     Uses SWORD entry-attribute search as a candidate index, then validates candidates against
+     JSword-style canonical Strong's tokens.
+
+     Android's find-all path is backed by JSword's indexed `strong` field. iOS does not yet have a
+     persistent Strong's index, but SWORD entry attributes can cheaply identify candidate verses for
+     many modules. This helper treats those candidates only as a narrowing mechanism: each candidate
+     still has to expose the requested canonical lexical tokens before it is returned.
+
+     - Parameters:
+       - module: Module to search.
+       - queryOptions: Normalized Strong's query variants to try in order.
+       - scope: Optional SWORD search scope string.
+     - Returns: Canonically validated candidate hits plus whether any candidate exposed lexical
+       Strong's tokens.
+     */
+    static func searchVerseHitsByEntryAttributeCandidates(
+        in module: SwordModule,
+        queryOptions: NormalizedStrongsQueryOptions,
+        scope: String? = nil
+    ) -> (hits: [StrongsSearchVerseHit], sawLexicalTokens: Bool) {
+        let candidateKeys = entryAttributeCandidateKeys(
+            in: module,
+            queryOptions: queryOptions,
+            scope: scope
+        )
+        guard !candidateKeys.isEmpty else {
+            return ([], false)
+        }
+
+        return searchVerseHitsByCanonicalTokens(
+            in: module,
+            queryOptions: queryOptions,
+            scope: scope,
+            candidateKeys: candidateKeys
+        )
+    }
+
     private static func searchVerseHitsByEntryAttributes(
         in module: SwordModule,
         queryOptions: NormalizedStrongsQueryOptions,
@@ -229,16 +276,40 @@ enum StrongsSearchSupport {
         return []
     }
 
-    private static func searchVerseHitsByCanonicalTokens(
+    private static func entryAttributeCandidateKeys(
         in module: SwordModule,
         queryOptions: NormalizedStrongsQueryOptions,
         scope: String?
+    ) -> [String] {
+        var candidateKeys: [String] = []
+        var seenKeys = Set<String>()
+
+        for query in queryOptions.entryAttributeQueries {
+            let options = SearchOptions(
+                query: query,
+                searchType: .entryAttribute,
+                caseInsensitive: true,
+                scope: scope
+            )
+            for result in module.search(options).results.prefix(5000) where seenKeys.insert(result.key).inserted {
+                candidateKeys.append(result.key)
+            }
+        }
+
+        return candidateKeys
+    }
+
+    private static func searchVerseHitsByCanonicalTokens(
+        in module: SwordModule,
+        queryOptions: NormalizedStrongsQueryOptions,
+        scope: String?,
+        candidateKeys: [String]? = nil
     ) -> (hits: [StrongsSearchVerseHit], sawLexicalTokens: Bool) {
         var hits: [StrongsSearchVerseHit] = []
         var seenReferences = Set<String>()
         var sawLexicalTokens = false
 
-        for key in module.allKeys() {
+        for key in candidateKeys ?? module.allKeys() {
             let inspection = module.setKeyAndInspect(
                 key,
                 includeRenderedText: false,

--- a/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift
@@ -291,8 +291,8 @@ enum StrongsSearchSupport {
                 caseInsensitive: true,
                 scope: scope
             )
-            for result in module.search(options).results.prefix(5000) where seenKeys.insert(result.key).inserted {
-                candidateKeys.append(result.key)
+            for key in module.searchKeys(options, limit: 5000) where seenKeys.insert(key).inserted {
+                candidateKeys.append(key)
             }
         }
 

--- a/Sources/BibleUI/Tests/BibleUITests/NavigationTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/NavigationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class NavigationTests: XCTestCase {
     func testChapterCountMapping() {
         // Verify some chapter counts
-        let view = ChapterChooserView(bookName: "Genesis") { _ in }
+        let view = ChapterChooserView(bookName: "Genesis", chapterCount: 50) { _ in }
         // Chapter counts are embedded in the view — this is a basic compilation test
         XCTAssertNotNil(view)
     }

--- a/Sources/SwordKit/CLibSword/include/flatapi.h
+++ b/Sources/SwordKit/CLibSword/include/flatapi.h
@@ -125,9 +125,10 @@ const char *SWModule_getConfigEntry(void *module, const char *key);
 /// Set the module's cipher key (for encrypted modules).
 void SWModule_setCipherKey(void *module, const char *key);
 
-/// Get key children for VerseKey modules.
-/// Returns a NULL-terminated array of strings:
-/// [testament, book, chapter, verse, chapterMax, verseMax, bookName, osisRef, ...]
+/// Get key children for VerseKey and tree-key modules.
+/// VerseKey modules return a NULL-terminated array of copied strings:
+/// [testament, book, chapter, verse, chapterMax, verseMax, bookName, osisRef, shortText, bookAbbreviation, osisBookName].
+/// Module and testament intro positions keep numeric fields but leave text fields empty.
 const char **SWModule_getKeyChildren(void *module);
 
 /// Get the current VerseKey intro-inclusive index, or -1 when the module key is not a VerseKey.

--- a/Sources/SwordKit/CLibSword/include/flatapi.h
+++ b/Sources/SwordKit/CLibSword/include/flatapi.h
@@ -130,6 +130,12 @@ void SWModule_setCipherKey(void *module, const char *key);
 /// [testament, book, chapter, verse, chapterMax, verseMax, bookName, osisRef, ...]
 const char **SWModule_getKeyChildren(void *module);
 
+/// Get the current VerseKey intro-inclusive index, or -1 when the module key is not a VerseKey.
+long SWModule_getVerseKeyIndex(void *module);
+
+/// Set the current VerseKey intro-inclusive index. Returns 0 on success and nonzero on failure.
+int SWModule_setVerseKeyIndex(void *module, long index);
+
 /// Pop the last error code. Returns 0 if no error.
 char SWModule_popError(void *module);
 

--- a/Sources/SwordKit/CLibSword/sword_adapter.c
+++ b/Sources/SwordKit/CLibSword/sword_adapter.c
@@ -18,6 +18,8 @@
 
 #include "sword_real_api.h"
 
+const char **SWModule_getVerseKeyChildrenDirect(void *module);
+
 // --- Cached state for module list iteration ---
 static const struct org_crosswire_sword_ModInfo *cached_mod_list = NULL;
 static SWHANDLE cached_mod_list_mgr = 0;
@@ -310,6 +312,8 @@ void SWModule_setCipherKey(void *module, const char *key) {
 
 const char **SWModule_getKeyChildren(void *module) {
     if (!module) return NULL;
+    const char **verseKeyChildren = SWModule_getVerseKeyChildrenDirect(module);
+    if (verseKeyChildren) return verseKeyChildren;
     return org_crosswire_sword_SWModule_getKeyChildren(
         (SWHANDLE)(uintptr_t)module);
 }

--- a/Sources/SwordKit/CLibSword/sword_adapter.c
+++ b/Sources/SwordKit/CLibSword/sword_adapter.c
@@ -518,6 +518,8 @@ int SWModule_hasFeature(void *module, const char *feature) { return 0; }
 const char *SWModule_getConfigEntry(void *module, const char *key) { return NULL; }
 void SWModule_setCipherKey(void *module, const char *key) { }
 const char **SWModule_getKeyChildren(void *module) { return NULL; }
+long SWModule_getVerseKeyIndex(void *module) { return -1; }
+int SWModule_setVerseKeyIndex(void *module, long index) { return 1; }
 
 void *InstallMgr_new(const char *basePath) {
     static int sentinel = 2;

--- a/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
+++ b/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
@@ -2,6 +2,9 @@
 
 #ifdef USE_REAL_SWORD
 
+#include <array>
+#include <string>
+
 #include <swmodule.h>
 #include <versekey.h>
 
@@ -27,6 +30,50 @@ sword::VerseKey *verseKeyForModule(void *moduleHandle) {
     return SWDYNAMIC_CAST(sword::VerseKey, key);
 }
 
+struct VerseKeyChildrenStorage {
+    std::array<std::string, 11> values;
+    std::array<const char *, 12> pointers;
+};
+
+const char *safeCString(const char *value) {
+    return value ? value : "";
+}
+
+thread_local VerseKeyChildrenStorage verseKeyChildrenStorage;
+
+}
+
+extern "C" const char **SWModule_getVerseKeyChildrenDirect(void *module) {
+    auto *verseKey = verseKeyForModule(module);
+    if (!verseKey || verseKey->getError()) {
+        return nullptr;
+    }
+
+    int testament = verseKey->getTestament();
+    int book = verseKey->getBook();
+    int chapter = verseKey->getChapter();
+    int verse = verseKey->getVerse();
+    bool hasBook = testament > 0 && book > 0;
+    bool hasChapter = hasBook && chapter > 0;
+
+    auto &storage = verseKeyChildrenStorage;
+    storage.values[0] = std::to_string(testament);
+    storage.values[1] = std::to_string(book);
+    storage.values[2] = std::to_string(chapter);
+    storage.values[3] = std::to_string(verse);
+    storage.values[4] = hasBook ? std::to_string(verseKey->getChapterMax()) : "0";
+    storage.values[5] = hasChapter ? std::to_string(verseKey->getVerseMax()) : "0";
+    storage.values[6] = hasBook ? safeCString(verseKey->getBookName()) : "";
+    storage.values[7] = hasBook ? safeCString(verseKey->getOSISRef()) : "";
+    storage.values[8] = hasBook ? safeCString(verseKey->getShortText()) : "";
+    storage.values[9] = hasBook ? safeCString(verseKey->getBookAbbrev()) : "";
+    storage.values[10] = hasBook ? safeCString(verseKey->getOSISBookName()) : "";
+
+    for (std::size_t index = 0; index < storage.values.size(); ++index) {
+        storage.pointers[index] = storage.values[index].c_str();
+    }
+    storage.pointers[storage.values.size()] = nullptr;
+    return storage.pointers.data();
 }
 
 extern "C" long SWModule_getVerseKeyIndex(void *module) {

--- a/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
+++ b/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
@@ -1,0 +1,50 @@
+#include "include/flatapi.h"
+
+#ifdef USE_REAL_SWORD
+
+#include <swmodule.h>
+#include <versekey.h>
+
+namespace {
+
+struct FlatAPIHandleSWModule {
+    // Mirrors the first field of SWORD flatapi's HandleSWModule wrapper.
+    sword::SWModule *mod;
+};
+
+sword::VerseKey *verseKeyForModule(void *moduleHandle) {
+    if (!moduleHandle) {
+        return nullptr;
+    }
+
+    auto *handle = reinterpret_cast<FlatAPIHandleSWModule *>(moduleHandle);
+    auto *swordModule = handle->mod;
+    if (!swordModule) {
+        return nullptr;
+    }
+
+    auto *key = swordModule->getKey();
+    return SWDYNAMIC_CAST(sword::VerseKey, key);
+}
+
+}
+
+extern "C" long SWModule_getVerseKeyIndex(void *module) {
+    auto *verseKey = verseKeyForModule(module);
+    if (!verseKey) {
+        return -1;
+    }
+    return verseKey->getIndex();
+}
+
+extern "C" int SWModule_setVerseKeyIndex(void *module, long index) {
+    auto *verseKey = verseKeyForModule(module);
+    if (!verseKey) {
+        return 1;
+    }
+
+    verseKey->setIndex(index);
+    return verseKey->getError();
+}
+
+#endif

--- a/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
@@ -83,7 +83,8 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
 /**
  Swift wrapper around SWORD's InstallMgr for downloading and installing modules.
 
- All operations are serialized since libsword is not thread-safe.
+ All native operations are serialized through `SwordRuntime` since libsword and the flat bridge
+ keep process-global state and are not thread-safe.
 
  Usage:
  ```swift
@@ -117,7 +118,6 @@ public final class InstallManager: @unchecked Sendable {
     ]
 
     private let handle: UnsafeMutableRawPointer
-    private let queue = DispatchQueue(label: "org.andbible.InstallManager", qos: .userInitiated)
 
     /// The base path for install manager data.
     public let basePath: String
@@ -133,15 +133,19 @@ public final class InstallManager: @unchecked Sendable {
         // Ensure default remote sources config exists
         InstallManager.ensureDefaultConfig(at: path)
 
-        guard let h = InstallMgr_new(path) else { return nil }
+        guard let h = SwordRuntime.sync({ InstallMgr_new(path) }) else { return nil }
         self.handle = h
 
         // Accept disclaimer to enable remote operations
-        InstallMgr_setUserDisclaimerConfirmed(h)
+        SwordRuntime.sync {
+            InstallMgr_setUserDisclaimerConfirmed(h)
+        }
     }
 
     deinit {
-        InstallMgr_delete(handle)
+        SwordRuntime.sync {
+            InstallMgr_delete(handle)
+        }
     }
 
     /// Default base path for InstallManager data.
@@ -268,7 +272,7 @@ public final class InstallManager: @unchecked Sendable {
 
     /// List configured remote sources.
     public func remoteSources() -> [RemoteSource] {
-        queue.sync {
+        SwordRuntime.sync {
             let count = InstallMgr_getRemoteSourceCount(handle)
             var sources: [RemoteSource] = []
             sources.reserveCapacity(Int(count))
@@ -289,7 +293,7 @@ public final class InstallManager: @unchecked Sendable {
      */
     @discardableResult
     public func refreshSource(_ sourceName: String) -> Bool {
-        queue.sync {
+        SwordRuntime.sync {
             InstallMgr_refreshRemoteSource(handle, sourceName) == 0
         }
     }
@@ -302,7 +306,7 @@ public final class InstallManager: @unchecked Sendable {
      - Returns: List of available modules.
      */
     public func availableModules(from sourceName: String) -> [RemoteModuleInfo] {
-        queue.sync {
+        SwordRuntime.sync {
             let count = InstallMgr_getRemoteModuleCount(handle, sourceName)
             var modules: [RemoteModuleInfo] = []
             modules.reserveCapacity(Int(count))
@@ -355,9 +359,9 @@ public final class InstallManager: @unchecked Sendable {
     @discardableResult
     public func install(moduleName: String, from sourceName: String, into manager: SwordManager) -> Bool {
         // Note: This blocks until download completes. Call from a background task.
-        let mgrHandle = manager.rawHandle
-        return queue.sync {
-            InstallMgr_installModule(handle, mgrHandle, sourceName, moduleName) == 0
+        return SwordRuntime.sync {
+            let mgrHandle = manager.rawHandle
+            return InstallMgr_installModule(handle, mgrHandle, sourceName, moduleName) == 0
         }
     }
 
@@ -370,9 +374,9 @@ public final class InstallManager: @unchecked Sendable {
      */
     @discardableResult
     public func uninstall(moduleName: String, from manager: SwordManager) -> Bool {
-        let mgrHandle = manager.rawHandle
-        return queue.sync {
-            InstallMgr_uninstallModule(handle, mgrHandle, moduleName) == 0
+        return SwordRuntime.sync {
+            let mgrHandle = manager.rawHandle
+            return InstallMgr_uninstallModule(handle, mgrHandle, moduleName) == 0
         }
     }
 }

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -1532,6 +1532,7 @@ public final class ModuleRepository: @unchecked Sendable {
        - streams readable MyBible SQLite payloads into a staged directory
        - writes installed-module metadata beside the extracted payload
        - atomically replaces any previous install for the same MyBible module initials
+       - posts `SwordModuleStore.modulesDidChangeNotification` after the staged install publishes
      - Throws:
        - `ModuleRepositoryError.invalidURL` when the manifest row has no HTTPS package URL
        - `ModuleRepositoryError.invalidZip` when the package is empty or lacks a MyBible payload
@@ -1604,6 +1605,7 @@ public final class ModuleRepository: @unchecked Sendable {
 
         try Task.checkCancellation()
         try commitStagedMyBibleInstall(stagingDirURL: stagingDirURL, moduleName: entry.name)
+        SwordModuleStore.notifyModulesDidChange()
         progress?(1.0)
     }
 
@@ -2359,7 +2361,10 @@ public final class ModuleRepository: @unchecked Sendable {
      and config files and invalidates SWORD's module cache.
 
      - Parameter moduleName: Installed module initials to remove.
-     - Side effects: deletes module files and may invalidate SWORD's module cache.
+     - Side effects:
+       - deletes module files
+       - invalidates SWORD's module cache for SWORD modules
+       - posts `SwordModuleStore.modulesDidChangeNotification` when a module is actually removed
      - Throws: file-system errors when deletion fails; SWORD lookup failures surface as
        `ModuleRepositoryError.moduleNotFound`.
      */
@@ -2408,7 +2413,9 @@ public final class ModuleRepository: @unchecked Sendable {
 
      - Parameter moduleName: MyBible module initials to remove.
      - Returns: `true` when a MyBible install was found and removed, otherwise `false`.
-     - Side effects: deletes the installed MyBible module directory.
+     - Side effects:
+       - deletes the installed MyBible module directory
+       - posts `SwordModuleStore.modulesDidChangeNotification` after successful removal
      - Failure modes: propagates file-system deletion errors.
      */
     private func uninstallMyBibleModuleIfPresent(named moduleName: String) throws -> Bool {
@@ -2418,15 +2425,28 @@ public final class ModuleRepository: @unchecked Sendable {
             return false
         }
         try FileManager.default.removeItem(at: moduleDirURL)
+        SwordModuleStore.notifyModulesDidChange()
         return true
     }
 
-    /// Delete SWORD's modules-conf.cache so the next SWMgr instance rescans mods.d/.
+    /**
+     Deletes SWORD's module cache and announces that installed-module snapshots should rescan.
+
+     Side effects:
+     - deletes `mods.d/modules-conf.cache` on a best-effort basis
+     - posts `SwordModuleStore.modulesDidChangeNotification` after successful module install or
+       uninstall paths publish their file-system mutations
+
+     Failure modes:
+     - cache deletion errors are ignored because SWORD can rebuild the cache and callers have already
+       completed the user-visible storage operation.
+     */
     private func invalidateModuleCache() {
         let cachePath = (swordPath as NSString)
             .appendingPathComponent("mods.d")
             .appending("/modules-conf.cache")
         try? FileManager.default.removeItem(atPath: cachePath)
+        SwordModuleStore.notifyModulesDidChange()
     }
 
     // MARK: - Install from ZIP

--- a/Sources/SwordKit/Sources/SwordKit/SwordConfig.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordConfig.swift
@@ -6,11 +6,11 @@ import CLibSword
 /**
  Swift wrapper around SWORD's SWConfig for reading/writing configuration files.
 
- Used to manage sword.conf and module .conf files.
+ Used to manage sword.conf and module .conf files. Native config calls are routed through
+ `SwordRuntime` because the flat SWORD bridge is process-global and not thread-safe.
  */
 public final class SwordConfig: @unchecked Sendable {
     private let handle: UnsafeMutableRawPointer
-    private let queue = DispatchQueue(label: "org.andbible.SwordConfig", qos: .userInitiated)
 
     /// The file path this config was loaded from.
     public let filePath: String
@@ -21,12 +21,14 @@ public final class SwordConfig: @unchecked Sendable {
      */
     public init?(filePath: String) {
         self.filePath = filePath
-        guard let h = SWConfig_new(filePath) else { return nil }
+        guard let h = SwordRuntime.sync({ SWConfig_new(filePath) }) else { return nil }
         self.handle = h
     }
 
     deinit {
-        SWConfig_delete(handle)
+        SwordRuntime.sync {
+            SWConfig_delete(handle)
+        }
     }
 
     /**
@@ -37,7 +39,7 @@ public final class SwordConfig: @unchecked Sendable {
      - Returns: The value, or nil if not found.
      */
     public func getValue(section: String, key: String) -> String? {
-        queue.sync {
+        SwordRuntime.sync {
             guard let cStr = SWConfig_getValue(handle, section, key) else { return nil }
             let value = String(cString: cStr)
             return value.isEmpty ? nil : value
@@ -52,14 +54,14 @@ public final class SwordConfig: @unchecked Sendable {
        - value: The value to set.
      */
     public func setValue(section: String, key: String, value: String) {
-        queue.sync {
+        SwordRuntime.sync {
             SWConfig_setValue(handle, section, key, value)
         }
     }
 
     /// Save configuration changes to disk.
     public func save() {
-        queue.sync {
+        SwordRuntime.sync {
             SWConfig_save(handle)
         }
     }

--- a/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
@@ -9,8 +9,8 @@ import CLibSword
  Manages the SWORD module installation directory, provides access to
  installed modules, and controls global rendering options.
 
- All libsword operations are serialized on an internal queue since
- the library is not thread-safe.
+ All libsword operations are serialized through `SwordRuntime` since
+ the library and bridge keep process-global state and are not thread-safe.
 
  Usage:
  ```swift
@@ -24,7 +24,6 @@ import CLibSword
  */
 public final class SwordManager: @unchecked Sendable {
     private let handle: UnsafeMutableRawPointer
-    private let queue = DispatchQueue(label: "org.andbible.SwordManager", qos: .userInitiated)
 
     /// Internal access to the C handle for InstallManager operations.
     var rawHandle: UnsafeMutableRawPointer { handle }
@@ -42,13 +41,15 @@ public final class SwordManager: @unchecked Sendable {
         let path = modulePath ?? SwordManager.defaultModulePath()
         self.modulePath = path
 
-        guard let h = SWMgr_new(path) else { return nil }
+        guard let h = SwordRuntime.sync({ SWMgr_new(path) }) else { return nil }
         self.handle = h
     }
 
     deinit {
-        moduleCache.removeAll()
-        SWMgr_delete(handle)
+        SwordRuntime.sync {
+            moduleCache.removeAll()
+            SWMgr_delete(handle)
+        }
     }
 
     /// Default path for SWORD modules in the app's documents directory.
@@ -67,14 +68,14 @@ public final class SwordManager: @unchecked Sendable {
 
     /// Get the number of installed modules.
     public var moduleCount: Int {
-        queue.sync {
+        SwordRuntime.sync {
             Int(SWMgr_getModuleCount(handle))
         }
     }
 
     /// List all installed modules.
     public func installedModules() -> [ModuleInfo] {
-        queue.sync {
+        SwordRuntime.sync {
             let count = SWMgr_getModuleCount(handle)
             var modules: [ModuleInfo] = []
             modules.reserveCapacity(Int(count))
@@ -103,7 +104,7 @@ public final class SwordManager: @unchecked Sendable {
      - Returns: The module, or nil if not installed.
      */
     public func module(named name: String) -> SwordModule? {
-        queue.sync {
+        SwordRuntime.sync {
             if let cached = moduleCache[name] { return cached }
             guard let modHandle = SWMgr_getModuleByName(handle, name) else { return nil }
             return getOrCreateModule(name: name, handle: modHandle)
@@ -112,7 +113,7 @@ public final class SwordManager: @unchecked Sendable {
 
     private func getOrCreateModule(name: String, handle: UnsafeMutableRawPointer) -> SwordModule {
         if let cached = moduleCache[name] { return cached }
-        let mod = SwordModule(handle: handle, queue: queue, modulePath: modulePath)
+        let mod = SwordModule(handle: handle, modulePath: modulePath)
         moduleCache[name] = mod
         return mod
     }
@@ -138,7 +139,7 @@ public final class SwordManager: @unchecked Sendable {
        - enabled: Whether the option should be enabled.
      */
     public func setGlobalOption(_ option: GlobalOption, enabled: Bool) {
-        queue.sync {
+        SwordRuntime.sync {
             SWMgr_setGlobalOption(handle, option.rawValue, enabled ? "On" : "Off")
         }
     }
@@ -149,7 +150,7 @@ public final class SwordManager: @unchecked Sendable {
      - Returns: Whether the option is currently enabled.
      */
     public func isGlobalOptionEnabled(_ option: GlobalOption) -> Bool {
-        queue.sync {
+        SwordRuntime.sync {
             guard let value = SWMgr_getGlobalOption(handle, option.rawValue) else { return false }
             return String(cString: value) == "On"
         }
@@ -159,7 +160,7 @@ public final class SwordManager: @unchecked Sendable {
 
     /// The configuration path used by the manager.
     public var configPath: String {
-        queue.sync {
+        SwordRuntime.sync {
             guard let path = SWMgr_getConfigPath(handle) else { return "" }
             return String(cString: path)
         }
@@ -167,7 +168,7 @@ public final class SwordManager: @unchecked Sendable {
 
     /// The prefix path (module install root).
     public var prefixPath: String {
-        queue.sync {
+        SwordRuntime.sync {
             guard let path = SWMgr_getPrefixPath(handle) else { return "" }
             return String(cString: path)
         }
@@ -180,7 +181,7 @@ public final class SwordManager: @unchecked Sendable {
      Call after installing or uninstalling modules.
      */
     public func refresh() {
-        queue.sync {
+        SwordRuntime.sync {
             moduleCache.removeAll()
         }
         // Recreate is the simplest way to refresh libsword's module list.

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -858,6 +858,44 @@ public final class SwordModule: @unchecked Sendable {
         }
     }
 
+    /**
+     Iterate through all entries while capturing plain text and raw OSIS from the same cursor.
+
+     Search-index creation needs the cleaned verse text shown to users and the lexical markup
+     Android's JSword indexes for Strong's lookup. Reading both values inside one runtime block
+     prevents another SWORD operation from moving the module cursor between the stripped-text and
+     raw-entry reads.
+
+     - Parameter callback: Receives `(key, plainText, rawEntry, index)` for each module entry and
+       returns `true` to continue or `false` to stop early.
+     - Side effects: Moves the module cursor from the beginning through each entry, then restores
+       the cursor that was active before iteration.
+     - Failure modes: Stops without invoking the callback when SWORD cannot position at the first
+       entry. Native rendering failures surface as empty strings from SWORD and are left for the
+       caller to filter.
+     - Important: Callback work runs while holding `SwordRuntime`; keep it bounded and do not wait
+       on work that also needs SWORD access from another thread.
+     */
+    public func iterateAllEntriesWithRaw(_ callback: (String, String, String, Int) -> Bool) {
+        SwordRuntime.sync {
+            let savedKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, savedKey) }
+
+            SWModule_begin(handle)
+            guard SWModule_popError(handle) == 0 else { return }
+
+            var index = 0
+            while true {
+                let key = String(cString: SWModule_getKeyText(handle))
+                let text = String(cString: SWModule_getStripText(handle))
+                let rawEntry = String(cString: SWModule_getRawEntry(handle))
+                if !callback(key, text, rawEntry, index) { break }
+                index += 1
+                if SWModule_next(handle) != 0 { break }
+            }
+        }
+    }
+
     // MARK: - Search
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -9,6 +9,8 @@ public struct VerseKeyChildren: Sendable {
     public let book: Int
     public let chapter: Int
     public let verse: Int
+    /// Calculated verse ordinal when supplied by the caller; raw flat SWORD key children do not expose this directly.
+    public let index: Int
     public let chapterMax: Int
     public let verseMax: Int
     public let bookName: String
@@ -16,6 +18,53 @@ public struct VerseKeyChildren: Sendable {
     public let shortText: String
     public let bookAbbreviation: String
     public let osisBookName: String
+}
+
+/**
+ A resolved verse reference from SWORD's active versification.
+
+ The reader bridge needs the same category of answers Android receives from JSword's
+ `Versification`: exact book/chapter/verse identity plus the intro-inclusive ordinal used by
+ bookmarks, navigation, highlighting, memorization, and reference documents. This value is copied
+ out of the SWORD module while the module cursor is protected by `SwordModule`'s serialization
+ queue, so callers can retain it without holding any SWORD-owned pointers.
+ */
+public struct VerseKeyReference: Sendable, Equatable {
+    /// OSIS book identifier, such as `Gen`, `Ruth`, or `1Cor`.
+    public let osisBookId: String
+
+    /// One-based chapter number resolved by the module's versification.
+    public let chapter: Int
+
+    /// One-based verse number resolved by the module's versification.
+    public let verse: Int
+
+    /// SWORD/JSword-style versification ordinal including book and chapter intro slots.
+    public let ordinal: Int
+
+    /**
+     Creates a copied verse reference for callers outside the SwordKit module.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier, such as `Gen` or `1Cor`.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+       - ordinal: SWORD/JSword-style versification ordinal.
+     - Side effects: None.
+     - Failure modes: None; callers are responsible for supplying values already validated by
+       SWORD or by a documented no-module compatibility fallback.
+     */
+    public init(osisBookId: String, chapter: Int, verse: Int, ordinal: Int) {
+        self.osisBookId = osisBookId
+        self.chapter = chapter
+        self.verse = verse
+        self.ordinal = ordinal
+    }
+
+    /// Canonical OSIS reference for this verse.
+    public var osisRef: String {
+        "\(osisBookId).\(chapter).\(verse)"
+    }
 }
 
 /**
@@ -29,6 +78,8 @@ public struct VerseKeyChildren: Sendable {
 public final class SwordModule: @unchecked Sendable {
     let handle: UnsafeMutableRawPointer
     private let queue: DispatchQueue
+    private var cachedVersificationBooks: [VersificationBook]?
+    private var cachedVerseCountsByBookChapter: [String: [Int: Int]] = [:]
 
     /// Module metadata.
     public let info: ModuleInfo
@@ -98,6 +149,71 @@ public final class SwordModule: @unchecked Sendable {
         }
     }
 
+    /// Get the current SWORD VerseKey index for verse-key modules.
+    public func currentVerseKeyIndex() -> Int? {
+        queue.sync {
+            guard let children = Self.currentVerseKeyChildren(handle: handle) else { return nil }
+            return verseOrdinalLocked(
+                osisBookId: children.osisBookName,
+                chapter: children.chapter,
+                verse: children.verse
+            )
+        }
+    }
+
+    /**
+     Resolves a verse to the ordinal used by the module's active versification.
+
+     Android gets these ordinals through JSword `Versification.getOrdinal(Verse)`. SWORD exposes
+     the equivalent through `VerseKey.getIndex()`, including intro slots for the Bible, testament,
+     book, and chapter. The method uses exact-key syntax and validates the resolved key so a missing
+     or out-of-range verse cannot silently normalize to a neighboring reference.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier such as `Gen`, `Ruth`, or `1Cor`.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: The versification ordinal, or `nil` when the reference cannot be resolved exactly.
+     - Side effects: Temporarily moves the SWORD module cursor inside the serialization queue and
+       restores the previous key before returning.
+     - Important: Use this for reader bridge ordinals instead of arithmetic based on chapter and
+       verse counts; those arithmetic schemes do not match JSword/SWORD versification semantics.
+     */
+    public func verseOrdinal(osisBookId: String, chapter: Int, verse: Int) -> Int? {
+        guard chapter > 0, verse > 0, !osisBookId.isEmpty else { return nil }
+
+        return queue.sync {
+            let previousKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, previousKey) }
+
+            return verseOrdinalLocked(osisBookId: osisBookId, chapter: chapter, verse: verse)
+        }
+    }
+
+    /**
+     Resolves a versification ordinal back to a concrete verse reference.
+
+     Android can reverse-map bookmark and memorization ordinals through JSword's versification. This
+     method provides the same boundary for iOS by positioning SWORD's `VerseKey` with
+     `setIndex(_:)`, reading structured key metadata, and then restoring the caller's prior cursor.
+     When `osisBookId` is provided, the method rejects ordinals that resolve outside that book.
+
+     - Parameters:
+       - osisBookId: Optional OSIS book identifier that the ordinal must resolve within.
+       - ordinal: SWORD/JSword-style versification ordinal.
+     - Returns: A copied verse reference, or `nil` if the ordinal does not represent a normal
+       verse for the requested book.
+     - Side effects: Temporarily moves the SWORD module cursor inside the serialization queue and
+       restores the previous key before returning.
+     */
+    public func verseReference(osisBookId: String? = nil, ordinal: Int) -> VerseKeyReference? {
+        guard ordinal > 0 else { return nil }
+
+        return queue.sync {
+            verseReferenceLocked(osisBookId: osisBookId, ordinal: ordinal)
+        }
+    }
+
     /**
      Atomically inspects one verse key and restores the module's previous cursor.
 
@@ -130,12 +246,12 @@ public final class SwordModule: @unchecked Sendable {
 
         var parts: [String] = []
         var index = 0
-        while index < 11, let ptr = children[index] {
+        while index < 8, let ptr = children[index] {
             parts.append(String(cString: ptr))
             index += 1
         }
 
-        guard parts.count >= 11,
+        guard parts.count >= 8,
               let testament = Int(parts[0]),
               let book = Int(parts[1]),
               let chapter = Int(parts[2]),
@@ -150,14 +266,269 @@ public final class SwordModule: @unchecked Sendable {
             book: book,
             chapter: chapter,
             verse: verse,
+            index: 0,
             chapterMax: chapterMax,
             verseMax: verseMax,
             bookName: parts[6],
             osisRef: parts[7],
-            shortText: parts[8],
-            bookAbbreviation: parts[9],
-            osisBookName: parts[10]
+            shortText: parts[7],
+            bookAbbreviation: parts[7].components(separatedBy: ".").first ?? parts[7],
+            osisBookName: parts[7].components(separatedBy: ".").first ?? parts[7]
         )
+    }
+
+    /**
+     Canonical OSIS candidates used to discover the active SWORD versification order.
+
+     SWORD's flat key-children API exposes testament/book ordinals only after positioning a key; it
+     does not expose a book iterator. This list gives the probe set, while SWORD decides which
+     identifiers are valid for the module's versification and how they sort.
+     */
+    private static let versificationProbeOsisBookIds: [String] = [
+        "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Ruth",
+        "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh", "Esth",
+        "Job", "Ps", "Prov", "Eccl", "Song", "Isa", "Jer", "Lam", "Ezek", "Dan",
+        "Hos", "Joel", "Amos", "Obad", "Jonah", "Mic", "Nah", "Hab", "Zeph",
+        "Hag", "Zech", "Mal", "Tob", "Jdt", "AddEsth", "Wis", "Sir", "Bar",
+        "EpJer", "PrAzar", "Sus", "Bel", "1Macc", "2Macc", "3Macc", "4Macc",
+        "PrMan", "1Esd", "2Esd", "Ps151", "Matt", "Mark", "Luke", "John",
+        "Acts", "Rom", "1Cor", "2Cor", "Gal", "Eph", "Phil", "Col", "1Thess",
+        "2Thess", "1Tim", "2Tim", "Titus", "Phlm", "Heb", "Jas", "1Pet",
+        "2Pet", "1John", "2John", "3John", "Jude", "Rev",
+    ]
+
+    /// One book resolved from SWORD's active versification and sorted by SWORD book order.
+    private struct VersificationBook: Sendable {
+        let osisBookId: String
+        let testament: Int
+        let book: Int
+        let chapterMax: Int
+    }
+
+    /**
+     Computes a JSword/SWORD-style ordinal while the module queue is already held.
+
+     The flat SWORD API does not expose `VerseKey.getIndex()`. Android's JSword ordinal includes
+     testament, book, and chapter intro slots, so this method derives the same value from SWORD's
+     active versification order and per-chapter verse counts instead of using fixed chapter math.
+     */
+    private func verseOrdinalLocked(osisBookId: String, chapter: Int, verse: Int) -> Int? {
+        guard let target = exactVerseKeyChildrenLocked(
+            osisBookId: osisBookId,
+            chapter: chapter,
+            verse: verse
+        ) else {
+            return nil
+        }
+
+        var ordinal = 0
+        var currentTestament = 0
+        for book in versificationBooksLocked() {
+            if book.testament != currentTestament {
+                ordinal += 1
+                currentTestament = book.testament
+            }
+
+            ordinal += 1
+            for chapterNumber in 1...book.chapterMax {
+                ordinal += 1
+                if book.osisBookId == target.osisBookName && chapterNumber == target.chapter {
+                    guard target.verse <= verseCountLocked(osisBookId: book.osisBookId, chapter: chapterNumber) else {
+                        return nil
+                    }
+                    return ordinal + target.verse
+                }
+                ordinal += verseCountLocked(osisBookId: book.osisBookId, chapter: chapterNumber)
+            }
+        }
+
+        return nil
+    }
+
+    /**
+     Reverse-maps a JSword/SWORD-style ordinal while the module queue is already held.
+
+     Intro slots for testament, book, and chapter intentionally do not produce verse references.
+     That matches JSword's distinction between structural keys and normal `Verse` keys.
+     */
+    private func verseReferenceLocked(osisBookId: String?, ordinal: Int) -> VerseKeyReference? {
+        var cursor = 0
+        var currentTestament = 0
+        for book in versificationBooksLocked() {
+            if book.testament != currentTestament {
+                cursor += 1
+                if cursor == ordinal { return nil }
+                currentTestament = book.testament
+            }
+
+            cursor += 1
+            if cursor == ordinal { return nil }
+
+            for chapter in 1...book.chapterMax {
+                cursor += 1
+                if cursor == ordinal { return nil }
+
+                let verseCount = verseCountLocked(osisBookId: book.osisBookId, chapter: chapter)
+                if ordinal <= cursor + verseCount {
+                    let verse = ordinal - cursor
+                    guard verse > 0 else { return nil }
+                    if let osisBookId, osisBookId != book.osisBookId {
+                        return nil
+                    }
+                    return VerseKeyReference(
+                        osisBookId: book.osisBookId,
+                        chapter: chapter,
+                        verse: verse,
+                        ordinal: ordinal
+                    )
+                }
+                cursor += verseCount
+            }
+        }
+        return nil
+    }
+
+    /// Returns active-versification books sorted by SWORD testament/book order.
+    private func versificationBooksLocked() -> [VersificationBook] {
+        if let cachedVersificationBooks {
+            return cachedVersificationBooks
+        }
+
+        var books: [VersificationBook] = []
+        var seen = Set<String>()
+        for osisBookId in Self.versificationProbeOsisBookIds {
+            SWModule_setKeyText(handle, "=\(osisBookId).1.1")
+            guard let children = Self.currentVerseKeyChildren(handle: handle),
+                  children.testament > 0,
+                  children.chapter == 1,
+                  children.verse == 1,
+                  children.osisBookName == osisBookId,
+                  seen.insert(osisBookId).inserted else {
+                continue
+            }
+            books.append(VersificationBook(
+                osisBookId: osisBookId,
+                testament: children.testament,
+                book: children.book,
+                chapterMax: children.chapterMax
+            ))
+        }
+
+        let sortedBooks = books.sorted {
+            if $0.testament != $1.testament {
+                return $0.testament < $1.testament
+            }
+            return $0.book < $1.book
+        }
+        cachedVersificationBooks = sortedBooks
+        return sortedBooks
+    }
+
+    /// Returns a SWORD verse count for one chapter while caching repeated ordinal calculations.
+    private func verseCountLocked(osisBookId: String, chapter: Int) -> Int {
+        if let cached = cachedVerseCountsByBookChapter[osisBookId]?[chapter] {
+            return cached
+        }
+
+        let count: Int
+        if let children = exactVerseKeyChildrenLocked(osisBookId: osisBookId, chapter: chapter, verse: 1) {
+            count = max(0, children.verseMax)
+        } else {
+            count = 0
+        }
+
+        var chapterCounts = cachedVerseCountsByBookChapter[osisBookId] ?? [:]
+        chapterCounts[chapter] = count
+        cachedVerseCountsByBookChapter[osisBookId] = chapterCounts
+        return count
+    }
+
+    /// Positions an exact verse key and rejects SWORD normalization to neighboring references.
+    private func exactVerseKeyChildrenLocked(osisBookId: String, chapter: Int, verse: Int) -> VerseKeyChildren? {
+        SWModule_setKeyText(handle, "=\(osisBookId).\(chapter).\(verse)")
+        guard let children = Self.currentVerseKeyChildren(handle: handle),
+              children.osisBookName == osisBookId,
+              children.chapter == chapter,
+              children.verse == verse else {
+            return nil
+        }
+        return children
+    }
+
+    /**
+     Parses a Bible key string through SWORD's VerseKey parser and returns normalized OSIS keys.
+
+     Android routes Bible references through JSword `PassageKeyFactory`; the closest available
+     iOS boundary in the current flat bridge is SWORD's `SWModule_parseKeyList`, which expands
+     ranges and lists against the active module's versification instead of using string splitting.
+     The result is copied immediately because the C array belongs to the module handle and is
+     invalidated by later parse calls.
+
+     - Parameter keyText: OSIS or human-readable key text such as `Gen.1.1-Gen.1.3`.
+     - Returns: Normalized OSIS references, one per parsed verse/range item. Returns an empty
+       array when SWORD cannot parse the text for a VerseKey module.
+     - Side effects: Uses SWORD's parser inside the module serialization queue. The method restores
+       the module cursor after parsing so callers can use it in reader link handling without
+       desynchronizing later raw-entry reads.
+     */
+    public func parseKeyList(_ keyText: String) -> [String] {
+        queue.sync {
+            let previousKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, previousKey) }
+
+            guard let values = SWModule_parseKeyList(handle, keyText) else { return [] }
+            return Self.copyCStringArray(values)
+        }
+    }
+
+    /**
+     Returns the active module versification's last verse number for a chapter.
+
+     Android's passage chooser uses JSword `Versification.getLastVerse(book, chapterNo)`. SWORD
+     exposes the equivalent through the current `VerseKey` children after resolving any verse in
+     the target chapter. The method rejects SWORD normalization onto a neighboring key by checking
+     the resolved OSIS book and chapter before returning `verseMax`.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier such as `Gen`, `Ruth`, or `1Cor`.
+       - chapter: One-based chapter number.
+     - Returns: The last valid verse number for that chapter, or `nil` if the reference cannot be
+       resolved exactly by the module's versification.
+     - Side effects: Temporarily moves the module cursor and restores the previous key before
+       returning.
+     */
+    public func verseCount(osisBookId: String, chapter: Int) -> Int? {
+        guard chapter > 0, !osisBookId.isEmpty else { return nil }
+
+        return queue.sync {
+            let previousKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, previousKey) }
+
+            SWModule_setKeyText(handle, "=\(osisBookId).\(chapter).1")
+            guard let children = Self.currentVerseKeyChildren(handle: handle),
+                  children.osisBookName == osisBookId,
+                  children.chapter == chapter,
+                  children.verseMax > 0 else {
+                return nil
+            }
+            return children.verseMax
+        }
+    }
+
+    /**
+     Copies a NULL-terminated C string array returned by the SWORD flat API.
+
+     - Parameter values: Pointer to a NULL-terminated array owned by SWORD.
+     - Returns: Swift strings copied before a later SWORD call can invalidate the backing storage.
+     */
+    private static func copyCStringArray(_ values: UnsafePointer<UnsafePointer<CChar>?>) -> [String] {
+        var result: [String] = []
+        var index = 0
+        while let value = values[index] {
+            result.append(String(cString: value))
+            index += 1
+        }
+        return result
     }
 
     /**
@@ -190,13 +561,7 @@ public final class SwordModule: @unchecked Sendable {
                             return []
                         }
 
-                        var result: [String] = []
-                        var index = 0
-                        while let value = values[index] {
-                            result.append(String(cString: value))
-                            index += 1
-                        }
-                        return result
+                        return Self.copyCStringArray(values)
                     }
                 }
             }
@@ -256,19 +621,29 @@ public final class SwordModule: @unchecked Sendable {
     }
 
     /**
-     Atomically set key, then capture the resolved key plus both raw and rendered entry forms.
+     Atomically set key, then capture the resolved key and entry text forms.
 
-     Dictionary lookups need all three values together because SWORD can reposition to a nearby
-     key when an exact match is missing, and some dictionary modules expose the canonical key only
-     through the raw entry metadata rather than `currentKey()`.
+     Dictionary and lexical-search lookups need these values together because SWORD can reposition
+     to a nearby key when an exact match is missing, and some modules expose canonical metadata only
+     through raw entry markup. Callers that need only raw OSIS can skip rendered/stripped text to
+     avoid paying that cost for every verse during module-wide scans.
      */
-    public func setKeyAndInspect(_ keyText: String) -> (actualKey: String, rawEntry: String, renderedText: String) {
+    public func setKeyAndInspect(
+        _ keyText: String,
+        includeRenderedText: Bool = true,
+        includeStrippedText: Bool = true
+    ) -> (actualKey: String, rawEntry: String, renderedText: String, strippedText: String) {
         queue.sync {
             SWModule_setKeyText(handle, keyText)
             let actualKey = String(cString: SWModule_getKeyText(handle))
             let rawEntry = String(cString: SWModule_getRawEntry(handle))
-            let renderedText = String(cString: SWModule_getRenderText(handle))
-            return (actualKey, rawEntry, renderedText)
+            let renderedText = includeRenderedText
+                ? String(cString: SWModule_getRenderText(handle))
+                : ""
+            let strippedText = includeStrippedText
+                ? String(cString: SWModule_getStripText(handle))
+                : ""
+            return (actualKey, rawEntry, renderedText, strippedText)
         }
     }
 
@@ -329,13 +704,19 @@ public final class SwordModule: @unchecked Sendable {
     /**
      Get the list of all books in this Bible module's versification.
 
-     Iterates through the module's verse key positions using `getKeyChildren()`,
-     collecting book metadata (name, OSIS ID, abbreviation, chapter count, testament).
-     Jumps between books efficiently by setting the key to the last chapter of each book
-     and advancing to the next.
+     Mirrors Android's `DocumentBibleBooks`/JSword contract as closely as the current
+     CLibSword wrapper allows: discover candidate books from real SWORD key positions, then
+     include only books whose first or second verse resolves exactly and has raw content.
+     This intentionally avoids synthetic "high verse" jumps such as `Gen 50:200`;
+     compressed zText modules can normalize those fake keys past intervening books, which
+     hides valid restored Android module content from the reader's book picker.
 
      - Returns: Ordered array of `BookInfo` for each book in the module's canon.
        Returns empty array for non-Bible modules or if the module has no verse key.
+     - Side effects: Temporarily moves the module cursor while holding the module queue,
+       then restores the previously selected key before returning.
+     - Complexity: O(n) over the module's key entries. The reader calls this only when
+       refreshing module metadata, and correctness is more important than key-jump speed.
      */
     public func getBookList() -> [BookInfo] {
         guard info.category == .bible || info.category == .commentary else { return [] }
@@ -346,53 +727,185 @@ public final class SwordModule: @unchecked Sendable {
             SWModule_begin(handle)
             guard SWModule_popError(handle) == 0 else { return [] }
 
-            var books: [BookInfo] = []
-            var lastBookNum = -1
+            var candidateBooks: [BookInfo] = []
+            var seenBookIds = Set<String>()
+            var previousKey: String?
+            let isProbablyIBTSynodalDocument = Self.isProbablyIBTSynodalDocument(handle: handle)
 
             while true {
-                guard let children = SWModule_getKeyChildren(handle) else { break }
+                let key = String(cString: SWModule_getKeyText(handle))
+                guard key != previousKey else { break }
+                previousKey = key
 
-                // Parse key children array: [testament, book, chapter, verse,
-                //   chapterMax, verseMax, bookName, osisRef, shortText, bookAbbrev, osisBookName]
-                var parts: [String] = []
-                var i = 0
-                while let ptr = children[i], i < 11 {
-                    parts.append(String(cString: ptr))
-                    i += 1
-                }
-                guard parts.count >= 11 else { break }
-
-                let bookNum = Int(parts[1]) ?? -1
-                let testament = Int(parts[0]) ?? 0
-
-                if bookNum != lastBookNum && testament > 0 {
-                    let chapterMax = Int(parts[4]) ?? 1
-                    let bookName = parts[6]
-                    let osisBookName = parts[10]
-                    let bookAbbrev = parts[9]
-
-                    books.append(BookInfo(
-                        name: bookName,
-                        osisId: osisBookName,
-                        abbreviation: bookAbbrev,
-                        chapterCount: chapterMax,
-                        testament: testament
+                if let children = Self.currentVerseKeyChildren(handle: handle),
+                   children.testament > 0,
+                   !children.osisBookName.isEmpty,
+                   seenBookIds.insert(children.osisBookName).inserted {
+                    candidateBooks.append(BookInfo(
+                        name: children.bookName,
+                        osisId: children.osisBookName,
+                        abbreviation: children.bookAbbreviation,
+                        chapterCount: children.chapterMax,
+                        testament: children.testament
                     ))
-                    lastBookNum = bookNum
-
-                    // Jump to the end of this book (last chapter, high verse) to skip
-                    // to the next book on the subsequent next() call
-                    SWModule_setKeyText(handle, "\(osisBookName) \(chapterMax):200")
                 }
 
-                // Advance to next position (should land on the first verse of the next book)
                 if SWModule_next(handle) != 0 { break }
-                if SWModule_popError(handle) != 0 { break }
             }
 
-            return books
+            return candidateBooks.filter { book in
+                Self.moduleContainsAndroidProbeVerse(
+                    handle: handle,
+                    book: book,
+                    chapter: 1,
+                    verse: 1,
+                    isProbablyIBTSynodalDocument: isProbablyIBTSynodalDocument
+                ) || Self.moduleContainsAndroidProbeVerse(
+                    handle: handle,
+                    book: book,
+                    chapter: 1,
+                    verse: 2,
+                    isProbablyIBTSynodalDocument: isProbablyIBTSynodalDocument
+                )
+            }
         }
     }
+
+    /**
+     Checks one Android-compatible book-list probe verse.
+
+     Android's `DocumentBibleBooks.isVerseInBook()` includes a book only when JSword's backend
+     reports raw content for either 1:1 or 1:2. This helper uses exact OSIS keys and verifies
+     that SWORD did not normalize the request onto a neighboring key before checking raw content.
+     It runs inside `getBookList()`'s serialized queue block and intentionally leaves cursor
+     restoration to the outer caller.
+
+     - Parameters:
+       - handle: SWORD module handle already owned by the caller's queue.
+       - book: Candidate book metadata collected from real SWORD key traversal.
+       - chapter: Probe chapter number, normally `1`.
+       - verse: Probe verse number, normally `1` or `2`.
+       - isProbablyIBTSynodalDocument: Whether the module matches Android's known IBT Synodal
+         empty-stub pattern for deuterocanonical books.
+     - Returns: `true` when the requested exact verse belongs to the candidate book and has
+       non-empty raw content that Android would treat as real content.
+     - Side effects: Moves the module cursor to the probe key.
+     */
+    private static func moduleContainsAndroidProbeVerse(
+        handle: UnsafeMutableRawPointer,
+        book: BookInfo,
+        chapter: Int,
+        verse: Int,
+        isProbablyIBTSynodalDocument: Bool
+    ) -> Bool {
+        guard let rawEntryLength = rawEntryLengthForExactVerse(
+            handle: handle,
+            osisBookId: book.osisId,
+            chapter: chapter,
+            verse: verse
+        ), rawEntryLength > 0 else {
+            return false
+        }
+
+        if isProbablyIBTSynodalDocument,
+           isProbablyIBTEmptyVerseStub(rawEntryLength: rawEntryLength, isShortBook: book.chapterCount <= 1) {
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     Returns the raw entry length for one exact OSIS verse key.
+
+     SWORD may normalize invalid references to nearby verses. Android's JSword path checks a
+     concrete `Verse`, so this helper rejects normalized probes by comparing structured
+     `VerseKey` children after setting the key.
+
+     - Parameters:
+       - handle: SWORD module handle already owned by the caller's queue.
+       - osisBookId: OSIS book identifier such as `Gen` or `1Cor`.
+       - chapter: Chapter to inspect.
+       - verse: Verse to inspect.
+     - Returns: Raw entry character count when SWORD resolves exactly to the requested verse;
+       otherwise `nil`.
+     - Side effects: Moves the module cursor to the requested key.
+     */
+    private static func rawEntryLengthForExactVerse(
+        handle: UnsafeMutableRawPointer,
+        osisBookId: String,
+        chapter: Int,
+        verse: Int
+    ) -> Int? {
+        SWModule_setKeyText(handle, "=\(osisBookId).\(chapter).\(verse)")
+        guard let children = currentVerseKeyChildren(handle: handle),
+              children.osisBookName == osisBookId,
+              children.chapter == chapter,
+              children.verse == verse else {
+            return nil
+        }
+        return String(cString: SWModule_getRawEntry(handle)).count
+    }
+
+    /**
+     Detects Android's known IBT Synodal empty deuterocanonical-verse stub condition.
+
+     Android checks for Synodal modules where `Tob 1:1` contains generated empty markup rather
+     than real verse content, then excludes similarly-shaped stubs from the book list. This keeps
+     iOS book visibility aligned for the same module family without applying the heuristic to
+     unrelated versifications.
+
+     - Parameter handle: SWORD module handle already owned by the caller's queue.
+     - Returns: `true` when the module declares `Versification=Synodal` and `Tob 1:1` has the
+       raw-length signature Android treats as an IBT empty stub.
+     - Side effects: Moves the module cursor to `Tob 1:1`; `getBookList()` restores the original
+       cursor before returning.
+     */
+    private static func isProbablyIBTSynodalDocument(handle: UnsafeMutableRawPointer) -> Bool {
+        let versificationPointer = SWModule_getConfigEntry(handle, "Versification")
+        let versificationName = versificationPointer.map { String(cString: $0) } ?? "KJV"
+        guard versificationName == "Synodal",
+              let rawEntryLength = rawEntryLengthForExactVerse(
+                handle: handle,
+                osisBookId: "Tob",
+                chapter: 1,
+                verse: 1
+              ) else {
+            return false
+        }
+        return isProbablyIBTEmptyVerseStub(rawEntryLength: rawEntryLength, isShortBook: false)
+    }
+
+    /**
+     Matches Android's raw-length heuristic for IBT Synodal empty verse stubs.
+
+     Android identifies generated empty markup by length range because the affected modules return
+     non-empty raw XML for books that are not actually present. The constants below are the Swift
+     equivalents of `DocumentBibleBooks` in Android.
+
+     - Parameters:
+       - rawEntryLength: Length of the raw SWORD entry.
+       - isShortBook: Whether the probed book has a single chapter.
+     - Returns: `true` when the raw entry length falls inside Android's empty-stub range.
+     */
+    private static func isProbablyIBTEmptyVerseStub(rawEntryLength: Int, isShortBook: Bool) -> Bool {
+        if isShortBook {
+            return ibtShortBookEmptyVerseStubRange.contains(rawEntryLength)
+        }
+        return ibtEmptyVerseStubRange.contains(rawEntryLength)
+    }
+
+    private static let ibtEmptyVerseStubRange: ClosedRange<Int> = {
+        let lowerBound = "<chapter eID=\"gen4\" osisID=\"Gen.1\"/>".count
+        let upperBound = "<chapter eID=\"gen1146\" osisID=\"1Macc.1\"/>".count
+        return lowerBound...upperBound
+    }()
+
+    private static let ibtShortBookEmptyVerseStubRange: ClosedRange<Int> = {
+        let lowerBound = "<chapter eID=\"gen955\" osisID=\"Obad.1\"/> <div eID=\"gen954\" osisID=\"Obad\" type=\"book\"/> <div eID=\"gen953\" type=\"x-Synodal-empty\"/>".count
+        let upperBound = "<chapter eID=\"gen1136\" osisID=\"EpJer.1\"/> <div eID=\"gen1135\" osisID=\"EpJer\" type=\"book\"/> <div eID=\"gen1134\" type=\"x-Synodal-non-canonical\"/>".count
+        return lowerBound...upperBound
+    }()
 
     // MARK: - Key Browsing
 

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -9,7 +9,7 @@ public struct VerseKeyChildren: Sendable {
     public let book: Int
     public let chapter: Int
     public let verse: Int
-    /// Calculated verse ordinal when supplied by the caller; raw flat SWORD key children do not expose this directly.
+    /// SWORD/JSword-style versification ordinal including book and chapter intro slots.
     public let index: Int
     public let chapterMax: Int
     public let verseMax: Int
@@ -78,8 +78,6 @@ public struct VerseKeyReference: Sendable, Equatable {
 public final class SwordModule: @unchecked Sendable {
     let handle: UnsafeMutableRawPointer
     private let queue: DispatchQueue
-    private var cachedVersificationBooks: [VersificationBook]?
-    private var cachedVerseCountsByBookChapter: [String: [Int: Int]] = [:]
 
     /// Module metadata.
     public let info: ModuleInfo
@@ -152,22 +150,18 @@ public final class SwordModule: @unchecked Sendable {
     /// Get the current SWORD VerseKey index for verse-key modules.
     public func currentVerseKeyIndex() -> Int? {
         queue.sync {
-            guard let children = Self.currentVerseKeyChildren(handle: handle) else { return nil }
-            return verseOrdinalLocked(
-                osisBookId: children.osisBookName,
-                chapter: children.chapter,
-                verse: children.verse
-            )
+            let index = SWModule_getVerseKeyIndex(handle)
+            return index >= 0 ? Int(index) : nil
         }
     }
 
     /**
      Resolves a verse to the ordinal used by the module's active versification.
 
-     Android gets these ordinals through JSword `Versification.getOrdinal(Verse)`. SWORD exposes
-     the equivalent through `VerseKey.getIndex()`, including intro slots for the Bible, testament,
-     book, and chapter. The method uses exact-key syntax and validates the resolved key so a missing
-     or out-of-range verse cannot silently normalize to a neighboring reference.
+     Android gets these ordinals through JSword `Versification.getOrdinal(Verse)`. This method
+     delegates to SWORD's native `VerseKey.getIndex()`, including intro slots for the Bible,
+     testament, book, and chapter. The method uses exact-key syntax and validates the resolved key
+     so a missing or out-of-range verse cannot silently normalize to a neighboring reference.
 
      - Parameters:
        - osisBookId: OSIS book identifier such as `Gen`, `Ruth`, or `1Cor`.
@@ -186,7 +180,17 @@ public final class SwordModule: @unchecked Sendable {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, previousKey) }
 
-            return verseOrdinalLocked(osisBookId: osisBookId, chapter: chapter, verse: verse)
+            guard let children = exactVerseKeyChildrenLocked(
+                osisBookId: osisBookId,
+                chapter: chapter,
+                verse: verse
+            ) else {
+                return nil
+            }
+
+            let index = SWModule_getVerseKeyIndex(handle)
+            guard index >= 0, children.chapter > 0, children.verse > 0 else { return nil }
+            return Int(index)
         }
     }
 
@@ -194,7 +198,7 @@ public final class SwordModule: @unchecked Sendable {
      Resolves a versification ordinal back to a concrete verse reference.
 
      Android can reverse-map bookmark and memorization ordinals through JSword's versification. This
-     method provides the same boundary for iOS by positioning SWORD's `VerseKey` with
+     method provides the same boundary for iOS by positioning SWORD's native `VerseKey` with
      `setIndex(_:)`, reading structured key metadata, and then restoring the caller's prior cursor.
      When `osisBookId` is provided, the method rejects ordinals that resolve outside that book.
 
@@ -210,7 +214,29 @@ public final class SwordModule: @unchecked Sendable {
         guard ordinal > 0 else { return nil }
 
         return queue.sync {
-            verseReferenceLocked(osisBookId: osisBookId, ordinal: ordinal)
+            let previousKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, previousKey) }
+
+            guard SWModule_setVerseKeyIndex(handle, CLong(ordinal)) == 0,
+                  let children = Self.currentVerseKeyChildren(handle: handle),
+                  children.chapter > 0,
+                  children.verse > 0 else {
+                return nil
+            }
+
+            let resolvedOsisBookId = children.osisBookName
+            if let osisBookId, osisBookId != resolvedOsisBookId {
+                return nil
+            }
+
+            let resolvedOrdinal = SWModule_getVerseKeyIndex(handle)
+            guard Int(resolvedOrdinal) == ordinal else { return nil }
+            return VerseKeyReference(
+                osisBookId: resolvedOsisBookId,
+                chapter: children.chapter,
+                verse: children.verse,
+                ordinal: Int(resolvedOrdinal)
+            )
         }
     }
 
@@ -246,7 +272,7 @@ public final class SwordModule: @unchecked Sendable {
 
         var parts: [String] = []
         var index = 0
-        while index < 8, let ptr = children[index] {
+        while index < 11, let ptr = children[index] {
             parts.append(String(cString: ptr))
             index += 1
         }
@@ -261,186 +287,29 @@ public final class SwordModule: @unchecked Sendable {
             return nil
         }
 
+        let keyIndex = SWModule_getVerseKeyIndex(handle)
+        guard keyIndex >= 0 else { return nil }
+
+        let osisRef = parts[7]
+        let fallbackOsisBookName = osisRef.components(separatedBy: ".").first ?? osisRef
+        let shortText = parts.count > 8 && !parts[8].isEmpty ? parts[8] : osisRef
+        let bookAbbreviation = parts.count > 9 && !parts[9].isEmpty ? parts[9] : fallbackOsisBookName
+        let osisBookName = parts.count > 10 && !parts[10].isEmpty ? parts[10] : fallbackOsisBookName
+
         return VerseKeyChildren(
             testament: testament,
             book: book,
             chapter: chapter,
             verse: verse,
-            index: 0,
+            index: Int(keyIndex),
             chapterMax: chapterMax,
             verseMax: verseMax,
             bookName: parts[6],
-            osisRef: parts[7],
-            shortText: parts[7],
-            bookAbbreviation: parts[7].components(separatedBy: ".").first ?? parts[7],
-            osisBookName: parts[7].components(separatedBy: ".").first ?? parts[7]
+            osisRef: osisRef,
+            shortText: shortText,
+            bookAbbreviation: bookAbbreviation,
+            osisBookName: osisBookName
         )
-    }
-
-    /**
-     Canonical OSIS candidates used to discover the active SWORD versification order.
-
-     SWORD's flat key-children API exposes testament/book ordinals only after positioning a key; it
-     does not expose a book iterator. This list gives the probe set, while SWORD decides which
-     identifiers are valid for the module's versification and how they sort.
-     */
-    private static let versificationProbeOsisBookIds: [String] = [
-        "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Ruth",
-        "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh", "Esth",
-        "Job", "Ps", "Prov", "Eccl", "Song", "Isa", "Jer", "Lam", "Ezek", "Dan",
-        "Hos", "Joel", "Amos", "Obad", "Jonah", "Mic", "Nah", "Hab", "Zeph",
-        "Hag", "Zech", "Mal", "Tob", "Jdt", "AddEsth", "Wis", "Sir", "Bar",
-        "EpJer", "PrAzar", "Sus", "Bel", "1Macc", "2Macc", "3Macc", "4Macc",
-        "PrMan", "1Esd", "2Esd", "Ps151", "Matt", "Mark", "Luke", "John",
-        "Acts", "Rom", "1Cor", "2Cor", "Gal", "Eph", "Phil", "Col", "1Thess",
-        "2Thess", "1Tim", "2Tim", "Titus", "Phlm", "Heb", "Jas", "1Pet",
-        "2Pet", "1John", "2John", "3John", "Jude", "Rev",
-    ]
-
-    /// One book resolved from SWORD's active versification and sorted by SWORD book order.
-    private struct VersificationBook: Sendable {
-        let osisBookId: String
-        let testament: Int
-        let book: Int
-        let chapterMax: Int
-    }
-
-    /**
-     Computes a JSword/SWORD-style ordinal while the module queue is already held.
-
-     The flat SWORD API does not expose `VerseKey.getIndex()`. Android's JSword ordinal includes
-     testament, book, and chapter intro slots, so this method derives the same value from SWORD's
-     active versification order and per-chapter verse counts instead of using fixed chapter math.
-     */
-    private func verseOrdinalLocked(osisBookId: String, chapter: Int, verse: Int) -> Int? {
-        guard let target = exactVerseKeyChildrenLocked(
-            osisBookId: osisBookId,
-            chapter: chapter,
-            verse: verse
-        ) else {
-            return nil
-        }
-
-        var ordinal = 0
-        var currentTestament = 0
-        for book in versificationBooksLocked() {
-            if book.testament != currentTestament {
-                ordinal += 1
-                currentTestament = book.testament
-            }
-
-            ordinal += 1
-            for chapterNumber in 1...book.chapterMax {
-                ordinal += 1
-                if book.osisBookId == target.osisBookName && chapterNumber == target.chapter {
-                    guard target.verse <= verseCountLocked(osisBookId: book.osisBookId, chapter: chapterNumber) else {
-                        return nil
-                    }
-                    return ordinal + target.verse
-                }
-                ordinal += verseCountLocked(osisBookId: book.osisBookId, chapter: chapterNumber)
-            }
-        }
-
-        return nil
-    }
-
-    /**
-     Reverse-maps a JSword/SWORD-style ordinal while the module queue is already held.
-
-     Intro slots for testament, book, and chapter intentionally do not produce verse references.
-     That matches JSword's distinction between structural keys and normal `Verse` keys.
-     */
-    private func verseReferenceLocked(osisBookId: String?, ordinal: Int) -> VerseKeyReference? {
-        var cursor = 0
-        var currentTestament = 0
-        for book in versificationBooksLocked() {
-            if book.testament != currentTestament {
-                cursor += 1
-                if cursor == ordinal { return nil }
-                currentTestament = book.testament
-            }
-
-            cursor += 1
-            if cursor == ordinal { return nil }
-
-            for chapter in 1...book.chapterMax {
-                cursor += 1
-                if cursor == ordinal { return nil }
-
-                let verseCount = verseCountLocked(osisBookId: book.osisBookId, chapter: chapter)
-                if ordinal <= cursor + verseCount {
-                    let verse = ordinal - cursor
-                    guard verse > 0 else { return nil }
-                    if let osisBookId, osisBookId != book.osisBookId {
-                        return nil
-                    }
-                    return VerseKeyReference(
-                        osisBookId: book.osisBookId,
-                        chapter: chapter,
-                        verse: verse,
-                        ordinal: ordinal
-                    )
-                }
-                cursor += verseCount
-            }
-        }
-        return nil
-    }
-
-    /// Returns active-versification books sorted by SWORD testament/book order.
-    private func versificationBooksLocked() -> [VersificationBook] {
-        if let cachedVersificationBooks {
-            return cachedVersificationBooks
-        }
-
-        var books: [VersificationBook] = []
-        var seen = Set<String>()
-        for osisBookId in Self.versificationProbeOsisBookIds {
-            SWModule_setKeyText(handle, "=\(osisBookId).1.1")
-            guard let children = Self.currentVerseKeyChildren(handle: handle),
-                  children.testament > 0,
-                  children.chapter == 1,
-                  children.verse == 1,
-                  children.osisBookName == osisBookId,
-                  seen.insert(osisBookId).inserted else {
-                continue
-            }
-            books.append(VersificationBook(
-                osisBookId: osisBookId,
-                testament: children.testament,
-                book: children.book,
-                chapterMax: children.chapterMax
-            ))
-        }
-
-        let sortedBooks = books.sorted {
-            if $0.testament != $1.testament {
-                return $0.testament < $1.testament
-            }
-            return $0.book < $1.book
-        }
-        cachedVersificationBooks = sortedBooks
-        return sortedBooks
-    }
-
-    /// Returns a SWORD verse count for one chapter while caching repeated ordinal calculations.
-    private func verseCountLocked(osisBookId: String, chapter: Int) -> Int {
-        if let cached = cachedVerseCountsByBookChapter[osisBookId]?[chapter] {
-            return cached
-        }
-
-        let count: Int
-        if let children = exactVerseKeyChildrenLocked(osisBookId: osisBookId, chapter: chapter, verse: 1) {
-            count = max(0, children.verseMax)
-        } else {
-            count = 0
-        }
-
-        var chapterCounts = cachedVerseCountsByBookChapter[osisBookId] ?? [:]
-        chapterCounts[chapter] = count
-        cachedVerseCountsByBookChapter[osisBookId] = chapterCounts
-        return count
     }
 
     /// Positions an exact verse key and rejects SWORD normalization to neighboring references.
@@ -449,7 +318,9 @@ public final class SwordModule: @unchecked Sendable {
         guard let children = Self.currentVerseKeyChildren(handle: handle),
               children.osisBookName == osisBookId,
               children.chapter == chapter,
-              children.verse == verse else {
+              children.verse == verse,
+              children.chapter <= children.chapterMax,
+              children.verse <= children.verseMax else {
             return nil
         }
         return children
@@ -508,6 +379,7 @@ public final class SwordModule: @unchecked Sendable {
             guard let children = Self.currentVerseKeyChildren(handle: handle),
                   children.osisBookName == osisBookId,
                   children.chapter == chapter,
+                  children.chapter <= children.chapterMax,
                   children.verseMax > 0 else {
                 return nil
             }

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -26,8 +26,8 @@ public struct VerseKeyChildren: Sendable {
  The reader bridge needs the same category of answers Android receives from JSword's
  `Versification`: exact book/chapter/verse identity plus the intro-inclusive ordinal used by
  bookmarks, navigation, highlighting, memorization, and reference documents. This value is copied
- out of the SWORD module while the module cursor is protected by `SwordModule`'s serialization
- queue, so callers can retain it without holding any SWORD-owned pointers.
+ out of the SWORD module while the module cursor is protected by `SwordRuntime`, so callers can
+ retain it without holding any SWORD-owned pointers.
  */
 public struct VerseKeyReference: Sendable, Equatable {
     /// OSIS book identifier, such as `Gen`, `Ruth`, or `1Cor`.
@@ -71,54 +71,55 @@ public struct VerseKeyReference: Sendable, Equatable {
  Swift wrapper around a SWORD SWModule instance.
 
  Provides verse key navigation, text retrieval, and search capabilities.
- All operations are serialized on an internal queue since libsword is not thread-safe.
+ All operations are serialized through `SwordRuntime` since libsword and the flat bridge keep
+ process-global state and are not thread-safe.
 
  Do not create instances directly — obtain them from `SwordManager.module(named:)`.
  */
 public final class SwordModule: @unchecked Sendable {
     let handle: UnsafeMutableRawPointer
-    private let queue: DispatchQueue
 
     /// Module metadata.
     public let info: ModuleInfo
 
-    init(handle: UnsafeMutableRawPointer, queue: DispatchQueue, modulePath: String? = nil) {
+    init(handle: UnsafeMutableRawPointer, modulePath: String? = nil) {
         self.handle = handle
-        self.queue = queue
 
-        // Extract metadata once at init
-        let name = String(cString: SWModule_getName(handle))
-        let description = String(cString: SWModule_getDescription(handle))
-        let typeStr = String(cString: SWModule_getType(handle))
-        let language = String(cString: SWModule_getLanguage(handle))
+        self.info = SwordRuntime.sync {
+            // Extract metadata once at init
+            let name = String(cString: SWModule_getName(handle))
+            let description = String(cString: SWModule_getDescription(handle))
+            let typeStr = String(cString: SWModule_getType(handle))
+            let language = String(cString: SWModule_getLanguage(handle))
 
-        // Detect features by parsing the .conf file directly from disk.
-        // SWORD's flat API getConfigEntry() only returns the FIRST value for
-        // multi-value keys (Feature, GlobalOptionFilter), so modules like KJV
-        // where StrongsNumbers isn't the first entry are missed. Reading the
-        // .conf file catches ALL entries.
-        let features = SwordModule.detectFeatures(
-            name: name, handle: handle, modulePath: modulePath
-        )
+            // Detect features by parsing the .conf file directly from disk.
+            // SWORD's flat API getConfigEntry() only returns the FIRST value for
+            // multi-value keys (Feature, GlobalOptionFilter), so modules like KJV
+            // where StrongsNumbers isn't the first entry are missed. Reading the
+            // .conf file catches ALL entries.
+            let features = SwordModule.detectFeatures(
+                name: name, handle: handle, modulePath: modulePath
+            )
 
-        let cipherKey = SWModule_getConfigEntry(handle, "CipherKey")
-        let isEncrypted = cipherKey != nil
-        let directionPtr = SWModule_getConfigEntry(handle, "Direction")
-        let direction = directionPtr != nil ? String(cString: directionPtr!) : "LtoR"
-        let versionPtr = SWModule_getConfigEntry(handle, "Version")
-        let versionStr = versionPtr != nil ? String(cString: versionPtr!) : ""
+            let cipherKey = SWModule_getConfigEntry(handle, "CipherKey")
+            let isEncrypted = cipherKey != nil
+            let directionPtr = SWModule_getConfigEntry(handle, "Direction")
+            let direction = directionPtr != nil ? String(cString: directionPtr!) : "LtoR"
+            let versionPtr = SWModule_getConfigEntry(handle, "Version")
+            let versionStr = versionPtr != nil ? String(cString: versionPtr!) : ""
 
-        self.info = ModuleInfo(
-            name: name,
-            description: description,
-            category: ModuleCategory(typeString: typeStr),
-            language: language,
-            version: versionStr,
-            isEncrypted: isEncrypted,
-            isUnlocked: !isEncrypted || (cipherKey.map { String(cString: $0) } ?? "").isEmpty == false,
-            features: features,
-            isRightToLeft: direction == "RtoL"
-        )
+            return ModuleInfo(
+                name: name,
+                description: description,
+                category: ModuleCategory(typeString: typeStr),
+                language: language,
+                version: versionStr,
+                isEncrypted: isEncrypted,
+                isUnlocked: !isEncrypted || (cipherKey.map { String(cString: $0) } ?? "").isEmpty == false,
+                features: features,
+                isRightToLeft: direction == "RtoL"
+            )
+        }
     }
 
     // MARK: - Key Navigation
@@ -128,28 +129,28 @@ public final class SwordModule: @unchecked Sendable {
      - Parameter keyText: A verse reference like "Gen 1:1" or a dictionary key.
      */
     public func setKey(_ keyText: String) {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_setKeyText(handle, keyText)
         }
     }
 
     /// Get the current key text.
     public func currentKey() -> String {
-        queue.sync {
+        SwordRuntime.sync {
             String(cString: SWModule_getKeyText(handle))
         }
     }
 
     /// Get structured VerseKey data for the current position when the module uses VerseKey.
     public func currentVerseKeyChildren() -> VerseKeyChildren? {
-        queue.sync {
+        SwordRuntime.sync {
             Self.currentVerseKeyChildren(handle: handle)
         }
     }
 
     /// Get the current SWORD VerseKey index for verse-key modules.
     public func currentVerseKeyIndex() -> Int? {
-        queue.sync {
+        SwordRuntime.sync {
             let index = SWModule_getVerseKeyIndex(handle)
             return index >= 0 ? Int(index) : nil
         }
@@ -176,7 +177,7 @@ public final class SwordModule: @unchecked Sendable {
     public func verseOrdinal(osisBookId: String, chapter: Int, verse: Int) -> Int? {
         guard chapter > 0, verse > 0, !osisBookId.isEmpty else { return nil }
 
-        return queue.sync {
+        return SwordRuntime.sync {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, previousKey) }
 
@@ -213,7 +214,7 @@ public final class SwordModule: @unchecked Sendable {
     public func verseReference(osisBookId: String? = nil, ordinal: Int) -> VerseKeyReference? {
         guard ordinal > 0 else { return nil }
 
-        return queue.sync {
+        return SwordRuntime.sync {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, previousKey) }
 
@@ -256,7 +257,7 @@ public final class SwordModule: @unchecked Sendable {
     public func inspectVerseKeyAndRawEntryRestoringPrevious(
         _ keyText: String
     ) -> (actualKey: String, verseKey: VerseKeyChildren?, rawEntry: String) {
-        queue.sync {
+        SwordRuntime.sync {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             SWModule_setKeyText(handle, keyText)
             let actualKey = String(cString: SWModule_getKeyText(handle))
@@ -343,7 +344,7 @@ public final class SwordModule: @unchecked Sendable {
        desynchronizing later raw-entry reads.
      */
     public func parseKeyList(_ keyText: String) -> [String] {
-        queue.sync {
+        SwordRuntime.sync {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, previousKey) }
 
@@ -371,7 +372,7 @@ public final class SwordModule: @unchecked Sendable {
     public func verseCount(osisBookId: String, chapter: Int) -> Int? {
         guard chapter > 0, !osisBookId.isEmpty else { return nil }
 
-        return queue.sync {
+        return SwordRuntime.sync {
             let previousKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, previousKey) }
 
@@ -414,7 +415,7 @@ public final class SwordModule: @unchecked Sendable {
                                 level2: String? = nil,
                                 level3: String? = nil,
                                 filtered: Bool = false) -> [String] {
-        queue.sync {
+        SwordRuntime.sync {
             func withOptionalCString<T>(_ value: String?, _ body: (UnsafePointer<CChar>?) -> T) -> T {
                 guard let value else { return body(nil) }
                 return value.withCString(body)
@@ -446,7 +447,7 @@ public final class SwordModule: @unchecked Sendable {
      */
     @discardableResult
     public func next() -> Bool {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_next(handle) == 0
         }
     }
@@ -457,21 +458,21 @@ public final class SwordModule: @unchecked Sendable {
      */
     @discardableResult
     public func previous() -> Bool {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_previous(handle) == 0
         }
     }
 
     /// Navigate to the beginning of the module.
     public func begin() {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_begin(handle)
         }
     }
 
     /// Check if the current position is at the end.
     public var isAtEnd: Bool {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_isEnd(handle) != 0
         }
     }
@@ -479,12 +480,12 @@ public final class SwordModule: @unchecked Sendable {
     // MARK: - Text Retrieval
 
     /**
-     Atomically set key, read back actual key, and render text in one queue.sync block.
+     Atomically set key, read back actual key, and render text in one `SwordRuntime.sync` block.
      This prevents interleaving with other SWORD operations between setKey/currentKey/renderText.
      Returns (actualKey, renderedText).
      */
     public func setKeyAndRender(_ keyText: String) -> (actualKey: String, text: String) {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_setKeyText(handle, keyText)
             let actualKey = String(cString: SWModule_getKeyText(handle))
             let text = String(cString: SWModule_getRenderText(handle))
@@ -505,7 +506,7 @@ public final class SwordModule: @unchecked Sendable {
         includeRenderedText: Bool = true,
         includeStrippedText: Bool = true
     ) -> (actualKey: String, rawEntry: String, renderedText: String, strippedText: String) {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_setKeyText(handle, keyText)
             let actualKey = String(cString: SWModule_getKeyText(handle))
             let rawEntry = String(cString: SWModule_getRawEntry(handle))
@@ -521,28 +522,28 @@ public final class SwordModule: @unchecked Sendable {
 
     /// Get rendered text (with markup/HTML) at the current position.
     public func renderText() -> String {
-        queue.sync {
+        SwordRuntime.sync {
             String(cString: SWModule_getRenderText(handle))
         }
     }
 
     /// Get raw entry text at the current position (no markup processing).
     public func rawEntry() -> String {
-        queue.sync {
+        SwordRuntime.sync {
             String(cString: SWModule_getRawEntry(handle))
         }
     }
 
     /// Get plain/strip text at the current position (no markup at all).
     public func stripText() -> String {
-        queue.sync {
+        SwordRuntime.sync {
             String(cString: SWModule_getStripText(handle))
         }
     }
 
     /// Get rendered header text (chapter/book introductions).
     public func renderHeader() -> String {
-        queue.sync {
+        SwordRuntime.sync {
             String(cString: SWModule_getRenderHeader(handle))
         }
     }
@@ -555,7 +556,7 @@ public final class SwordModule: @unchecked Sendable {
      - Returns: The value, or nil if not found.
      */
     public func configEntry(_ key: String) -> String? {
-        queue.sync {
+        SwordRuntime.sync {
             guard let cStr = SWModule_getConfigEntry(handle, key) else { return nil }
             return String(cString: cStr)
         }
@@ -566,7 +567,7 @@ public final class SwordModule: @unchecked Sendable {
      - Parameter key: The decryption key.
      */
     public func setCipherKey(_ key: String) {
-        queue.sync {
+        SwordRuntime.sync {
             SWModule_setCipherKey(handle, key)
         }
     }
@@ -592,7 +593,7 @@ public final class SwordModule: @unchecked Sendable {
      */
     public func getBookList() -> [BookInfo] {
         guard info.category == .bible || info.category == .commentary else { return [] }
-        return queue.sync {
+        return SwordRuntime.sync {
             let savedKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, savedKey) }
 
@@ -787,7 +788,7 @@ public final class SwordModule: @unchecked Sendable {
      Faster than `iterateAllEntries` since it skips text retrieval.
      */
     public func allKeys() -> [String] {
-        queue.sync {
+        SwordRuntime.sync {
             let savedKey = String(cString: SWModule_getKeyText(handle))
             defer { SWModule_setKeyText(handle, savedKey) }
 
@@ -809,7 +810,7 @@ public final class SwordModule: @unchecked Sendable {
      Returns the NULL-terminated string array from SWORD's getKeyChildren.
      */
     public func keyChildren() -> [String] {
-        queue.sync {
+        SwordRuntime.sync {
             guard let children = SWModule_getKeyChildren(handle) else { return [] }
             var result: [String] = []
             var i = 0
@@ -827,13 +828,13 @@ public final class SwordModule: @unchecked Sendable {
      Iterate through all entries in the module, calling the callback for each.
 
      The callback receives `(key, plainText, index)` and should return `true` to continue.
-     All SWORD operations run in a single queue.sync block for efficiency.
+     All SWORD operations run in a single `SwordRuntime.sync` block for correctness.
      The module's current key position is saved and restored after iteration.
 
      - Parameter callback: Called for each entry. Return `false` to stop early.
      */
     public func iterateAllEntries(_ callback: (String, String, Int) -> Bool) {
-        queue.sync {
+        SwordRuntime.sync {
             // Save current position
             let savedKey = String(cString: SWModule_getKeyText(handle))
 
@@ -865,7 +866,7 @@ public final class SwordModule: @unchecked Sendable {
      - Returns: Search results.
      */
     public func search(_ options: SearchOptions) -> SearchResults {
-        queue.sync {
+        SwordRuntime.sync {
             let flags: Int32 = options.caseInsensitive ? 2 : 0 // REG_ICASE = 2
 
             _ = SWModule_search(

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -902,6 +902,52 @@ public final class SwordModule: @unchecked Sendable {
         }
     }
 
+    /**
+     Search the module and return only matching keys.
+
+     Strong's candidate-index searches need SWORD's result keys but validate and render each verse
+     through a separate canonical-token path. Keeping this key-only avoids stripping preview text
+     for thousands of candidates before the caller knows which verses are semantically valid.
+
+     - Parameters:
+       - options: Search configuration.
+       - limit: Optional maximum number of keys to return.
+     - Returns: Matching SWORD keys in result order.
+     - Side effects:
+       - performs a SWORD search while holding the runtime lock
+       - restores the module's current key after reading search results
+     - Failure modes:
+       - returns an empty list when SWORD reports no results or the limit is zero
+     */
+    public func searchKeys(_ options: SearchOptions, limit: Int? = nil) -> [String] {
+        SwordRuntime.sync {
+            let savedKey = String(cString: SWModule_getKeyText(handle))
+            defer { SWModule_setKeyText(handle, savedKey) }
+
+            let flags: Int32 = options.caseInsensitive ? 2 : 0 // REG_ICASE = 2
+
+            _ = SWModule_search(
+                handle,
+                options.query,
+                Int32(options.searchType.rawValue),
+                flags,
+                options.scope,
+                nil
+            )
+
+            let count = Int(SWModule_searchResultCount(handle))
+            let boundedCount = limit.map { min(max($0, 0), count) } ?? count
+            guard boundedCount > 0 else { return [] }
+
+            var keys: [String] = []
+            keys.reserveCapacity(boundedCount)
+            for index in 0..<boundedCount {
+                keys.append(String(cString: SWModule_getSearchResultKeyText(handle, Int32(index))))
+            }
+            return keys
+        }
+    }
+
     // MARK: - Feature Detection
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/SwordModuleStore.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModuleStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/**
+ Shared notification contract for mutations to the installed module store.
+
+ `SwordManager` instances cache SWORD's module list at both Swift and C bridge levels, and Downloads
+ also combines that list with sidecar MyBible installs. File-system mutations therefore need a
+ process-wide signal so already-open UI surfaces can rebuild their snapshots instead of waiting for
+ an app restart. The notification intentionally carries no payload: consumers must rescan storage
+ because installs, restores, overwrites, and uninstalls can affect multiple categories and module
+ names.
+ */
+public enum SwordModuleStore {
+    /**
+     Posted after a successful mutation of installed module files.
+
+     Side effects:
+     - observers may rebuild `SwordManager` instances and refresh installed-module UI state
+
+     Failure modes:
+     - notification delivery is best-effort and synchronous according to `NotificationCenter`
+       semantics; the storage mutation has already completed before the event is posted.
+     */
+    public static let modulesDidChangeNotification = Notification.Name(
+        "org.andbible.SwordModuleStore.modulesDidChange"
+    )
+
+    /**
+     Announces that installed module files changed and cached module snapshots should rescan.
+
+     - Parameter center: Notification center used for publication. Tests may inject a local center,
+       while production uses `.default`.
+     - Side effects: Posts `modulesDidChangeNotification`.
+     - Failure modes: None; `NotificationCenter` posting does not throw.
+     */
+    public static func notifyModulesDidChange(center: NotificationCenter = .default) {
+        center.post(name: modulesDidChangeNotification, object: nil)
+    }
+}

--- a/Sources/SwordKit/Sources/SwordKit/SwordRuntime.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordRuntime.swift
@@ -1,0 +1,50 @@
+// SwordRuntime.swift - process-wide SWORD runtime serialization
+
+import Foundation
+
+/**
+ Process-wide gate for every call into libsword and the local C adapter.
+
+ SWORD and the bridge layer keep process-global state, including cached flat-API pointer lists and
+ native parser/rendering state. Instance-level queues cannot protect that state when separate
+ `SwordManager`, `SwordModule`, `InstallManager`, or `SwordConfig` values are used concurrently.
+ This runtime provides one serialization point for those native calls while remaining reentrant, so
+ composite SwordKit methods can call smaller helpers without deadlocking.
+
+ - Inputs: A synchronous closure that performs one or more SWORD or SWORD-adjacent C calls.
+ - Returns: The closure's copied Swift result after native pointers have been consumed.
+ - Side effects: Serializes all work submitted through this type on a single private queue.
+ - Failure modes: Rethrows closure errors. Native crashes remain possible if code bypasses this
+   runtime and calls the non-thread-safe SWORD bridge directly.
+ - Important: Keep callbacks passed to `sync(_:)` bounded and avoid waiting on work that itself
+   needs the SWORD runtime from another thread.
+ */
+enum SwordRuntime {
+    private static let queueKey = DispatchSpecificKey<Void>()
+
+    private static let queue: DispatchQueue = {
+        let queue = DispatchQueue(label: "org.andbible.SwordRuntime", qos: .userInitiated)
+        queue.setSpecific(key: queueKey, value: ())
+        return queue
+    }()
+
+    /**
+     Executes SWORD work on the shared runtime queue.
+
+     Nested calls execute inline when the current thread is already on the runtime queue. This keeps
+     higher-level operations such as module creation safe when they call helper methods that also
+     need SWORD access.
+
+     - Parameter operation: Closure containing native SWORD bridge calls and immediate pointer
+       copying.
+     - Returns: The value returned by `operation`.
+     - Throws: Rethrows errors from `operation`.
+     - Side effects: May block until prior SWORD work completes.
+     */
+    static func sync<T>(_ operation: () throws -> T) rethrows -> T {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return try operation()
+        }
+        return try queue.sync(execute: operation)
+    }
+}

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -553,7 +553,10 @@ private final class FixtureContext {
         _ rows: [(verseKey: String, plainText: String, moduleName: String)],
         into db: OpaquePointer
     ) throws {
-        let sql = "INSERT INTO verse_fts (verse_key, plain_text, module_name) VALUES (?, ?, ?)"
+        let sql = """
+            INSERT INTO verse_fts (verse_key, plain_text, module_name, entry_order)
+            VALUES (?, ?, ?, ?)
+        """
         var statement: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK,
               let statement else {
@@ -564,12 +567,13 @@ private final class FixtureContext {
         }
         defer { sqlite3_finalize(statement) }
 
-        for row in rows {
+        for (entryOrder, row) in rows.enumerated() {
             sqlite3_reset(statement)
             sqlite3_clear_bindings(statement)
             sqlite3_bind_text(statement, 1, row.verseKey, -1, sqliteTransient)
             sqlite3_bind_text(statement, 2, row.plainText, -1, sqliteTransient)
             sqlite3_bind_text(statement, 3, row.moduleName, -1, sqliteTransient)
+            sqlite3_bind_int(statement, 4, Int32(entryOrder))
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 throw sqliteError(
                     from: db,
@@ -581,6 +585,9 @@ private final class FixtureContext {
 
     /**
      Records the seeded module metadata expected by `SearchIndexService.hasIndex`.
+
+     The schema version comes from production `SearchIndexService` so fixture-generated search
+     databases remain valid when the app intentionally invalidates older index formats.
      *
      * - Parameters:
      *   - moduleName: Module abbreviation to record as indexed.
@@ -605,7 +612,7 @@ private final class FixtureContext {
 
         sqlite3_bind_text(statement, 1, moduleName, -1, sqliteTransient)
         sqlite3_bind_int(statement, 2, verseCount)
-        sqlite3_bind_int(statement, 3, 2)
+        sqlite3_bind_int(statement, 3, Int32(SearchIndexService.currentSchemaVersion))
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw sqliteError(
@@ -628,6 +635,7 @@ private final class FixtureContext {
                 verse_key,
                 plain_text,
                 module_name UNINDEXED,
+                entry_order UNINDEXED,
                 tokenize='unicode61'
             )
         """, db: db)

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -2,6 +2,7 @@ import Foundation
 import SQLite3
 import SwiftData
 import BibleCore
+import SwordKit
 
 /**
  Host-side fixture writer for XCUITests.
@@ -130,6 +131,9 @@ private struct ToolArguments {
 private enum FixtureToolError: LocalizedError {
     case usage(String)
     case sqlite(String)
+    case missingBundledSwordResources(String)
+    case missingSwordModule(String)
+    case unresolvedVerse(String)
     case missingWorkspace
     case missingWindow
     case missingPageManager
@@ -140,6 +144,12 @@ private enum FixtureToolError: LocalizedError {
             return message
         case .sqlite(let message):
             return message
+        case .missingBundledSwordResources(let path):
+            return "Fixture seeding could not find bundled SWORD resources at '\(path)'."
+        case .missingSwordModule(let moduleName):
+            return "Fixture seeding could not load required SWORD module '\(moduleName)'."
+        case .unresolvedVerse(let reference):
+            return "Fixture seeding could not resolve required SWORD verse '\(reference)'."
         case .missingWorkspace:
             return "Fixture seeding could not resolve or create an active workspace."
         case .missingWindow:
@@ -279,6 +289,7 @@ private struct FixtureTool {
             swordURL.appendingPathComponent("mods.d/uitestweb.conf", isDirectory: false),
             swordURL.appendingPathComponent("modules/comments/rawcom/uitestcomm", isDirectory: true),
             swordURL.appendingPathComponent("modules/texts/rawtext/uitestweb", isDirectory: true),
+            swordURL.appendingPathComponent("modules/texts/ztext/uitestweb", isDirectory: true),
         ]
         for candidate in candidates where fileManager.fileExists(atPath: candidate.path) {
             try fileManager.removeItem(at: candidate)
@@ -297,6 +308,7 @@ private final class FixtureContext {
     private let bookmarkService: BookmarkService
     private let remoteSyncSettingsStore: RemoteSyncSettingsStore
     private let fileManager = FileManager.default
+    private var swordManager: SwordManager?
 
     /**
      Creates the store-backed fixture writer for one simulator container.
@@ -391,23 +403,23 @@ private final class FixtureContext {
             try seedUITestBibleModule()
             try seedMultiTranslationSearchIndex()
         case .bookmarkNavigation:
-            seedBookmarkNavigation()
+            try seedBookmarkNavigation()
         case .bookmarkMultiRow:
-            seedBookmarkMultiRow()
+            try seedBookmarkMultiRow()
         case .bookmarkFilter:
-            seedBookmarkFilter()
+            try seedBookmarkFilter()
         case .bookmarkRowLabel:
-            seedBookmarkRowLabel()
+            try seedBookmarkRowLabel()
         case .bookmarkGenericVisible:
             seedBookmarkGenericVisible()
         case .bookmarkStudyPad:
-            seedBookmarkStudyPad()
+            try seedBookmarkStudyPad()
         case .historySingle:
             seedHistorySingle(window: baseline.window)
         case .historyMultiRow:
             seedHistoryMultiRow(window: baseline.window)
         case .myNotesSingle:
-            seedMyNotesSingle()
+            try seedMyNotesSingle()
         case .syncNextCloud:
             seedSyncNextCloud(enabledCategories: [])
         case .syncNextCloudBookmarksEnabled:
@@ -699,45 +711,48 @@ private final class FixtureContext {
     }
 
     /**
-     Seeds a minimal SWORD Bible module used by multi-translation Search UI tests.
+     Seeds a real SWORD Bible module used by multi-translation Search UI tests.
 
-     Search assertions read deterministic FTS rows from `search_indexes.sqlite`, so the module only
-     needs enough SWORD metadata to appear as an installed Bible translation in the real picker.
+     Search assertions read deterministic FTS rows from `search_indexes.sqlite`, but production
+     module discovery and book-list generation now require normal SWORD zText semantics. The fixture
+     therefore clones the bundled KJV module data under deterministic `UITESTWEB` metadata instead of
+     publishing an empty RawText shell that Android/JSword-style discovery would reject.
      */
     private func seedUITestBibleModule() throws {
         let swordURL = paths.documentsURL.appendingPathComponent("sword", isDirectory: true)
         let modsDURL = swordURL.appendingPathComponent("mods.d", isDirectory: true)
         let dataURL = swordURL.appendingPathComponent(
-            "modules/texts/rawtext/uitestweb",
+            "modules/texts/ztext/uitestweb",
             isDirectory: true
         )
+        let sourceDataURL = try bundledSwordResourceURL()
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("texts", isDirectory: true)
+            .appendingPathComponent("ztext", isDirectory: true)
+            .appendingPathComponent("kjv", isDirectory: true)
+
         try fileManager.createDirectory(at: modsDURL, withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: dataURL, withIntermediateDirectories: true)
         try removeCachedSwordModuleConfig(in: modsDURL)
+        try copyDirectoryContents(from: sourceDataURL, to: dataURL, replacingExisting: true)
 
         let conf = """
         [UITESTWEB]
         Description=UI Test Web Bible
-        DataPath=./modules/texts/rawtext/uitestweb/
-        ModDrv=RawText
+        DataPath=./modules/texts/ztext/uitestweb/
+        ModDrv=zText
         SourceType=OSIS
         Encoding=UTF-8
+        CompressType=ZIP
+        BlockType=BOOK
         Lang=en
         Versification=KJV
-        About=Deterministic empty Bible module for iOS multi-translation Search UI automation.
+        About=Deterministic Bible module for iOS multi-translation Search UI automation.
         """
         try conf.write(
             to: modsDURL.appendingPathComponent("uitestweb.conf", isDirectory: false),
             atomically: true,
             encoding: .utf8
         )
-
-        for fileName in ["ot", "ot.vss", "nt", "nt.vss"] {
-            let url = dataURL.appendingPathComponent(fileName, isDirectory: false)
-            if !fileManager.fileExists(atPath: url.path) {
-                try Data().write(to: url)
-            }
-        }
     }
 
     /**
@@ -787,6 +802,106 @@ private final class FixtureContext {
         let cacheURL = modsDURL.appendingPathComponent("modules-conf.cache", isDirectory: false)
         if fileManager.fileExists(atPath: cacheURL.path) {
             try fileManager.removeItem(at: cacheURL)
+        }
+    }
+
+    /**
+     Resolves the repo-bundled SWORD resource directory used by the app at first launch.
+
+     The host fixture tool runs outside the app bundle, so it cannot use `Bundle.main`. Resolving from
+     `#filePath` keeps the fixture tied to the checked-out resources that Xcode also packages into
+     the app.
+
+     - Returns: Repository `AndBible/Resources/sword` directory.
+     - Throws: `FixtureToolError.missingBundledSwordResources` when the resources are unavailable.
+     */
+    private func bundledSwordResourceURL() throws -> URL {
+        let repositoryRootURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let bundledSwordURL = repositoryRootURL
+            .appendingPathComponent("AndBible", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("sword", isDirectory: true)
+
+        guard fileManager.fileExists(atPath: bundledSwordURL.path) else {
+            throw FixtureToolError.missingBundledSwordResources(bundledSwordURL.path)
+        }
+        return bundledSwordURL
+    }
+
+    /**
+     Ensures the simulator SWORD directory contains the bundled KJV module.
+
+     UI fixture commands can run before app launch has copied bundled modules. Bookmark fixtures need
+     KJV available immediately so their persisted ordinals are produced by SWORD instead of by a
+     static approximation.
+
+     - Returns: Simulator document `sword` directory.
+     - Throws: Filesystem errors or `FixtureToolError.missingBundledSwordResources`.
+     */
+    @discardableResult
+    private func ensureBundledKJVSwordModuleAvailable() throws -> URL {
+        let sourceSwordURL = try bundledSwordResourceURL()
+        let destinationSwordURL = paths.documentsURL.appendingPathComponent("sword", isDirectory: true)
+        let sourceConfURL = sourceSwordURL
+            .appendingPathComponent("mods.d", isDirectory: true)
+            .appendingPathComponent("kjv.conf", isDirectory: false)
+        let destinationModsDURL = destinationSwordURL.appendingPathComponent("mods.d", isDirectory: true)
+        let destinationConfURL = destinationModsDURL.appendingPathComponent("kjv.conf", isDirectory: false)
+        let sourceDataURL = sourceSwordURL
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("texts", isDirectory: true)
+            .appendingPathComponent("ztext", isDirectory: true)
+            .appendingPathComponent("kjv", isDirectory: true)
+        let destinationDataURL = destinationSwordURL
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("texts", isDirectory: true)
+            .appendingPathComponent("ztext", isDirectory: true)
+            .appendingPathComponent("kjv", isDirectory: true)
+
+        try fileManager.createDirectory(at: destinationModsDURL, withIntermediateDirectories: true)
+        if !fileManager.fileExists(atPath: destinationConfURL.path) {
+            try fileManager.copyItem(at: sourceConfURL, to: destinationConfURL)
+        }
+        try copyDirectoryContents(from: sourceDataURL, to: destinationDataURL, replacingExisting: false)
+        return destinationSwordURL
+    }
+
+    /**
+     Recursively copies directory contents for deterministic SWORD fixture modules.
+
+     - Parameters:
+       - source: Source directory to copy.
+       - destination: Destination directory to create or update.
+       - replacingExisting: Whether an existing destination tree should be removed first.
+     - Throws: Filesystem errors when copying fails.
+     */
+    private func copyDirectoryContents(from source: URL, to destination: URL, replacingExisting: Bool) throws {
+        if replacingExisting, fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        for item in try fileManager.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) {
+            let values = try item.resourceValues(forKeys: [.isDirectoryKey])
+            let target = destination.appendingPathComponent(
+                item.lastPathComponent,
+                isDirectory: values.isDirectory == true
+            )
+
+            if values.isDirectory == true {
+                try copyDirectoryContents(from: item, to: target, replacingExisting: replacingExisting)
+            } else if replacingExisting || !fileManager.fileExists(atPath: target.path) {
+                if fileManager.fileExists(atPath: target.path) {
+                    try fileManager.removeItem(at: target)
+                }
+                try fileManager.copyItem(at: item, to: target)
+            }
         }
     }
 
@@ -843,8 +958,8 @@ private final class FixtureContext {
     /**
      Seeds one bookmark that should navigate from Genesis 1 to Exodus 2.
      */
-    private func seedBookmarkNavigation() {
-        _ = createBibleBookmark(
+    private func seedBookmarkNavigation() throws {
+        _ = try createBibleBookmark(
             bookName: "Exodus",
             chapter: 2,
             labelName: nil,
@@ -856,15 +971,15 @@ private final class FixtureContext {
     /**
      Seeds two bookmark rows used by delete and sort workflows.
      */
-    private func seedBookmarkMultiRow() {
-        _ = createBibleBookmark(
+    private func seedBookmarkMultiRow() throws {
+        _ = try createBibleBookmark(
             bookName: "Matthew",
             chapter: 3,
             labelName: nil,
             note: nil,
             createdAt: seededDate(offset: 20)
         )
-        _ = createBibleBookmark(
+        _ = try createBibleBookmark(
             bookName: "Exodus",
             chapter: 2,
             labelName: nil,
@@ -876,17 +991,17 @@ private final class FixtureContext {
     /**
      Seeds two labeled bookmark rows used by filter-reset workflows.
      */
-    private func seedBookmarkFilter() {
+    private func seedBookmarkFilter() throws {
         let uiTestLabel = ensureUserLabel(name: "UI Test Seed", color: 0xFF91A7FF)
         let secondaryLabel = ensureUserLabel(name: "Other Label", color: 0xFFFFCC99)
-        _ = createBibleBookmark(
+        _ = try createBibleBookmark(
             bookName: "Exodus",
             chapter: 2,
             label: secondaryLabel,
             note: nil,
             createdAt: seededDate(offset: 10)
         )
-        _ = createBibleBookmark(
+        _ = try createBibleBookmark(
             bookName: "Genesis",
             chapter: 1,
             label: uiTestLabel,
@@ -898,9 +1013,9 @@ private final class FixtureContext {
     /**
      Seeds one bookmark assigned to the primary UI-test label.
      */
-    private func seedBookmarkRowLabel() {
+    private func seedBookmarkRowLabel() throws {
         let uiTestLabel = ensureUserLabel(name: "UI Test Seed", color: 0xFF91A7FF)
-        _ = createBibleBookmark(
+        _ = try createBibleBookmark(
             bookName: "Genesis",
             chapter: 1,
             label: uiTestLabel,
@@ -928,9 +1043,9 @@ private final class FixtureContext {
     /**
      Seeds one label-backed bookmark and an initial empty StudyPad entry.
      */
-    private func seedBookmarkStudyPad() {
+    private func seedBookmarkStudyPad() throws {
         let uiTestLabel = ensureUserLabel(name: "UI Test Seed", color: 0xFF91A7FF)
-        _ = createBibleBookmark(
+        _ = try createBibleBookmark(
             bookName: "Genesis",
             chapter: 1,
             label: uiTestLabel,
@@ -984,8 +1099,8 @@ private final class FixtureContext {
     /**
      Seeds one Genesis 1 bookmark note for the My Notes flow.
      */
-    private func seedMyNotesSingle() {
-        let bookmark = createBibleBookmark(
+    private func seedMyNotesSingle() throws {
+        let bookmark = try createBibleBookmark(
             bookName: "Genesis",
             chapter: 1,
             labelName: nil,
@@ -1022,15 +1137,162 @@ private final class FixtureContext {
     }
 
     /**
+     Resolves one KJV verse ordinal through SWORD versification metadata.
+
+     Bookmark and My Notes fixtures must store SWORD/JSword-style ordinals, including intro slots.
+     Arithmetic ordinals are invalid under the current reader contract and break chapter-range
+     lookups as soon as production code asks SWORD for real verse positions. The host fixture
+     executable runs on macOS, so it derives the ordinal from SWORD's book order and chapter verse
+     counts using JSword's introduction-slot model instead of trusting platform-local
+     `VerseKey.getIndex()` behavior.
+
+     - Parameters:
+       - bookName: Human-readable SWORD book name such as `Genesis` or `Matthew`.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: Native SWORD verse-key ordinal.
+     - Throws: `FixtureToolError` when the bundled KJV module or verse cannot be resolved.
+     */
+    private func resolveKJVOrdinal(bookName: String, chapter: Int, verse: Int) throws -> Int {
+        let module = try kjvSwordModule()
+        let osisBookId = try resolveOsisBookId(bookName: bookName, chapter: chapter, module: module)
+        return try resolveIntroInclusiveOrdinal(
+            osisBookId: osisBookId,
+            chapter: chapter,
+            verse: verse,
+            module: module
+        )
+    }
+
+    /**
+     Loads the bundled KJV module from the simulator SWORD directory.
+
+     The returned module borrows handles owned by `SwordManager`, so the manager is cached for the
+     lifetime of the fixture context.
+
+     - Returns: Loaded bundled KJV SWORD module.
+     - Throws: `FixtureToolError.missingSwordModule` if SWORD cannot load KJV.
+     */
+    private func kjvSwordModule() throws -> SwordModule {
+        let swordURL = try ensureBundledKJVSwordModuleAvailable()
+        let manager: SwordManager
+        if let existingManager = swordManager {
+            manager = existingManager
+        } else if let createdManager = SwordManager(modulePath: swordURL.path) {
+            swordManager = createdManager
+            manager = createdManager
+        } else {
+            throw FixtureToolError.missingSwordModule("KJV")
+        }
+
+        guard let module = manager.module(named: "KJV") else {
+            throw FixtureToolError.missingSwordModule("KJV")
+        }
+        return module
+    }
+
+    /**
+     Resolves a human-readable book name to the active SWORD OSIS identifier.
+
+     The primary path uses SWORD's discovered book list. The parser fallback still delegates to SWORD
+     and covers alternate names or abbreviations without adding a parallel iOS-only book table.
+
+     - Parameters:
+       - bookName: Human-readable book name to resolve.
+       - chapter: Chapter used when asking SWORD's parser for a concrete key fallback.
+       - module: Loaded SWORD module.
+     - Returns: OSIS book identifier, such as `Gen`, `Exod`, or `Matt`.
+     - Throws: `FixtureToolError.unresolvedVerse` when SWORD cannot resolve the book.
+     */
+    private func resolveOsisBookId(bookName: String, chapter: Int, module: SwordModule) throws -> String {
+        let normalizedBookName = bookName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let book = module.getBookList().first(where: { book in
+            book.name.lowercased() == normalizedBookName ||
+            book.abbreviation.lowercased() == normalizedBookName ||
+            book.osisId.lowercased() == normalizedBookName
+        }) {
+            return book.osisId
+        }
+
+        let parsedKeys = module.parseKeyList("\(bookName) \(chapter):1")
+        if let firstKey = parsedKeys.first,
+           let osisBookId = firstKey.split(separator: ".").first,
+           !osisBookId.isEmpty {
+            return String(osisBookId)
+        }
+
+        throw FixtureToolError.unresolvedVerse("\(bookName) \(chapter):1")
+    }
+
+    /**
+     Computes JSword/SWORD-style ordinals from real SWORD book and chapter metadata.
+
+     JSword ordinals include the Bible introduction, testament introductions, one book introduction
+     per book, and one chapter introduction per real chapter. This mirrors the iOS reader contract
+     protected by `testBundledKJVVerseOrdinalsUseIntroInclusiveVersification` while avoiding the
+     previous fixture-only `chapter * 40` approximation.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier resolved by SWORD.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+       - module: Loaded SWORD module supplying book order and chapter lengths.
+     - Returns: Intro-inclusive ordinal for the requested verse.
+     - Throws: `FixtureToolError.unresolvedVerse` when the reference is outside the module.
+     */
+    private func resolveIntroInclusiveOrdinal(
+        osisBookId: String,
+        chapter: Int,
+        verse: Int,
+        module: SwordModule
+    ) throws -> Int {
+        var ordinal = 0
+        var currentTestament: Int?
+
+        for book in module.getBookList() {
+            if currentTestament != book.testament {
+                ordinal += 1
+                currentTestament = book.testament
+            }
+
+            ordinal += 1
+            guard book.chapterCount > 0 else { continue }
+
+            for candidateChapter in 1...book.chapterCount {
+                ordinal += 1
+
+                guard let verseCount = module.verseCount(
+                    osisBookId: book.osisId,
+                    chapter: candidateChapter
+                ) else {
+                    throw FixtureToolError.unresolvedVerse("\(book.osisId).\(candidateChapter).1")
+                }
+
+                if book.osisId == osisBookId && candidateChapter == chapter {
+                    guard (1...verseCount).contains(verse) else {
+                        throw FixtureToolError.unresolvedVerse("\(osisBookId).\(chapter).\(verse)")
+                    }
+                    return ordinal + verse
+                }
+
+                ordinal += verseCount
+            }
+        }
+
+        throw FixtureToolError.unresolvedVerse("\(osisBookId).\(chapter).\(verse)")
+    }
+
+    /**
      Creates one deterministic Bible bookmark with optional label and note state.
      *
      * - Parameters:
      *   - bookName: Human-readable book name surfaced by the bookmark list.
-     *   - chapter: One-based chapter number. The test bookmark UI only needs chapter-level fidelity.
+     *   - chapter: One-based chapter number. The fixture stores the first verse in that chapter.
      *   - label: Optional user label that should be assigned as the primary label.
      *   - note: Optional bookmark note.
      *   - createdAt: Deterministic creation date used to control list ordering.
      * - Returns: The persisted bookmark.
+     * - Throws: `FixtureToolError` when SWORD cannot resolve the requested verse.
      */
     @discardableResult
     private func createBibleBookmark(
@@ -1039,8 +1301,8 @@ private final class FixtureContext {
         label: Label?,
         note: String?,
         createdAt: Date
-    ) -> BibleBookmark {
-        let ordinalStart = (chapter - 1) * 40 + 1
+    ) throws -> BibleBookmark {
+        let ordinalStart = try resolveKJVOrdinal(bookName: bookName, chapter: chapter, verse: 1)
         let bookmark = bookmarkService.addBibleBookmark(
             bookInitials: "KJV",
             startOrdinal: ordinalStart,
@@ -1071,9 +1333,9 @@ private final class FixtureContext {
         labelName: String?,
         note: String?,
         createdAt: Date
-    ) -> BibleBookmark {
+    ) throws -> BibleBookmark {
         let label = labelName.map { ensureUserLabel(name: $0, color: Label.defaultColor) }
-        return createBibleBookmark(
+        return try createBibleBookmark(
             bookName: bookName,
             chapter: chapter,
             label: label,

--- a/Tools/UITestFixtureTool/main.swift
+++ b/Tools/UITestFixtureTool/main.swift
@@ -464,11 +464,13 @@ private final class FixtureContext {
 
         try prepareSearchIndexSchema(in: db)
         try executeSearchSQL("DELETE FROM verse_fts WHERE module_name = 'KJV'", db: db)
+        try executeSearchSQL("DELETE FROM verse_strongs WHERE module_name = 'KJV'", db: db)
         try executeSearchSQL("DELETE FROM indexed_modules WHERE module_name = 'KJV'", db: db)
         try executeSearchSQL("BEGIN TRANSACTION", db: db)
 
         do {
             try insertSeededSearchRows(into: db)
+            try insertSeededStrongRows(into: db)
             try recordSeededSearchModule(
                 "KJV",
                 into: db,
@@ -513,6 +515,7 @@ private final class FixtureContext {
         try prepareSearchIndexSchema(in: db)
         for moduleName in ["KJV", "UITESTWEB"] {
             try executeSearchSQL("DELETE FROM verse_fts WHERE module_name = '\(moduleName)'", db: db)
+            try executeSearchSQL("DELETE FROM verse_strongs WHERE module_name = '\(moduleName)'", db: db)
             try executeSearchSQL("DELETE FROM indexed_modules WHERE module_name = '\(moduleName)'", db: db)
         }
         try executeSearchSQL("BEGIN TRANSACTION", db: db)
@@ -520,6 +523,7 @@ private final class FixtureContext {
         do {
             let rows = Self.seededSearchRows + Self.seededMultiTranslationSearchRows
             try insertSeededSearchRows(rows, into: db)
+            try insertSeededStrongRows(into: db)
             for moduleName in Set(rows.map { $0.moduleName }).sorted() {
                 let verseCount = rows.filter { $0.moduleName == moduleName }.count
                 try recordSeededSearchModule(moduleName, into: db, verseCount: Int32(verseCount))
@@ -584,6 +588,48 @@ private final class FixtureContext {
     }
 
     /**
+     Inserts deterministic Strong's-token rows paired with the seeded KJV FTS rows.
+
+     The Search UI treats ordinary text search and Strong's lookup as separate index facets, just
+     like Android's JSword/Lucene index has distinct text and `strong` fields. The fixture must
+     therefore seed lexical-token rows for Strong's UI tests instead of marking a text-only index as
+     Strong's-ready.
+
+     - Parameter db: Open SQLite handle for `search_indexes.sqlite`.
+     - Throws: `FixtureToolError.sqlite` when row insertion fails.
+     */
+    private func insertSeededStrongRows(into db: OpaquePointer) throws {
+        let sql = """
+            INSERT OR IGNORE INTO verse_strongs (module_name, token, verse_key, entry_order)
+            VALUES (?, ?, ?, ?)
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw sqliteError(
+                from: db,
+                fallback: "Unable to prepare seeded Strong's row insert statement."
+            )
+        }
+        defer { sqlite3_finalize(statement) }
+
+        for row in Self.seededStrongRows {
+            sqlite3_reset(statement)
+            sqlite3_clear_bindings(statement)
+            sqlite3_bind_text(statement, 1, row.moduleName, -1, sqliteTransient)
+            sqlite3_bind_text(statement, 2, row.token, -1, sqliteTransient)
+            sqlite3_bind_text(statement, 3, row.verseKey, -1, sqliteTransient)
+            sqlite3_bind_int(statement, 4, Int32(row.entryOrder))
+            guard sqlite3_step(statement) == SQLITE_DONE else {
+                throw sqliteError(
+                    from: db,
+                    fallback: "Unable to insert seeded Strong's row '\(row.verseKey)'."
+                )
+            }
+        }
+    }
+
+    /**
      Records the seeded module metadata expected by `SearchIndexService.hasIndex`.
 
      The schema version comes from production `SearchIndexService` so fixture-generated search
@@ -640,6 +686,19 @@ private final class FixtureContext {
             )
         """, db: db)
         try executeSearchSQL("""
+            CREATE TABLE IF NOT EXISTS verse_strongs (
+                module_name TEXT NOT NULL,
+                token TEXT NOT NULL,
+                verse_key TEXT NOT NULL,
+                entry_order INTEGER NOT NULL,
+                PRIMARY KEY (module_name, token, verse_key)
+            )
+        """, db: db)
+        try executeSearchSQL("""
+            CREATE INDEX IF NOT EXISTS idx_verse_strongs_module_token
+            ON verse_strongs (module_name, token, entry_order)
+        """, db: db)
+        try executeSearchSQL("""
             CREATE TABLE IF NOT EXISTS indexed_modules (
                 module_name TEXT PRIMARY KEY,
                 verse_count INTEGER DEFAULT 0,
@@ -694,6 +753,22 @@ private final class FixtureContext {
             verseKey: "Matthew 1:1",
             plainText: "The book of the generation of Jesus Christ, the son of David, the son of Abraham.",
             moduleName: "KJV"
+        ),
+    ]
+
+    /**
+     SQLite rows preseeded into the bundled KJV Strong's index facet.
+
+     The token is attached to `Genesis 1:2`, which already exists in `seededSearchRows`; this keeps
+     Strong's fixture coverage without changing the deterministic ordinary-text result totals for
+     broad `earth` searches.
+     */
+    private static let seededStrongRows: [(verseKey: String, token: String, moduleName: String, entryOrder: Int)] = [
+        (
+            verseKey: "Genesis 1:2",
+            token: "H0430",
+            moduleName: "KJV",
+            entryOrder: 0
         ),
     ]
 

--- a/docs/parity/search/contract.md
+++ b/docs/parity/search/contract.md
@@ -7,10 +7,13 @@ Primary code references:
 
 - search UI and state machine:
   `Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift`
-- direct SWORD search logic:
+- indexed search logic:
+  `Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift`
+- direct SWORD fallback logic:
   `Sources/BibleCore/Sources/BibleCore/Services/SearchService.swift`
 - Strong's support:
   `Sources/BibleUI/Sources/BibleUI/Search/StrongsSearchSupport.swift`
+  and `Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift`
 
 ## Search State Contract
 
@@ -52,7 +55,11 @@ Strong's and lemma searches preserve Android-oriented semantics:
 - `strong:<key>` and `lemma:` forms are accepted directly
 - shorthand `H1234` and `G5620` forms are normalized
 - these queries bypass normal word-mode decoration
-- the search type changes to entry-attribute search where required
+- Strong's-capable Bible modules require an index before the visible search runs
+- the index stores canonical Strong's tokens from raw OSIS lexical markup, matching
+  Android's JSword/Lucene `strong` field behavior
+- direct SWORD entry-attribute search remains a fallback when no index service is
+  available
 
 ## Multi-Translation Contract
 

--- a/docs/parity/search/contract.md
+++ b/docs/parity/search/contract.md
@@ -70,6 +70,8 @@ The result surface preserves:
 
 - per-module hit totals
 - flattened passage hit rows for navigation
+- canonical module entry ordering for scripture hits, matching Android's
+  book/chapter/verse display order rather than search-engine relevance rank
 
 ## Result Navigation Contract
 

--- a/docs/parity/search/dispositions.md
+++ b/docs/parity/search/dispositions.md
@@ -24,11 +24,17 @@ Disposition:
 
 - Strong's and lemma queries are detected early and are not quoted or decorated
   like ordinary word-mode searches.
+- They still participate in the index-readiness state machine when an index
+  service is available. The Strong's index stores canonical tokens extracted
+  from raw OSIS lexical markup, mirroring Android's JSword/Lucene `strong`
+  field. Direct SWORD entry-attribute search is reserved for no-index-service
+  fallback behavior.
 
 Reason:
 
 - Decorating these queries as normal text searches would break the Android-style
-  entry-attribute behavior.
+  lexical-token behavior, while bypassing index readiness would reintroduce the
+  slow visible SWORD scan that Android avoids.
 
 ## 3. Current-book scope is tied to the active reader context
 

--- a/docs/parity/search/guardrails.md
+++ b/docs/parity/search/guardrails.md
@@ -30,6 +30,12 @@ rules explicit for changes in:
    expected search contract. Changing normalization rules is a parity change,
    not a local cleanup.
 
+   Strong's queries must also keep the indexed lexical-token path when an index
+   service is available. Android relies on JSword's indexed `strong` field for
+   find-all behavior; iOS should use raw-OSIS canonical tokens in
+   `SearchIndexService` and reserve direct SWORD entry-attribute scanning for
+   no-index-service fallback.
+
 4. Treat result selection as a reader-navigation contract, not only a search
    list affordance.
 
@@ -66,7 +72,7 @@ described in `regression-report.md` green, especially:
 - direct-launch query retention and index creation
 - scope rerun behavior
 - word-mode rerun behavior
-- Strong's normalization regressions
+- Strong's normalization and indexed lexical-token regressions
 - result selection navigation back into the reader
 
 If a change touches the still-partial multi-translation area, raise the bar and
@@ -75,7 +81,7 @@ add focused coverage rather than relying on the current subset alone.
 ## Current Automation Status
 
 - The repo currently has focused search UI coverage and targeted unit
-  regressions for Strong's normalization and bundled KJV hits.
+  regressions for Strong's normalization, indexed canonical tokens, and bundled KJV hits.
 - Current protection is a combination of:
   - search workflow tests in `AndBibleUITests`
   - Strong's search regressions in `AndBibleTests`

--- a/docs/parity/search/regression-report.md
+++ b/docs/parity/search/regression-report.md
@@ -1,6 +1,6 @@
 # SEARCH-702 Regression Report
 
-Date: 2026-05-15
+Date: 2026-06-18
 
 ## Scope
 
@@ -10,7 +10,7 @@ Regression verification for the current search parity surface, covering:
 - local index creation against bundled modules
 - scope and word-mode rerun semantics
 - multi-translation selection with grouped-result totals
-- Strong's normalization and bundled-module hit search
+- Strong's normalization, indexed lexical-token search, and bundled-module hit search
 - navigation from real search results back into the reader
 - local Android reference comparison for word modes and multi-translation result flow
 
@@ -38,6 +38,8 @@ Verification matrix:
 - `AndBibleTests/testParseVerseKeySupportsOsisFormat`
 - `AndBibleTests/testParseVerseKeySupportsOsisFormatWithSuffix`
 - `AndBibleTests/testStrongsSearchFindAllOccurrencesReturnsBundledKJVMatches`
+- `AndBibleTests/testStrongsSearchFindAllOccurrencesSupportsIntermediateZeroTrimVariant`
+- `AndBibleTests/testSearchIndexFindsCanonicalStrongsTokens`
 
 ### UI
 
@@ -76,6 +78,8 @@ Verification matrix:
 - `H02022` normalization preserves both padded and unpadded lookup forms
 - decorated `lemma:strong:` input is accepted unchanged
 - bundled KJV Strong's searches return at least one real verse hit
+- KJV index creation stores canonical H00430/H0430 Strong's tokens from raw OSIS
+- indexed Strong's search returns Genesis 1:1 with cleaned snippet text
 
 ### Reader integration
 
@@ -84,8 +88,8 @@ Verification matrix:
 
 ## Historical Result And Current Interpretation
 
-Focused search validation was refreshed on 2026-05-15 after adding
-`testSearchMultiTranslationSelectionUpdatesGroupedTotals`.
+Focused Strong's validation was refreshed on 2026-06-18 after adding indexed
+canonical-token coverage for the H00430/H0430 KJV path.
 
 - unit: `6` tests, `0` failures
 - UI: `6` tests, `0` failures
@@ -100,7 +104,7 @@ This gives the search domain current regression evidence for:
 - word-mode mutation
 - multi-translation grouped totals
 - grouped-result navigation
-- Strong's normalization/hit search
+- Strong's normalization/indexed lexical-token hit search
 - result navigation into the reader
 
 ## Remaining Gap

--- a/docs/parity/search/regression-report.md
+++ b/docs/parity/search/regression-report.md
@@ -40,6 +40,7 @@ Verification matrix:
 - `AndBibleTests/testStrongsSearchFindAllOccurrencesReturnsBundledKJVMatches`
 - `AndBibleTests/testStrongsSearchFindAllOccurrencesSupportsIntermediateZeroTrimVariant`
 - `AndBibleTests/testSearchIndexFindsCanonicalStrongsTokens`
+- `AndBibleTests/testSearchIndexReturnsTextHitsInCanonicalEntryOrder`
 
 ### UI
 
@@ -57,6 +58,7 @@ Verification matrix:
 - seeded query survives hydration into the visible Search screen
 - the harness can build a disposable index against bundled modules
 - the ready state reports non-zero bundled results for deterministic queries
+- indexed text results are emitted in canonical verse order for broad queries
 
 ### Search options
 

--- a/docs/parity/search/verification-matrix.md
+++ b/docs/parity/search/verification-matrix.md
@@ -22,7 +22,7 @@ Date: 2026-06-18
 
 ## Summary
 
-- `Pass`: 6
+- `Pass`: 7
 - `Adapted Pass`: 2
 - `Partial`: 0
 
@@ -35,6 +35,7 @@ Date: 2026-06-18
 | Search scopes (`whole Bible`, `OT`, `NT`, `current book`) rerun the active query | `SearchView.swift` scope controls and rerun path; UI test `testSearchScopeChangeRerunsQueryAndUpdatesResults` | Pass | Current-book scope is reader-context driven and documented as an iOS adaptation. |
 | Strong's and lemma query normalization plus indexed lexical search | `SearchView.swift` Strong's index-readiness flow; `SearchIndexService.searchStrongs(...)`; `StrongsTokenNormalizer`; unit tests for `H02022`, decorated input, bundled KJV Strong's hit search, and indexed H00430/H0430 lookup | Pass | Shorthand and decorated forms stay Android-compatible, and Strong's find-all uses indexed canonical tokens extracted from raw OSIS before falling back to direct SWORD search. |
 | Result selection navigates the reader | `SearchView.navigateTo(_:)`; UI test `testSearchResultSelectionNavigatesReaderToBundledReference` | Pass | Search is verified as a real reader-owned workflow, not only a direct-launch harness. |
+| Indexed scripture result ordering | `SearchIndexService.search(...)`; unit test `testSearchIndexReturnsTextHitsInCanonicalEntryOrder`; Android reference sorts grouped scripture results by book/chapter/verse in `SearchControl.getMultiSearchResults(...)` | Pass | iOS stores module entry order in the FTS index so broad queries display canonical scripture order instead of SQLite rank order. |
 | Direct-launch query retention for deterministic search workflows | UI test `testSearchDirectLaunchRetainsSeededQuery` | Pass | This protects the test harness path used by deeper search regression coverage. |
 | Search implementation backing via local FTS service plus direct SWORD fallback | `SearchView.swift`, `SearchService.swift`, `SearchIndexService`; documented in `dispositions.md` | Adapted Pass | The parity goal is query semantics and user-facing behavior, not Android's exact internal search stack. |
 | Multi-translation selection and grouped result totals | `SearchView.swift` translation picker, `MultiResultGroup`, and rerun-on-selection path; `SearchIndexService.searchMultiple(...)`; UI test `testSearchMultiTranslationSelectionUpdatesGroupedTotals`; Android reference uses `selectedTranslations` and `getMultiSearchResults(...)` in `SearchResults.kt` | Pass | The focused UI regression selects a second translation, verifies grouped totals/per-module counts, and selects a grouped result, so this path now fails if Search only returns the primary translation or grouped rows stop navigating. |

--- a/docs/parity/search/verification-matrix.md
+++ b/docs/parity/search/verification-matrix.md
@@ -1,12 +1,13 @@
 # SEARCH-701 Verification Matrix (Android Search -> iOS)
 
-Date: 2026-05-15
+Date: 2026-06-18
 
 ## Scope and Method
 
 - Contract baseline: `docs/parity/search/contract.md`
 - Verification method:
-  - direct code inspection of `SearchView`, `SearchService`, and `StrongsSearchSupport`
+  - direct code inspection of `SearchView`, `SearchIndexService`, `SearchService`,
+    `StrongsSearchSupport`, and `StrongsTokenNormalizer`
   - direct comparison with a local Android reference checkout, especially
     `Search.kt`, `SearchResults.kt`, `EpubSearch.kt`, and `MultiSearchItemAdapter.kt`
   - focused simulator-backed UI coverage from `AndBibleUITests`
@@ -32,7 +33,7 @@ Date: 2026-05-15
 | Indexed search state machine (`checkingIndex -> needsIndex -> creatingIndex -> ready`) | `SearchView.swift` state machine and index-check flow; UI tests cover direct-launch query retention plus index creation | Adapted Pass | iOS uses `SearchIndexService` + native sheet flow instead of Android implementation internals, but preserves the visible contract. |
 | Word modes (`all words`, `any word`, `phrase`) rerun the active query | `SearchView.swift` option changes rerun the active query; `SearchService.swift` word-mode decoration and `searchType`; UI test `testSearchWordModeChangeRerunsQueryAndUpdatesResults` | Pass | Phrase mode is verified to collapse `earth void` to zero hits, and any-word restores hits. |
 | Search scopes (`whole Bible`, `OT`, `NT`, `current book`) rerun the active query | `SearchView.swift` scope controls and rerun path; UI test `testSearchScopeChangeRerunsQueryAndUpdatesResults` | Pass | Current-book scope is reader-context driven and documented as an iOS adaptation. |
-| Strong's and lemma query normalization | `SearchService.isStrongsQuery`, `SearchService.normalizeStrongsQuery`, `StrongsSearchSupport`; unit tests for `H02022`, decorated input, and bundled KJV Strong's hit search | Pass | Shorthand and decorated forms stay Android-compatible. |
+| Strong's and lemma query normalization plus indexed lexical search | `SearchView.swift` Strong's index-readiness flow; `SearchIndexService.searchStrongs(...)`; `StrongsTokenNormalizer`; unit tests for `H02022`, decorated input, bundled KJV Strong's hit search, and indexed H00430/H0430 lookup | Pass | Shorthand and decorated forms stay Android-compatible, and Strong's find-all uses indexed canonical tokens extracted from raw OSIS before falling back to direct SWORD search. |
 | Result selection navigates the reader | `SearchView.navigateTo(_:)`; UI test `testSearchResultSelectionNavigatesReaderToBundledReference` | Pass | Search is verified as a real reader-owned workflow, not only a direct-launch harness. |
 | Direct-launch query retention for deterministic search workflows | UI test `testSearchDirectLaunchRetainsSeededQuery` | Pass | This protects the test harness path used by deeper search regression coverage. |
 | Search implementation backing via local FTS service plus direct SWORD fallback | `SearchView.swift`, `SearchService.swift`, `SearchIndexService`; documented in `dispositions.md` | Adapted Pass | The parity goal is query semantics and user-facing behavior, not Android's exact internal search stack. |


### PR DESCRIPTION
Summary
- Align iOS reader/module semantics with Android's JSword-backed behavior across active module book lists, chapter and verse counts, ordinals, parseRef, cross-reference documents, commentary documents, and Strong's occurrence search.

Scope
- SwordKit active-module helpers for book traversal, exact verse counts, ordinals, verse references, and parsed key-list expansion.
- BibleUI reader payload construction, navigation chooser data, bookmark/memorization ordinal handling, cross-reference and compare documents, commentary selected-verse documents, and parseRef validation.
- Strong's query normalization and occurrence search parity with JSword canonical strong-field behavior.
- Regression tests covering the affected JSword parity surfaces.

Contract references
- Android/JSword reference behavior: PassageKeyFactory parsing, active versification getLastChapter/getLastVerse, DocumentBibleBooks content-based book list, CurrentCommentaryPage single-key commentary, and JSword Strong's indexing semantics.
- GitNexus detect_changes scope=all reported CRITICAL breadth across reader/navigation/search flows, matching this deliberate architectural scope.

Change details
- Removed active-module static canon fallback when an active module cannot expose a safe book list.
- Replaced fixed 40-verse ordinal assumptions with active SWORD versification queries for rendered documents and reader-side ordinal consumers.
- Made active-module reference parsing fail closed for invalid explicit coordinates and reverse ranges instead of accepting SWORD-normalized or sentinel values.
- Expanded multi-reference and cross-reference payloads through active-module ordinals so no middle verses are silently omitted.
- Scoped commentary documents to the selected verse, matching Android's single-key commentary page behavior.
- Added JSword-style Strong's canonical token extraction and zero-padding variants before falling back to SWORD entry attributes.

Validation evidence
- git diff --check
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 with focused JSword parity only-testing set: 18 tests passed, 0 failures.

Risks/follow-ups
- Risk is broad because this touches core reader navigation, document payload generation, module cursor behavior, and search semantics.
- Existing full CI shards should run because this PR intentionally changes production reader behavior, not only tests.

Closes #192