### PR TITLE
test(ui): guard seeded search fixture readiness

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -446,7 +446,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
 
       - name: Retry upload reuse producer xcodebuild result bundle
         if: always() && steps.upload_reuse_producer_xcresult.outcome == 'failure'
@@ -456,7 +456,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -568,7 +568,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
 
       - name: Retry upload reuse consumer xcodebuild result bundle
         if: always() && steps.upload_reuse_consumer_xcresult.outcome == 'failure'
@@ -578,7 +578,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -729,7 +729,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_unit_xcresult.outcome == 'failure'
@@ -739,7 +739,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -901,7 +901,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
 
       - name: Retry upload xcodebuild test result bundle
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_ui_xcresult.outcome == 'failure'
@@ -911,7 +911,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 14
           overwrite: true
 
       - name: Delete dedicated simulator

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -446,7 +446,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
 
       - name: Retry upload reuse producer xcodebuild result bundle
         if: always() && steps.upload_reuse_producer_xcresult.outcome == 'failure'
@@ -456,7 +456,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -568,7 +568,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
 
       - name: Retry upload reuse consumer xcodebuild result bundle
         if: always() && steps.upload_reuse_consumer_xcresult.outcome == 'failure'
@@ -578,7 +578,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -729,7 +729,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
 
       - name: Retry upload xcodebuild test result bundle
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_unit_xcresult.outcome == 'failure'
@@ -739,7 +739,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
           overwrite: true
 
       - name: Delete dedicated simulator
