### PR TITLE
refactor(reader): extract bookmark bridge action coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -872,8 +872,8 @@ extension AndBibleTests {
         bookmarkService.saveBibleBookmarkNote(bookmarkId: bibleBookmark.id, note: "Bible note")
         bookmarkService.saveBibleBookmarkNote(bookmarkId: genericBookmark.id, note: "Generic note")
 
-        controller.bridge(BibleBridge(), saveBookmarkNote: bibleBookmark.id.uuidString, note: " \n\t ")
-        controller.bridge(BibleBridge(), saveBookmarkNote: genericBookmark.id.uuidString, note: " \n\t ")
+        controller.bridge(bridge, saveBookmarkNote: bibleBookmark.id.uuidString, note: " \n\t ")
+        controller.bridge(bridge, saveBookmarkNote: genericBookmark.id.uuidString, note: " \n\t ")
 
         XCTAssertTrue(try modelContext.fetch(FetchDescriptor<BibleBookmarkNotes>()).isEmpty)
         XCTAssertTrue(try modelContext.fetch(FetchDescriptor<GenericBookmarkNotes>()).isEmpty)
@@ -884,6 +884,121 @@ extension AndBibleTests {
         XCTAssertEqual(payload["id"] as? String, bibleBookmark.id.uuidString)
         XCTAssertEqual(payload["notes"] as? String, "")
         XCTAssertTrue(payload["notesContentType"] is NSNull)
+    }
+
+    /**
+     Verifies the bookmark action collaborator applies Android's auto-label creation contract.
+
+     Android `BibleView.makeBookmark` assigns both `autoAssignLabels` and `autoAssignPrimaryLabel`,
+     then opens the bookmark label modal only when there are no initial labels or notes are requested.
+     This protects the extraction from preserving the old iOS-only behavior where auto-assigned
+     bookmarks still opened the label modal and never received the configured primary label.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorAppliesAndroidAutoAssignPrimaryLabelAndSuppressesLabelModal() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let assignedLabel = bookmarkService.createLabel(name: "Assigned")
+        let primaryLabel = bookmarkService.createLabel(name: "Primary")
+        let coordinator = makeBookmarkActionCoordinator(bookmarkService: bookmarkService)
+        let workspaceSettings = WorkspaceSettings(
+            autoAssignLabels: [assignedLabel.id, primaryLabel.id],
+            autoAssignPrimaryLabel: primaryLabel.id,
+            studyPadCursors: [assignedLabel.id: 7]
+        )
+
+        let result = coordinator.addOrUpdateBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            addNote: false,
+            wholeVerse: true,
+            workspaceSettings: workspaceSettings
+        )
+
+        let bookmark = try XCTUnwrap(bookmarkService.bookmarks(for: 1, endOrdinal: 1, book: "Genesis").first)
+        XCTAssertEqual(bookmark.primaryLabelId, primaryLabel.id)
+        XCTAssertNotNil(bookmarkService.bibleBookmarkToLabel(bookmarkId: bookmark.id, labelId: assignedLabel.id))
+        XCTAssertEqual(result.updatedWorkspaceSettings?.studyPadCursors[assignedLabel.id], 1)
+        XCTAssertTrue(result.requiresPersistState)
+
+        guard case .bookmarksUpdated(let payloads) = result.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+        XCTAssertEqual(payloads.first?.id, bookmark.id.uuidString)
+        XCTAssertFalse(
+            result.events.contains { event in
+                if case .bookmarkClicked = event { return true }
+                return false
+            },
+            "Android does not open the label modal when auto labels are already assigned and notes were not requested."
+        )
+    }
+
+    /**
+     Verifies primary-label changes reject Android's reserved unlabelled system label.
+
+     Android `BibleJavascriptInterface.setAsPrimaryLabel` returns before mutation when the selected
+     label is the synthetic unlabelled label. The extracted iOS collaborator must not preserve the
+     previous drift where any valid UUID could become `primaryLabelId`.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorRejectsUnlabeledPrimaryLabelLikeAndroidBridge() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let coordinator = makeBookmarkActionCoordinator(bookmarkService: bookmarkService)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+
+        let result = coordinator.setPrimaryLabel(
+            bookmarkId: bookmark.id.uuidString,
+            labelId: Label.unlabeledId.uuidString
+        )
+
+        XCTAssertNil(bookmarkService.bibleBookmark(id: bookmark.id)?.primaryLabelId)
+        XCTAssertTrue(result.events.isEmpty)
+        XCTAssertNil(result.recentLabelId)
+    }
+
+    /**
+     Verifies whole-verse bridge edits keep Android's text-range guard.
+
+     Android refuses to turn off whole-verse rendering when a bookmark has no text range, because
+     there is no partial selection to restore. This test exercises both the guarded no-op and the
+     allowed mutation once offsets exist.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorRejectsWholeVerseOffWithoutTextRangeLikeAndroidBridge() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let coordinator = makeBookmarkActionCoordinator(bookmarkService: bookmarkService)
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 1,
+            endOrdinal: 1,
+            wholeVerse: true
+        )
+
+        let rejected = coordinator.setBookmarkWholeVerse(bookmarkId: bookmark.id.uuidString, value: false)
+        XCTAssertTrue(bookmarkService.bibleBookmark(id: bookmark.id)?.wholeVerse ?? false)
+        XCTAssertTrue(rejected.events.isEmpty)
+
+        bookmark.startOffset = 3
+        bookmark.endOffset = 8
+        let accepted = coordinator.setBookmarkWholeVerse(bookmarkId: bookmark.id.uuidString, value: false)
+
+        XCTAssertFalse(bookmarkService.bibleBookmark(id: bookmark.id)?.wholeVerse ?? true)
+        guard case .bookmarksUpdated(let payloads) = accepted.events.first else {
+            return XCTFail("Expected whole-verse mutation to re-emit the updated bookmark")
+        }
+        XCTAssertEqual(payloads.first?.wholeVerse, false)
     }
 
     /**
@@ -902,6 +1017,32 @@ extension AndBibleTests {
                 bookList: [],
                 unlabeledLabelID: Label.unlabeledId.uuidString
             ),
+            currentNotesContentType: { notesContentType }
+        )
+    }
+
+    /**
+     Builds the proposed bookmark action coordinator with production payload projection.
+
+     The helper intentionally mirrors the controller seam: the coordinator owns bookmark mutation
+     rules while the test supplies the same annotation payload factory the reader would use. A compile
+     failure here means the extraction seam has not been implemented yet; assertion failures mean the
+     seam exists but no longer matches Android's bridge contract.
+     */
+    private func makeBookmarkActionCoordinator(
+        bookmarkService: BookmarkService,
+        notesContentType: String = "HTML"
+    ) -> BibleReaderBookmarkActionCoordinator {
+        BibleReaderBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: BibleReaderAnnotationPayloadFactory(
+                currentBook: "Genesis",
+                activeModuleName: "KJV",
+                activeModule: nil,
+                bookList: [],
+                unlabeledLabelID: Label.unlabeledId.uuidString
+            ),
+            currentBook: "Genesis",
             currentNotesContentType: { notesContentType }
         )
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/BookmarkService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/BookmarkService.swift
@@ -4,6 +4,39 @@ import Foundation
 import Observation
 
 /**
+ Result of applying Android-style initial labels to a bookmark.
+
+ The result lets reader-side callers persist workspace cursor movement without coupling the UI layer
+ to bookmark-to-label insertion or StudyPad order maintenance.
+ */
+public struct BookmarkInitialLabelAssignmentResult {
+    /// Label identifiers that existed locally and were applied to the bookmark.
+    public let appliedLabelIds: [UUID]
+    /// Updated workspace settings when StudyPad cursors advanced, otherwise the unchanged input.
+    public let updatedWorkspaceSettings: WorkspaceSettings?
+    /// Whether the caller should persist the owning workspace after cursor changes.
+    public let changedWorkspaceSettings: Bool
+
+    /**
+     Creates an initial-label assignment result.
+
+     - Parameters:
+       - appliedLabelIds: Valid label identifiers applied to the bookmark.
+       - updatedWorkspaceSettings: Workspace settings after cursor changes, if settings were supplied.
+       - changedWorkspaceSettings: Whether cursor updates changed the workspace settings.
+     */
+    public init(
+        appliedLabelIds: [UUID],
+        updatedWorkspaceSettings: WorkspaceSettings?,
+        changedWorkspaceSettings: Bool
+    ) {
+        self.appliedLabelIds = appliedLabelIds
+        self.updatedWorkspaceSettings = updatedWorkspaceSettings
+        self.changedWorkspaceSettings = changedWorkspaceSettings
+    }
+}
+
+/**
  Business logic for bookmark operations, coordinating between
  BookmarkStore and the bridge layer.
  */
@@ -315,6 +348,68 @@ public final class BookmarkService {
         }
     }
 
