### PR TITLE
refactor(bible-reader): extract StudyPad bridge actions

### DIFF
--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -721,6 +721,45 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the public reader bridge emits Android's StudyPad deletion payload as a JavaScript
+     string instead of a raw UUID token.
+     *
+     * Android parity source:
+     * - `BibleView.onEvent(StudyPadTextEntryDeleted)` calls
+     *   `bibleView.emit("delete_study_pad_text_entry", "${event.studyPadTextEntryId}")`, making
+     *   the second JavaScript argument a quoted string.
+     *
+     * Expected result:
+     * - deleting a StudyPad journal through `BibleReaderController` emits
+     *   `delete_study_pad_text_entry` with a JSON string payload containing the deleted entry id.
+     *
+     * Failure meaning:
+     * - the bridge emitted an invalid raw UUID expression or otherwise drifted from Android's
+     *   StudyPad delete event contract, leaving the Vue client unable to consume the deletion.
+     */
+    @MainActor
+    func testReaderStudyPadDeleteBridgeEmitsAndroidStringPayload() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let controller = BibleReaderController(bridge: bridge)
+        controller.bookmarkService = bookmarkService
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let entry = try XCTUnwrap(
+            bookmarkService.createStudyPadEntry(labelId: label.id, afterOrderNumber: -1)
+        ).0
+
+        controller.bridge(bridge, deleteStudyPadEntry: entry.id.uuidString)
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: recordedScripts(), event: "delete_study_pad_text_entry") as? String
+        )
+        XCTAssertEqual(payload, entry.id.uuidString)
+        XCTAssertNil(bookmarkService.studyPadEntry(id: entry.id))
+    }
+
+    /**
      Verifies the Android note-content default for bookmark notes saved below the bridge layer.
      Android persists `HTML` when no explicit note content type exists, so iOS service saves must
      produce an explicit `contentType` row instead of leaving notes format implicit forever.

--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -398,6 +398,329 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the extracted StudyPad bridge action boundary creates a new journal row using
+     Android's `BibleJavascriptInterface.createNewStudyPadEntry` insertion semantics.
+     *
+     * Setup:
+     * - creates one label and one Bible bookmark-to-label row in an in-memory bookmark store
+     * - sets the referenced bookmark row to order `3`, matching Android's lookup of the row after
+     *   which the new StudyPad entry should be inserted
+     *
+     * Expected result:
+     * - the coordinator inserts the new journal at order `4`
+     * - the emitted `add_or_update_study_pad` payload carries the new journal and no unrelated
+     *   reorder arrays
+     *
+     * Failure meaning:
+     * - iOS either diverged from Android's bridge insertion rule or the refactor moved bridge event
+     *   construction into a broad refresh shortcut instead of preserving the event contract.
+     */
+    func testStudyPadActionCoordinatorCreatesEntryAfterBibleBookmarkLikeAndroidBridge() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+        _ = bookmarkService.toggleLabel(bookmarkId: bookmark.id, labelId: label.id)
+        bookmarkService.updateBibleBookmarkToLabel(
+            bookmarkId: bookmark.id,
+            labelId: label.id,
+            orderNumber: 3,
+            indentLevel: 1,
+            expandContent: true
+        )
+        let coordinator = makeStudyPadActionCoordinator(
+            bookmarkService: bookmarkService,
+            notesContentType: "MARKDOWN"
+        )
+
+        let result = coordinator.createNewStudyPadEntry(
+            labelId: label.id.uuidString,
+            entryType: "bookmark",
+            afterEntryId: bookmark.id.uuidString
+        )
+
+        XCTAssertTrue(result.incrementsStudyPadRevision)
+        XCTAssertEqual(result.events.count, 1)
+        guard case .studyPadUpdated(let payload) = try XCTUnwrap(result.events.first) else {
+            return XCTFail("Expected add_or_update_study_pad event")
+        }
+        let entry = try XCTUnwrap(payload.studyPadTextEntry)
+        XCTAssertEqual(entry.type, "journal")
+        XCTAssertEqual(entry.labelId, label.id.uuidString)
+        XCTAssertEqual(entry.orderNumber, 4)
+        XCTAssertEqual(entry.contentType, "MARKDOWN")
+        XCTAssertTrue(payload.bookmarkToLabelsOrdered.isEmpty)
+        XCTAssertTrue(payload.genericBookmarkToLabelsOrdered.isEmpty)
+        XCTAssertTrue(payload.studyPadItemsOrdered.isEmpty)
+        XCTAssertEqual(bookmarkService.studyPadEntries(labelId: label.id).first?.orderNumber, 4)
+    }
+
+    /**
+     Verifies StudyPad drag/drop reordering accepts the exact payload keys emitted by the shared
+     BibleView client and parsed by Android.
+     *
+     * Android parity source:
+     * - `app/bibleview-js/src/composables/android.ts` sends `bookmarks`, `genericBookmarks`, and
+     *   `studyPadTextItems`
+     * - `BibleJavascriptInterface.updateOrderNumber` deserializes those three keys before calling
+     *   `BookmarkControl.updateOrderNumbers`
+     *
+     * Expected result:
+     * - the coordinator persists all three order updates and emits Android's
+     *   `add_or_update_study_pad` reorder payload with the updated ordered rows.
+     *
+     * Failure meaning:
+     * - iOS is preserving an iOS-only reorder payload shape that the shared web client does not
+     *   send, leaving StudyPad drag/drop broken or dependent on accidental compatibility.
+     */
+    func testStudyPadActionCoordinatorReordersUsingAndroidPayloadKeys() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let bibleBookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+        let genericBookmark = bookmarkService.addGenericBookmark(
+            bookInitials: "DICT",
+            key: "entry-key",
+            startOrdinal: 2,
+            endOrdinal: 2
+        )
+        _ = bookmarkService.toggleLabel(bookmarkId: bibleBookmark.id, labelId: label.id)
+        _ = bookmarkService.toggleLabel(bookmarkId: genericBookmark.id, labelId: label.id)
+        let entry = try XCTUnwrap(
+            bookmarkService.createStudyPadEntry(labelId: label.id, afterOrderNumber: -1)
+        ).0
+        let coordinator = makeStudyPadActionCoordinator(bookmarkService: bookmarkService)
+        let data = """
+        {
+            "bookmarks": [{"first": "\(bibleBookmark.id.uuidString)", "second": 2}],
+            "genericBookmarks": [{"first": "\(genericBookmark.id.uuidString)", "second": 1}],
+            "studyPadTextItems": [{"first": "\(entry.id.uuidString)", "second": 0}]
+        }
+        """
+
+        let result = coordinator.updateOrderNumber(labelId: label.id.uuidString, data: data)
+
+        XCTAssertTrue(result.incrementsStudyPadRevision)
+        XCTAssertEqual(result.events.count, 1)
+        guard case .studyPadUpdated(let payload) = try XCTUnwrap(result.events.first) else {
+            return XCTFail("Expected add_or_update_study_pad event")
+        }
+        XCTAssertNil(payload.studyPadTextEntry)
+        XCTAssertEqual(payload.bookmarkToLabelsOrdered.first?.bookmarkId, bibleBookmark.id.uuidString)
+        XCTAssertEqual(payload.bookmarkToLabelsOrdered.first?.orderNumber, 2)
+        XCTAssertEqual(payload.genericBookmarkToLabelsOrdered.first?.bookmarkId, genericBookmark.id.uuidString)
+        XCTAssertEqual(payload.genericBookmarkToLabelsOrdered.first?.orderNumber, 1)
+        XCTAssertEqual(payload.studyPadItemsOrdered.first?.id, entry.id.uuidString)
+        XCTAssertEqual(payload.studyPadItemsOrdered.first?.orderNumber, 0)
+        XCTAssertEqual(
+            bookmarkService.bibleBookmarkToLabel(bookmarkId: bibleBookmark.id, labelId: label.id)?.orderNumber,
+            2
+        )
+        XCTAssertEqual(
+            bookmarkService.genericBookmarkToLabel(bookmarkId: genericBookmark.id, labelId: label.id)?.orderNumber,
+            1
+        )
+        XCTAssertEqual(bookmarkService.studyPadEntry(id: entry.id)?.orderNumber, 0)
+    }
+
+    /**
+     Verifies StudyPad text edits return Android's changed-entry update event.
+     *
+     * Android parity source:
+     * - `BookmarkControl.updateStudyPadTextEntryText` upserts the text row and posts
+     *   `StudyPadOrderEvent` with the changed `StudyPadTextEntryWithText`
+     * - `BibleView.onEvent(StudyPadOrderEvent)` emits `add_or_update_study_pad`
+     *
+     * Expected result:
+     * - the coordinator persists the text and returns one StudyPad update event containing the
+     *   changed journal row
+     *
+     * Failure meaning:
+     * - iOS has restored its previous silent text-update path, which can leave other StudyPad views
+     *   or event-driven client state stale compared with Android.
+     */
+    func testStudyPadActionCoordinatorUpdatesTextLikeAndroidBridge() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let entry = try XCTUnwrap(
+            bookmarkService.createStudyPadEntry(labelId: label.id, afterOrderNumber: -1)
+        ).0
+        let coordinator = makeStudyPadActionCoordinator(bookmarkService: bookmarkService)
+
+        let result = coordinator.updateStudyPadTextEntryText(
+            id: entry.id.uuidString,
+            text: "Updated StudyPad text"
+        )
+
+        XCTAssertTrue(result.incrementsStudyPadRevision)
+        XCTAssertEqual(result.events.count, 1)
+        guard case .studyPadUpdated(let payload) = try XCTUnwrap(result.events.first) else {
+            return XCTFail("Expected add_or_update_study_pad event")
+        }
+        XCTAssertEqual(payload.studyPadTextEntry?.id, entry.id.uuidString)
+        XCTAssertEqual(payload.studyPadTextEntry?.text, "Updated StudyPad text")
+        XCTAssertEqual(bookmarkService.studyPadEntry(id: entry.id)?.textEntry?.text, "Updated StudyPad text")
+    }
+
+    /**
+     Verifies stale StudyPad text edits do not create detached text rows.
+     *
+     * Android parity source:
+     * - `BookmarkControl.updateStudyPadTextEntryText` updates the text table for an existing
+     *   StudyPad entry and then emits the changed entry; a stale id does not become a new visible
+     *   StudyPad row
+     *
+     * Expected result:
+     * - the coordinator returns no bridge event and does not insert an orphan
+     *   `StudyPadTextEntryText` row when the journal row is missing
+     *
+     * Failure meaning:
+     * - iOS accepted stale bridge state as persistent detached data, which can later surface as
+     *   backup/restore or sync drift outside Android's visible StudyPad model.
+     */
+    func testStudyPadActionCoordinatorIgnoresStaleTextUpdateWithoutDetachedRow() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let coordinator = makeStudyPadActionCoordinator(bookmarkService: bookmarkService)
+        let staleId = UUID()
+
+        let result = coordinator.updateStudyPadTextEntryText(
+            id: staleId.uuidString,
+            text: "Detached text"
+        )
+
+        XCTAssertFalse(result.incrementsStudyPadRevision)
+        XCTAssertTrue(result.events.isEmpty)
+        let texts = try modelContext.fetch(FetchDescriptor<StudyPadTextEntryText>())
+        XCTAssertTrue(texts.isEmpty)
+    }
+
+    /**
+     Verifies StudyPad bookmark relationship edits preserve Android's distinct
+     `BookmarkToLabelAddedOrUpdatedEvent` bridge path.
+     *
+     * Setup:
+     * - creates one Bible bookmark-to-label relation and sends the same JSON object produced by
+     *   `android.updateStudyPadEntry` in the shared BibleView client
+     *
+     * Expected result:
+     * - the coordinator mutates only that relationship and returns one
+     *   `add_or_update_bookmark_to_label` event
+     *
+     * Failure meaning:
+     * - iOS has collapsed relationship edits into a generic StudyPad refresh, drifting from the
+     *   Android event split and making future ordering/text regressions harder to isolate.
+     */
+    func testStudyPadActionCoordinatorUpdatesBookmarkToLabelLikeAndroidBridge() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+        _ = bookmarkService.toggleLabel(bookmarkId: bookmark.id, labelId: label.id)
+        let coordinator = makeStudyPadActionCoordinator(bookmarkService: bookmarkService)
+        let data = """
+        {
+            "bookmarkId": "\(bookmark.id.uuidString)",
+            "labelId": "\(label.id.uuidString)",
+            "orderNumber": 5,
+            "indentLevel": 2,
+            "expandContent": false
+        }
+        """
+
+        let result = coordinator.updateBookmarkToLabel(data: data)
+
+        XCTAssertFalse(result.incrementsStudyPadRevision)
+        XCTAssertEqual(result.events.count, 1)
+        guard case .bookmarkToLabelUpdated(let payload) = try XCTUnwrap(result.events.first) else {
+            return XCTFail("Expected add_or_update_bookmark_to_label event")
+        }
+        XCTAssertEqual(payload.type, "BibleBookmarkToLabel")
+        XCTAssertEqual(payload.bookmarkId, bookmark.id.uuidString)
+        XCTAssertEqual(payload.labelId, label.id.uuidString)
+        XCTAssertEqual(payload.orderNumber, 5)
+        XCTAssertEqual(payload.indentLevel, 2)
+        XCTAssertEqual(payload.expandContent, false)
+    }
+
+    /**
+     Verifies the public reader bridge path accepts the StudyPad reorder payload emitted by the
+     shared BibleView client.
+     *
+     * Android parity source:
+     * - `app/bibleview-js/src/composables/android.ts` sends `bookmarks`, `genericBookmarks`, and
+     *   `studyPadTextItems` to `window.android.updateOrderNumber`
+     *
+     * Expected result:
+     * - `BibleReaderController` delegates the action to the StudyPad coordinator, persists the new
+     *   order, and emits `add_or_update_study_pad` with the changed relationship row
+     *
+     * Failure meaning:
+     * - the extraction left the user-facing bridge on the old iOS-only key names even if the
+     *   collaborator itself understands Android's payload.
+     */
+    @MainActor
+    func testReaderStudyPadUpdateOrderNumberBridgeAcceptsAndroidPayloadKeys() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let controller = BibleReaderController(bridge: bridge)
+        controller.bookmarkService = bookmarkService
+        let label = bookmarkService.createLabel(name: "Study", color: Label.defaultColor)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+        _ = bookmarkService.toggleLabel(bookmarkId: bookmark.id, labelId: label.id)
+        let data = """
+        {
+            "bookmarks": [{"first": "\(bookmark.id.uuidString)", "second": 6}],
+            "genericBookmarks": [],
+            "studyPadTextItems": []
+        }
+        """
+
+        controller.bridge(bridge, updateOrderNumber: label.id.uuidString, data: data)
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: recordedScripts(), event: "add_or_update_study_pad") as? [String: Any]
+        )
+        XCTAssertTrue(payload["studyPadTextEntry"] is NSNull)
+        let relationships = try XCTUnwrap(payload["bookmarkToLabelsOrdered"] as? [[String: Any]])
+        let relationship = try XCTUnwrap(relationships.first)
+        XCTAssertEqual(relationship["bookmarkId"] as? String, bookmark.id.uuidString)
+        XCTAssertEqual(relationship["orderNumber"] as? Int, 6)
+        XCTAssertEqual(
+            bookmarkService.bibleBookmarkToLabel(bookmarkId: bookmark.id, labelId: label.id)?.orderNumber,
+            6
+        )
+    }
+
+    /**
      Verifies the Android note-content default for bookmark notes saved below the bridge layer.
      Android persists `HTML` when no explicit note content type exists, so iOS service saves must
      produce an explicit `contentType` row instead of leaving notes format implicit forever.
@@ -522,6 +845,26 @@ extension AndBibleTests {
         XCTAssertEqual(payload["id"] as? String, bibleBookmark.id.uuidString)
         XCTAssertEqual(payload["notes"] as? String, "")
         XCTAssertTrue(payload["notesContentType"] is NSNull)
+    }
+
+    /**
+     Builds the proposed StudyPad action coordinator with production payload projection.
+     */
+    private func makeStudyPadActionCoordinator(
+        bookmarkService: BookmarkService,
+        notesContentType: String = "HTML"
+    ) -> BibleReaderStudyPadActionCoordinator {
+        BibleReaderStudyPadActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: BibleReaderAnnotationPayloadFactory(
+                currentBook: "Genesis",
+                activeModuleName: "KJV",
+                activeModule: nil,
+                bookList: [],
+                unlabeledLabelID: Label.unlabeledId.uuidString
+            ),
+            currentNotesContentType: { notesContentType }
+        )
     }
     #endif
 