@@ -901,7 +901,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
 
       - name: Retry upload xcodebuild test result bundle
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_ui_xcresult.outcome == 'failure'
@@ -911,7 +911,7 @@ jobs:
           path: .artifacts/*.xcresult
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 1
           overwrite: true
 
       - name: Delete dedicated simulator

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -375,6 +375,58 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies UI-test seeded Search fixtures satisfy the app's index-readiness checks.
+
+     The fixture tool writes deterministic `search-indexed` and `search-multi-translation`
+     metadata directly into `search_indexes.sqlite` before the app launches. SearchView decides
+     whether to prompt `state=needsIndex` through `SearchIndexService.hasIndex` and
+     `hasStrongsIndex`, so this test anchors that fixture schema to the same app-side readiness
+     contract instead of only checking that rows exist.
+
+     - Setup: Creates an isolated SQLite search-index database with KJV text/Strong's rows and
+       UITESTWEB text rows matching the seeded fixture shape.
+     - Expected result: KJV and UITESTWEB do not need indexing, and KJV is Strong's-ready.
+     - Failure meaning: Normal Search UI tests can fall back to runtime index creation despite the
+       fixture claiming to be preseeded.
+     - Side effects: Creates and removes one temporary SQLite database.
+     */
+    func testSeededSearchFixtureMetadataSatisfiesSearchIndexReadiness() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("search-fixture-readiness-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = SearchIndexService(databasePath: databaseURL.path)
+        try await service.performIndexMutationForTesting { db in
+            let sql = """
+            INSERT INTO verse_fts (verse_key, plain_text, module_name, entry_order)
+            VALUES
+                ('Genesis 1:2', 'And the Spirit of God moved upon the face of the waters.', 'KJV', 0),
+                ('Matthew 1:1', 'The book of the generation of Jesus Christ.', 'KJV', 1),
+                ('Genesis 6:8', 'But Noah found grace in the eyes of the Lord.', 'KJV', 2),
+                ('Genesis 1:2', 'The earth was formless and empty.', 'UITESTWEB', 0),
+                ('John 3:16', 'For God so loved the world.', 'UITESTWEB', 1);
+            INSERT INTO verse_strongs (module_name, token, verse_key, entry_order)
+            VALUES ('KJV', 'H0430', 'Genesis 1:1', 0);
+            INSERT INTO indexed_modules (module_name, verse_count, indexed_at, schema_version)
+            VALUES
+                ('KJV', 3, datetime('now'), \(SearchIndexService.currentSchemaVersion)),
+                ('UITESTWEB', 2, datetime('now'), \(SearchIndexService.currentSchemaVersion));
+            """
+            guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+                let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "SQLite write failed"
+                throw NSError(domain: "SearchIndexFixture", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: message
+                ])
+            }
+        }
+
+        XCTAssertTrue(service.hasIndex(for: "KJV"))
+        XCTAssertTrue(service.hasStrongsIndex(for: "KJV"))
+        XCTAssertTrue(service.hasIndex(for: "UITESTWEB"))
+        XCTAssertEqual(service.modulesNeedingIndex(from: ["KJV", "UITESTWEB"]), [])
+    }
+
+    /**
      Verifies indexed text search emits hits in Android-style canonical verse order.
 
      Android groups Lucene hits by verse and sorts scripture results by book, chapter, and verse

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -406,7 +406,7 @@ extension AndBibleTests {
                 ('Genesis 1:2', 'The earth was formless and empty.', 'UITESTWEB', 0),
                 ('John 3:16', 'For God so loved the world.', 'UITESTWEB', 1);
             INSERT INTO verse_strongs (module_name, token, verse_key, entry_order)
-            VALUES ('KJV', 'H0430', 'Genesis 1:1', 0);
+            VALUES ('KJV', 'H0430', 'Genesis 1:2', 0);
             INSERT INTO indexed_modules (module_name, verse_count, indexed_at, schema_version)
             VALUES
                 ('KJV', 3, datetime('now'), \(SearchIndexService.currentSchemaVersion)),

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -5,17 +5,59 @@ import XCTest
 import UIKit
 #endif
 
+private let seededSearchFixtureScenarios: Set<String> = [
+    "search-indexed",
+    "search-multi-translation",
+]
+
 extension AndBibleUITests {
+    /**
+     Opens Search and waits for it to become interactive under the current fixture contract.
+
+     Normal Search UI tests use the `search-indexed` and `search-multi-translation` fixture
+     scenarios from `scripts/ui_test_fixture_manifest.json`. Those scenarios must be detected by
+     the app as already indexed and must not enter `state=needsIndex`; otherwise the test is hiding
+     a fixture regression behind runtime index creation and long readiness waits. Intentional
+     runtime index-creation coverage should use a non-seeded fixture path and test that workflow
+     explicitly.
+
+     - Parameter app: Running application under test.
+     - Returns: The visible Search root element after the readiness contract is satisfied.
+     - Side effects:
+       - presents Search from the seeded launch route or reader action surface
+       - polls Search's accessibility state until the screen is ready
+       - fails immediately for seeded Search fixtures if Search asks to create an index
+     - Failure modes:
+       - records an XCTest failure when Search does not present or does not become interactive
+       - records an XCTest failure when a seeded Search fixture exposes `state=needsIndex`
+     */
     func openSearch(in app: XCUIApplication) -> XCUIElement {
+        let fixtureScenario = resolveFixtureScenario(
+            environment: ProcessInfo.processInfo.environment
+        )
+        let isSeededSearchFixtureScenario = fixtureScenario.map {
+            seededSearchFixtureScenarios.contains($0)
+        } ?? false
+
         if app.launchArguments.contains("-UITEST_SEARCH_QUERY"),
            let prePresentedSearch = waitForSearchScreenIfAlreadySeeded(in: app, timeout: 10) {
-            waitForSearchInteractionReady(on: prePresentedSearch, in: app, timeout: 120)
+            waitForSearchInteractionReady(
+                on: prePresentedSearch,
+                in: app,
+                timeout: 120,
+                allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario
+            )
             return prePresentedSearch
         }
 
         tapReaderSearchEntry(in: app, timeout: 15)
         let searchScreen = requireSearchScreen(in: app, timeout: 20)
-        waitForSearchInteractionReady(on: searchScreen, in: app, timeout: 120)
+        waitForSearchInteractionReady(
+            on: searchScreen,
+            in: app,
+            timeout: 120,
+            allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario
+        )
         return searchScreen
     }
 
@@ -145,41 +187,64 @@ extension AndBibleUITests {
     }
 
     /**
-     Waits for Search to become interactive and triggers index creation when the screen reports
-     that the active module needs one.
+     Waits for Search to become interactive and optionally triggers runtime index creation.
      *
      * - Parameters:
      *   - searchScreen: Search root element exporting deterministic state in its accessibility
      *     value.
      *   - app: Running application under test.
      *   - timeout: Maximum number of seconds to wait before failing.
+     *   - allowsRuntimeIndexCreation: Whether this workflow is allowed to tap the runtime index
+     *     creation prompt when Search reports `state=needsIndex`.
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
      *   - polls the Search accessibility value until it reports `state=ready`
-     *   - taps the visible `Create` button when Search reports `state=needsIndex`
+     *   - taps the visible `Create` button only when runtime index creation is allowed
      * - Failure modes:
      *   - records an XCTest failure if Search never becomes interactive within the timeout window
+     *   - records an XCTest failure immediately when runtime index creation is disallowed and
+     *     Search reports `state=needsIndex` or exposes the Create-index prompt, including which
+     *     signal was observed
      */
     func waitForSearchInteractionReady(
         on searchScreen: XCUIElement,
         in app: XCUIApplication,
         timeout: TimeInterval,
+        allowsRuntimeIndexCreation: Bool = true,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let deadline = Date().addingTimeInterval(timeout)
+        var lastState = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "nil")
+        var observedNeedsIndex = lastState.contains("state=needsIndex")
+        var observedCreatePrompt = false
 
         while Date() < deadline {
             let state = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "")