+    /**
+     Applies Android's initial bookmark-label assignment semantics to a newly-created bookmark.
+
+     For newly-created bookmarks, Android validates requested labels, inserts bookmark-to-label rows
+     at the workspace StudyPad cursor position clamped to the current StudyPad item count, bumps later
+     StudyPad rows, advances any used cursor, and repairs `primaryLabelId` so it points at one of the
+     assigned labels. Existing bookmark label replacement stays with the dedicated label-management
+     flows.
+
+     - Parameters:
+       - bookmarkId: Bible or generic bookmark identifier.
+       - labelIds: Desired initial label set for the new bookmark.
+       - workspaceSettings: Workspace settings that may contain StudyPad cursor positions.
+     - Returns: Assignment details, or `nil` when no matching bookmark exists.
+     - Side effects: Inserts bookmark-to-label rows, mutates affected StudyPad order numbers,
+       bookmark timestamps, primary-label state, and returned workspace settings.
+     - Failure modes: Missing labels are ignored; missing bookmarks return `nil`.
+     */
+    @discardableResult
+    public func applyInitialLabels(
+        bookmarkId: UUID,
+        labelIds: Set<UUID>,
+        workspaceSettings: WorkspaceSettings?
+    ) -> BookmarkInitialLabelAssignmentResult? {
+        let validLabelIds = labelIds
+            .compactMap { store.label(id: $0)?.id }
+            .filter { $0 != Label.unlabeledId }
+            .sorted { $0.uuidString < $1.uuidString }
+        var updatedWorkspaceSettings = workspaceSettings
+        var changedWorkspaceSettings = false
+
+        if let bookmark = store.bibleBookmark(id: bookmarkId) {
+            applyBibleLabels(
+                validLabelIds,
+                to: bookmark,
+                workspaceSettings: &updatedWorkspaceSettings,
+                changedWorkspaceSettings: &changedWorkspaceSettings
+            )
+            return BookmarkInitialLabelAssignmentResult(
+                appliedLabelIds: validLabelIds,
+                updatedWorkspaceSettings: updatedWorkspaceSettings,
+                changedWorkspaceSettings: changedWorkspaceSettings
+            )
+        }
+
+        if let bookmark = store.genericBookmark(id: bookmarkId) {
+            applyGenericLabels(
+                validLabelIds,
+                to: bookmark,
+                workspaceSettings: &updatedWorkspaceSettings,
+                changedWorkspaceSettings: &changedWorkspaceSettings
+            )
+            return BookmarkInitialLabelAssignmentResult(
+                appliedLabelIds: validLabelIds,
+                updatedWorkspaceSettings: updatedWorkspaceSettings,
+                changedWorkspaceSettings: changedWorkspaceSettings
+            )
+        }
+
+        return nil
+    }
+
     /// Set whole verse mode for a bookmark (Bible or generic).
     public func setWholeVerse(bookmarkId: UUID, value: Bool) {
         if let bookmark = store.bibleBookmark(id: bookmarkId) {
@@ -383,6 +478,90 @@ public final class BookmarkService {
         link.bookmark = bookmark
         link.label = label
         store.insert(link)
+    }
+
+    private func applyBibleLabels(
+        _ validLabelIds: [UUID],
+        to bookmark: BibleBookmark,
+        workspaceSettings: inout WorkspaceSettings?,
+        changedWorkspaceSettings: inout Bool
+    ) {
+        let existingLinks = bookmark.bookmarkToLabels ?? []
+        let existingLabelIds = Set(existingLinks.compactMap { $0.label?.id })
+
+        for labelId in validLabelIds where !existingLabelIds.contains(labelId) {
+            guard let label = store.label(id: labelId) else { continue }
+            let orderNumber = studyPadInsertionOrder(
+                labelId: labelId,
+                workspaceSettings: &workspaceSettings,
+                changedWorkspaceSettings: &changedWorkspaceSettings
+            )
+            _ = incrementOrderNumbers(labelId: labelId, fromOrder: orderNumber, excludingEntryId: nil)
+            let link = BibleBookmarkToLabel(orderNumber: orderNumber)
+            link.bookmark = bookmark
+            link.label = label
+            store.insert(link)
+        }
+
+        repairPrimaryLabel(validLabelIds: validLabelIds, primaryLabelId: &bookmark.primaryLabelId)
+        bookmark.lastUpdatedOn = Date()
+        store.saveChanges()
+    }
+
+    private func applyGenericLabels(
+        _ validLabelIds: [UUID],
+        to bookmark: GenericBookmark,
+        workspaceSettings: inout WorkspaceSettings?,
+        changedWorkspaceSettings: inout Bool
+    ) {
+        let existingLinks = bookmark.bookmarkToLabels ?? []
+        let existingLabelIds = Set(existingLinks.compactMap { $0.label?.id })
+
+        for labelId in validLabelIds where !existingLabelIds.contains(labelId) {
+            guard let label = store.label(id: labelId) else { continue }
+            let orderNumber = studyPadInsertionOrder(
+                labelId: labelId,
+                workspaceSettings: &workspaceSettings,
+                changedWorkspaceSettings: &changedWorkspaceSettings
+            )
+            _ = incrementOrderNumbers(labelId: labelId, fromOrder: orderNumber, excludingEntryId: nil)
+            let link = GenericBookmarkToLabel(orderNumber: orderNumber)
+            link.bookmark = bookmark
+            link.label = label
+            store.insert(link)
+        }
+
+        repairPrimaryLabel(validLabelIds: validLabelIds, primaryLabelId: &bookmark.primaryLabelId)
+        bookmark.lastUpdatedOn = Date()
+        store.saveChanges()
+    }
+
+    private func studyPadInsertionOrder(
+        labelId: UUID,
+        workspaceSettings: inout WorkspaceSettings?,
+        changedWorkspaceSettings: inout Bool
+    ) -> Int {
+        let itemCount = studyPadItemCount(labelId: labelId)
+        guard let cursor = workspaceSettings?.studyPadCursors[labelId] else {
+            return itemCount
+        }
+        let orderNumber = min(cursor, itemCount)
+        workspaceSettings?.studyPadCursors[labelId] = orderNumber + 1
+        changedWorkspaceSettings = true
+        return orderNumber
+    }
+
+    private func studyPadItemCount(labelId: UUID) -> Int {
+        store.bibleBookmarkToLabels(labelId: labelId).count
+            + store.genericBookmarkToLabels(labelId: labelId).count
+            + store.studyPadEntries(labelId: labelId).count
+    }
+
+    private func repairPrimaryLabel(validLabelIds: [UUID], primaryLabelId: inout UUID?) {
+        if let primaryLabelId, validLabelIds.contains(primaryLabelId) {
+            return
+        }
+        primaryLabelId = validLabelIds.first
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
@@ -1,0 +1,529 @@
+import Foundation
+import BibleCore
+import BibleView
+
+/**
+ Coordinates bookmark bridge mutations and turns their persistence effects into Vue bridge events.
+
+ `BibleReaderController` remains the `BibleBridgeDelegate` and still owns web-view emission,
+ controller state, logging, and UI-test revision counters. This coordinator owns the cohesive
+ bookmark action rules that Android keeps behind `BibleJavascriptInterface`, `BibleView`, and
+ `BookmarkControl`: bookmark creation, note persistence, label edits, primary label selection,
+ whole-verse toggles, custom icons, and edit actions.
+
+ Inputs:
+ - bridge identifiers and payloads received from the shared BibleView JavaScript runtime
+ - bookmark persistence through `BookmarkService`
+ - workspace settings needed for Android-compatible auto-label and StudyPad cursor behavior
+ - annotation payload projection for bookmark DTOs
+
+ Outputs:
+ - `BibleReaderBookmarkActionResult` values that describe native state changes and bridge events
+   the controller should emit
+
+ Side effects:
+ - mutates bookmark, note, label, and bookmark-to-label persistence through `BookmarkService`
+
+ Failure modes:
+ - invalid identifiers, missing bookmarks, missing labels, or malformed optional JSON return
+   `.noChange` where the existing iOS bridge is tolerant of stale client state
+ */
+struct BibleReaderBookmarkActionCoordinator {
+    /// Persistence facade used for every bookmark action mutation.
+    private let bookmarkService: BookmarkService
+    /// Payload projector shared with document rendering so event DTOs stay in one bridge schema.
+    private let payloadFactory: BibleReaderAnnotationPayloadFactory
+    /// Current reader book name used for legacy bookmark rows that do not carry their own book.
+    private let currentBook: String
+    /// Supplies the active Android-compatible notes content type for newly-created note rows.
+    private let currentNotesContentType: () -> String
+
+    /**
+     Creates a coordinator for one reader controller.
+
+     - Parameters:
+       - bookmarkService: Persistence facade for bookmark, label, note, and StudyPad mutations.
+       - payloadFactory: Factory that projects persisted models into typed Vue bridge DTOs.
+       - currentBook: Current reader book name to store on newly-created Bible bookmarks.
+       - currentNotesContentType: Closure returning the current notes-content-type preference for
+         new note rows.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        bookmarkService: BookmarkService,
+        payloadFactory: BibleReaderAnnotationPayloadFactory,
+        currentBook: String,
+        currentNotesContentType: @escaping () -> String
+    ) {
+        self.bookmarkService = bookmarkService
+        self.payloadFactory = payloadFactory
+        self.currentBook = currentBook
+        self.currentNotesContentType = currentNotesContentType
+    }
+
+    /**
+     Creates or updates a Bible bookmark requested by the web bridge or native selection action.
+
+     Android applies workspace auto-assigned labels and primary label before deciding whether to
+     open the label modal. It opens the modal only when no initial labels exist, or when the caller
+     explicitly requested note editing.
+
+     - Parameters:
+       - bookInitials: Module initials associated with the selected text.
+       - startOrdinal: Inclusive starting verse ordinal.
+       - endOrdinal: Inclusive ending verse ordinal.
+       - addNote: Whether the bookmark sheet should open directly to note editing.
+       - wholeVerse: Whether the new bookmark highlights whole verses.
+       - startOffset: Optional text-range start offset.
+       - endOffset: Optional text-range end offset.
+       - workspaceSettings: Active workspace settings for auto labels and StudyPad cursors.
+     - Returns: Bookmark update and optional modal/config persistence events.
+     - Side effects: May insert a Bible bookmark and bookmark-to-label rows.
+     - Failure modes: Missing labels in workspace settings are ignored by `BookmarkService`.
+     */
+    func addOrUpdateBibleBookmark(
+        bookInitials: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool,
+        wholeVerse: Bool,
+        startOffset: Int? = nil,
+        endOffset: Int? = nil,
+        workspaceSettings: WorkspaceSettings?
+    ) -> BibleReaderBookmarkActionResult {
+        let existing = bookmarkService.bookmarks(for: startOrdinal, endOrdinal: startOrdinal, book: currentBook)
+            .first(where: { $0.ordinalStart == startOrdinal })
+
+        let bookmark: BibleBookmark
+        let isNew: Bool
+        if let existing {
+            bookmark = existing
+            isNew = false
+        } else {
+            bookmark = bookmarkService.addBibleBookmark(
+                bookInitials: bookInitials,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal,
+                wholeVerse: wholeVerse,
+                startOffset: startOffset,
+                endOffset: endOffset,
+                addNote: addNote
+            )
+            bookmark.book = currentBook
+            applyAutoAssignPrimaryLabel(to: bookmark, workspaceSettings: workspaceSettings)
+            isNew = true
+        }
+
+        let assignment = isNew
+            ? bookmarkService.applyInitialLabels(
+                bookmarkId: bookmark.id,
+                labelIds: workspaceSettings?.autoAssignLabels ?? [],
+                workspaceSettings: workspaceSettings
+            )
+            : nil
+
+        var events: [BibleReaderBookmarkActionEvent] = [.bookmarksUpdated([payloadFactory.bookmarkJSONForStudyPad(bookmark)])]
+        if shouldOpenBookmarkModal(isNew: isNew, addNote: addNote, workspaceSettings: workspaceSettings) {
+            events.append(.bookmarkClicked(id: bookmark.id.uuidString, openLabels: true, openNotes: addNote))
+        }
+
+        return BibleReaderBookmarkActionResult(
+            events: events,
+            updatedWorkspaceSettings: assignment?.updatedWorkspaceSettings,
+            requiresPersistState: assignment?.changedWorkspaceSettings ?? false,
+            refreshesConfig: assignment?.changedWorkspaceSettings ?? false
+        )
+    }
+
+    /**
+     Creates a generic bookmark for non-Bible content.
+
+     Android's generic bookmark path shares the same auto-label, primary-label, and modal-opening
+     semantics as Bible bookmark creation.
+     */
+    func addGenericBookmark(
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool,
+        workspaceSettings: WorkspaceSettings?
+    ) -> BibleReaderBookmarkActionResult {
+        let bookmark = bookmarkService.addGenericBookmark(
+            bookInitials: bookInitials,
+            key: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+        applyAutoAssignPrimaryLabel(to: bookmark, workspaceSettings: workspaceSettings)
+        let assignment = bookmarkService.applyInitialLabels(
+            bookmarkId: bookmark.id,
+            labelIds: workspaceSettings?.autoAssignLabels ?? [],
+            workspaceSettings: workspaceSettings
+        )
+
+        var events: [BibleReaderBookmarkActionEvent] = [
+            .genericBookmarksUpdated([payloadFactory.genericBookmarkJSONForStudyPad(bookmark)]),
+        ]
+        if shouldOpenBookmarkModal(isNew: true, addNote: addNote, workspaceSettings: workspaceSettings) {
+            events.append(.bookmarkClicked(id: bookmark.id.uuidString, openLabels: true, openNotes: addNote))
+        }
+
+        return BibleReaderBookmarkActionResult(
+            events: events,
+            updatedWorkspaceSettings: assignment?.updatedWorkspaceSettings,
+            requiresPersistState: assignment?.changedWorkspaceSettings ?? false,
+            refreshesConfig: assignment?.changedWorkspaceSettings ?? false
+        )
+    }
+
+    /**
+     Creates a Bible paragraph-break bookmark.
+     */
+    func addParagraphBreakBibleBookmark(
+        bookInitials: String,
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) -> BibleReaderBookmarkActionResult {
+        let bookmark = bookmarkService.addParagraphBreakBibleBookmark(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            book: currentBook
+        )
+        return BibleReaderBookmarkActionResult(
+            events: [.bookmarksUpdated([payloadFactory.bookmarkJSONForStudyPad(bookmark)])],
+            refreshesLabels: true
+        )
+    }
+
+    /**
+     Creates a generic paragraph-break bookmark.
+     */
+    func addGenericParagraphBreakBookmark(
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) -> BibleReaderBookmarkActionResult {
+        let bookmark = bookmarkService.addParagraphBreakGenericBookmark(
+            bookInitials: bookInitials,
+            key: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+        return BibleReaderBookmarkActionResult(
+            events: [.genericBookmarksUpdated([payloadFactory.genericBookmarkJSONForStudyPad(bookmark)])],
+            refreshesLabels: true
+        )
+    }
+
+    /**
+     Removes a Bible bookmark and emits the bridge delete event expected by BibleView.
+     */
+    func removeBookmark(_ bookmarkId: String) -> BibleReaderBookmarkActionResult {
+        guard let uuid = UUID(uuidString: bookmarkId) else {
+            return .noChange
+        }
+        bookmarkService.removeBibleBookmark(id: uuid)
+        return BibleReaderBookmarkActionResult(
+            incrementsMyNotesRevision: true,
+            events: [.bookmarksDeleted([bookmarkId])]
+        )
+    }
+
+    /**
+     Removes a generic bookmark.
+     */
+    func removeGenericBookmark(_ bookmarkId: String) -> BibleReaderBookmarkActionResult {
+        guard let uuid = UUID(uuidString: bookmarkId) else {
+            return .noChange
+        }
+        bookmarkService.removeGenericBookmark(id: uuid)
+        return .noChange
+    }
+
+    /**
+     Saves, updates, or clears a bookmark note for Bible or generic bookmarks.
+     */
+    func saveBookmarkNote(bookmarkId: String, note: String?) -> BibleReaderBookmarkActionResult {
+        guard let uuid = UUID(uuidString: bookmarkId) else {
+            return .noChange
+        }
+        bookmarkService.saveBibleBookmarkNote(
+            bookmarkId: uuid,
+            note: note,
+            defaultContentType: currentNotesContentType()
+        )
+        let bibleNote = bookmarkService.bibleBookmark(id: uuid)?.notes
+        let genericNote = bookmarkService.genericBookmark(id: uuid)?.notes
+        let savedNote = bibleNote?.notes ?? genericNote?.notes
+        let notesContentType = bibleNote?.contentType ?? genericNote?.contentType
+        return BibleReaderBookmarkActionResult(
+            incrementsMyNotesRevision: true,
+            events: [
+                .bookmarkNoteModified(
+                    BookmarkNoteModifiedPayload(
+                        id: uuid.uuidString,
+                        notes: savedNote ?? "",
+                        notesContentType: notesContentType,
+                        lastUpdatedOn: Int(Date().timeIntervalSince1970 * 1000)
+                    )
+                ),
+            ]
+        )
+    }
+
+    /**
+     Toggles one label assignment on a Bible or generic bookmark.
+     */
+    func toggleBookmarkLabel(bookmarkId: String, labelId: String) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId),
+              let labelUUID = UUID(uuidString: labelId),
+              let type = bookmarkService.toggleLabel(bookmarkId: bookmarkUUID, labelId: labelUUID),
+              let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID, preferredType: type) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(
+            events: [event],
+            refreshesLabels: true,
+            recentLabelId: labelId
+        )
+    }
+
+    /**
+     Removes one label assignment from a Bible or generic bookmark.
+     */
+    func removeBookmarkLabel(bookmarkId: String, labelId: String) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId),
+              let labelUUID = UUID(uuidString: labelId) else {
+            return .noChange
+        }
+        bookmarkService.removeLabel(bookmarkId: bookmarkUUID, labelId: labelUUID)
+        guard let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(events: [event])
+    }
+
+    /**
+     Sets the primary label for a Bible or generic bookmark.
+     */
+    func setPrimaryLabel(bookmarkId: String, labelId: String) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId),
+              let labelUUID = UUID(uuidString: labelId),
+              labelUUID != Label.unlabeledId,
+              bookmarkService.label(id: labelUUID) != nil else {
+            return .noChange
+        }
+        bookmarkService.setPrimaryLabel(bookmarkId: bookmarkUUID, labelId: labelUUID)
+        guard let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(events: [event], recentLabelId: labelId)
+    }
+
+    /**
+     Updates whether a bookmark should render as whole-verse or text-range.
+     */
+    func setBookmarkWholeVerse(bookmarkId: String, value: Bool) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId),
+              bookmarkHasTextRangeIfNeeded(bookmarkId: bookmarkUUID, value: value) else {
+            return .noChange
+        }
+        bookmarkService.setWholeVerse(bookmarkId: bookmarkUUID, value: value)
+        guard let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(events: [event])
+    }
+
+    /**
+     Updates the custom icon attached to a Bible or generic bookmark.
+     */
+    func setBookmarkCustomIcon(bookmarkId: String, value: String?) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId) else {
+            return .noChange
+        }
+        bookmarkService.setCustomIcon(bookmarkId: bookmarkUUID, value: value)
+        guard let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(events: [event])
+    }
+
+    /**
+     Persists an optional bookmark edit action configured in the web client.
+     */
+    func setBookmarkEditAction(bookmarkId: String, value: String) -> BibleReaderBookmarkActionResult {
+        guard let bookmarkUUID = UUID(uuidString: bookmarkId) else {
+            return .noChange
+        }
+        bookmarkService.setBookmarkEditAction(bookmarkId: bookmarkUUID, editAction: editAction(from: value))
+        guard let event = bookmarkUpdateEvent(bookmarkId: bookmarkUUID) else {
+            return .noChange
+        }
+        return BibleReaderBookmarkActionResult(events: [event])
+    }
+
+    private func applyAutoAssignPrimaryLabel(to bookmark: BibleBookmark, workspaceSettings: WorkspaceSettings?) {
+        guard let labelId = workspaceSettings?.autoAssignPrimaryLabel,
+              bookmarkService.label(id: labelId) != nil else {
+            return
+        }
+        bookmark.primaryLabelId = labelId
+    }
+
+    private func applyAutoAssignPrimaryLabel(to bookmark: GenericBookmark, workspaceSettings: WorkspaceSettings?) {
+        guard let labelId = workspaceSettings?.autoAssignPrimaryLabel,
+              bookmarkService.label(id: labelId) != nil else {
+            return
+        }
+        bookmark.primaryLabelId = labelId
+    }
+
+    private func shouldOpenBookmarkModal(
+        isNew: Bool,
+        addNote: Bool,
+        workspaceSettings: WorkspaceSettings?
+    ) -> Bool {
+        addNote || (isNew && (workspaceSettings?.autoAssignLabels.isEmpty ?? true))
+    }
+
+    private func bookmarkUpdateEvent(
+        bookmarkId: UUID,
+        preferredType: String? = nil
+    ) -> BibleReaderBookmarkActionEvent? {
+        if preferredType != "generic", let bookmark = bookmarkService.bibleBookmark(id: bookmarkId) {
+            return .bookmarksUpdated([payloadFactory.bookmarkJSONForStudyPad(bookmark)])
+        }
+        if let bookmark = bookmarkService.genericBookmark(id: bookmarkId) {
+            return .genericBookmarksUpdated([payloadFactory.genericBookmarkJSONForStudyPad(bookmark)])
+        }
+        return nil
+    }
+
+    private func bookmarkHasTextRangeIfNeeded(bookmarkId: UUID, value: Bool) -> Bool {
+        if value {
+            return bookmarkService.bibleBookmark(id: bookmarkId) != nil
+                || bookmarkService.genericBookmark(id: bookmarkId) != nil
+        }
+        if let bookmark = bookmarkService.bibleBookmark(id: bookmarkId) {
+            return bookmark.startOffset != nil && bookmark.endOffset != nil
+        }
+        if let bookmark = bookmarkService.genericBookmark(id: bookmarkId) {
+            return bookmark.startOffset != nil && bookmark.endOffset != nil
+        }
+        return false
+    }
+
+    private func editAction(from value: String) -> EditAction? {
+        guard value != "null", !value.isEmpty else {
+            return nil
+        }
+        guard let data = value.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let mode = (object["mode"] as? String).flatMap { EditActionMode(rawValue: $0) }
+        return EditAction(mode: mode, content: object["content"] as? String)
+    }
+}
+
+/**
+ Result returned by bookmark action coordination.
+ */
+struct BibleReaderBookmarkActionResult {
+    /// Whether the controller should advance the My Notes mutation revision for UI-test snapshots.
+    let incrementsMyNotesRevision: Bool
+    /// Ordered bridge events that should be emitted after the persistence mutation.
+    let events: [BibleReaderBookmarkActionEvent]
+    /// Updated workspace settings after Android-style StudyPad cursor movement.
+    let updatedWorkspaceSettings: WorkspaceSettings?
+    /// Whether the controller should persist workspace state after applying settings.
+    let requiresPersistState: Bool
+    /// Whether label payloads should be refreshed in Vue.js.
+    let refreshesLabels: Bool
+    /// Whether config payloads should be refreshed in Vue.js.
+    let refreshesConfig: Bool
+    /// Recently used label identifier to track in controller-owned app settings.
+    let recentLabelId: String?
+
+    /// Result used when malformed or stale bridge input produces no persistence or bridge effects.
+    static let noChange = BibleReaderBookmarkActionResult(events: [])
+
+    /**
+     Creates a bookmark action result.
+     */
+    init(
+        incrementsMyNotesRevision: Bool = false,
+        events: [BibleReaderBookmarkActionEvent],
+        updatedWorkspaceSettings: WorkspaceSettings? = nil,
+        requiresPersistState: Bool = false,
+        refreshesLabels: Bool = false,
+        refreshesConfig: Bool = false,
+        recentLabelId: String? = nil
+    ) {
+        self.incrementsMyNotesRevision = incrementsMyNotesRevision
+        self.events = events
+        self.updatedWorkspaceSettings = updatedWorkspaceSettings
+        self.requiresPersistState = requiresPersistState
+        self.refreshesLabels = refreshesLabels
+        self.refreshesConfig = refreshesConfig
+        self.recentLabelId = recentLabelId
+    }
+}
+
+/**
+ Bridge events produced by bookmark action coordination.
+ */
+enum BibleReaderBookmarkActionEvent {
+    /// Emits Android's `add_or_update_bookmarks` payload for Bible bookmarks.
+    case bookmarksUpdated([BibleBookmarkData])
+    /// Emits Android's `add_or_update_bookmarks` payload for generic bookmarks.
+    case genericBookmarksUpdated([GenericBookmarkData])
+    /// Emits BibleView's `delete_bookmarks` payload after Bible bookmark deletion.
+    case bookmarksDeleted([String])
+    /// Emits BibleView's `bookmark_clicked` payload for modal opening.
+    case bookmarkClicked(id: String, openLabels: Bool, openNotes: Bool)
+    /// Emits BibleView's `bookmark_note_modified` payload after note persistence.
+    case bookmarkNoteModified(BookmarkNoteModifiedPayload)
+}
+
+/**
+ Payload emitted after bookmark note persistence.
+ */
+struct BookmarkNoteModifiedPayload: Encodable {
+    /// Bookmark identifier.
+    let id: String
+    /// Persisted note text, or an empty string when the note row was deleted.
+    let notes: String
+    /// Persisted Android notes content type, or `nil` when no note row exists.
+    let notesContentType: String?
+    /// Client timestamp in integer milliseconds.
+    let lastUpdatedOn: Int
+
+    /// Bridge payload keys consumed by BibleView.
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case notes
+        case notesContentType
+        case lastUpdatedOn
+    }
+
+    /**
+     Encodes nullable fields explicitly so Vue receives the same shape Android emits.
+     */
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(notes, forKey: .notes)
+        try container.encode(lastUpdatedOn, forKey: .lastUpdatedOn)
+        if let notesContentType {
+            try container.encode(notesContentType, forKey: .notesContentType)
+        } else {
+            try container.encodeNil(forKey: .notesContentType)
+        }
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2313,62 +2313,23 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         startOffset: Int? = nil,
         endOffset: Int? = nil
     ) {
-        guard let service = bookmarkService else {
+        guard let coordinator = bookmarkActionCoordinator() else {
             logger.warning("addBookmark: bookmarkService is nil")
             return
         }
-        // Check for an existing bookmark at the same verse (by startOrdinal + book)
-        let existing = service.bookmarks(for: startOrdinal, endOrdinal: startOrdinal, book: currentBook)
-            .first(where: { $0.ordinalStart == startOrdinal })
-
-        let bookmark: BibleBookmark
-        let isNew: Bool
-        if let existing {
-            bookmark = existing
-            isNew = false
-        } else {
-            bookmark = service.addBibleBookmark(
+        applyBookmarkActionResult(
+            coordinator.addOrUpdateBibleBookmark(
                 bookInitials: bookInitials,
                 startOrdinal: startOrdinal,
                 endOrdinal: endOrdinal,
+                addNote: addNote,
                 wholeVerse: wholeVerse,
                 startOffset: startOffset,
                 endOffset: endOffset,
-                addNote: addNote
-            )
-            bookmark.book = currentBook
-            isNew = true
-
-            // Auto-assign labels from workspace settings
-            let autoAssignIds = activeWindow?.workspace?.workspaceSettings?.autoAssignLabels ?? []
-            for labelId in autoAssignIds {
-                service.toggleLabel(bookmarkId: bookmark.id, labelId: labelId)
-                // Advance StudyPad cursor for this label
-                if let cursor = activeWindow?.workspace?.workspaceSettings?.studyPadCursors[labelId] {
-                    if let btl = service.bibleBookmarkToLabel(bookmarkId: bookmark.id, labelId: labelId) {
-                        btl.orderNumber = cursor
-                        activeWindow?.workspace?.workspaceSettings?.studyPadCursors[labelId] = cursor + 1
-                    }
-                }
-            }
-            if !autoAssignIds.isEmpty {
-                onPersistState?()
-            }
-        }
-
-        // Send the bookmark to Vue.js
-        bridge.emit(event: "add_or_update_bookmarks", data: [buildBookmarkJSON(bookmark)])
-
-        // Open the bookmark modal (matching Android's makeBookmark behavior):
-        // - New bookmarks always open with label assignment
-        // - addNote=true opens the notes editor directly
-        // - Existing bookmarks with addNote=true also open notes editor
-        let bmId = bookmark.id.uuidString
-        if addNote {
-            bridge.emit(event: "bookmark_clicked", data: "\"\(bmId)\", {\"openLabels\":true,\"openNotes\":true}")
-        } else if isNew {
-            bridge.emit(event: "bookmark_clicked", data: "\"\(bmId)\", {\"openLabels\":true}")
-        }
+                workspaceSettings: activeWindow?.workspace?.workspaceSettings
+            ),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2414,51 +2375,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, addGenericBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int, addNote: Bool) {
         logger.info("Add generic bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let service = bookmarkService else { return }
-        let bookmark = service.addGenericBookmark(
-            bookInitials: bookInitials,
-            key: osisRef,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.addGenericBookmark(
+                bookInitials: bookInitials,
+                osisRef: osisRef,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal,
+                addNote: addNote,
+                workspaceSettings: activeWindow?.workspace?.workspaceSettings
+            ),
+            bridge: bridge
         )
-
-        // Send the bookmark to Vue.js and open modal
-        bridge.emit(event: "add_or_update_bookmarks", data: [buildGenericBookmarkJSONForStudyPad(bookmark)])
-
-        let bmId = bookmark.id.uuidString
-        if addNote {
-            bridge.emit(event: "bookmark_clicked", data: "\"\(bmId)\", {\"openLabels\":true,\"openNotes\":true}")
-        } else {
-            bridge.emit(event: "bookmark_clicked", data: "\"\(bmId)\", {\"openLabels\":true}")
-        }
     }
 
     /// Creates a Bible paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addParagraphBreakBookmark bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
         logger.info("Add paragraph break bookmark: \(bookInitials)")
-        guard let service = bookmarkService else { return }
-        let bookmark = service.addParagraphBreakBibleBookmark(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal,
-            book: currentBook
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.addParagraphBreakBibleBookmark(
+                bookInitials: bookInitials,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal
+            ),
+            bridge: bridge
         )
-        sendLabelsToVueJS()
-        bridge.emit(event: "add_or_update_bookmarks", data: [buildBookmarkJSON(bookmark)])
     }
 
     /// Creates a generic paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addGenericParagraphBreakBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int) {
         logger.info("Add generic paragraph break bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let service = bookmarkService else { return }
-        let bookmark = service.addParagraphBreakGenericBookmark(
-            bookInitials: bookInitials,
-            key: osisRef,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.addGenericParagraphBreakBookmark(
+                bookInitials: bookInitials,
+                osisRef: osisRef,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal
+            ),
+            bridge: bridge
         )
-        sendLabelsToVueJS()
-        bridge.emit(event: "add_or_update_bookmarks", data: [buildGenericBookmarkJSONForStudyPad(bookmark)])
     }
 
     /**
@@ -2474,10 +2431,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeBookmark bookmarkId: String) {
         logger.info("Remove bookmark: \(bookmarkId)")
-        guard let service = bookmarkService, let uuid = UUID(uuidString: bookmarkId) else { return }
-        service.removeBibleBookmark(id: uuid)
-        myNotesMutationRevision += 1
-        bridge.emit(event: "delete_bookmarks", data: "[\"\(bookmarkId)\"]")
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(coordinator.removeBookmark(bookmarkId), bridge: bridge)
     }
 
     /**
@@ -2493,8 +2448,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeGenericBookmark bookmarkId: String) {
         logger.info("Remove generic bookmark: \(bookmarkId)")
-        guard let service = bookmarkService, let uuid = UUID(uuidString: bookmarkId) else { return }
-        service.removeGenericBookmark(id: uuid)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(coordinator.removeGenericBookmark(bookmarkId), bridge: bridge)
     }
 
     /**
@@ -2512,8 +2467,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, saveBookmarkNote bookmarkId: String, note: String?) {
         logger.info("Save bookmark note: \(bookmarkId)")
-        guard let uuid = UUID(uuidString: bookmarkId) else { return }
-        _ = saveBookmarkNoteAndNotify(bookmarkId: uuid, note: note)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.saveBookmarkNote(bookmarkId: bookmarkId, note: note),
+            bridge: bridge
+        )
     }
 
     private func applyUITestMyNotesAppendTextIfNeeded() {
@@ -2602,31 +2560,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @discardableResult
     private func saveBookmarkNoteAndNotify(bookmarkId: UUID, note: String?) -> Bool {
-        guard let service = bookmarkService else { return false }
-        service.saveBibleBookmarkNote(
-            bookmarkId: bookmarkId,
-            note: note,
-            defaultContentType: currentNotesContentType()
-        )
-        myNotesMutationRevision += 1
-        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-        let bibleNote = service.bibleBookmark(id: bookmarkId)?.notes
-        let genericNote = service.genericBookmark(id: bookmarkId)?.notes
-        let savedNote = bibleNote?.notes ?? genericNote?.notes
-        let notesContentType = bibleNote?.contentType ?? genericNote?.contentType
-        let payload: [String: Any] = [
-            "id": bookmarkId.uuidString,
-            "notes": savedNote ?? "",
-            "notesContentType": notesContentType ?? NSNull(),
-            "lastUpdatedOn": timestamp,
-        ]
-        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize bookmark note update for \(bookmarkId.uuidString)")
-            return false
-        }
-        self.bridge.emit(event: "bookmark_note_modified", data: json)
-        return true
+        guard let coordinator = bookmarkActionCoordinator() else { return false }
+        let result = coordinator.saveBookmarkNote(bookmarkId: bookmarkId.uuidString, note: note)
+        applyBookmarkActionResult(result, bridge: bridge)
+        return result.incrementsMyNotesRevision || !result.events.isEmpty
     }
 
     /**
@@ -2661,14 +2598,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, toggleBookmarkLabel bookmarkId: String, labelId: String) {
         logger.info("Toggle label \(labelId) on bookmark \(bookmarkId)")
-        guard let service = bookmarkService,
-              let bmId = UUID(uuidString: bookmarkId),
-              let lblId = UUID(uuidString: labelId) else { return }
-        let type = service.toggleLabel(bookmarkId: bmId, labelId: lblId)
-        trackRecentLabel(labelId)
-        // Emit updated bookmark back to Vue.js
-        emitBookmarkUpdate(bookmarkId: bmId, type: type)
-        sendLabelsToVueJS()
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2676,12 +2610,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeBookmarkLabel bookmarkId: String, labelId: String) {
         logger.info("Remove label \(labelId) from bookmark \(bookmarkId)")
-        guard let service = bookmarkService,
-              let bmId = UUID(uuidString: bookmarkId),
-              let lblId = UUID(uuidString: labelId) else { return }
-        service.removeLabel(bookmarkId: bmId, labelId: lblId)
-        // Emit updated bookmark back to Vue.js
-        emitBookmarkUpdate(bookmarkId: bmId)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2689,12 +2622,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setPrimaryLabel bookmarkId: String, labelId: String) {
         logger.info("Set primary label \(labelId) on bookmark \(bookmarkId)")
-        guard let service = bookmarkService,
-              let bmId = UUID(uuidString: bookmarkId),
-              let lblId = UUID(uuidString: labelId) else { return }
-        service.setPrimaryLabel(bookmarkId: bmId, labelId: lblId)
-        // Emit updated bookmark back to Vue.js
-        emitBookmarkUpdate(bookmarkId: bmId)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2702,8 +2634,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkWholeVerse bookmarkId: String, value: Bool) {
         logger.info("Set whole verse \(value) for bookmark \(bookmarkId)")
-        guard let service = bookmarkService, let uuid = UUID(uuidString: bookmarkId) else { return }
-        service.setWholeVerse(bookmarkId: uuid, value: value)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value),
+            bridge: bridge
+        )
     }
 
     /**
@@ -2711,8 +2646,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkCustomIcon bookmarkId: String, value: String?) {
         logger.info("Set custom icon for bookmark \(bookmarkId)")
-        guard let service = bookmarkService, let uuid = UUID(uuidString: bookmarkId) else { return }
-        service.setCustomIcon(bookmarkId: uuid, value: value)
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value),
+            bridge: bridge
+        )
     }
 
     // MARK: - BibleBridgeDelegate — StudyPad
@@ -2810,27 +2748,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkEditAction bookmarkId: String, value: String) {
         logger.info("Set edit action on bookmark \(bookmarkId): \(value)")
-        guard let service = bookmarkService,
-              let uuid = UUID(uuidString: bookmarkId) else { return }
-
-        // Parse the edit action JSON
-        let editAction: EditAction?
-        if value == "null" || value.isEmpty {
-            editAction = nil
-        } else if let data = value.data(using: .utf8),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            let mode = (dict["mode"] as? String).flatMap { EditActionMode(rawValue: $0) }
-            editAction = EditAction(mode: mode, content: dict["content"] as? String)
-        } else {
-            editAction = nil
-        }
-
-        service.setBookmarkEditAction(bookmarkId: uuid, editAction: editAction)
-
-        // Emit updated bookmark
-        if let bookmark = service.bibleBookmark(id: uuid) {
-            bridge.emit(event: "add_or_update_bookmarks", data: [buildBookmarkJSON(bookmark)])
-        }
+        guard let coordinator = bookmarkActionCoordinator() else { return }
+        applyBookmarkActionResult(
+            coordinator.setBookmarkEditAction(bookmarkId: bookmarkId, value: value),
+            bridge: bridge
+        )
     }
 
     /**
@@ -7237,6 +7159,95 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         } catch {
             logger.error("Failed to parse saved bridge state JSON: \(error.localizedDescription, privacy: .public)")
             return nil
+        }
+    }
+
+    // MARK: - Bookmark Event Helpers
+
+    /**
+     Creates the coordinator that owns bookmark bridge action mutation rules.
+
+     - Returns: A coordinator bound to the current bookmark service and reader payload context, or
+       `nil` when bookmark persistence is not available.
+     - Side effects: None during construction; returned coordinator methods mutate persistence.
+     - Failure modes: Returns `nil` rather than accepting bookmark actions without persistence.
+     */
+    private func bookmarkActionCoordinator() -> BibleReaderBookmarkActionCoordinator? {
+        guard let bookmarkService else { return nil }
+        return BibleReaderBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: annotationPayloadFactory(),
+            currentBook: currentBook,
+            currentNotesContentType: { [weak self] in
+                self?.currentNotesContentType() ?? "HTML"
+            }
+        )
+    }
+
+    /**
+     Applies a coordinated bookmark action result to controller-owned state and the active bridge.
+
+     - Parameters:
+       - result: Mutation result produced by `BibleReaderBookmarkActionCoordinator`.
+       - bridge: Bridge instance associated with the delegate callback being handled.
+     - Side effects: may advance My Notes revision state, update workspace settings, persist state,
+       refresh labels/config, track recent labels, and emit JavaScript events.
+     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
+     */
+    private func applyBookmarkActionResult(
+        _ result: BibleReaderBookmarkActionResult,
+        bridge: BibleBridge
+    ) {
+        if result.incrementsMyNotesRevision {
+            myNotesMutationRevision += 1
+        }
+        if let updatedWorkspaceSettings = result.updatedWorkspaceSettings {
+            activeWindow?.workspace?.workspaceSettings = updatedWorkspaceSettings
+        }
+        if result.requiresPersistState {
+            onPersistState?()
+        }
+        if let recentLabelId = result.recentLabelId {
+            trackRecentLabel(recentLabelId)
+        }
+        for event in result.events {
+            emitBookmarkActionEvent(event, bridge: bridge)
+        }
+        if result.refreshesLabels {
+            sendLabelsToVueJS()
+        }
+        if result.refreshesConfig {
+            bridge.emit(event: "set_config", data: buildConfigJSON())
+        }
+    }
+
+    /**
+     Emits one bookmark action event into Vue.js.
+
+     - Parameters:
+       - event: Typed event produced by the bookmark action coordinator.
+       - bridge: Bridge instance associated with the delegate callback being handled.
+     - Side effects: Sends JavaScript to the web client.
+     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
+     */
+    private func emitBookmarkActionEvent(
+        _ event: BibleReaderBookmarkActionEvent,
+        bridge: BibleBridge
+    ) {
+        switch event {
+        case .bookmarksUpdated(let payloads):
+            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
+        case .genericBookmarksUpdated(let payloads):
+            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
+        case .bookmarksDeleted(let ids):
+            bridge.emitEncoded(event: "delete_bookmarks", data: ids)
+        case .bookmarkClicked(let id, let openLabels, let openNotes):
+            bridge.emit(
+                event: "bookmark_clicked",
+                data: "\"\(id)\", {\"openLabels\":\(openLabels),\"openNotes\":\(openNotes)}"
+            )
+        case .bookmarkNoteModified(let payload):
+            bridge.emit(event: "bookmark_note_modified", data: payload)
         }
     }
 


### PR DESCRIPTION
## Summary

Extracts bookmark bridge mutation rules out of `BibleReaderController` into `BibleReaderBookmarkActionCoordinator`, while keeping the controller responsible for orchestration, state persistence, and Vue bridge emission.

## Scope

- Moves Bible/generic bookmark bridge mutations, note persistence, label edits, primary-label selection, whole-verse toggles, custom icons, edit actions, and paragraph-break bookmark actions into a focused coordinator.
- Adds `BookmarkService.applyInitialLabels` so Android-style auto-label assignment, primary-label repair, and StudyPad cursor advancement live in the bookmark service instead of the reader controller.
- Adds regression coverage for Android parity around auto-assigned labels, primary labels, and whole-verse text-range guards.
- Leaves unrelated reader responsibilities in place for later issue #146 slices.

## Contract References

- Android `BibleView.makeBookmark` applies `workspaceSettings.autoAssignLabels`, applies `workspaceSettings.autoAssignPrimaryLabel`, and opens `bookmark_clicked` only when no initial labels exist or notes are requested.
- Android `BookmarkControl.addOrUpdateBookmark` validates assigned labels, clamps StudyPad cursor insertion to the current item count, advances used cursors, and repairs `primaryLabelId` to an assigned label.
- Android `BibleJavascriptInterface.setAsPrimaryLabel` rejects the reserved unlabelled label.
- Android `setBookmarkWholeVerse` refuses to turn whole-verse off when no text range exists.

## Change Details

- `BibleReaderController` now delegates bookmark bridge actions to `BibleReaderBookmarkActionCoordinator` and applies typed action results through a small event-emission boundary.
- `BookmarkInitialLabelAssignmentResult` carries updated workspace settings back to the reader so cursor movement can be persisted without coupling UI code to label-row ordering.
- Tests exercise the new coordinator directly and keep the existing note-clearing bridge regression wired through the real recording bridge.

## Validation Evidence

- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .derived/issue-146-reader-bookmark-actions -only-testing:AndBibleTests`
- `python3 scripts/check_repo_standards.py all --rev-range HEAD^..HEAD`
- GitNexus staged `detect_changes` after re-indexing: HIGH risk, 4 changed files, 106 changed symbols, 6 affected bookmark/controller flows.

## Risks / Follow-ups

- Review risk is high because the reader bridge and bookmark persistence paths are touched.
- This intentionally does not change the broader iOS duplicate-bookmark semantics; that needs a separate parity decision because Android appears to create a new bookmark from selection while existing iOS updates an existing same-verse bookmark.
- Local worktree still contains unrelated unstaged instruction/derived-data files that are not part of this PR.

## Issue Closure

Refs #146. The issue is already closed upstream, so this PR references the refactor stream without adding a closing keyword.