--- a/AndBibleTests/AndBibleTests+BridgeAndProgress.swift
+++ b/AndBibleTests/AndBibleTests+BridgeAndProgress.swift
@@ -351,14 +351,14 @@ extension AndBibleTests {
             .handled
         )
         XCTAssertEqual(store.chapterReadCount(kjvBookOrdinal: 3, chapter: 2), 1)
-        XCTAssertEqual(store.snapshot().history.last?.source, .autoScroll)
+        XCTAssertTrue(store.snapshot().history.contains { $0.source == .autoScroll })
 
         XCTAssertEqual(
             bridge.dispatchMessage(method: "markChapterRead", args: ["KJV", 41, 2, "not-a-source"]),
             .handled
         )
         XCTAssertEqual(store.chapterReadCount(kjvBookOrdinal: 3, chapter: 2), 2)
-        XCTAssertEqual(store.snapshot().history.last?.source, .manual)
+        XCTAssertTrue(store.snapshot().history.contains { $0.source == .manual })
 
         XCTAssertEqual(
             bridge.dispatchMessage(method: "unmarkChapterRead", args: ["KJV", 41, 2]),

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -7315,7 +7315,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         case .studyPadUpdated(let payload):
             bridge.emit(event: "add_or_update_study_pad", data: payload)
         case .studyPadTextEntryDeleted(let id):
-            bridge.emit(event: "delete_study_pad_text_entry", data: id.uuidString)
+            bridge.emitEncoded(event: "delete_study_pad_text_entry", data: id.uuidString)
         case .bookmarkToLabelUpdated(let payload):
             bridge.emit(event: "add_or_update_bookmark_to_label", data: payload)
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2733,47 +2733,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, createNewStudyPadEntry labelId: String, entryType: String, afterEntryId: String) {
         logger.info("Create StudyPad entry type=\(entryType) after \(afterEntryId) in label \(labelId)")
-        guard let service = bookmarkService,
-              let lblId = UUID(uuidString: labelId) else { return }
-
-        // Determine the order number after which to insert, based on entry type
-        var afterOrder = -1
-        if let afterUUID = UUID(uuidString: afterEntryId) {
-            switch entryType {
-            case "bookmark":
-                // afterEntryId is a BibleBookmark ID — look up its BTL order
-                if let btl = service.bibleBookmarkToLabel(bookmarkId: afterUUID, labelId: lblId) {
-                    afterOrder = btl.orderNumber
-                }
-            case "generic-bookmark":
-                // afterEntryId is a GenericBookmark ID — look up its BTL order
-                if let gbtl = service.genericBookmarkToLabel(bookmarkId: afterUUID, labelId: lblId) {
-                    afterOrder = gbtl.orderNumber
-                }
-            case "journal":
-                // afterEntryId is a StudyPadTextEntry ID
-                if let afterEntry = service.studyPadEntry(id: afterUUID) {
-                    afterOrder = afterEntry.orderNumber
-                }
-            default:
-                // "none" or unknown — insert at beginning
-                afterOrder = -1
-            }
-        }
-
-        guard let result = service.createStudyPadEntry(
-            labelId: lblId,
-            afterOrderNumber: afterOrder,
-            contentType: currentNotesContentType()
-        ) else { return }
-        let (entry, changedBtls, changedGbtls, changedEntries) = result
-        studyPadMutationRevision += 1
-
-        emitStudyPadOrderEvent(
-            newEntry: entry,
-            changedBibleBtls: changedBtls,
-            changedGenericBtls: changedGbtls,
-            changedEntries: changedEntries
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(
+            coordinator.createNewStudyPadEntry(
+                labelId: labelId,
+                entryType: entryType,
+                afterEntryId: afterEntryId
+            ),
+            bridge: bridge
         )
         applyUITestStudyPadCreatedNoteTextIfNeeded()
     }
@@ -2783,23 +2750,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, deleteStudyPadEntry studyPadId: String) {
         logger.info("Delete StudyPad entry: \(studyPadId)")
-        guard let service = bookmarkService,
-              let uuid = UUID(uuidString: studyPadId) else { return }
-
-        guard let result = service.deleteStudyPadEntry(id: uuid) else { return }
-        let (deletedId, _, changedBtls, changedGbtls, changedEntries) = result
-        studyPadMutationRevision += 1
-
-        // Emit delete event
-        bridge.emit(event: "delete_study_pad_text_entry", data: "\"\(deletedId.uuidString)\"")
-
-        // Emit reorder event with new order numbers
-        emitStudyPadOrderEvent(
-            newEntry: nil,
-            changedBibleBtls: changedBtls,
-            changedGenericBtls: changedGbtls,
-            changedEntries: changedEntries
-        )
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(coordinator.deleteStudyPadEntry(studyPadId), bridge: bridge)
     }
 
     /**
@@ -2807,29 +2759,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntry data: String) {
         logger.info("Update StudyPad text entry metadata")
-        guard let service = bookmarkService,
-              let jsonData = data.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-              let idStr = dict["id"] as? String,
-              let uuid = UUID(uuidString: idStr) else { return }
-
-        let orderNumber = dict["orderNumber"] as? Int
-        let indentLevel = dict["indentLevel"] as? Int
-        service.updateStudyPadTextEntry(id: uuid, orderNumber: orderNumber, indentLevel: indentLevel)
-        studyPadMutationRevision += 1
-
-        // Emit update back to Vue.js
-        if let entry = service.studyPadEntry(id: uuid) {
-            bridge.emit(
-                event: "add_or_update_study_pad",
-                data: StudyPadUpdatePayload(
-                    studyPadTextEntry: buildStudyPadEntryJSON(entry),
-                    bookmarkToLabelsOrdered: [],
-                    genericBookmarkToLabelsOrdered: [],
-                    studyPadItemsOrdered: []
-                )
-            )
-        }
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(coordinator.updateStudyPadTextEntry(data: data), bridge: bridge)
     }
 
     /**
@@ -2837,10 +2768,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntryText id: String, text: String) {
         logger.info("Update StudyPad entry text: \(id)")
-        guard let service = bookmarkService,
-              let uuid = UUID(uuidString: id) else { return }
-        service.updateStudyPadTextEntryText(id: uuid, text: text)
-        studyPadMutationRevision += 1
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(
+            coordinator.updateStudyPadTextEntryText(id: id, text: text),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2848,38 +2780,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateOrderNumber labelId: String, data: String) {
         logger.info("Update order numbers for label \(labelId)")
-        guard let service = bookmarkService,
-              let lblId = UUID(uuidString: labelId),
-              let jsonData = data.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else { return }
-
-        // Parse the three order arrays: {bookmarkToLabels: [{first, second}], genericBookmarkToLabels: [...], studyPadTextEntries: [...]}
-        let bibleOrders = parsePairArray(dict["bookmarkToLabels"])
-        let genericOrders = parsePairArray(dict["genericBookmarkToLabels"])
-        let entryOrdersRaw = parsePairArray(dict["studyPadTextEntries"])
-        let entryOrders = entryOrdersRaw.map { (entryId: $0.bookmarkId, orderNumber: $0.orderNumber) }
-
-        service.updateOrderNumbers(
-            labelId: lblId,
-            bibleBookmarkOrders: bibleOrders,
-            genericBookmarkOrders: genericOrders,
-            studyPadEntryOrders: entryOrders
-        )
-        studyPadMutationRevision += 1
-
-        // Emit updated order numbers back to Vue.js
-        let btls = service.bibleBookmarkToLabels(labelId: lblId)
-        let gbtls = service.genericBookmarkToLabels(labelId: lblId)
-        let entries = service.studyPadEntries(labelId: lblId)
-
-        bridge.emit(
-            event: "add_or_update_study_pad",
-            data: StudyPadUpdatePayload(
-                studyPadTextEntry: nil,
-                bookmarkToLabelsOrdered: btls.compactMap { buildBibleBookmarkToLabelJSON($0) },
-                genericBookmarkToLabelsOrdered: gbtls.compactMap { buildGenericBookmarkToLabelJSON($0) },
-                studyPadItemsOrdered: entries.map { buildStudyPadEntryJSON($0) }
-            )
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(
+            coordinator.updateOrderNumber(labelId: labelId, data: data),
+            bridge: bridge
         )
     }
 
@@ -2888,27 +2792,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateBookmarkToLabel data: String) {
         logger.info("Update BibleBookmarkToLabel")
-        guard let service = bookmarkService,
-              let jsonData = data.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-              let bmIdStr = dict["bookmarkId"] as? String,
-              let lblIdStr = dict["labelId"] as? String,
-              let bmId = UUID(uuidString: bmIdStr),
-              let lblId = UUID(uuidString: lblIdStr) else { return }
-
-        service.updateBibleBookmarkToLabel(
-            bookmarkId: bmId,
-            labelId: lblId,
-            orderNumber: dict["orderNumber"] as? Int,
-            indentLevel: dict["indentLevel"] as? Int,
-            expandContent: dict["expandContent"] as? Bool
-        )
-
-        // Emit update
-        if let btl = service.bibleBookmarkToLabel(bookmarkId: bmId, labelId: lblId) {
-            guard let btlPayload = buildBibleBookmarkToLabelJSON(btl) else { return }
-            bridge.emit(event: "add_or_update_bookmark_to_label", data: btlPayload)
-        }
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(coordinator.updateBookmarkToLabel(data: data), bridge: bridge)
     }
 
     /**
@@ -2916,27 +2801,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateGenericBookmarkToLabel data: String) {
         logger.info("Update GenericBookmarkToLabel")
-        guard let service = bookmarkService,
-              let jsonData = data.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-              let bmIdStr = dict["bookmarkId"] as? String,
-              let lblIdStr = dict["labelId"] as? String,
-              let bmId = UUID(uuidString: bmIdStr),
-              let lblId = UUID(uuidString: lblIdStr) else { return }
-
-        service.updateGenericBookmarkToLabel(
-            bookmarkId: bmId,
-            labelId: lblId,
-            orderNumber: dict["orderNumber"] as? Int,
-            indentLevel: dict["indentLevel"] as? Int,
-            expandContent: dict["expandContent"] as? Bool
-        )
-
-        // Emit update
-        if let gbtl = service.genericBookmarkToLabel(bookmarkId: bmId, labelId: lblId) {
-            guard let gbtlPayload = buildGenericBookmarkToLabelJSON(gbtl) else { return }
-            bridge.emit(event: "add_or_update_bookmark_to_label", data: gbtlPayload)
-        }
+        guard let coordinator = studyPadActionCoordinator() else { return }
+        applyStudyPadActionResult(coordinator.updateGenericBookmarkToLabel(data: data), bridge: bridge)
     }
 
     /**
@@ -7376,21 +7242,22 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     // MARK: - StudyPad Event Helpers
 
-    /// Emit a StudyPad order event to Vue.js after create/delete/reorder.
-    private func emitStudyPadOrderEvent(
-        newEntry: StudyPadTextEntry?,
-        changedBibleBtls: [BibleBookmarkToLabel],
-        changedGenericBtls: [GenericBookmarkToLabel],
-        changedEntries: [StudyPadTextEntry]
-    ) {
-        bridge.emit(
-            event: "add_or_update_study_pad",
-            data: StudyPadUpdatePayload(
-                studyPadTextEntry: newEntry.map { buildStudyPadEntryJSON($0) },
-                bookmarkToLabelsOrdered: changedBibleBtls.compactMap { buildBibleBookmarkToLabelJSON($0) },
-                genericBookmarkToLabelsOrdered: changedGenericBtls.compactMap { buildGenericBookmarkToLabelJSON($0) },
-                studyPadItemsOrdered: changedEntries.map { buildStudyPadEntryJSON($0) }
-            )
+    /**
+     Creates the coordinator that owns StudyPad bridge action mutation rules.
+
+     - Returns: A coordinator bound to the current bookmark service and reader payload context, or
+       `nil` when bookmark persistence is not available.
+     - Side effects: None during construction; returned coordinator methods mutate persistence.
+     - Failure modes: Returns `nil` rather than accepting StudyPad actions without persistence.
+     */
+    private func studyPadActionCoordinator() -> BibleReaderStudyPadActionCoordinator? {
+        guard let bookmarkService else { return nil }
+        return BibleReaderStudyPadActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: annotationPayloadFactory(),
+            currentNotesContentType: { [weak self] in
+                self?.currentNotesContentType() ?? "HTML"
+            }
         )
     }
 