+            if !state.isEmpty {
+                lastState = state
+            }
             if state.contains("state=ready") {
                 return
             }
             let createButton = resolveSearchCreateIndexButton(in: app)
-            if state.contains("state=needsIndex")
-                || createButton.exists
-                || createButton.waitForExistence(timeout: 0.2)
-            {
+            let sawNeedsIndex = state.contains("state=needsIndex")
+            let sawCreatePrompt = createButton.exists || createButton.waitForExistence(timeout: 0.2)
+            if sawNeedsIndex || sawCreatePrompt {
+                observedNeedsIndex = observedNeedsIndex || sawNeedsIndex
+                observedCreatePrompt = observedCreatePrompt || sawCreatePrompt
+                if !allowsRuntimeIndexCreation {
+                    XCTFail(
+                        "Expected seeded Search fixture to be ready without runtime index creation; "
+                            + "last Search state was '\(lastState)'; "
+                            + "state=needsIndex observed=\(observedNeedsIndex); "
+                            + "Create-index prompt observed=\(observedCreatePrompt).",
+                        file: file,
+                        line: line
+                    )
+                    return
+                }
                 tapElementReliably(createButton, timeout: 10, file: file, line: line)
                 continue
             }
@@ -187,7 +252,10 @@ extension AndBibleUITests {
         }
 
         XCTFail(
-            "Expected Search to become interactive within \(timeout) seconds.",
+            "Expected Search to become interactive within \(timeout) seconds; "
+                + "last Search state was '\(lastState)'; "
+                + "state=needsIndex observed=\(observedNeedsIndex); "
+                + "Create-index prompt observed=\(observedCreatePrompt).",
             file: file,
             line: line
         )

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -232,6 +232,16 @@ extension AndBibleUITests {
         var lastState = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "nil")
         var observedNeedsIndex = lastState.contains("state=needsIndex")
         var observedCreatePrompt = false
+        func failSeededFixtureReadiness() {
+            XCTFail(
+                "Expected seeded Search fixture to be ready without runtime index creation; "
+                    + "last Search state was '\(lastState)'; "
+                    + "state=needsIndex observed=\(observedNeedsIndex); "
+                    + "Create-index prompt observed=\(observedCreatePrompt).",
+                file: file,
+                line: line
+            )
+        }
 
         while Date() < deadline {
             let state = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "")
@@ -241,21 +251,24 @@ extension AndBibleUITests {
             if state.contains("state=ready") {
                 return
             }
-            let createButton = resolveSearchCreateIndexButton(in: app)
             let sawNeedsIndex = state.contains("state=needsIndex")
-            let sawCreatePrompt = createButton.exists || createButton.waitForExistence(timeout: 0.2)
-            if sawNeedsIndex || sawCreatePrompt {
-                observedNeedsIndex = observedNeedsIndex || sawNeedsIndex
-                observedCreatePrompt = observedCreatePrompt || sawCreatePrompt
+            if sawNeedsIndex {
+                observedNeedsIndex = true
                 if !allowsRuntimeIndexCreation {
-                    XCTFail(
-                        "Expected seeded Search fixture to be ready without runtime index creation; "
-                            + "last Search state was '\(lastState)'; "
-                            + "state=needsIndex observed=\(observedNeedsIndex); "
-                            + "Create-index prompt observed=\(observedCreatePrompt).",
-                        file: file,
-                        line: line
-                    )
+                    failSeededFixtureReadiness()
+                    return
+                }
+                let createButton = resolveSearchCreateIndexButton(in: app)
+                tapElementReliably(createButton, timeout: 10, file: file, line: line)
+                continue
+            }
+
+            let createButton = resolveSearchCreateIndexButton(in: app)
+            let sawCreatePrompt = createButton.exists || createButton.waitForExistence(timeout: 0.2)
+            if sawCreatePrompt {
+                observedCreatePrompt = true
+                if !allowsRuntimeIndexCreation {
+                    failSeededFixtureReadiness()
                     return
                 }
                 tapElementReliably(createButton, timeout: 10, file: file, line: line)

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -21,7 +21,10 @@ extension AndBibleUITests {
      runtime index-creation coverage should use a non-seeded fixture path and test that workflow
      explicitly.
 
-     - Parameter app: Running application under test.
+     - Parameters:
+       - app: Running application under test.
+       - file: Source file used for XCTest failure attribution.
+       - line: Source line used for XCTest failure attribution.
      - Returns: The visible Search root element after the readiness contract is satisfied.
      - Side effects:
        - presents Search from the seeded launch route or reader action surface
@@ -31,9 +34,15 @@ extension AndBibleUITests {
        - records an XCTest failure when Search does not present or does not become interactive
        - records an XCTest failure when a seeded Search fixture exposes `state=needsIndex`
      */
-    func openSearch(in app: XCUIApplication) -> XCUIElement {
+    func openSearch(
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCUIElement {
         let fixtureScenario = resolveFixtureScenario(
-            environment: ProcessInfo.processInfo.environment
+            environment: ProcessInfo.processInfo.environment,
+            file: file,
+            line: line
         )
         let isSeededSearchFixtureScenario = fixtureScenario.map {
             seededSearchFixtureScenarios.contains($0)
@@ -45,18 +54,22 @@ extension AndBibleUITests {
                 on: prePresentedSearch,
                 in: app,
                 timeout: 120,
-                allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario
+                allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario,
+                file: file,
+                line: line
             )
             return prePresentedSearch
         }
 
-        tapReaderSearchEntry(in: app, timeout: 15)
-        let searchScreen = requireSearchScreen(in: app, timeout: 20)
+        tapReaderSearchEntry(in: app, timeout: 15, file: file, line: line)
+        let searchScreen = requireSearchScreen(in: app, timeout: 20, file: file, line: line)
         waitForSearchInteractionReady(
             on: searchScreen,
             in: app,
             timeout: 120,
-            allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario
+            allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario,
+            file: file,
+            line: line
         )
         return searchScreen
     }

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -259,6 +259,7 @@ extension AndBibleUITests {
                     return
                 }
                 let createButton = resolveSearchCreateIndexButton(in: app)
+                observedCreatePrompt = true
                 tapElementReliably(createButton, timeout: 10, file: file, line: line)
                 continue
             }

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -225,6 +225,16 @@ extension AndBibleUITests {
     }
 
     /**
+     Search fixture contract for normal UI workflows.
+
+     `scripts/ui_test_fixture_manifest.json` maps these Search tests to the `search-indexed` or
+     `search-multi-translation` scenarios. Those scenarios seed `search_indexes.sqlite` before app
+     launch, so the app should detect the selected modules as already indexed. Normal Search tests
+     must not enter `state=needsIndex`; runtime index-creation coverage belongs in a separate test
+     and fixture path so it cannot hide seeded-fixture regressions.
+     */
+
+    /**
      Verifies that Search preserves a seeded initial query typed through the real UI.
      *
      * - Side effects:

--- a/scripts/test_ios_ci_ui_shard_guardrails.py
+++ b/scripts/test_ios_ci_ui_shard_guardrails.py
@@ -93,6 +93,37 @@ def workflow_job_block(workflow_text: str, job_name: str) -> str:
 class IOSCIUIShardGuardrailsTests(unittest.TestCase):
     """Checks the workflow-level guardrail around dynamic UI shard counts."""
 
+    def test_ios_ci_upload_artifact_steps_retention_is_one_day(self) -> None:
+        """Keep CI artifacts short-lived so test bundles do not accumulate storage churn."""
+        workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")
+        upload_step_pattern = re.compile(r"^(\s*)uses:\s+actions/upload-artifact@v\d+\s*$")
+        upload_count = 0
+
+        lines = workflow_text.splitlines()
+        for index, line in enumerate(lines):
+            upload_match = upload_step_pattern.match(line)
+            if upload_match is None:
+                continue
+
+            upload_count += 1
+            step_indent = len(upload_match.group(1))
+            step_lines: list[str] = []
+            for step_line in lines[index + 1 :]:
+                if step_line.startswith(" " * (step_indent - 2) + "- name:"):
+                    break
+                step_lines.append(step_line)
+
+            self.assertIn(
+                1,
+                [
+                    int(match.group(1))
+                    for match in re.finditer(r"^\s+retention-days:\s+(\d+)\s*$", "\n".join(step_lines), re.MULTILINE)
+                ],
+                f"Expected upload-artifact step near line {index + 1} to retain artifacts for one day.",
+            )
+
+        self.assertGreater(upload_count, 0, "Expected the workflow to contain upload-artifact steps.")
+
     def test_ios_ci_passes_max_shard_count_to_ui_shard_planner(self) -> None:
         workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")
         shard_plan_run = workflow_step_run_block(workflow_text, "Generate UI shard matrix")

--- a/scripts/test_ios_ci_ui_shard_guardrails.py
+++ b/scripts/test_ios_ci_ui_shard_guardrails.py
@@ -114,32 +114,36 @@ def upload_artifact_steps(workflow_text: str) -> list[tuple[int, str]]:
     return steps
 
 
+def upload_step_scalar(step_text: str, key: str) -> str:
+    """Returns one scalar `with:` value from an upload-artifact step."""
+    match = re.search(rf"^\s+{re.escape(key)}:\s+(.+?)\s*$", step_text, re.MULTILINE)
+    if match is None:
+        raise AssertionError(f"Expected upload-artifact step to declare {key!r}.\n{step_text}")
+    return match.group(1)
+
+
 class IOSCIUIShardGuardrailsTests(unittest.TestCase):
     """Checks the workflow-level guardrail around dynamic UI shard counts."""
 
-    def test_ios_ci_upload_artifact_steps_retention_is_one_day(self) -> None:
-        """Keep CI artifacts short-lived so test bundles do not accumulate storage churn."""
+    def test_ios_ci_upload_artifact_retention_matches_artifact_type(self) -> None:
+        """Keep build products short-lived while retaining diagnostic result bundles."""
         workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")
 
         upload_steps = upload_artifact_steps(workflow_text)
         for line_number, step_text in upload_steps:
-            self.assertIn(
-                1,
-                [
-                    int(match.group(1))
-                    for match in re.finditer(
-                        r"^\s+retention-days:\s+(\d+)\s*$",
-                        step_text,
-                        re.MULTILINE,
-                    )
-                ],
-                f"Expected upload-artifact step near line {line_number} to retain artifacts for one day.",
+            path = upload_step_scalar(step_text, "path")
+            retention_days = int(upload_step_scalar(step_text, "retention-days"))
+            expected_retention_days = 14 if ".xcresult" in path else 1
+            self.assertEqual(
+                expected_retention_days,
+                retention_days,
+                f"Unexpected upload-artifact retention near line {line_number} for path {path!r}.",
             )
 
         self.assertGreater(len(upload_steps), 0, "Expected the workflow to contain upload-artifact steps.")
 
     def test_upload_artifact_retention_guardrail_handles_name_less_steps(self) -> None:
-        """Ensure the retention guardrail also catches valid `- uses:` upload steps."""
+        """Ensure the retention guardrail classifies valid `- uses:` upload steps."""
         workflow_text = """
 name: demo
 jobs:
@@ -148,7 +152,12 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: result
-          path: output.txt
+          path: .artifacts/*.xcresult
+          retention-days: 14
+      - uses: actions/upload-artifact@v6
+        with:
+          name: build-product
+          path: build-products.tar.gz
           retention-days: 1
       - name: Later step
         run: true
@@ -156,8 +165,11 @@ jobs:
 
         upload_steps = upload_artifact_steps(workflow_text)
 
-        self.assertEqual(1, len(upload_steps))
-        self.assertIn("retention-days: 1", upload_steps[0][1])
+        self.assertEqual(2, len(upload_steps))
+        self.assertEqual(".artifacts/*.xcresult", upload_step_scalar(upload_steps[0][1], "path"))
+        self.assertEqual("14", upload_step_scalar(upload_steps[0][1], "retention-days"))
+        self.assertEqual("build-products.tar.gz", upload_step_scalar(upload_steps[1][1], "path"))
+        self.assertEqual("1", upload_step_scalar(upload_steps[1][1], "retention-days"))
 
     def test_ios_ci_passes_max_shard_count_to_ui_shard_planner(self) -> None:
         workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")

--- a/scripts/test_ios_ci_ui_shard_guardrails.py
+++ b/scripts/test_ios_ci_ui_shard_guardrails.py
@@ -90,39 +90,74 @@ def workflow_job_block(workflow_text: str, job_name: str) -> str:
     raise AssertionError(f"Unable to find workflow job {job_name!r}.")
 
 
+def upload_artifact_steps(workflow_text: str) -> list[tuple[int, str]]:
+    """Returns every upload-artifact workflow step with its source line number."""
+    upload_step_pattern = re.compile(r"^(\s*)(-\s*)?uses:\s+actions/upload-artifact@v\d+\s*$")
+    steps: list[tuple[int, str]] = []
+    lines = workflow_text.splitlines()
+
+    for index, line in enumerate(lines):
+        upload_match = upload_step_pattern.match(line)
+        if upload_match is None:
+            continue
+
+        uses_indent = len(upload_match.group(1))
+        step_indent = uses_indent if upload_match.group(2) is not None else uses_indent - 2
+        step_boundary = re.compile(rf"^ {{{step_indent}}}-\s+")
+        step_lines = [line]
+        for step_line in lines[index + 1 :]:
+            if step_boundary.match(step_line):
+                break
+            step_lines.append(step_line)
+        steps.append((index + 1, "\n".join(step_lines)))
+
+    return steps
+
+
 class IOSCIUIShardGuardrailsTests(unittest.TestCase):
     """Checks the workflow-level guardrail around dynamic UI shard counts."""
 
     def test_ios_ci_upload_artifact_steps_retention_is_one_day(self) -> None:
         """Keep CI artifacts short-lived so test bundles do not accumulate storage churn."""
         workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")
-        upload_step_pattern = re.compile(r"^(\s*)uses:\s+actions/upload-artifact@v\d+\s*$")
-        upload_count = 0
 
-        lines = workflow_text.splitlines()
-        for index, line in enumerate(lines):
-            upload_match = upload_step_pattern.match(line)
-            if upload_match is None:
-                continue
-
-            upload_count += 1
-            step_indent = len(upload_match.group(1))
-            step_lines: list[str] = []
-            for step_line in lines[index + 1 :]:
-                if step_line.startswith(" " * (step_indent - 2) + "- name:"):
-                    break
-                step_lines.append(step_line)
-
+        upload_steps = upload_artifact_steps(workflow_text)
+        for line_number, step_text in upload_steps:
             self.assertIn(
                 1,
                 [
                     int(match.group(1))
-                    for match in re.finditer(r"^\s+retention-days:\s+(\d+)\s*$", "\n".join(step_lines), re.MULTILINE)
+                    for match in re.finditer(
+                        r"^\s+retention-days:\s+(\d+)\s*$",
+                        step_text,
+                        re.MULTILINE,
+                    )
                 ],
-                f"Expected upload-artifact step near line {index + 1} to retain artifacts for one day.",
+                f"Expected upload-artifact step near line {line_number} to retain artifacts for one day.",
             )
 
-        self.assertGreater(upload_count, 0, "Expected the workflow to contain upload-artifact steps.")
+        self.assertGreater(len(upload_steps), 0, "Expected the workflow to contain upload-artifact steps.")
+
+    def test_upload_artifact_retention_guardrail_handles_name_less_steps(self) -> None:
+        """Ensure the retention guardrail also catches valid `- uses:` upload steps."""
+        workflow_text = """
+name: demo
+jobs:
+  demo:
+    steps:
+      - uses: actions/upload-artifact@v6
+        with:
+          name: result
+          path: output.txt
+          retention-days: 1
+      - name: Later step
+        run: true
+"""
+
+        upload_steps = upload_artifact_steps(workflow_text)
+
+        self.assertEqual(1, len(upload_steps))
+        self.assertIn("retention-days: 1", upload_steps[0][1])
 
     def test_ios_ci_passes_max_shard_count_to_ui_shard_planner(self) -> None:
         workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -99,6 +99,24 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
         self.assertIn("state=needsIndex observed", support_source)
         self.assertIn("Create-index prompt observed", support_source)
 
+        needs_index_branch = re.search(
+            r"if sawNeedsIndex \{(?P<body>[\s\S]*?tapElementReliably\(createButton,[\s\S]*?continue)"
+            r"\s*\n\s*\}",
+            support_source,
+        )
+        self.assertIsNotNone(needs_index_branch)
+        branch_body = needs_index_branch.group("body")
+        expected_order = [
+            "observedNeedsIndex = true",
+            "if !allowsRuntimeIndexCreation",
+            "let createButton = resolveSearchCreateIndexButton(in: app)",
+            "observedCreatePrompt = true",
+            "tapElementReliably(createButton",
+        ]
+        positions = [branch_body.find(token) for token in expected_order]
+        self.assertNotIn(-1, positions)
+        self.assertEqual(sorted(positions), positions)
+
     def test_search_tests_document_seeded_index_contract_near_workflow_tests(self) -> None:
         """Keep the fixture expectation visible where future Search UI tests are added."""
         search_source = (REPO_ROOT / "AndBibleUITests/AndBibleUITests+Search.swift").read_text(

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -1,0 +1,86 @@
+"""Guardrails for seeded Search UI fixture contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SEEDED_SEARCH_FIXTURES = {"search-indexed", "search-multi-translation"}
+
+
+class SearchFixtureGuardrailsTests(unittest.TestCase):
+    """Protects Search UI tests from silently falling back to runtime index creation."""
+
+    def test_search_fixture_manifest_maps_search_workflows_to_seeded_indexes(self) -> None:
+        """Document which normal Search UI tests are expected to start indexed."""
+        manifest = json.loads(
+            (REPO_ROOT / "scripts/ui_test_fixture_manifest.json").read_text(encoding="utf-8")
+        )
+        search_entries = {
+            test_identifier: scenario
+            for test_identifier, scenario in manifest.items()
+            if "/testSearch" in test_identifier
+        }
+
+        self.assertTrue(search_entries, "Expected manifest entries for Search UI tests.")
+        self.assertEqual(
+            {
+                "AndBibleUITests/AndBibleUITests/testSearchMultiTranslationSelectionUpdatesGroupedTotals":
+                    "search-multi-translation"
+            },
+            {
+                test_identifier: scenario
+                for test_identifier, scenario in search_entries.items()
+                if scenario == "search-multi-translation"
+            },
+        )
+        for test_identifier, scenario in search_entries.items():
+            self.assertIn(
+                scenario,
+                SEEDED_SEARCH_FIXTURES,
+                f"{test_identifier} must use a seeded Search fixture or be split into intentional "
+                "runtime index-creation coverage.",
+            )
+
+    def test_search_open_path_rejects_runtime_index_creation_for_seeded_fixtures(self) -> None:
+        """Ensure normal seeded Search tests cannot tap Create and hide fixture regressions."""
+        support_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("seededSearchFixtureScenarios", support_source)
+        for scenario in SEEDED_SEARCH_FIXTURES:
+            self.assertIn(f'"{scenario}"', support_source)
+        self.assertIn("allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario", support_source)
+
+    def test_search_readiness_failure_reports_final_state_and_needs_index_history(self) -> None:
+        """Keep readiness failures actionable when seeded indexes are missing or stale."""
+        support_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("observedNeedsIndex", support_source)
+        self.assertIn("last Search state", support_source)
+        self.assertIn("state=needsIndex observed", support_source)
+        self.assertIn("Create-index prompt observed", support_source)
+
+    def test_search_tests_document_seeded_index_contract_near_workflow_tests(self) -> None:
+        """Keep the fixture expectation visible where future Search UI tests are added."""
+        search_source = (REPO_ROOT / "AndBibleUITests/AndBibleUITests+Search.swift").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertRegex(
+            search_source,
+            re.compile(
+                r"search-indexed.*search-multi-translation.*state=needsIndex",
+                re.IGNORECASE | re.DOTALL,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -73,9 +73,9 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
         for expected_pattern in [
             r"resolveFixtureScenario\(\s*environment:\s*ProcessInfo\.processInfo\.environment,"
             r"\s*file:\s*file,\s*line:\s*line\s*\)",
-            r"tapReaderSearchEntry\(\s*in:\s*app,\s*timeout:\s*15,\s*file:\s*file,"
+            r"tapReaderSearchEntry\(\s*in:\s*app\s*,\s*(?:timeout:\s*[^,]+,\s*)?file:\s*file,"
             r"\s*line:\s*line\s*\)",
-            r"requireSearchScreen\(\s*in:\s*app,\s*timeout:\s*20,\s*file:\s*file,"
+            r"requireSearchScreen\(\s*in:\s*app\s*,\s*(?:timeout:\s*[^,]+,\s*)?file:\s*file,"
             r"\s*line:\s*line\s*\)",
         ]:
             self.assertRegex(support_source, re.compile(expected_pattern, re.DOTALL))

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -70,19 +70,23 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
                 re.DOTALL,
             ),
         )
-        open_search_body = re.search(
-            r"func openSearch\([\s\S]+?\n    }\n\n    /// Reuses",
+        for expected_pattern in [
+            r"resolveFixtureScenario\(\s*environment:\s*ProcessInfo\.processInfo\.environment,"
+            r"\s*file:\s*file,\s*line:\s*line\s*\)",
+            r"tapReaderSearchEntry\(\s*in:\s*app,\s*timeout:\s*15,\s*file:\s*file,"
+            r"\s*line:\s*line\s*\)",
+            r"requireSearchScreen\(\s*in:\s*app,\s*timeout:\s*20,\s*file:\s*file,"
+            r"\s*line:\s*line\s*\)",
+        ]:
+            self.assertRegex(support_source, re.compile(expected_pattern, re.DOTALL))
+
+        readiness_calls = re.findall(
+            r"waitForSearchInteractionReady\([\s\S]*?"
+            r"allowsRuntimeIndexCreation:\s*!isSeededSearchFixtureScenario,\s*"
+            r"file:\s*file,\s*line:\s*line\s*\)",
             support_source,
         )
-        self.assertIsNotNone(open_search_body)
-        body = open_search_body.group(0)
-        for expected_snippet in [
-            "resolveFixtureScenario(\n            environment: ProcessInfo.processInfo.environment,\n            file: file,\n            line: line",
-            "file: file,\n                line: line\n            )",
-            "tapReaderSearchEntry(in: app, timeout: 15, file: file, line: line)",
-            "requireSearchScreen(in: app, timeout: 20, file: file, line: line)",
-        ]:
-            self.assertIn(expected_snippet, body)
+        self.assertEqual(2, len(readiness_calls))
 
     def test_search_readiness_failure_reports_final_state_and_needs_index_history(self) -> None:
         """Keep readiness failures actionable when seeded indexes are missing or stale."""

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -56,6 +56,34 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
             self.assertIn(f'"{scenario}"', support_source)
         self.assertIn("allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario", support_source)
 
+    def test_search_open_path_preserves_call_site_failure_attribution(self) -> None:
+        """Ensure seeded fixture failures point at the invoking Search UI test."""
+        support_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertRegex(
+            support_source,
+            re.compile(
+                r"func openSearch\(\s*in app: XCUIApplication,\s*"
+                r"file: StaticString = #filePath,\s*line: UInt = #line",
+                re.DOTALL,
+            ),
+        )
+        open_search_body = re.search(
+            r"func openSearch\([\s\S]+?\n    }\n\n    /// Reuses",
+            support_source,
+        )
+        self.assertIsNotNone(open_search_body)
+        body = open_search_body.group(0)
+        for expected_snippet in [
+            "resolveFixtureScenario(\n            environment: ProcessInfo.processInfo.environment,\n            file: file,\n            line: line",
+            "file: file,\n                line: line\n            )",
+            "tapReaderSearchEntry(in: app, timeout: 15, file: file, line: line)",
+            "requireSearchScreen(in: app, timeout: 20, file: file, line: line)",
+        ]:
+            self.assertIn(expected_snippet, body)
+
     def test_search_readiness_failure_reports_final_state_and_needs_index_history(self) -> None:
         """Keep readiness failures actionable when seeded indexes are missing or stale."""
         support_source = (


### PR DESCRIPTION
## Summary
This change makes the seeded Search UI fixture contract explicit and enforced. Normal Search UI tests now fail if the app reports `state=needsIndex` or exposes the Create-index prompt under the `search-indexed` and `search-multi-translation` fixtures, instead of masking stale fixture metadata through runtime index creation.

It also adds a CI guardrail for the existing upload-artifact retention split: build-product artifacts stay short-lived at one day, while `.xcresult` diagnostic result bundles retain 14 days.

## Scope
In scope:
- Search UI readiness diagnostics for final Search state, `state=needsIndex` history, and Create-index prompt visibility.
- Guardrails proving normal Search UI tests are mapped to seeded Search fixtures.
- App-side coverage that the seeded KJV and UITESTWEB fixture metadata satisfies `SearchIndexService` readiness checks.
- iOS CI upload-artifact retention guardrails for build-product and result-bundle artifact types.

Out of scope:
- New fixture preseeding mechanisms.
- Lowering the 120-second Search readiness timeout.
- Darwin notifications or a custom bridge for readiness.
- New runtime index-creation UI coverage.
- Changing the iOS CI workflow artifact-retention values.

## Contract References
- Closes #200
- `scripts/ui_test_fixture_manifest.json`
- Search fixture scenarios: `search-indexed`, `search-multi-translation`
- Repo commit and docblock standards enforced by `scripts/check_repo_standards.py`

## Change Details
- Added seeded Search scenario detection in `openSearch` and passed `allowsRuntimeIndexCreation: false` for normal seeded Search fixture scenarios.
- Extended `waitForSearchInteractionReady` failure messages with the last exported Search state, whether `state=needsIndex` was observed, and whether the Create-index prompt was observed.
- Added unit coverage for KJV and UITESTWEB seeded index metadata against `SearchIndexService.hasIndex`, `hasStrongsIndex`, and `modulesNeedingIndex`.
- Added Python guardrails for Search fixture manifest routing and Search readiness diagnostics.
- Added a Python guardrail that parses every `upload-artifact` step and preserves the existing retention policy: one day for build-product artifacts, 14 days for `.xcresult` diagnostic result bundles.

## Validation Evidence
- `python3 -m unittest scripts.test_ios_ci_ui_shard_guardrails scripts.test_search_fixture_guardrails`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-ci.yml"); puts "yaml ok"'`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_repo_standards.py all --base-ref origin/main --head-ref HEAD`
- `swift build --product UITestFixtureTool`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-issue200 CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleTests/AndBibleTests/testSeededSearchFixtureMetadataSatisfiesSearchIndexReadiness`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-issue200 CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testSearchDirectLaunchUsesSeededIndexAndReturnsBundledResults`
- GitNexus impact checks for edited Search/test symbols and final compare detection against `origin/main`.

Note: the first local UI test attempt failed in setup because this fresh worktree did not yet have `UITestFixtureTool` built; after building the fixture tool, the same seeded Search UI test passed.

## Risks / Follow-ups
- Search UI tests that intentionally exercise runtime index creation must use a non-seeded fixture path; the normal seeded Search fixtures now reject that path by design.
- Local validation required `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` because the machine-wide `xcode-select` points at Command Line Tools.

## Screenshots
none

## Closes
Closes #200
