### PR TITLE
refactor(reader): extract content document collaborators

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -19,6 +19,46 @@ import struct SwiftUI.Color
 
 extension AndBibleTests {
     /**
+     Builds a fully shaped placeholder bookmark payload for document-payload factory tests.
+
+     The factory tests below use empty bookmark arrays and fail if the bookmark projection closure
+     is invoked. Swift still requires the closure to return the exact bridge DTO type, so this
+     helper centralizes the inert value and keeps the tests focused on document schema behavior.
+     */
+    private func emptyBibleBookmarkDataForFactoryTest() -> BibleBookmarkData {
+        BibleBookmarkData(
+            id: "",
+            type: "bookmark",
+            hashCode: 0,
+            ordinalRange: [],
+            offsetRange: nil,
+            labels: [],
+            bookInitials: "",
+            bookName: "",
+            bookAbbreviation: "",
+            createdAt: 0,
+            text: "",
+            fullText: "",
+            bookmarkToLabels: [],
+            primaryLabelId: nil,
+            lastUpdatedOn: 0,
+            notes: nil,
+            notesContentType: nil,
+            hasNote: false,
+            wholeVerse: true,
+            customIcon: nil,
+            editAction: EditActionData(),
+            osisRef: "",
+            originalOrdinalRange: [],
+            verseRange: "",
+            verseRangeOnlyNumber: "",
+            verseRangeAbbreviated: "",
+            v11n: "KJVA",
+            osisFragment: nil
+        )
+    }
+
+    /**
      Protects Android/JSword ordinal parity for compare links.
 
      The web client sends verse ordinals into the native compare bridge. Android resolves those
@@ -83,6 +123,229 @@ extension AndBibleTests {
         XCTAssertTrue(addDocumentsScript.contains(#""bookAbbreviation":"\#(activeModuleName)""#))
         XCTAssertTrue(addDocumentsScript.contains(#""osisRef":"2Cor.2.5-2Cor.2.7""#))
         XCTAssertTrue(addDocumentsScript.contains(#""keyName":"\#(secondCorinthians) 2:5-7""#))
+    }
+
+    /**
+     Protects the extracted reader document payload factory's Bible document contract.
+
+     Android and Vue consume document ordinals, Strong's capability, reading progress, and
+     memorization metadata from the same document object. This test supplies deterministic
+     collaborators for those controller-owned dependencies and verifies the serialized JSON still
+     carries them after the schema assembly moved out of `BibleReaderController`.
+     */
+    func testReaderDocumentPayloadFactoryBuildsBibleDocumentWithProgressContracts() throws {
+        let factory = BibleReaderDocumentPayloadFactory(
+            activeModuleName: "KJV",
+            hasStrongs: true,
+            bookmarkPayload: { bookmark in
+                XCTFail("No bookmarks should be projected in this fixture: \(bookmark.id)")
+                return self.emptyBibleBookmarkDataForFactoryTest()
+            },
+            chapterOrdinalRange: { book, chapter, verseCount in
+                XCTAssertEqual(book, "Genesis")
+                XCTAssertEqual(chapter, 1)
+                XCTAssertEqual(verseCount, 3)
+                return (start: 100, end: 103, verseCount: verseCount)
+            },
+            kjvBookOrdinal: { book in
+                XCTAssertEqual(book, "Genesis")
+                return 1
+            },
+            chapterReadCount: { kjvBookOrdinal, chapter in
+                XCTAssertEqual(kjvBookOrdinal, 1)
+                XCTAssertEqual(chapter, 1)
+                return 2
+            },
+            memorizedOrdinals: { bookInitials, startOrdinal, endOrdinal in
+                XCTAssertEqual(bookInitials, "KJV")
+                XCTAssertEqual(startOrdinal, 100)
+                XCTAssertEqual(endOrdinal, 103)
+                return [100, 101]
+            },
+            targetOrdinals: { bookInitials, startOrdinal, endOrdinal in
+                XCTAssertEqual(bookInitials, "KJV")
+                XCTAssertEqual(startOrdinal, 100)
+                XCTAssertEqual(endOrdinal, 103)
+                return [103]
+            }
+        )
+
+        let json = try XCTUnwrap(
+            factory.documentJSON(
+                BibleReaderDocumentPayloadRequest(
+                    osisBookId: "Gen",
+                    bookName: "Genesis",
+                    chapter: 1,
+                    verseCount: 3,
+                    isNewTestament: false,
+                    xml: #"<div><verse osisID="Gen.1.1">In the beginning</verse></div>"#
+                )
+            )
+        )
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let document = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let fragment = try XCTUnwrap(document["osisFragment"] as? [String: Any])
+
+        XCTAssertEqual(document["type"] as? String, "bible")
+        XCTAssertEqual(document["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(document["bookCategory"] as? String, "BIBLE")
+        XCTAssertEqual(document["key"] as? String, "Gen.1")
+        XCTAssertEqual(document["ordinalRange"] as? [Int], [100, 103])
+        XCTAssertEqual(document["chapterReadCount"] as? Int, 2)
+        XCTAssertEqual(document["memorizedOrdinals"] as? [Int], [100, 101])
+        XCTAssertEqual(document["targetOrdinals"] as? [Int], [103])
+        XCTAssertEqual(fragment["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(fragment["bookCategory"] as? String, "BIBLE")
+        XCTAssertEqual(fragment["hasStrongs"] as? Bool, true)
+        XCTAssertEqual(fragment["ordinalRange"] as? [Int], [100, 103])
+    }
+
+    /**
+     Verifies Bible documents still fail closed when the active SWORD/JSword versification cannot
+     resolve an ordinal range.
+
+     The reader must not emit a Bible document with synthetic `[0, 0]` ordinals because bookmarks,
+     memorization, scroll sync, and reading progress all depend on real JSword/SWORD ordinals.
+     A failure means the extracted factory is masking missing module range data instead of
+     preserving the controller's previous `nil` behavior.
+     */
+    func testReaderDocumentPayloadFactoryRejectsBibleDocumentWithoutOrdinalRange() {
+        let factory = BibleReaderDocumentPayloadFactory(
+            activeModuleName: "KJV",
+            hasStrongs: false,
+            bookmarkPayload: { _ in
+                XCTFail("No bookmarks should be projected when ordinal range resolution fails")
+                return self.emptyBibleBookmarkDataForFactoryTest()
+            },
+            chapterOrdinalRange: { _, _, _ in nil },
+            kjvBookOrdinal: { _ in nil },
+            chapterReadCount: { _, _ in nil },
+            memorizedOrdinals: { _, _, _ in [] },
+            targetOrdinals: { _, _, _ in [] }
+        )
+
+        XCTAssertNil(
+            factory.documentJSON(
+                BibleReaderDocumentPayloadRequest(
+                    osisBookId: "Gen",
+                    bookName: "Genesis",
+                    chapter: 1,
+                    verseCount: 31,
+                    isNewTestament: false,
+                    xml: "<div></div>"
+                )
+            )
+        )
+    }
+
+    /**
+     Protects the EPUB document path used by the shared Vue reader.
+
+     EPUB sections are rendered as native HTML through `OsisDocument`, not the Bible document path.
+     This matches the existing iOS bridge behavior while using the same document surface Android
+     uses for general rendered content. A failure means EPUB content can regress to blank rendering
+     because Vue may try to parse XHTML as OSIS.
+     */
+    func testReaderDocumentPayloadFactoryBuildsEpubNativeHtmlDocument() throws {
+        let factory = BibleReaderDocumentPayloadFactory(
+            activeModuleName: "KJV",
+            hasStrongs: false,
+            bookmarkPayload: { _ in
+                XCTFail("EPUB documents do not project Bible bookmarks")
+                return self.emptyBibleBookmarkDataForFactoryTest()
+            },
+            chapterOrdinalRange: { _, _, _ in
+                XCTFail("EPUB documents should not resolve Bible ordinal ranges")
+                return nil
+            },
+            kjvBookOrdinal: { _ in nil },
+            chapterReadCount: { _, _ in nil },
+            memorizedOrdinals: { _, _, _ in [] },
+            targetOrdinals: { _, _, _ in [] }
+        )
+
+        let json = factory.epubDocumentJSON(
+            bookName: "Chapter One",
+            bookInitials: "Pilgrim",
+            content: #"<html><body><a id="start"></a>Text</body></html>"#
+        )
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let document = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let fragment = try XCTUnwrap(document["osisFragment"] as? [String: Any])
+
+        XCTAssertEqual(document["type"] as? String, "osis")
+        XCTAssertEqual(document["bookCategory"] as? String, "GENERAL_BOOK")
+        XCTAssertEqual(document["bookInitials"] as? String, "Pilgrim")
+        XCTAssertEqual(document["bookName"] as? String, "Chapter One")
+        XCTAssertEqual(document["isNativeHtml"] as? Bool, true)
+        XCTAssertEqual(document["ordinalRange"] as? [Int], [0, 0])
+        XCTAssertEqual(fragment["xml"] as? String, #"<html><body><a id="start"></a>Text</body></html>"#)
+        XCTAssertEqual(fragment["bookCategory"] as? String, "GENERAL_BOOK")
+        XCTAssertEqual(fragment["hasStrongs"] as? Bool, false)
+        XCTAssertEqual(fragment["ordinalRange"] as? [Int], [0, 0])
+    }
+
+    /**
+     Verifies the controller's auxiliary no-module fallbacks survive delegation to the loader.
+
+     The module picker and auxiliary browsers can ask the reader to show dictionary, general-book,
+     or map content before a module is selected. Android keeps those as reader documents rather than
+     native alerts. A failure means the extraction changed the visible fallback document or the
+     compact rendered-content state UI tests use to observe the active reader.
+     */
+    func testReaderAuxiliaryContentNoModuleFallbacksEmitReaderDocuments() throws {
+        let cases: [
+            (
+                action: (BibleReaderController) -> Void,
+                category: String,
+                bookCategory: String,
+                renderedState: String,
+                expectedXML: String
+            )
+        ] = [
+            (
+                action: { $0.loadDictionaryEntry() },
+                category: "dictionary",
+                bookCategory: "DICTIONARY",
+                renderedState: "category=dictionary;module=none;book=Dictionary;chapter=none;key=none",
+                expectedXML: "No dictionary module is selected."
+            ),
+            (
+                action: { $0.loadGeneralBookEntry() },
+                category: "general_book",
+                bookCategory: "GENERAL_BOOK",
+                renderedState: "category=general_book;module=none;book=General Book;chapter=none;key=none",
+                expectedXML: "No general book module is selected."
+            ),
+            (
+                action: { $0.loadMapEntry() },
+                category: "map",
+                bookCategory: "MAP",
+                renderedState: "category=map;module=none;book=Map;chapter=none;key=none",
+                expectedXML: "No map module is selected."
+            ),
+        ]
+
+        for testCase in cases {
+            let (bridge, recordedScripts) = makeRecordingBridge()
+            let controller = BibleReaderController(bridge: bridge, initializesSword: false)
+
+            testCase.action(controller)
+
+            let document = try XCTUnwrap(
+                bridgeEmissionPayload(from: recordedScripts(), event: "add_documents") as? [String: Any],
+                "Expected \(testCase.category) to emit an auxiliary fallback document"
+            )
+            let fragment = try XCTUnwrap(document["osisFragment"] as? [String: Any])
+
+            XCTAssertEqual(document["bookCategory"] as? String, testCase.bookCategory)
+            XCTAssertEqual(fragment["bookCategory"] as? String, testCase.bookCategory)
+            XCTAssertTrue(
+                (fragment["xml"] as? String)?.contains(testCase.expectedXML) == true,
+                "Expected \(testCase.category) XML to contain fallback copy"
+            )
+            XCTAssertEqual(controller.renderedContentState, testCase.renderedState)
+        }
     }
 
     func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {

--- a/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -488,8 +488,11 @@ extension AndBibleUITests {
      *   - line: Source line used for nested helper attribution.
      * - Returns: `true` when the production drawer becomes visible.
      * - Side effects:
-     *   - prefers XCTest's native tap path for the production navigation-drawer button, then falls
-     *     back to the sampled chrome coordinate when the hosted button is not yet hittable
+     *   - prefers the sampled production chrome coordinate before querying hittability because
+     *     hosted SwiftUI header buttons can expose an invalid XCTest activation point while the
+     *     actual reader chrome is already tappable
+     *   - falls back to XCTest's native tap path for the production navigation-drawer button when
+     *     coordinate sampling does not open the drawer
      *   - waits for drawer affordances to appear after each activation attempt
      * - Failure modes:
      *   - returns `false` when the drawer never appears before the local retry budget expires
@@ -505,6 +508,14 @@ extension AndBibleUITests {
         let drawerButton = unresolvedElement("readerNavigationDrawerButton", in: app)
 
         repeat {
+            if tapReaderNavigationDrawerChromeCoordinate(in: app),
+               waitForReaderNavigationDrawer(
+                   in: app,
+                   timeout: min(2, max(1, deadline.timeIntervalSinceNow))
+               ) {
+                return true
+            }
+
             if waitForElementToBecomeHittable(drawerButton, timeout: 0.5) {
                 drawerButton.tap()
                 if waitForReaderNavigationDrawer(
@@ -513,14 +524,6 @@ extension AndBibleUITests {
                 ) {
                     return true
                 }
-            }
-
-            if tapReaderNavigationDrawerChromeCoordinate(in: app),
-               waitForReaderNavigationDrawer(
-                   in: app,
-                   timeout: min(2, max(1, deadline.timeIntervalSinceNow))
-               ) {
-                return true
             }
             if waitForReaderNavigationDrawer(
                 in: app,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAuxiliaryContentLoader.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAuxiliaryContentLoader.swift
@@ -1,0 +1,296 @@
+// BibleReaderAuxiliaryContentLoader.swift - Dictionary, general-book, and map document loading
+
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+
+/**
+ Describes one SWORD-backed auxiliary document load request.
+
+ Dictionary, general book, and map modules all follow the same Android-style reader workflow:
+ resolve a module/key, wrap rendered module HTML in an OSIS-like fragment, emit a single Vue
+ document, and update the native rendered-content state. This request captures the category-specific
+ labels and fallback messages while keeping mutable controller state outside the loader.
+
+ - Side effects: None; this is an immutable request value.
+ - Failure modes: None during initialization. Missing module/key cases are rendered as fallback
+   documents by `BibleReaderAuxiliaryContentLoader`.
+ */
+struct BibleReaderAuxiliaryModuleEntryRequest {
+    /// High-level document category represented by the module.
+    let category: DocumentCategory
+    /// Active SWORD module, if one is selected.
+    let module: SwordModule?
+    /// Active module initials/name used by the web document.
+    let moduleName: String?
+    /// Explicit key requested by the browser/search UI.
+    let requestedKey: String?
+    /// Previously selected key restored from pane state.
+    let currentKey: String?
+    /// Pseudo OSIS book identifier for the generated document.
+    let osisBookId: String
+    /// Display document name used when no concrete entry key is available.
+    let fallbackBookName: String
+    /// Bridge category raw value emitted into document metadata.
+    let bookCategory: String
+    /// Title shown when no module is selected.
+    let noModuleTitle: String
+    /// Paragraph shown when no module is selected.
+    let noModuleMessage: String
+    /// Paragraph shown when a module exists but no entry key is selected.
+    let noSelectionMessage: String
+    /// Phrase used for empty-entry messages.
+    let noContentNoun: String
+    /// Persists a resolved entry key back into the controller/PageManager.
+    let persistResolvedKey: (String) -> Void
+}
+
+/**
+ Loads auxiliary SWORD module content into the Vue reader.
+
+ `BibleReaderController` owns active module state, persistence, and public entry points. This
+ collaborator owns the repeated auxiliary-module rendering workflow shared by dictionaries, general
+ books, and maps: reset transient reader state, build fallback or entry XML, emit bridge events, and
+ update the rendered-content state token.
+
+ Side effects:
+ - invokes controller-supplied reset, rendered-state, persistence, and background closures
+ - moves the selected `SwordModule` cursor to the requested key before rendering text
+ - emits `clear_document`, `add_documents`, and `setup_content` events through `BibleBridge`
+
+ Failure modes:
+ - if document JSON serialization fails, no document event is emitted after any required state reset
+ - missing modules and missing keys produce deterministic fallback documents instead of throwing
+ - empty rendered module text produces a no-content document for the selected key
+ */
+struct BibleReaderAuxiliaryContentLoader {
+    /// Updates the controller's compact rendered-content state after a document is emitted.
+    typealias RenderedContentStateSetter = (DocumentCategory, String?, String, String?) -> Void
+
+    /// Shared setup payload used by auxiliary single-document loads.
+    private static let setupContentPayload = """
+    {"jumpToOrdinal":null,"jumpToAnchor":null,"jumpToId":null,"topOffset":0,"bottomOffset":0}
+    """
+
+    /// Bridge used to emit Vue reader events.
+    private let bridge: BibleBridge
+    /// Factory that owns document JSON schema assembly.
+    private let documentPayloadFactory: BibleReaderDocumentPayloadFactory
+    /// Controller callback that clears transient reader state before replacing content.
+    private let resetReaderState: () -> Void
+    /// Controller callback that updates `renderedContentState`.
+    private let setRenderedContentState: RenderedContentStateSetter
+    /// Controller callback that reapplies active reader background colors.
+    private let applyNightModeBackground: () -> Void
+
+    /**
+     Creates an auxiliary content loader for one render pass.
+
+     - Parameters:
+       - bridge: Web bridge used to emit document events.
+       - documentPayloadFactory: Factory configured from the controller's current reader state.
+       - resetReaderState: Clears transient selection/editing/special-document flags.
+       - setRenderedContentState: Records the rendered category/module/book/key for UI tests.
+       - applyNightModeBackground: Reapplies background styling after the Vue document changes.
+     - Side effects: None during initialization.
+     - Failure modes: None during initialization.
+     */
+    init(
+        bridge: BibleBridge,
+        documentPayloadFactory: BibleReaderDocumentPayloadFactory,
+        resetReaderState: @escaping () -> Void,
+        setRenderedContentState: @escaping RenderedContentStateSetter,
+        applyNightModeBackground: @escaping () -> Void
+    ) {
+        self.bridge = bridge
+        self.documentPayloadFactory = documentPayloadFactory
+        self.resetReaderState = resetReaderState
+        self.setRenderedContentState = setRenderedContentState
+        self.applyNightModeBackground = applyNightModeBackground
+    }
+
+    /**
+     Loads one dictionary, general-book, or map entry.
+
+     - Parameter request: Category-specific module/key/fallback details.
+     - Returns: The resolved entry key when concrete module content was selected; otherwise `nil`.
+     - Side effects: Resets transient reader state, may persist the resolved key, moves the module
+       cursor, emits Vue document/setup events, updates rendered-content state, and reapplies the
+       reader background.
+     - Failure modes: Missing module/key states render fallback documents; document serialization
+       failure stops before emitting `add_documents`.
+     */
+    @discardableResult
+    func loadModuleEntry(_ request: BibleReaderAuxiliaryModuleEntryRequest) -> String? {
+        resetReaderState()
+
+        guard let module = request.module else {
+            emitFallbackDocument(
+                request: request,
+                title: request.noModuleTitle,
+                message: request.noModuleMessage,
+                bookName: request.fallbackBookName,
+                bookInitials: "none",
+                renderedModuleName: request.moduleName,
+                renderedBook: request.fallbackBookName,
+                renderedKey: "none"
+            )
+            return nil
+        }
+
+        let entryKey = request.requestedKey ?? request.currentKey
+        guard let entryKey else {
+            let moduleName = request.moduleName ?? request.fallbackBookName
+            emitFallbackDocument(
+                request: request,
+                title: moduleName,
+                message: request.noSelectionMessage,
+                bookName: moduleName,
+                bookInitials: moduleName,
+                renderedModuleName: moduleName,
+                renderedBook: moduleName,
+                renderedKey: "none"
+            )
+            return nil
+        }
+
+        module.setKey(entryKey)
+        let text = module.renderText()
+        let moduleName = request.moduleName ?? request.fallbackBookName
+        request.persistResolvedKey(entryKey)
+
+        let xml: String
+        if text.isEmpty {
+            xml = paragraphDocumentXML(
+                title: entryKey,
+                message: "No \(request.noContentNoun) available for \"\(entryKey)\" in \(moduleName)."
+            )
+        } else {
+            xml = htmlDocumentXML(title: entryKey, html: text)
+        }
+
+        emitDocument(
+            request: request,
+            xml: xml,
+            bookName: entryKey,
+            bookInitials: moduleName,
+            renderedModuleName: moduleName,
+            renderedBook: entryKey,
+            renderedKey: entryKey
+        )
+        return entryKey
+    }
+
+    /**
+     Emits a deterministic reader document for missing-module or missing-key auxiliary states.
+
+     - Parameters:
+       - request: Category-specific document metadata and fallback copy.
+       - title: Title written into the generated OSIS-like XML.
+       - message: Paragraph shown to the user inside the reader surface.
+       - bookName: Document book name sent to Vue.
+       - bookInitials: Module initials sent to Vue, or `"none"` when no module exists.
+       - renderedModuleName: Module token recorded in the compact rendered-content state.
+       - renderedBook: Book token recorded in rendered-content state.
+       - renderedKey: Key token recorded in rendered-content state.
+     - Side effects: Emits the same bridge events and rendered-state update as concrete content.
+     - Failure modes: Delegates serialization failure handling to `emitDocument`.
+     */
+    private func emitFallbackDocument(
+        request: BibleReaderAuxiliaryModuleEntryRequest,
+        title: String,
+        message: String,
+        bookName: String,
+        bookInitials: String,
+        renderedModuleName: String?,
+        renderedBook: String,
+        renderedKey: String
+    ) {
+        emitDocument(
+            request: request,
+            xml: paragraphDocumentXML(title: title, message: message),
+            bookName: bookName,
+            bookInitials: bookInitials,
+            renderedModuleName: renderedModuleName,
+            renderedBook: renderedBook,
+            renderedKey: renderedKey
+        )
+    }
+
+    /**
+     Serializes and emits one auxiliary document through the shared Vue reader bridge.
+
+     - Parameters:
+       - request: Category metadata for the generated document.
+       - xml: OSIS-like fragment containing fallback copy or rendered module HTML.
+       - bookName: Document book name sent to Vue.
+       - bookInitials: Module initials sent to Vue.
+       - renderedModuleName: Module token recorded in rendered-content state.
+       - renderedBook: Book token recorded in rendered-content state.
+       - renderedKey: Key token recorded in rendered-content state.
+     - Side effects: Emits `clear_document`, `add_documents`, and `setup_content`, updates the
+       controller-rendered content state through a closure, and reapplies reader background styling.
+     - Failure modes: If document serialization fails, the reader is cleared but no replacement
+       document/setup event is emitted, matching the previous inline controller behavior.
+     */
+    private func emitDocument(
+        request: BibleReaderAuxiliaryModuleEntryRequest,
+        xml: String,
+        bookName: String,
+        bookInitials: String,
+        renderedModuleName: String?,
+        renderedBook: String,
+        renderedKey: String
+    ) {
+        bridge.emit(event: "clear_document")
+        guard let document = documentPayloadFactory.documentJSON(
+            BibleReaderDocumentPayloadRequest(
+                osisBookId: request.osisBookId,
+                bookName: bookName,
+                chapter: 1,
+                verseCount: 1,
+                isNewTestament: false,
+                xml: xml,
+                bookCategory: request.bookCategory,
+                bookInitials: bookInitials
+            )
+        ) else {
+            return
+        }
+        bridge.emit(event: "add_documents", data: document)
+        bridge.emit(event: "setup_content", data: Self.setupContentPayload)
+        setRenderedContentState(request.category, renderedModuleName, renderedBook, renderedKey)
+        applyNightModeBackground()
+    }
+
+    /**
+     Wraps plain fallback copy in the OSIS-like structure accepted by the Vue document renderer.
+
+     - Parameters:
+       - title: Visible generated title.
+       - message: Plain paragraph text.
+     - Returns: XML fragment matching the legacy auxiliary fallback document shape.
+     - Side effects: None.
+     - Failure modes: Input is inserted verbatim, preserving the previous caller-owned escaping
+       contract for these fixed/native strings.
+     */
+    private func paragraphDocumentXML(title: String, message: String) -> String {
+        "<div><title type=\"x-gen\">\(title)</title><div type=\"paragraph\"><p>\(message)</p></div></div>"
+    }
+
+    /**
+     Wraps rendered module HTML in the OSIS-like paragraph shell expected by Vue.
+
+     - Parameters:
+       - title: Resolved module key shown as the generated title.
+       - html: HTML returned by SWORD `renderText()`.
+     - Returns: XML fragment containing the rendered HTML without additional escaping.
+     - Side effects: None.
+     - Failure modes: Preserves the previous trust boundary where SWORD-rendered HTML is passed
+       through for web rendering.
+     */
+    private func htmlDocumentXML(title: String, html: String) -> String {
+        "<div><title type=\"x-gen\">\(title)</title><div type=\"paragraph\">\(html)</div></div>"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1256,258 +1256,135 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     // MARK: - Dictionary/GenBook/Map Content Loading
 
     /**
+     Clears transient reader state before replacing the visible document with auxiliary content.
+
+     Dictionary, general-book, and map loads should leave My Notes, StudyPad, editing, and selection
+     state the same way the previous inline implementations did. Keeping this reset in the
+     controller preserves ownership of reader state while allowing the auxiliary loader to share the
+     document-emission workflow.
+     */
+    private func resetAuxiliaryContentState() {
+        showingMyNotes = false
+        showingStudyPad = false
+        activeStudyPadLabelId = nil
+        activeStudyPadLabelName = nil
+        editingInWebView = false
+        hasActiveSelection = false
+        selectedText = ""
+    }
+
+    /**
+     Creates the auxiliary content loader for the current bridge and payload factory.
+
+     - Returns: A loader configured with bridge emission, document JSON, rendered-state, and
+       background callbacks for this controller instance.
+     - Side effects: None during construction. The returned loader mutates state only through the
+       explicit closures supplied here.
+     - Failure modes: None during construction.
+     */
+    private func auxiliaryContentLoader() -> BibleReaderAuxiliaryContentLoader {
+        BibleReaderAuxiliaryContentLoader(
+            bridge: bridge,
+            documentPayloadFactory: documentPayloadFactory(),
+            resetReaderState: { [self] in
+                resetAuxiliaryContentState()
+            },
+            setRenderedContentState: { [self] category, moduleName, book, key in
+                setRenderedContentState(
+                    category: category,
+                    moduleName: moduleName,
+                    book: book,
+                    key: key
+                )
+            },
+            applyNightModeBackground: { [self] in
+                applyNightModeBackground()
+            }
+        )
+    }
+
+    /**
      Load a dictionary entry and display it in the WebView.
      Uses renderText() since dictionary entries are typically HTML-formatted definitions.
      */
     public func loadDictionaryEntry(key: String? = nil) {
-        showingMyNotes = false
-        showingStudyPad = false
-        activeStudyPadLabelId = nil
-        activeStudyPadLabelName = nil
-        editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
-
-        guard let module = activeDictionaryModule else {
-            bridge.emit(event: "clear_document")
-            let xml = "<div><title type=\"x-gen\">No Dictionary</title><div type=\"paragraph\"><p>No dictionary module is selected. Download one from the module browser.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "Dict", bookName: "Dictionary", chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: "none"
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
+        auxiliaryContentLoader().loadModuleEntry(
+            BibleReaderAuxiliaryModuleEntryRequest(
                 category: .dictionary,
+                module: activeDictionaryModule,
                 moduleName: activeDictionaryModuleName,
-                book: "Dictionary",
-                key: "none"
+                requestedKey: key,
+                currentKey: currentDictionaryKey,
+                osisBookId: "Dict",
+                fallbackBookName: "Dictionary",
+                bookCategory: DocumentCategory.dictionary.rawValue,
+                noModuleTitle: "No Dictionary",
+                noModuleMessage: "No dictionary module is selected. Download one from the module browser.",
+                noSelectionMessage: "Select an entry from the key browser to view its definition.",
+                noContentNoun: "definition",
+                persistResolvedKey: { [self] entryKey in
+                    currentDictionaryKey = entryKey
+                    if let pm = activeWindow?.pageManager {
+                        pm.dictionaryKey = entryKey
+                        onPersistState?()
+                    }
+                }
             )
-            applyNightModeBackground()
-            return
-        }
-
-        let entryKey = key ?? currentDictionaryKey
-        guard let entryKey else {
-            // No key selected yet — show prompt
-            bridge.emit(event: "clear_document")
-            let moduleName = activeDictionaryModuleName ?? "Dictionary"
-            let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view its definition.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "Dict", bookName: moduleName, chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: moduleName
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
-                category: .dictionary,
-                moduleName: moduleName,
-                book: moduleName,
-                key: "none"
-            )
-            applyNightModeBackground()
-            return
-        }
-
-        currentDictionaryKey = entryKey
-        module.setKey(entryKey)
-        let text = module.renderText()
-        let moduleName = activeDictionaryModuleName ?? "Dictionary"
-
-        // Persist key
-        if let pm = activeWindow?.pageManager {
-            pm.dictionaryKey = entryKey
-            onPersistState?()
-        }
-
-        let xml: String
-        if text.isEmpty {
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\"><p>No definition available for \"\(entryKey)\" in \(moduleName).</p></div></div>"
-        } else {
-            // Wrap rendered HTML in OSIS-like structure for Vue.js
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\">\(text)</div></div>"
-        }
-
-        bridge.emit(event: "clear_document")
-        guard let document = buildDocumentJSON(
-            osisBookId: "Dict", bookName: entryKey, chapter: 1, verseCount: 1,
-            isNT: false, xml: xml, bookCategory: "DICTIONARY", bookInitials: moduleName
-        ) else { return }
-        bridge.emit(event: "add_documents", data: document)
-        bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-        setRenderedContentState(
-            category: .dictionary,
-            moduleName: moduleName,
-            book: entryKey,
-            key: entryKey
         )
-        applyNightModeBackground()
     }
 
     /// Load a general book entry and display it in the WebView.
     public func loadGeneralBookEntry(key: String? = nil) {
-        showingMyNotes = false
-        showingStudyPad = false
-        activeStudyPadLabelId = nil
-        activeStudyPadLabelName = nil
-        editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
-
-        guard let module = activeGeneralBookModule else {
-            bridge.emit(event: "clear_document")
-            let xml = "<div><title type=\"x-gen\">No General Book</title><div type=\"paragraph\"><p>No general book module is selected. Download one from the module browser.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "GenBook", bookName: "General Book", chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: "none"
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
+        auxiliaryContentLoader().loadModuleEntry(
+            BibleReaderAuxiliaryModuleEntryRequest(
                 category: .generalBook,
+                module: activeGeneralBookModule,
                 moduleName: activeGeneralBookModuleName,
-                book: "General Book",
-                key: "none"
+                requestedKey: key,
+                currentKey: currentGeneralBookKey,
+                osisBookId: "GenBook",
+                fallbackBookName: "General Book",
+                bookCategory: DocumentCategory.generalBook.rawValue,
+                noModuleTitle: "No General Book",
+                noModuleMessage: "No general book module is selected. Download one from the module browser.",
+                noSelectionMessage: "Select an entry from the key browser to view its content.",
+                noContentNoun: "content",
+                persistResolvedKey: { [self] entryKey in
+                    currentGeneralBookKey = entryKey
+                    if let pm = activeWindow?.pageManager {
+                        pm.generalBookKey = entryKey
+                        onPersistState?()
+                    }
+                }
             )
-            applyNightModeBackground()
-            return
-        }
-
-        let entryKey = key ?? currentGeneralBookKey
-        guard let entryKey else {
-            bridge.emit(event: "clear_document")
-            let moduleName = activeGeneralBookModuleName ?? "General Book"
-            let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view its content.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "GenBook", bookName: moduleName, chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: moduleName
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
-                category: .generalBook,
-                moduleName: moduleName,
-                book: moduleName,
-                key: "none"
-            )
-            applyNightModeBackground()
-            return
-        }
-
-        currentGeneralBookKey = entryKey
-        module.setKey(entryKey)
-        let text = module.renderText()
-        let moduleName = activeGeneralBookModuleName ?? "General Book"
-
-        if let pm = activeWindow?.pageManager {
-            pm.generalBookKey = entryKey
-            onPersistState?()
-        }
-
-        let xml: String
-        if text.isEmpty {
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\"><p>No content available for \"\(entryKey)\" in \(moduleName).</p></div></div>"
-        } else {
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\">\(text)</div></div>"
-        }
-
-        bridge.emit(event: "clear_document")
-        guard let document = buildDocumentJSON(
-            osisBookId: "GenBook", bookName: entryKey, chapter: 1, verseCount: 1,
-            isNT: false, xml: xml, bookCategory: "GENERAL_BOOK", bookInitials: moduleName
-        ) else { return }
-        bridge.emit(event: "add_documents", data: document)
-        bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-        setRenderedContentState(
-            category: .generalBook,
-            moduleName: moduleName,
-            book: entryKey,
-            key: entryKey
         )
-        applyNightModeBackground()
     }
 
     /// Load a map entry and display it in the WebView.
     public func loadMapEntry(key: String? = nil) {
-        showingMyNotes = false
-        showingStudyPad = false
-        activeStudyPadLabelId = nil
-        activeStudyPadLabelName = nil
-        editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
-
-        guard let module = activeMapModule else {
-            bridge.emit(event: "clear_document")
-            let xml = "<div><title type=\"x-gen\">No Map</title><div type=\"paragraph\"><p>No map module is selected. Download one from the module browser.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "Map", bookName: "Map", chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "MAP", bookInitials: "none"
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
+        auxiliaryContentLoader().loadModuleEntry(
+            BibleReaderAuxiliaryModuleEntryRequest(
                 category: .map,
+                module: activeMapModule,
                 moduleName: activeMapModuleName,
-                book: "Map",
-                key: "none"
+                requestedKey: key,
+                currentKey: currentMapKey,
+                osisBookId: "Map",
+                fallbackBookName: "Map",
+                bookCategory: DocumentCategory.map.rawValue,
+                noModuleTitle: "No Map",
+                noModuleMessage: "No map module is selected. Download one from the module browser.",
+                noSelectionMessage: "Select an entry from the key browser to view the map.",
+                noContentNoun: "content",
+                persistResolvedKey: { [self] entryKey in
+                    currentMapKey = entryKey
+                    if let pm = activeWindow?.pageManager {
+                        pm.mapKey = entryKey
+                        onPersistState?()
+                    }
+                }
             )
-            applyNightModeBackground()
-            return
-        }
-
-        let entryKey = key ?? currentMapKey
-        guard let entryKey else {
-            bridge.emit(event: "clear_document")
-            let moduleName = activeMapModuleName ?? "Map"
-            let xml = "<div><title type=\"x-gen\">\(moduleName)</title><div type=\"paragraph\"><p>Select an entry from the key browser to view the map.</p></div></div>"
-            guard let document = buildDocumentJSON(
-                osisBookId: "Map", bookName: moduleName, chapter: 1, verseCount: 1,
-                isNT: false, xml: xml, bookCategory: "MAP", bookInitials: moduleName
-            ) else { return }
-            bridge.emit(event: "add_documents", data: document)
-            bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-            setRenderedContentState(
-                category: .map,
-                moduleName: moduleName,
-                book: moduleName,
-                key: "none"
-            )
-            applyNightModeBackground()
-            return
-        }
-
-        currentMapKey = entryKey
-        module.setKey(entryKey)
-        let text = module.renderText()
-        let moduleName = activeMapModuleName ?? "Map"
-
-        if let pm = activeWindow?.pageManager {
-            pm.mapKey = entryKey
-            onPersistState?()
-        }
-
-        let xml: String
-        if text.isEmpty {
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\"><p>No content available for \"\(entryKey)\" in \(moduleName).</p></div></div>"
-        } else {
-            xml = "<div><title type=\"x-gen\">\(entryKey)</title><div type=\"paragraph\">\(text)</div></div>"
-        }
-
-        bridge.emit(event: "clear_document")
-        guard let document = buildDocumentJSON(
-            osisBookId: "Map", bookName: entryKey, chapter: 1, verseCount: 1,
-            isNT: false, xml: xml, bookCategory: "MAP", bookInitials: moduleName
-        ) else { return }
-        bridge.emit(event: "add_documents", data: document)
-        bridge.emit(event: "setup_content", data: "{\"jumpToOrdinal\":null,\"jumpToAnchor\":null,\"jumpToId\":null,\"topOffset\":0,\"bottomOffset\":0}")
-        setRenderedContentState(
-            category: .map,
-            moduleName: moduleName,
-            book: entryKey,
-            key: entryKey
         )
-        applyNightModeBackground()
     }
 
     // MARK: - EPUB Support
@@ -1633,51 +1510,25 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /**
      Build document JSON for EPUB content with isNativeHtml: true.
-     Uses JSONSerialization for correct escaping of all special characters in HTML content.
-     IMPORTANT: Uses type "osis" (not "bible") because OsisDocument.vue passes isNativeHtml
-     to OsisFragment, whereas BibleDocument.vue does not — without this, the EPUB HTML
-     would go through OSIS template conversion and render as blank.
+
+     The controller remains the orchestration boundary for selecting the active EPUB section, while
+     `BibleReaderDocumentPayloadFactory` owns the Vue document schema and serialization details.
+
+     - Parameters:
+       - bookName: Visible EPUB section title.
+       - bookInitials: Parent EPUB title used as document initials.
+       - content: Rewritten EPUB XHTML/HTML loaded from the EPUB index.
+     - Returns: Serialized Vue document JSON, or `{}` when serialization fails.
+     - Side effects: None directly; failures are logged by the payload factory.
+     - Failure modes: Returns `{}` if the payload cannot be serialized, preserving the legacy
+       controller behavior for malformed native HTML payloads.
      */
     private func buildEpubDocumentJSON(bookName: String, bookInitials: String, content: String) -> String {
-        let doc: [String: Any] = [
-            "id": "doc-1",
-            "type": "osis",
-            "osisFragment": [
-                "xml": content,
-                "key": "epub",
-                "keyName": bookName,
-                "v11n": "KJVA",
-                "bookCategory": "GENERAL_BOOK",
-                "bookInitials": bookInitials,
-                "bookAbbreviation": "Epub",
-                "osisRef": "epub",
-                "isNewTestament": false,
-                "features": [String: Any](),
-                "hasStrongs": false,
-                "ordinalRange": [0, 0],
-                "language": "en",
-                "direction": "ltr"
-            ] as [String: Any],
-            "bookInitials": bookInitials,
-            "bookCategory": "GENERAL_BOOK",
-            "bookAbbreviation": "Epub",
-            "bookName": bookName,
-            "key": "epub",
-            "v11n": "KJVA",
-            "osisRef": "epub",
-            "annotateRef": "",
-            "genericBookmarks": [Any](),
-            "ordinalRange": [0, 0],
-            "isNativeHtml": true,
-            "highlightedOrdinalRange": NSNull()
-        ]
-
-        guard let data = try? JSONSerialization.data(withJSONObject: doc, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize EPUB document JSON")
-            return "{}"
-        }
-        return json
+        documentPayloadFactory().epubDocumentJSON(
+            bookName: bookName,
+            bookInitials: bookInitials,
+            content: content
+        )
     }
 
     /// Return the active module name for a given category.
@@ -7963,6 +7814,57 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
+     Creates the document payload factory for the controller's current reader state.
+
+     `BibleReaderDocumentPayloadFactory` owns bridge JSON assembly; this method supplies the
+     controller-owned dependencies it needs for the current render pass. The factory receives
+     closures instead of the controller so it cannot mutate navigation, modal, bridge, or
+     persistence state outside the document payload contract.
+
+     - Returns: A factory configured with active module initials, Strong's capability, bookmark
+       projection, JSword/SWORD ordinal resolution, reading progress, and memorization progress.
+     - Side effects: None during construction. The returned factory may read controller services
+       through closures while serializing a document.
+     - Failure modes: Missing optional stores resolve to empty progress data; Bible ordinal lookup
+       failures are reported by the factory as `nil` document payloads.
+     */
+    private func documentPayloadFactory() -> BibleReaderDocumentPayloadFactory {
+        BibleReaderDocumentPayloadFactory(
+            activeModuleName: activeModuleName,
+            hasStrongs: hasStrongs,
+            bookmarkPayload: { [self] bookmark in
+                buildBookmarkJSON(bookmark)
+            },
+            chapterOrdinalRange: { [self] book, chapter, verseCount in
+                chapterOrdinalRange(book: book, chapter: chapter, verseCount: verseCount)
+            },
+            kjvBookOrdinal: { [self] book in
+                kjvBookOrdinal(for: book)
+            },
+            chapterReadCount: { [readingProgressStore] kjvBookOrdinal, chapter in
+                readingProgressStore?.chapterReadCount(
+                    kjvBookOrdinal: kjvBookOrdinal,
+                    chapter: chapter
+                )
+            },
+            memorizedOrdinals: { [memorizationProgressStore] bookInitials, startOrdinal, endOrdinal in
+                memorizationProgressStore?.memorizedOrdinals(
+                    bookInitials: bookInitials,
+                    startOrdinal: startOrdinal,
+                    endOrdinal: endOrdinal
+                ) ?? []
+            },
+            targetOrdinals: { [memorizationProgressStore] bookInitials, startOrdinal, endOrdinal in
+                memorizationProgressStore?.targetOrdinals(
+                    bookInitials: bookInitials,
+                    startOrdinal: startOrdinal,
+                    endOrdinal: endOrdinal
+                ) ?? []
+            }
+        )
+    }
+
+    /**
      Wraps chapter XML and bookmark metadata in the document JSON format expected by Vue.js.
 
      - Parameters:
@@ -8000,99 +7902,24 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                                    documentKey: String? = nil,
                                    keyName: String? = nil,
                                    ordinalRangeOverride: [Int]? = nil) -> String? {
-        let key = documentKey ?? "\(osisBookId).\(chapter)"
-        let displayKeyName = keyName ?? "\(bookName) \(chapter)"
-        let documentOrdinalRange: [Int]
-        if let ordinalRangeOverride {
-            documentOrdinalRange = ordinalRangeOverride
-        } else if bookCategory == DocumentCategory.bible.rawValue {
-            guard let range = chapterOrdinalRange(book: bookName, chapter: chapter, verseCount: verseCount) else {
-                logger.error("Failed to resolve Bible document range for \(osisBookId, privacy: .public).\(chapter)")
-                return nil
-            }
-            documentOrdinalRange = [range.start, range.end]
-        } else {
-            documentOrdinalRange = [0, 0]
-        }
-        let ordinalStart = documentOrdinalRange.first ?? 0
-        let ordinalEnd = documentOrdinalRange.last ?? ordinalStart
-        let initials = bookInitials ?? activeModuleName
-
-        func jsonObject<T: Encodable>(from value: T) -> Any? {
-            guard let data = try? bridgeEncoder.encode(value) else { return nil }
-            return try? JSONSerialization.jsonObject(with: data)
-        }
-
-        func osisFragmentObject(xml: String, ordinalRange: [Int], keySuffix: String) -> [String: Any] {
-            [
-                "xml": xml,
-                "key": keySuffix,
-                "keyName": displayKeyName,
-                "v11n": "KJVA",
-                "bookCategory": bookCategory,
-                "bookInitials": initials,
-                "bookAbbreviation": osisBookId,
-                "osisRef": key,
-                "isNewTestament": isNT,
-                "features": [String: Any](),
-                "hasStrongs": hasStrongs,
-                "ordinalRange": ordinalRange,
-                "language": "en",
-                "direction": "ltr",
-            ]
-        }
-
-        let bookmarkObjects = bookmarks.compactMap { jsonObject(from: buildBookmarkJSON($0)) }
-        let chapterReadCount = readingProgressStore.flatMap { store -> Int? in
-            guard bookCategory == "BIBLE",
-                  let kjvBookOrdinal = kjvBookOrdinal(for: bookName) else {
-                return nil
-            }
-            return store.chapterReadCount(kjvBookOrdinal: kjvBookOrdinal, chapter: chapter)
-        }
-
-        var doc: [String: Any] = [
-            "id": "doc-1",
-            "type": "bible",
-            "osisFragment": osisFragmentObject(xml: xml, ordinalRange: documentOrdinalRange, keySuffix: key),
-            "bookInitials": initials,
-            "bookCategory": bookCategory,
-            "bookAbbreviation": osisBookId,
-            "bookName": bookName,
-            "key": key,
-            "v11n": "KJVA",
-            "osisRef": key,
-            "annotateRef": "",
-            "genericBookmarks": [Any](),
-            "ordinalRange": documentOrdinalRange,
-            "isNativeHtml": false,
-            "bookmarks": bookmarkObjects,
-            "bibleBookName": bookName,
-            "addChapter": addChapter,
-            "chapterNumber": chapter,
-            "originalOrdinalRange": originalOrdinalRange ?? NSNull(),
-            "memorizedOrdinals": memorizationProgressStore?.memorizedOrdinals(
-                bookInitials: initials,
-                startOrdinal: ordinalStart,
-                endOrdinal: ordinalEnd
-            ) ?? [],
-            "targetOrdinals": memorizationProgressStore?.targetOrdinals(
-                bookInitials: initials,
-                startOrdinal: ordinalStart,
-                endOrdinal: ordinalEnd
-            ) ?? [],
-        ]
-        if let chapterReadCount {
-            doc["chapterReadCount"] = chapterReadCount
-        }
-
-        guard let data = try? JSONSerialization.data(withJSONObject: doc, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize document JSON for \(osisBookId, privacy: .public) \(chapter)")
-            return nil
-        }
-
-        return json
+        documentPayloadFactory().documentJSON(
+            BibleReaderDocumentPayloadRequest(
+                osisBookId: osisBookId,
+                bookName: bookName,
+                chapter: chapter,
+                verseCount: verseCount,
+                isNewTestament: isNT,
+                xml: xml,
+                bookmarks: bookmarks,
+                bookCategory: bookCategory,
+                bookInitials: bookInitials,
+                addChapter: addChapter,
+                originalOrdinalRange: originalOrdinalRange,
+                documentKey: documentKey,
+                keyName: keyName,
+                ordinalRangeOverride: ordinalRangeOverride
+            )
+        )
     }
 
     // MARK: - Genesis 1 Real Content

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderDocumentPayloadFactory.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderDocumentPayloadFactory.swift
@@ -1,0 +1,400 @@
+// BibleReaderDocumentPayloadFactory.swift - Vue document payload assembly for reader content
+
+import Foundation
+import BibleCore
+import BibleView
+import os.log
+
+private let documentPayloadLogger = Logger(subsystem: "org.andbible", category: "BibleReaderDocumentPayloadFactory")
+
+/**
+ Describes one OSIS-backed document payload the native reader sends to the Vue document renderer.
+
+ `BibleReaderController` decides what content should be shown. This value carries only the stable
+ bridge contract fields needed to serialize that content, so document JSON assembly can be tested
+ and evolved without coupling it to controller navigation, modal, or persistence responsibilities.
+
+ - Side effects: None; this is an immutable request value.
+ - Failure modes: None during initialization. Invalid combinations are handled by the factory when
+   it cannot resolve a required Bible ordinal range or cannot serialize the resulting JSON object.
+ */
+struct BibleReaderDocumentPayloadRequest {
+    /// OSIS book or pseudo-book identifier emitted as `bookAbbreviation`.
+    let osisBookId: String
+    /// User-visible book/document name emitted in document metadata.
+    let bookName: String
+    /// One-based chapter number for Bible-like documents and placeholder chapter metadata.
+    let chapter: Int
+    /// Number of verses represented by the OSIS fragment.
+    let verseCount: Int
+    /// Whether the fragment belongs to a New Testament document.
+    let isNewTestament: Bool
+    /// OSIS or OSIS-like XML consumed by the web renderer.
+    let xml: String
+    /// Bible bookmarks associated with the represented range.
+    let bookmarks: [BibleBookmark]
+    /// Raw `DocumentCategory` bridge value such as `BIBLE`, `COMMENTARY`, or `DICTIONARY`.
+    let bookCategory: String
+    /// Optional module initials override. `nil` uses the active Bible module initials.
+    let bookInitials: String?
+    /// Whether Vue should inject a chapter marker for this document.
+    let addChapter: Bool
+    /// Optional original navigation target used by highlight restoration.
+    let originalOrdinalRange: [Int]?
+    /// Optional exact document key. Bible chapters default to `Book.Chapter`.
+    let documentKey: String?
+    /// Optional display label for the document key.
+    let keyName: String?
+    /// Optional exact ordinal range for single-key or non-chapter documents.
+    let ordinalRangeOverride: [Int]?
+
+    /**
+     Creates a document payload request while preserving the controller's historical defaults.
+
+     - Parameters mirror the legacy `BibleReaderController.buildDocumentJSON(...)` signature so
+       callers can migrate incrementally without changing emitted document semantics.
+     - Side effects: None.
+     - Failure modes: None; validation is deferred until serialization.
+     */
+    init(
+        osisBookId: String,
+        bookName: String,
+        chapter: Int,
+        verseCount: Int,
+        isNewTestament: Bool,
+        xml: String,
+        bookmarks: [BibleBookmark] = [],
+        bookCategory: String = DocumentCategory.bible.rawValue,
+        bookInitials: String? = nil,
+        addChapter: Bool = true,
+        originalOrdinalRange: [Int]? = nil,
+        documentKey: String? = nil,
+        keyName: String? = nil,
+        ordinalRangeOverride: [Int]? = nil
+    ) {
+        self.osisBookId = osisBookId
+        self.bookName = bookName
+        self.chapter = chapter
+        self.verseCount = verseCount
+        self.isNewTestament = isNewTestament
+        self.xml = xml
+        self.bookmarks = bookmarks
+        self.bookCategory = bookCategory
+        self.bookInitials = bookInitials
+        self.addChapter = addChapter
+        self.originalOrdinalRange = originalOrdinalRange
+        self.documentKey = documentKey
+        self.keyName = keyName
+        self.ordinalRangeOverride = ordinalRangeOverride
+    }
+}
+
+/**
+ Builds the JSON document records emitted to the Vue reader.
+
+ The factory owns the bridge payload schema for rendered documents. Controller-owned concerns are
+ supplied as closures: module initials, JSword/SWORD ordinal lookup, bookmark projection, reading
+ progress, and memorization progress. This keeps JSON shape centralized without letting the factory
+ mutate reader state or know about windows, modals, or bridge event routing.
+
+ Side effects:
+ - calls supplied closures to project bookmarks and read progress snapshots
+ - logs serialization failures
+
+ Failure modes:
+ - returns `nil` for Bible documents whose ordinal range cannot be resolved
+ - returns `nil` when JSON serialization fails
+ - omits bookmark payloads that fail the shared bridge encoder, matching the prior controller logic
+ */
+struct BibleReaderDocumentPayloadFactory {
+    /**
+     Resolves the ordinal range for a Bible chapter.
+
+     - Parameters are display book name, one-based chapter, and caller-supplied verse count.
+     - Returns the start/end ordinals plus resolved verse count, or `nil` when the active module
+       cannot resolve the chapter.
+     */
+    typealias ChapterOrdinalRangeResolver = (String, Int, Int) -> (start: Int, end: Int, verseCount: Int)?
+
+    /// Projects one persisted Bible bookmark into the typed Vue bridge DTO.
+    typealias BookmarkPayloadBuilder = (BibleBookmark) -> BibleBookmarkData
+
+    /// Maps a display book name to the KJV book ordinal used by reading-progress persistence.
+    typealias KJVBookOrdinalResolver = (String) -> Int?
+
+    /// Reads the chapter read count for a KJV book ordinal/chapter pair.
+    typealias ChapterReadCountProvider = (Int, Int) -> Int?
+
+    /// Reads memorization ordinals for the supplied module initials and rendered ordinal range.
+    typealias OrdinalProgressProvider = (String, Int, Int) -> [Int]
+
+    /// Active Bible module initials used when a request does not override `bookInitials`.
+    private let activeModuleName: String
+    /// Whether the active Bible document exposes Strong's metadata.
+    private let hasStrongs: Bool
+    /// Controller-supplied bookmark payload projection.
+    private let bookmarkPayload: BookmarkPayloadBuilder
+    /// Controller/SWORD-supplied Bible ordinal lookup.
+    private let chapterOrdinalRange: ChapterOrdinalRangeResolver
+    /// Controller-supplied KJV ordinal lookup for reading progress.
+    private let kjvBookOrdinal: KJVBookOrdinalResolver
+    /// Reading-progress store snapshot access.
+    private let chapterReadCount: ChapterReadCountProvider
+    /// Memorized ordinal lookup.
+    private let memorizedOrdinals: OrdinalProgressProvider
+    /// Memorization target ordinal lookup.
+    private let targetOrdinals: OrdinalProgressProvider
+
+    /**
+     Creates a document payload factory for one snapshot of controller reader state.
+
+     - Parameters:
+       - activeModuleName: Module initials used by default for `bookInitials`.
+       - hasStrongs: Whether Bible fragments should advertise Strong's support.
+       - bookmarkPayload: Converts `BibleBookmark` models to bridge DTOs.
+       - chapterOrdinalRange: Resolves Bible chapter ordinal ranges through active versification.
+       - kjvBookOrdinal: Resolves KJV book ordinals for reading progress.
+       - chapterReadCount: Reads persisted read counts for rendered Bible chapters.
+       - memorizedOrdinals: Reads memorized ordinals for the rendered range.
+       - targetOrdinals: Reads memorization target ordinals for the rendered range.
+     - Side effects: None during initialization; closures are invoked by serialization methods.
+     - Failure modes: None during initialization.
+     */
+    init(
+        activeModuleName: String,
+        hasStrongs: Bool,
+        bookmarkPayload: @escaping BookmarkPayloadBuilder,
+        chapterOrdinalRange: @escaping ChapterOrdinalRangeResolver,
+        kjvBookOrdinal: @escaping KJVBookOrdinalResolver,
+        chapterReadCount: @escaping ChapterReadCountProvider,
+        memorizedOrdinals: @escaping OrdinalProgressProvider,
+        targetOrdinals: @escaping OrdinalProgressProvider
+    ) {
+        self.activeModuleName = activeModuleName
+        self.hasStrongs = hasStrongs
+        self.bookmarkPayload = bookmarkPayload
+        self.chapterOrdinalRange = chapterOrdinalRange
+        self.kjvBookOrdinal = kjvBookOrdinal
+        self.chapterReadCount = chapterReadCount
+        self.memorizedOrdinals = memorizedOrdinals
+        self.targetOrdinals = targetOrdinals
+    }
+
+    /**
+     Serializes an OSIS-backed reader document in the shape expected by Vue.
+
+     - Parameter request: Complete payload description for the document being rendered.
+     - Returns: JSON for one Vue document record, or `nil` when required Bible range data or JSON
+       serialization is unavailable.
+     - Side effects: Reads bookmark/progress data through injected closures and logs failures.
+     - Failure modes: Bible documents require a resolvable ordinal range unless an override is
+       supplied; non-Bible documents default to `[0, 0]` to preserve existing bridge semantics.
+     */
+    func documentJSON(_ request: BibleReaderDocumentPayloadRequest) -> String? {
+        let key = request.documentKey ?? "\(request.osisBookId).\(request.chapter)"
+        let displayKeyName = request.keyName ?? "\(request.bookName) \(request.chapter)"
+        let documentOrdinalRange: [Int]
+        if let ordinalRangeOverride = request.ordinalRangeOverride {
+            documentOrdinalRange = ordinalRangeOverride
+        } else if request.bookCategory == DocumentCategory.bible.rawValue {
+            guard let range = chapterOrdinalRange(request.bookName, request.chapter, request.verseCount) else {
+                documentPayloadLogger.error(
+                    "Failed to resolve Bible document range for \(request.osisBookId, privacy: .public).\(request.chapter)"
+                )
+                return nil
+            }
+            documentOrdinalRange = [range.start, range.end]
+        } else {
+            documentOrdinalRange = [0, 0]
+        }
+
+        let ordinalStart = documentOrdinalRange.first ?? 0
+        let ordinalEnd = documentOrdinalRange.last ?? ordinalStart
+        let initials = request.bookInitials ?? activeModuleName
+        let bookmarkObjects = request.bookmarks.compactMap { jsonObject(from: bookmarkPayload($0)) }
+        let chapterReadCountValue = chapterReadCountValue(
+            bookCategory: request.bookCategory,
+            bookName: request.bookName,
+            chapter: request.chapter
+        )
+
+        var doc: [String: Any] = [
+            "id": "doc-1",
+            "type": "bible",
+            "osisFragment": osisFragmentObject(
+                request: request,
+                key: key,
+                displayKeyName: displayKeyName,
+                initials: initials,
+                ordinalRange: documentOrdinalRange
+            ),
+            "bookInitials": initials,
+            "bookCategory": request.bookCategory,
+            "bookAbbreviation": request.osisBookId,
+            "bookName": request.bookName,
+            "key": key,
+            "v11n": "KJVA",
+            "osisRef": key,
+            "annotateRef": "",
+            "genericBookmarks": [Any](),
+            "ordinalRange": documentOrdinalRange,
+            "isNativeHtml": false,
+            "bookmarks": bookmarkObjects,
+            "bibleBookName": request.bookName,
+            "addChapter": request.addChapter,
+            "chapterNumber": request.chapter,
+            "originalOrdinalRange": request.originalOrdinalRange ?? NSNull(),
+            "memorizedOrdinals": memorizedOrdinals(initials, ordinalStart, ordinalEnd),
+            "targetOrdinals": targetOrdinals(initials, ordinalStart, ordinalEnd),
+        ]
+        if let chapterReadCountValue {
+            doc["chapterReadCount"] = chapterReadCountValue
+        }
+
+        return serializedDocument(doc, failureDescription: "\(request.osisBookId) \(request.chapter)")
+    }
+
+    /**
+     Serializes EPUB XHTML as a native-HTML OSIS document for the Vue reader.
+
+     Android routes EPUB-like general content through the same document surface as other reader
+     documents. iOS must mark this payload as `isNativeHtml` and use document type `osis` so the
+     Vue `OsisDocument` path passes the HTML through to `OsisFragment` without OSIS conversion.
+
+     - Parameters:
+       - bookName: Visible EPUB section title.
+       - bookInitials: Parent EPUB title used as document initials.
+       - content: Rewritten XHTML/HTML content loaded from the EPUB index.
+     - Returns: Serialized JSON payload. Returns `{}` if JSON serialization fails.
+     - Side effects: Logs serialization failures.
+     - Failure modes: Invalid JSON object construction returns `{}` to match the previous
+       controller behavior.
+     */
+    func epubDocumentJSON(bookName: String, bookInitials: String, content: String) -> String {
+        let doc: [String: Any] = [
+            "id": "doc-1",
+            "type": "osis",
+            "osisFragment": [
+                "xml": content,
+                "key": "epub",
+                "keyName": bookName,
+                "v11n": "KJVA",
+                "bookCategory": DocumentCategory.generalBook.rawValue,
+                "bookInitials": bookInitials,
+                "bookAbbreviation": "Epub",
+                "osisRef": "epub",
+                "isNewTestament": false,
+                "features": [String: Any](),
+                "hasStrongs": false,
+                "ordinalRange": [0, 0],
+                "language": "en",
+                "direction": "ltr"
+            ] as [String: Any],
+            "bookInitials": bookInitials,
+            "bookCategory": DocumentCategory.generalBook.rawValue,
+            "bookAbbreviation": "Epub",
+            "bookName": bookName,
+            "key": "epub",
+            "v11n": "KJVA",
+            "osisRef": "epub",
+            "annotateRef": "",
+            "genericBookmarks": [Any](),
+            "ordinalRange": [0, 0],
+            "isNativeHtml": true,
+            "highlightedOrdinalRange": NSNull()
+        ]
+
+        return serializedDocument(doc, failureDescription: "EPUB document") ?? "{}"
+    }
+
+    /**
+     Builds the nested OSIS fragment object shared by Bible and OSIS-like auxiliary documents.
+
+     - Parameters:
+       - request: Source document metadata and XML content.
+       - key: Exact Vue document key and OSIS reference.
+       - displayKeyName: Human-readable key label shown by the web reader.
+       - initials: Module initials already resolved from the request or active Bible module.
+       - ordinalRange: Ordinal range emitted at both document and fragment levels.
+     - Returns: A JSON-compatible dictionary for the document's `osisFragment` field.
+     - Side effects: None.
+     - Failure modes: None directly; JSON compatibility is validated by `serializedDocument`.
+     */
+    private func osisFragmentObject(
+        request: BibleReaderDocumentPayloadRequest,
+        key: String,
+        displayKeyName: String,
+        initials: String,
+        ordinalRange: [Int]
+    ) -> [String: Any] {
+        [
+            "xml": request.xml,
+            "key": key,
+            "keyName": displayKeyName,
+            "v11n": "KJVA",
+            "bookCategory": request.bookCategory,
+            "bookInitials": initials,
+            "bookAbbreviation": request.osisBookId,
+            "osisRef": key,
+            "isNewTestament": request.isNewTestament,
+            "features": [String: Any](),
+            "hasStrongs": hasStrongs,
+            "ordinalRange": ordinalRange,
+            "language": "en",
+            "direction": "ltr",
+        ]
+    }
+
+    /**
+     Resolves optional reading-progress metadata for Bible documents only.
+
+     - Parameters:
+       - bookCategory: Raw document category value supplied by the request.
+       - bookName: Display book name used to resolve a KJV book ordinal.
+       - chapter: One-based chapter number.
+     - Returns: Stored chapter read count when the document is a Bible chapter and the KJV ordinal
+       can be resolved; otherwise `nil` so non-Bible documents omit the field.
+     - Side effects: Reads through the injected progress closures only.
+     - Failure modes: Missing KJV ordinal or progress data is represented as `nil`.
+     */
+    private func chapterReadCountValue(bookCategory: String, bookName: String, chapter: Int) -> Int? {
+        guard bookCategory == DocumentCategory.bible.rawValue,
+              let ordinal = kjvBookOrdinal(bookName) else {
+            return nil
+        }
+        return chapterReadCount(ordinal, chapter)
+    }
+
+    /**
+     Converts a typed bridge DTO into a JSON-compatible object for inclusion in document payloads.
+
+     - Parameter value: Encodable bridge value using the shared `bridgeEncoder`.
+     - Returns: Foundation JSON object on success, or `nil` when encoding/parsing fails.
+     - Side effects: None.
+     - Failure modes: Encoding failures are intentionally dropped to preserve the prior compact-map
+       behavior for bookmark payloads.
+     */
+    private func jsonObject<T: Encodable>(from value: T) -> Any? {
+        guard let data = try? bridgeEncoder.encode(value) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data)
+    }
+
+    /**
+     Serializes one assembled document dictionary for bridge emission.
+
+     - Parameters:
+       - doc: JSON-compatible document dictionary.
+       - failureDescription: Log context identifying the document being serialized.
+     - Returns: UTF-8 JSON string sorted by key for deterministic tests, or `nil` on failure.
+     - Side effects: Logs serialization failures.
+     - Failure modes: Non-JSON values or UTF-8 conversion failure prevent document emission.
+     */
+    private func serializedDocument(_ doc: [String: Any], failureDescription: String) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: doc, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            documentPayloadLogger.error("Failed to serialize document JSON for \(failureDescription, privacy: .public)")
+            return nil
+        }
+        return json
+    }
+}


### PR DESCRIPTION
## Summary
This continues the #146 reader-controller decomposition by moving document payload assembly and auxiliary module rendering out of BibleReaderController into focused collaborators.

The intended outcome is no user-visible behavior change: the controller still owns reader state, active modules, persistence, and bridge orchestration, while the new collaborators own tested document payload contracts.

## Scope
In scope:
- Extract Vue reader document JSON assembly into BibleReaderDocumentPayloadFactory.
- Extract dictionary, general-book, and map auxiliary document loading into BibleReaderAuxiliaryContentLoader.
- Keep controller-owned state mutation behind explicit closures rather than moving window or persistence ownership.
- Add focused tests for Bible document payloads, fail-closed ordinal behavior, EPUB native HTML payloads, and auxiliary no-module fallbacks.

Out of scope:
- Changing user-visible reader behavior.
- Moving bridge event routing, StudyPad, bookmark, or TTS responsibilities in this PR.
- Reopening or reclosing #146, which is already closed.

## Contract References
- #146
- Documentation Standards v0.1
- Commit Message Standard v0.1
- GitNexus impact and detect_changes guardrails
- Existing shared Vue reader document contract

## Change Details
- BibleReaderDocumentPayloadFactory now owns Bible, non-Bible, and EPUB document JSON assembly while receiving controller dependencies as closures for bookmarks, ordinal resolution, reading progress, and memorization progress.
- BibleReaderAuxiliaryContentLoader now owns the repeated dictionary/general-book/map workflow for fallback documents, selected-key rendering, setup_content emission, rendered-content state updates, and background reapplication.
- BibleReaderController now constructs these collaborators per render path and keeps mutable reader state and PageManager persistence local to the controller.
- Reader-navigation tests cover the extracted contracts directly and preserve prior fail-closed handling when Bible ordinal ranges cannot be resolved.

## Validation Evidence
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F with focused reader payload tests.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F with broader affected reader tests.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -skip-testing:AndBibleUITests -skip-testing:AndBibleTests/AndBibleTests/testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks.
- python3 -m unittest discover -s scripts -p test_*.py.
- python3 scripts/check_bridge_parity_inventory.py.
- python3 scripts/check_repo_standards.py docblocks --all-files.
- python3 scripts/check_repo_standards.py commits.
- git diff --cached --check.
- GitNexus detect_changes on staged changes reported medium staged risk; direct factory impact is high because it feeds reader document emission paths.

## Risks / Follow-ups
- Main risk is document-emission regression across Bible, commentary, EPUB, dictionary, general-book, and map reader content. The new focused tests plus the full non-UI unit suite cover the affected paths found by GitNexus.
- Follow-up decomposition can continue with bridge event routing, StudyPad/bookmark actions, or other remaining controller responsibilities.

## Screenshots
none

## Closes
Closes: none

Refs #146