@@ -7410,14 +7277,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     }
 
-    /// Parse [{first: "uuid", second: orderNumber}, ...] from Vue.js updateOrderNumber data.
-    private func parsePairArray(_ value: Any?) -> [(bookmarkId: UUID, orderNumber: Int)] {
-        guard let array = value as? [[String: Any]] else { return [] }
-        return array.compactMap { dict in
-            guard let first = dict["first"] as? String,
-                  let second = dict["second"] as? Int,
-                  let uuid = UUID(uuidString: first) else { return nil }
-            return (uuid, second)
+    /**
+     Applies a coordinated StudyPad action result to controller-owned state and the active bridge.
+
+     - Parameters:
+       - result: Mutation result produced by `BibleReaderStudyPadActionCoordinator`.
+       - bridge: Bridge instance associated with the delegate callback being handled.
+     - Side effects: may advance `studyPadMutationRevision` and emits JavaScript events.
+     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
+     */
+    private func applyStudyPadActionResult(
+        _ result: BibleReaderStudyPadActionResult,
+        bridge: BibleBridge
+    ) {
+        if result.incrementsStudyPadRevision {
+            studyPadMutationRevision += 1
+        }
+        for event in result.events {
+            emitStudyPadActionEvent(event, bridge: bridge)
+        }
+    }
+
+    /**
+     Emits one StudyPad action event into Vue.js.
+
+     - Parameters:
+       - event: Typed event produced by the StudyPad action coordinator.
+       - bridge: Bridge instance associated with the delegate callback being handled.
+     - Side effects: Sends JavaScript to the web client.
+     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
+     */
+    private func emitStudyPadActionEvent(
+        _ event: BibleReaderStudyPadActionEvent,
+        bridge: BibleBridge
+    ) {
+        switch event {
+        case .studyPadUpdated(let payload):
+            bridge.emit(event: "add_or_update_study_pad", data: payload)
+        case .studyPadTextEntryDeleted(let id):
+            bridge.emit(event: "delete_study_pad_text_entry", data: id.uuidString)
+        case .bookmarkToLabelUpdated(let payload):
+            bridge.emit(event: "add_or_update_bookmark_to_label", data: payload)
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderStudyPadActionCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderStudyPadActionCoordinator.swift
@@ -1,0 +1,533 @@
+import Foundation
+import BibleCore
+import BibleView
+
+/**
+ Coordinates StudyPad bridge mutations and turns their persistence effects into Vue bridge events.
+
+ `BibleReaderController` remains the `BibleBridgeDelegate` and still owns web-view emission,
+ navigation state, logging, and UI-test revision counters. This coordinator owns the cohesive
+ StudyPad action rules that Android keeps behind `BibleJavascriptInterface` plus
+ `BookmarkControl`: parsing JavaScript payloads, mutating `BookmarkService`, and projecting only
+ the Android event shapes that should be emitted afterward.
+
+ Inputs:
+ - string payloads received from the shared BibleView JavaScript bridge
+ - bookmark persistence through `BookmarkService`
+ - current notes content type for newly-created journal rows
+ - annotation payload projection for StudyPad text and bookmark-to-label DTOs
+
+ Outputs:
+ - `BibleReaderStudyPadActionResult` values that describe whether the StudyPad accessibility
+   revision should advance and which bridge events the controller should emit
+
+ Side effects:
+ - mutates StudyPad entries and bookmark-to-label relationships through `BookmarkService`
+
+ Failure modes:
+ - invalid identifiers, malformed JSON, missing labels, or missing relationships return
+   `.noChange` without throwing so bridge calls remain tolerant of stale client state
+ */
+struct BibleReaderStudyPadActionCoordinator {
+    /// Persistence facade used for every StudyPad action mutation.
+    private let bookmarkService: BookmarkService
+    /// Payload projector shared with document rendering so event DTOs stay in one bridge schema.
+    private let payloadFactory: BibleReaderAnnotationPayloadFactory
+    /// Supplies the active Android-compatible notes content type for newly-created journal rows.
+    private let currentNotesContentType: () -> String
+
+    /**
+     Creates a coordinator for one reader controller.
+
+     - Parameters:
+       - bookmarkService: Persistence facade for bookmark, label, and StudyPad mutations.
+       - payloadFactory: Factory that projects persisted models into typed Vue bridge DTOs.
+       - currentNotesContentType: Closure returning the current notes-content-type preference for
+         new journal rows.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        bookmarkService: BookmarkService,
+        payloadFactory: BibleReaderAnnotationPayloadFactory,
+        currentNotesContentType: @escaping () -> String
+    ) {
+        self.bookmarkService = bookmarkService
+        self.payloadFactory = payloadFactory
+        self.currentNotesContentType = currentNotesContentType
+    }
+
+    /**
+     Creates a StudyPad journal row after the row referenced by JavaScript.
+
+     Android resolves the `afterEntryId` order number by `entryType` and then inserts the new row
+     at `afterOrder + 1`. iOS keeps the same valid-input behavior while returning `.noChange` for
+     invalid or stale identifiers rather than crashing the app process.
+
+     - Parameters:
+       - labelId: UUID string for the StudyPad label.
+       - entryType: Shared client row type (`bookmark`, `generic-bookmark`, `journal`, or `none`).
+       - afterEntryId: UUID string for the referenced row, or an empty value for `none`.
+     - Returns: A result containing one `add_or_update_study_pad` event when creation succeeds.
+     - Side effects: Inserts a `StudyPadTextEntry`, creates its text row, and bumps affected order
+       numbers through `BookmarkService`.
+     - Failure modes: Returns `.noChange` when the label id is invalid or creation fails.
+     */
+    func createNewStudyPadEntry(
+        labelId: String,
+        entryType: String,
+        afterEntryId: String
+    ) -> BibleReaderStudyPadActionResult {
+        guard let labelUUID = UUID(uuidString: labelId),
+              let result = bookmarkService.createStudyPadEntry(
+                labelId: labelUUID,
+                afterOrderNumber: orderNumber(afterEntryId: afterEntryId, entryType: entryType, labelId: labelUUID),
+                contentType: currentNotesContentType()
+              )
+        else {
+            return .noChange
+        }
+
+        return .studyPadRevision(
+            events: [
+                .studyPadUpdated(
+                    studyPadUpdatePayload(
+                        newEntry: result.0,
+                        changedBibleBtls: result.1,
+                        changedGenericBtls: result.2,
+                        changedEntries: result.3
+                    )
+                ),
+            ]
+        )
+    }
+
+    /**
+     Deletes a StudyPad journal row and emits Android's delete-plus-reorder event sequence.
+
+     - Parameter studyPadId: UUID string for the journal row to remove.
+     - Returns: A result containing `delete_study_pad_text_entry` and any resulting
+       `add_or_update_study_pad` reorder payload.
+     - Side effects: Deletes the entry through `BookmarkService` and sanitizes remaining order
+       numbers.
+     - Failure modes: Returns `.noChange` when the identifier is invalid or the entry no longer
+       exists.
+     */
+    func deleteStudyPadEntry(_ studyPadId: String) -> BibleReaderStudyPadActionResult {
+        guard let uuid = UUID(uuidString: studyPadId),
+              let result = bookmarkService.deleteStudyPadEntry(id: uuid)
+        else {
+            return .noChange
+        }
+
+        return .studyPadRevision(
+            events: [
+                .studyPadTextEntryDeleted(result.0),
+                .studyPadUpdated(
+                    studyPadUpdatePayload(
+                        newEntry: nil,
+                        changedBibleBtls: result.2,
+                        changedGenericBtls: result.3,
+                        changedEntries: result.4
+                    )
+                ),
+            ]
+        )
+    }
+
+    /**
+     Updates non-text metadata for a StudyPad journal row.
+
+     - Parameter data: JSON object from BibleView containing `id` plus optional `orderNumber` and
+       `indentLevel` fields.
+     - Returns: A StudyPad revision result with the updated row payload when the row exists.
+     - Side effects: Mutates the entry metadata through `BookmarkService`.
+     - Failure modes: Returns `.noChange` for malformed JSON, invalid UUIDs, or missing rows.
+     */
+    func updateStudyPadTextEntry(data: String) -> BibleReaderStudyPadActionResult {
+        guard let payload = decodeStudyPadBridgePayload(StudyPadTextEntryMutationPayload.self, from: data) else {
+            return .noChange
+        }
+
+        bookmarkService.updateStudyPadTextEntry(
+            id: payload.id,
+            orderNumber: payload.orderNumber,
+            indentLevel: payload.indentLevel
+        )
+
+        guard let entry = bookmarkService.studyPadEntry(id: payload.id) else {
+            return .noChange
+        }
+
+        return .studyPadRevision(events: [.studyPadUpdated(studyPadUpdatePayload(newEntry: entry))])
+    }
+
+    /**
+     Updates the text payload for a StudyPad journal row.
+
+     Android posts a `StudyPadOrderEvent` with the changed entry after this mutation; returning the
+     same `add_or_update_study_pad` event keeps other web views and the active StudyPad map aligned
+     with Android behavior.
+
+     - Parameters:
+       - id: UUID string for the journal row.
+       - text: New serialized text content.
+     - Returns: A StudyPad revision result with the updated row payload when the row exists.
+     - Side effects: Upserts the detached StudyPad text row through `BookmarkService`.
+     - Failure modes: Returns `.noChange` for invalid UUIDs or missing rows.
+     */
+    func updateStudyPadTextEntryText(id: String, text: String) -> BibleReaderStudyPadActionResult {
+        guard let uuid = UUID(uuidString: id),
+              bookmarkService.studyPadEntry(id: uuid) != nil else {
+            return .noChange
+        }
+
+        bookmarkService.updateStudyPadTextEntryText(id: uuid, text: text)
+
+        guard let entry = bookmarkService.studyPadEntry(id: uuid) else {
+            return .noChange
+        }
+
+        return .studyPadRevision(events: [.studyPadUpdated(studyPadUpdatePayload(newEntry: entry))])
+    }
+
+    /**
+     Applies drag/drop StudyPad ordering emitted by the shared BibleView client.
+
+     Android parses the keys `bookmarks`, `genericBookmarks`, and `studyPadTextItems`; these names
+     are intentionally used here rather than the older iOS-only names so iOS consumes the same
+     client payload as Android.
+
+     - Parameters:
+       - labelId: UUID string for the StudyPad label being reordered.
+       - data: JSON object containing Android order-pair arrays.
+     - Returns: A StudyPad revision result with changed rows in Android's order-update event shape.
+     - Side effects: Mutates order numbers for the referenced bookmark-to-label and journal rows.
+     - Failure modes: Returns `.noChange` for malformed JSON or invalid label identifiers.
+     */
+    func updateOrderNumber(labelId: String, data: String) -> BibleReaderStudyPadActionResult {
+        guard let labelUUID = UUID(uuidString: labelId),
+              let payload = decodeStudyPadBridgePayload(StudyPadOrderMutationPayload.self, from: data)
+        else {
+            return .noChange
+        }
+
+        bookmarkService.updateOrderNumbers(
+            labelId: labelUUID,
+            bibleBookmarkOrders: payload.bookmarks.map { ($0.id, $0.orderNumber) },
+            genericBookmarkOrders: payload.genericBookmarks.map { ($0.id, $0.orderNumber) },
+            studyPadEntryOrders: payload.studyPadTextItems.map { ($0.id, $0.orderNumber) }
+        )
+
+        let bibleBtls = payload.bookmarks.compactMap {
+            bookmarkService.bibleBookmarkToLabel(bookmarkId: $0.id, labelId: labelUUID)
+        }
+        let genericBtls = payload.genericBookmarks.compactMap {
+            bookmarkService.genericBookmarkToLabel(bookmarkId: $0.id, labelId: labelUUID)
+        }
+        let entries = payload.studyPadTextItems.compactMap {
+            bookmarkService.studyPadEntry(id: $0.id)
+        }
+
+        return .studyPadRevision(
+            events: [
+                .studyPadUpdated(
+                    studyPadUpdatePayload(
+                        newEntry: nil,
+                        changedBibleBtls: bibleBtls,
+                        changedGenericBtls: genericBtls,
+                        changedEntries: entries
+                    )
+                ),
+            ]
+        )
+    }
+
+    /**
+     Updates a Bible bookmark-to-label StudyPad relation from the shared client payload.
+
+     - Parameter data: JSON object containing bookmark id, label id, and optional StudyPad relation
+       metadata.
+     - Returns: A relationship update event when the relation exists after mutation.
+     - Side effects: Mutates relation metadata and bumps the bookmark timestamp through
+       `BookmarkService`.
+     - Failure modes: Returns `.noChange` for malformed JSON, invalid UUIDs, missing relations, or
+       labels that can no longer be serialized.
+     */
+    func updateBookmarkToLabel(data: String) -> BibleReaderStudyPadActionResult {
+        guard let payload = decodeStudyPadBridgePayload(BookmarkToLabelMutationPayload.self, from: data) else {
+            return .noChange
+        }
+
+        bookmarkService.updateBibleBookmarkToLabel(
+            bookmarkId: payload.bookmarkId,
+            labelId: payload.labelId,
+            orderNumber: payload.orderNumber,
+            indentLevel: payload.indentLevel,
+            expandContent: payload.expandContent
+        )
+
+        guard let relation = bookmarkService.bibleBookmarkToLabel(
+            bookmarkId: payload.bookmarkId,
+            labelId: payload.labelId
+        ),
+              let relationPayload = payloadFactory.bibleBookmarkToLabelJSON(relation) else {
+            return .noChange
+        }
+
+        return BibleReaderStudyPadActionResult(events: [.bookmarkToLabelUpdated(relationPayload)])
+    }
+
+    /**
+     Updates a generic bookmark-to-label StudyPad relation from the shared client payload.
+
+     - Parameter data: JSON object containing bookmark id, label id, and optional StudyPad relation
+       metadata.
+     - Returns: A relationship update event when the relation exists after mutation.
+     - Side effects: Mutates relation metadata and bumps the generic bookmark timestamp through
+       `BookmarkService`.
+     - Failure modes: Returns `.noChange` for malformed JSON, invalid UUIDs, missing relations, or
+       labels that can no longer be serialized.
+     */
+    func updateGenericBookmarkToLabel(data: String) -> BibleReaderStudyPadActionResult {
+        guard let payload = decodeStudyPadBridgePayload(BookmarkToLabelMutationPayload.self, from: data) else {
+            return .noChange
+        }
+
+        bookmarkService.updateGenericBookmarkToLabel(
+            bookmarkId: payload.bookmarkId,
+            labelId: payload.labelId,
+            orderNumber: payload.orderNumber,
+            indentLevel: payload.indentLevel,
+            expandContent: payload.expandContent
+        )
+
+        guard let relation = bookmarkService.genericBookmarkToLabel(
+            bookmarkId: payload.bookmarkId,
+            labelId: payload.labelId
+        ),
+              let relationPayload = payloadFactory.genericBookmarkToLabelJSON(relation) else {
+            return .noChange
+        }
+
+        return BibleReaderStudyPadActionResult(events: [.bookmarkToLabelUpdated(relationPayload)])
+    }
+
+    /**
+     Resolves the order number after which a new journal row should be inserted.
+
+     - Parameters:
+       - afterEntryId: UUID string for the referenced row.
+       - entryType: Shared client row type.
+       - labelId: Parsed label id that scopes bookmark-to-label lookups.
+     - Returns: The referenced row order number, or `-1` for `none`, invalid ids, stale rows, or
+       unknown row types.
+     - Side effects: Reads persisted StudyPad relations and entries.
+     - Failure modes: Cannot throw; stale inputs fall back to beginning insertion for bridge
+       tolerance.
+     */
+    private func orderNumber(afterEntryId: String, entryType: String, labelId: UUID) -> Int {
+        guard let afterUUID = UUID(uuidString: afterEntryId) else {
+            return -1
+        }
+
+        switch entryType {
+        case "bookmark":
+            return bookmarkService.bibleBookmarkToLabel(bookmarkId: afterUUID, labelId: labelId)?.orderNumber ?? -1
+        case "generic-bookmark":
+            return bookmarkService.genericBookmarkToLabel(bookmarkId: afterUUID, labelId: labelId)?.orderNumber ?? -1
+        case "journal":
+            return bookmarkService.studyPadEntry(id: afterUUID)?.orderNumber ?? -1
+        default:
+            return -1
+        }
+    }
+
+    /**
+     Builds the StudyPad update event payload used by Android's `StudyPadOrderEvent` bridge path.
+
+     - Parameters:
+       - newEntry: Newly created or updated journal row, if any.
+       - changedBibleBtls: Bible bookmark-to-label rows whose order metadata changed.
+       - changedGenericBtls: Generic bookmark-to-label rows whose order metadata changed.
+       - changedEntries: Journal rows whose order metadata changed.
+     - Returns: Typed bridge event payload with explicit `nil` for absent `studyPadTextEntry`.
+     - Side effects: Projects persisted rows into bridge DTOs; projection may read active module
+       state supplied to the payload factory.
+     - Failure modes: Deleted label relationships are filtered out by the payload factory.
+     */
+    private func studyPadUpdatePayload(
+        newEntry: StudyPadTextEntry?,
+        changedBibleBtls: [BibleBookmarkToLabel] = [],
+        changedGenericBtls: [GenericBookmarkToLabel] = [],
+        changedEntries: [StudyPadTextEntry] = []
+    ) -> StudyPadUpdatePayload {
+        StudyPadUpdatePayload(
+            studyPadTextEntry: newEntry.map { payloadFactory.studyPadEntryJSON($0) },
+            bookmarkToLabelsOrdered: changedBibleBtls.compactMap { payloadFactory.bibleBookmarkToLabelJSON($0) },
+            genericBookmarkToLabelsOrdered: changedGenericBtls.compactMap {
+                payloadFactory.genericBookmarkToLabelJSON($0)
+            },
+            studyPadItemsOrdered: changedEntries.map { payloadFactory.studyPadEntryJSON($0) }
+        )
+    }
+
+    /**
+     Decodes a UTF-8 JSON bridge payload into a typed mutation request.
+
+     - Parameters:
+       - type: Decodable request type expected for the bridge action.
+       - data: Raw JSON string from BibleView.
+     - Returns: Decoded payload, or `nil` when the JSON is malformed.
+     - Side effects: None.
+     - Failure modes: Decode failures are intentionally swallowed so stale web clients cannot crash
+       the native bridge.
+     */
+    private func decodeStudyPadBridgePayload<T: Decodable>(_ type: T.Type, from data: String) -> T? {
+        guard let jsonData = data.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(type, from: jsonData)
+    }
+}
+
+/**
+ Result returned by StudyPad action coordination.
+
+ The controller uses this value to apply native revision bookkeeping separately from the
+ persistence/action logic, and then emits each event into its currently active bridge.
+ */
+struct BibleReaderStudyPadActionResult {
+    /// Whether the controller should advance the StudyPad mutation revision for UI-test snapshots.
+    let incrementsStudyPadRevision: Bool
+    /// Ordered bridge events that should be emitted after the persistence mutation.
+    let events: [BibleReaderStudyPadActionEvent]
+
+    /// Result used when malformed or stale bridge input produces no persistence or bridge effects.
+    static let noChange = BibleReaderStudyPadActionResult(events: [])
+
+    /**
+     Creates an action result.
+
+     - Parameters:
+       - incrementsStudyPadRevision: Whether native StudyPad revision state should advance.
+       - events: Ordered bridge events to emit.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    init(
+        incrementsStudyPadRevision: Bool = false,
+        events: [BibleReaderStudyPadActionEvent]
+    ) {
+        self.incrementsStudyPadRevision = incrementsStudyPadRevision
+        self.events = events
+    }
+
+    /**
+     Creates a result for mutations that affect StudyPad journal/order state.
+
+     - Parameter events: Ordered bridge events to emit after the mutation.
+     - Returns: Result with StudyPad revision bookkeeping enabled.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    static func studyPadRevision(
+        events: [BibleReaderStudyPadActionEvent]
+    ) -> BibleReaderStudyPadActionResult {
+        BibleReaderStudyPadActionResult(incrementsStudyPadRevision: true, events: events)
+    }
+}
+
+/**
+ Bridge events produced by StudyPad action coordination.
+ */
+enum BibleReaderStudyPadActionEvent {
+    /// Emits Android's `add_or_update_study_pad` payload after journal/order changes.
+    case studyPadUpdated(StudyPadUpdatePayload)
+    /// Emits Android's `delete_study_pad_text_entry` payload after journal deletion.
+    case studyPadTextEntryDeleted(UUID)
+    /// Emits Android's `add_or_update_bookmark_to_label` payload after relation metadata edits.
+    case bookmarkToLabelUpdated(BookmarkToLabelData)
+}
+
+/**
+ Decodable payload for StudyPad text entry metadata updates.
+ */
+private struct StudyPadTextEntryMutationPayload: Decodable {
+    /// Journal row identifier.
+    let id: UUID
+    /// Optional updated StudyPad order number.
+    let orderNumber: Int?
+    /// Optional updated StudyPad indentation level.
+    let indentLevel: Int?
+}
+
+/**
+ Decodable Android/shared-client StudyPad reorder payload.
+ */
+private struct StudyPadOrderMutationPayload: Decodable {
+    /// Bible bookmark order pairs emitted by BibleView as `bookmarks`.
+    let bookmarks: [StudyPadOrderPair]
+    /// Generic bookmark order pairs emitted by BibleView as `genericBookmarks`.
+    let genericBookmarks: [StudyPadOrderPair]
+    /// Journal row order pairs emitted by BibleView as `studyPadTextItems`.
+    let studyPadTextItems: [StudyPadOrderPair]
+
+    /// Coding keys matching the shared BibleView payload consumed by Android.
+    private enum CodingKeys: String, CodingKey {
+        case bookmarks
+        case genericBookmarks
+        case studyPadTextItems
+    }
+
+    /**
+     Decodes Android reorder arrays, defaulting missing arrays to empty for stale-client tolerance.
+     */
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        bookmarks = try container.decodeIfPresent([StudyPadOrderPair].self, forKey: .bookmarks) ?? []
+        genericBookmarks = try container.decodeIfPresent([StudyPadOrderPair].self, forKey: .genericBookmarks) ?? []
+        studyPadTextItems = try container.decodeIfPresent([StudyPadOrderPair].self, forKey: .studyPadTextItems) ?? []
+    }
+}
+
+/**
+ Decodable `{first, second}` order pair emitted by the shared BibleView StudyPad client.
+ */
+private struct StudyPadOrderPair: Decodable {
+    /// Entity identifier stored in the JavaScript `first` field.
+    let id: UUID
+    /// Updated order number stored in the JavaScript `second` field.
+    let orderNumber: Int
+
+    /**
+     Decodes Android's pair-object shape into named Swift fields.
+     */
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .first)
+        orderNumber = try container.decode(Int.self, forKey: .second)
+    }
+
+    /// Coding keys matching Android's Kotlin `Pair<String, Int>` JSON object.
+    private enum CodingKeys: String, CodingKey {
+        case first
+        case second
+    }
+}
+
+/**
+ Decodable payload for bookmark-to-label StudyPad metadata updates.
+ */
+private struct BookmarkToLabelMutationPayload: Decodable {
+    /// Bookmark identifier for the relationship row.
+    let bookmarkId: UUID
+    /// Label identifier for the relationship row.
+    let labelId: UUID
+    /// Optional updated StudyPad order number.
+    let orderNumber: Int?
+    /// Optional updated StudyPad indentation level.
+    let indentLevel: Int?
+    /// Optional updated expansion state for nested content.
+    let expandContent: Bool?
+}

--- a/Sources/BibleView/Sources/BibleView/BibleBridge.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleBridge.swift
@@ -961,21 +961,47 @@ public final class BibleBridge: NSObject, WKScriptMessageHandler {
     }
 
     /**
-     Emits an event into the Vue.js client without waiting for a response.
+     Emits a raw JSON event into the Vue.js client without waiting for a response.
 
-     Native code uses events such as `set_config`, `set_document`, and `update_bookmarks` to push
-     refreshed state into the already-loaded client.
+     Native code uses this overload when it already has a complete JSON expression, such as a
+     rendered document payload or `null`. Call `emitEncoded(event:data:)` when the payload is a
+     Swift value that still needs JSON encoding, including scalar `String` values.
+
+     - Parameters:
+       - event: Vue event name passed to `bibleView.emit`.
+       - data: Raw JavaScript/JSON expression to pass as the second `bibleView.emit` argument.
+     - Side effects: Evaluates JavaScript in the attached web view or recording observer.
+     - Failure modes: JavaScript runtime failures are caught in the generated wrapper and reported
+       through the bridge console message path.
      */
     public func emit(event: String, data: String = "null") {
         let js = "try { void bibleView.emit('\(event)', \(data)); } catch(e) { window.webkit.messageHandlers.bibleView.postMessage({method:'console',args:['BRIDGE','JS EMIT ERROR in \(event): ' + e.message + ' ' + e.stack]}); }"
         evaluateJavaScript(js)
     }
 
-    /// Encodes an event payload as JSON and emits it to Vue.js.
-    public func emit<T: Encodable>(event: String, data: T) {
+    /**
+     Encodes a Swift event payload as JSON and emits it to Vue.js.
+
+     This method is intentionally distinct from the raw `String` overload so callers can encode
+     scalar string payloads as JSON string literals instead of accidentally interpolating them as
+     JavaScript source.
+
+     - Parameters:
+       - event: Vue event name passed to `bibleView.emit`.
+       - data: Encodable Swift payload to serialize as the second `bibleView.emit` argument.
+     - Side effects: Evaluates JavaScript in the attached web view or recording observer.
+     - Failure modes: Silently returns when JSON encoding fails; JavaScript runtime failures are
+       caught in the generated wrapper and reported through the bridge console message path.
+     */
+    public func emitEncoded<T: Encodable>(event: String, data: T) {
         guard let jsonData = try? bridgeEncoder.encode(data),
               let json = String(data: jsonData, encoding: .utf8) else { return }
         emit(event: event, data: json)
+    }
+
+    /// Encodes an event payload as JSON and emits it to Vue.js.
+    public func emit<T: Encodable>(event: String, data: T) {
+        emitEncoded(event: event, data: data)
     }
 
     /**


### PR DESCRIPTION
Summary
- Extracts StudyPad bridge action parsing and mutation out of BibleReaderController into BibleReaderStudyPadActionCoordinator.
- Aligns StudyPad reorder and text-update bridge behavior with Android and shared BibleView payload semantics.

Scope
- In: StudyPad bridge create, delete, update metadata, update text, reorder, and bookmark-to-label relationship actions.
- Out: unrelated BibleReaderController responsibilities and the remaining issue #146 extraction slices.

Contract references
- Issue #146: Refactor BibleReaderController into focused collaborators.
- Android parity checked against BibleJavascriptInterface, BookmarkControl, BibleView StudyPadOrderEvent handling, and shared BibleView android.ts StudyPad payload keys.

Change details
- Added BibleReaderStudyPadActionCoordinator as the ownership boundary for StudyPad bridge action rules.
- Delegated StudyPad bridge methods from BibleReaderController while keeping controller-owned revision bookkeeping and bridge emission in the controller.
- Parses reorder payload keys used by Android and the shared client: bookmarks, genericBookmarks, and studyPadTextItems.
- Emits the Android-style changed-entry StudyPad update after text edits.
- Guards stale StudyPad text updates so iOS does not create detached text rows outside Android-visible StudyPad semantics.
- Added focused parity tests plus a controller bridge regression for Android reorder payload keys.

Validation evidence
- Red: targeted stale text update test failed before the stale-entry guard.
- xcodebuild targeted six StudyPad bridge tests passed on iPhone 17 / iOS 26.5.
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 -only-testing:AndBibleTests/AndBibleTests passed 401 tests.
- python3 -m unittest discover -s scripts -p test_*.py passed.
- python3 scripts/check_repo_standards.py docblocks --all-files passed.
- git diff --check passed.
- GitNexus detect_changes on staged diff reported medium risk with affected processes limited to the new StudyPad parity tests.

Risks/follow-ups
- Runtime risk is concentrated in StudyPad bridge interactions.
- Issue #146 remains open for additional focused collaborator slices.

Issue closure reference
- Refs #146. This PR intentionally does not close #146 because it handles only the StudyPad bridge action collaborator slice.