### PR TITLE
refactor(reader): extract accessibility state export

### DIFF
--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -1381,6 +1381,84 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the extracted accessibility snapshot factory owns My Notes and StudyPad export assembly
+     without depending on `BibleReaderController`.
+     *
+     * Setup:
+     * - creates in-memory bookmark storage with one Bible note and one StudyPad text entry
+     * - supplies explicit ordinal and verse-reference closures matching the reader's current chapter
+     *
+     * Expected result:
+     * - My Notes exports the visible note reference, revision, and sanitized note token
+     * - StudyPad exports the visible label, revision, entry count, and sanitized text token
+     *
+     * Failure meaning:
+     * - UI automation state export has leaked back into controller-specific behavior or no longer
+     *   matches the compact token contract consumed by reader UI tests.
+     */
+    func testAccessibilitySnapshotFactoryBuildsMyNotesAndStudyPadState() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkStore = BookmarkStore(modelContext: modelContext)
+        let bookmarkService = BookmarkService(store: bookmarkStore)
+        let noteOrdinal = (119 - 1) * 40 + 3
+        let noteBookmark = BibleBookmark(
+            kjvOrdinalStart: noteOrdinal,
+            kjvOrdinalEnd: noteOrdinal,
+            ordinalStart: noteOrdinal,
+            ordinalEnd: noteOrdinal,
+            v11n: "KJVA"
+        )
+        noteBookmark.book = "Psalms"
+        modelContext.insert(noteBookmark)
+        try modelContext.save()
+        bookmarkService.saveBibleBookmarkNote(bookmarkId: noteBookmark.id, note: "Line=One;Two|Three")
+
+        let label = bookmarkService.createLabel(name: "Study=Pad;One", color: Label.defaultColor)
+        let createdEntry = try XCTUnwrap(bookmarkService.createStudyPadEntry(labelId: label.id, afterOrderNumber: -1))
+        bookmarkService.updateStudyPadTextEntryText(id: createdEntry.0.id, text: "Entry|One,Two")
+
+        let factory = BibleReaderAccessibilitySnapshotFactory(
+            bookmarkService: bookmarkService,
+            currentBook: "Psalms",
+            currentChapter: 119,
+            showingMyNotes: true,
+            showingStudyPad: true,
+            editingInWebView: true,
+            myNotesMutationRevision: 7,
+            studyPadMutationRevision: 8,
+            activeStudyPadLabelId: label.id,
+            activeStudyPadLabelName: label.name,
+            rowLimit: 2,
+            chapterOrdinalRange: { (start: noteOrdinal - 2, end: noteOrdinal + 2, verseCount: 5) },
+            verseReference: { _, ordinal in
+                VerseKeyReference(
+                    osisBookId: "Ps",
+                    chapter: 119,
+                    verse: ordinal - ((119 - 1) * 40),
+                    ordinal: ordinal
+                )
+            }
+        )
+
+        let myNotesSnapshot = factory.myNotesAccessibilitySnapshot()
+        XCTAssertTrue(myNotesSnapshot.isVisible)
+        XCTAssertTrue(myNotesSnapshot.isEditing)
+        XCTAssertEqual(myNotesSnapshot.revision, 7)
+        XCTAssertEqual(myNotesSnapshot.totalCount, 1)
+        XCTAssertEqual(myNotesSnapshot.rowReferenceTokens, ["Psalms_119_3"])
+        XCTAssertEqual(myNotesSnapshot.noteTokens.map(\.encodedValue), ["|Psalms_119_3=Line_One_Two_Three|"])
+
+        let studyPadSnapshot = factory.studyPadAccessibilitySnapshot()
+        XCTAssertTrue(studyPadSnapshot.isVisible)
+        XCTAssertTrue(studyPadSnapshot.isEditing)
+        XCTAssertEqual(studyPadSnapshot.revision, 8)
+        XCTAssertEqual(studyPadSnapshot.labelToken, "Study_Pad_One")
+        XCTAssertEqual(studyPadSnapshot.textEntryCount, 1)
+        XCTAssertEqual(studyPadSnapshot.textTokens.map(\.encodedValue), ["|0=Entry_One_Two|"])
+    }
+
+    /**
      Verifies that creating and editing one StudyPad entry persists its text payload in the backing
      SwiftData rows.
      *

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -386,6 +386,13 @@ extension AndBibleTests {
         XCTAssertEqual(tokens["chapter"], "none")
         XCTAssertEqual(tokens["key"], "H00430_entry selected")
         XCTAssertEqual(BibleReaderRenderedContentState.empty.encodedValue, BibleReaderController.emptyRenderedContentState)
+
+        let duplicateTokens = BibleReaderRenderedContentState.tokens(
+            from: "category=bible;module=KJV;module=ESV;malformed;book=Genesis"
+        )
+        XCTAssertEqual(duplicateTokens["category"], "bible")
+        XCTAssertEqual(duplicateTokens["module"], "ESV")
+        XCTAssertEqual(duplicateTokens["book"], "Genesis")
     }
 
     func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -348,6 +348,46 @@ extension AndBibleTests {
         }
     }
 
+    /**
+     Verifies the shared rendered-content token contract used by the reader, bottom tab labels, and
+     compact UI-test state export.
+     *
+     * Setup:
+     * - constructs a dictionary rendered-content state with delimiter characters in display fields
+     *
+     * Expected result:
+     * - encoding preserves the existing semicolon-separated field order and sanitizes delimiter
+     *   characters the same way the controller did inline
+     * - parsing returns the same key/value tokens so non-controller consumers do not duplicate token
+     *   parsing logic
+     *
+     * Failure meaning:
+     * - reader rendered-content state consumers have drifted from the controller's accessibility and
+     *   tab-display contract.
+     */
+    func testRenderedContentStateBuildsAndParsesSharedTokens() {
+        let state = BibleReaderRenderedContentState(
+            category: .dictionary,
+            moduleName: "Strongs=Hebrew;Primary",
+            book: "H00430|lemma",
+            chapter: nil,
+            key: "H00430,entry\nselected"
+        )
+
+        XCTAssertEqual(
+            state.encodedValue,
+            "category=dictionary;module=Strongs_Hebrew_Primary;book=H00430_lemma;chapter=none;key=H00430_entry selected"
+        )
+
+        let tokens = BibleReaderRenderedContentState.tokens(from: state.encodedValue)
+        XCTAssertEqual(tokens["category"], "dictionary")
+        XCTAssertEqual(tokens["module"], "Strongs_Hebrew_Primary")
+        XCTAssertEqual(tokens["book"], "H00430_lemma")
+        XCTAssertEqual(tokens["chapter"], "none")
+        XCTAssertEqual(tokens["key"], "H00430_entry selected")
+        XCTAssertEqual(BibleReaderRenderedContentState.empty.encodedValue, BibleReaderController.emptyRenderedContentState)
+    }
+
     func testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest() throws {
         let bridge = BibleBridge()
         let controller = BibleReaderController(bridge: bridge)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
@@ -81,17 +81,16 @@ struct BibleReaderRenderedContentState: Equatable {
      - Parameter encodedValue: Token string produced by `encodedValue` or a legacy controller value.
      - Returns: Dictionary of parsed key/value pairs.
      - Side effects: None.
-     - Failure modes: Malformed fields are ignored; duplicate keys keep Swift's dictionary behavior
-       from the previous inline implementation.
+     - Failure modes: Malformed fields are ignored; duplicate keys keep the last valid value.
      */
     static func tokens(from encodedValue: String) -> [String: String] {
-        Dictionary(uniqueKeysWithValues: encodedValue
-            .split(separator: ";")
-            .compactMap { part -> (String, String)? in
-                let pieces = part.split(separator: "=", maxSplits: 1).map(String.init)
-                guard pieces.count == 2 else { return nil }
-                return (pieces[0], pieces[1])
-            })
+        var tokens: [String: String] = [:]
+        for part in encodedValue.split(separator: ";") {
+            let pieces = part.split(separator: "=", maxSplits: 1).map(String.init)
+            guard pieces.count == 2 else { continue }
+            tokens[pieces[0]] = pieces[1]
+        }
+        return tokens
     }
 }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
@@ -1,0 +1,396 @@
+import Foundation
+import BibleCore
+import SwordKit
+
+/**
+ Encodes the reader's current rendered document identity for compact native state export.
+
+ The encoded form is intentionally a small semicolon-delimited token string because UI tests and
+ tab labels need stable state without inspecting the full Vue document. The field names and order
+ preserve the legacy `BibleReaderController.renderedContentState` contract.
+ */
+struct BibleReaderRenderedContentState: Equatable {
+    /// Neutral state used before the WebView has rendered any reader document.
+    static let empty = BibleReaderRenderedContentState(
+        encodedValue: "category=none;module=none;book=none;chapter=none;key=none"
+    )
+
+    /// Serialized key/value token consumed by reader UI tests and bottom tab label logic.
+    let encodedValue: String
+
+    /**
+     Creates a rendered-content token from the reader's document identity.
+    
+     - Parameters:
+       - category: Document category that owns the displayed content.
+       - moduleName: Optional module or synthetic document label; `nil` is encoded as `none`.
+       - book: Book, label, dictionary key, or document title to show in compact state.
+       - chapter: Optional chapter number; `nil` is encoded as `none`.
+       - key: Optional durable or transient content key; `nil` is encoded as `none`.
+     - Side effects: None.
+     - Failure modes: None; delimiter characters are sanitized so parsing remains deterministic.
+     */
+    init(
+        category: DocumentCategory,
+        moduleName: String?,
+        book: String,
+        chapter: Int? = nil,
+        key: String? = nil
+    ) {
+        self.encodedValue = [
+            "category=\(category.pageManagerKey)",
+            "module=\(Self.token(moduleName))",
+            "book=\(Self.token(book))",
+            "chapter=\(chapter.map(String.init) ?? "none")",
+            "key=\(Self.token(key))",
+        ].joined(separator: ";")
+    }
+
+    /**
+     Creates a state from an already-serialized token.
+    
+     - Parameter encodedValue: Existing semicolon-delimited state string.
+     - Side effects: None.
+     - Failure modes: The initializer does not validate fields so callers can preserve legacy
+       neutral and malformed states for fail-closed consumers.
+     */
+    private init(encodedValue: String) {
+        self.encodedValue = encodedValue
+    }
+
+    /**
+     Escapes semantically important content-state tokens for accessibility export and tests.
+    
+     - Parameter raw: Optional raw token value.
+     - Returns: A sanitized token, or `none` for `nil`.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    static func token(_ raw: String?) -> String {
+        (raw ?? "none")
+            .replacingOccurrences(of: ";", with: "_")
+            .replacingOccurrences(of: ",", with: "_")
+            .replacingOccurrences(of: "|", with: "_")
+            .replacingOccurrences(of: "=", with: "_")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    /**
+     Parses a semicolon-delimited rendered-content token into field values.
+    
+     - Parameter encodedValue: Token string produced by `encodedValue` or a legacy controller value.
+     - Returns: Dictionary of parsed key/value pairs.
+     - Side effects: None.
+     - Failure modes: Malformed fields are ignored; duplicate keys keep Swift's dictionary behavior
+       from the previous inline implementation.
+     */
+    static func tokens(from encodedValue: String) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: encodedValue
+            .split(separator: ";")
+            .compactMap { part -> (String, String)? in
+                let pieces = part.split(separator: "=", maxSplits: 1).map(String.init)
+                guard pieces.count == 2 else { return nil }
+                return (pieces[0], pieces[1])
+            })
+    }
+}
+
+/// One compact My Notes row token emitted for detailed UI-test accessibility state.
+struct MyNotesAccessibilityNoteToken: Equatable {
+    /// Stable verse-reference token for the note row.
+    let referenceToken: String
+
+    /// Sanitized note body token.
+    let noteToken: String
+
+    /// Encoded row fragment consumed by UI tests.
+    var encodedValue: String {
+        "|\(referenceToken)=\(noteToken)|"
+    }
+}
+
+/// Compact My Notes state emitted for UI automation after the real document is visible.
+struct MyNotesAccessibilitySnapshot: Equatable {
+    /// Whether the reader is currently showing My Notes.
+    let isVisible: Bool
+
+    /// Whether the WebView editor is active.
+    let isEditing: Bool
+
+    /// Monotonic mutation marker updated when My Notes content changes.
+    let revision: Int
+
+    /// Full count of current-chapter notes before row-token truncation.
+    let totalCount: Int
+
+    /// Stable row reference tokens for the exported prefix.
+    let rowReferenceTokens: [String]
+
+    /// Stable note-content tokens for the exported prefix.
+    let noteTokens: [MyNotesAccessibilityNoteToken]
+
+    /// Neutral snapshot used when no controller is available to the reader view.
+    static let empty = MyNotesAccessibilitySnapshot(
+        isVisible: false,
+        isEditing: false,
+        revision: 0,
+        totalCount: 0,
+        rowReferenceTokens: [],
+        noteTokens: []
+    )
+
+    /// Encoded state consumed by the hidden UI-test export label.
+    var encodedValue: String {
+        let rowTokens = rowReferenceTokens.map { "|\($0)|" }.joined(separator: ",")
+        let notes = noteTokens.map(\.encodedValue).joined(separator: ",")
+        return [
+            "myNotesVisible=\(isVisible)",
+            "myNotesEditing=\(isEditing)",
+            "myNotesRevision=\(revision)",
+            "myNotesCount=\(totalCount)",
+            "myNotesRows=\(rowTokens)",
+            "myNotesNotes=\(notes)",
+        ].joined(separator: ";")
+    }
+}
+
+/// One compact StudyPad text-entry token emitted for detailed UI-test accessibility state.
+struct StudyPadAccessibilityTextToken: Equatable {
+    /// Current StudyPad order number for the text entry.
+    let orderNumber: Int
+
+    /// Sanitized text body token.
+    let textToken: String
+
+    /// Encoded row fragment consumed by UI tests.
+    var encodedValue: String {
+        "|\(orderNumber)=\(textToken)|"
+    }
+}
+
+/// Compact StudyPad state emitted for UI automation after the real document is visible.
+struct StudyPadAccessibilitySnapshot: Equatable {
+    /// Whether the reader is currently showing a StudyPad document.
+    let isVisible: Bool
+
+    /// Whether the WebView editor is active.
+    let isEditing: Bool
+
+    /// Monotonic mutation marker updated when StudyPad content changes.
+    let revision: Int
+
+    /// Sanitized label token for the active StudyPad.
+    let labelToken: String
+
+    /// Full count of StudyPad text entries before row-token truncation.
+    let textEntryCount: Int
+
+    /// Stable text-entry tokens for the exported prefix.
+    let textTokens: [StudyPadAccessibilityTextToken]
+
+    /// Neutral snapshot used when no controller is available to the reader view.
+    static let empty = StudyPadAccessibilitySnapshot(
+        isVisible: false,
+        isEditing: false,
+        revision: 0,
+        labelToken: "none",
+        textEntryCount: 0,
+        textTokens: []
+    )
+
+    /// Encoded state consumed by the hidden UI-test export label.
+    var encodedValue: String {
+        let texts = textTokens.map(\.encodedValue).joined(separator: ",")
+        return [
+            "studyPadVisible=\(isVisible)",
+            "studyPadEditing=\(isEditing)",
+            "studyPadRevision=\(revision)",
+            "studyPadLabel=\(labelToken)",
+            "studyPadTextEntryCount=\(textEntryCount)",
+            "studyPadTexts=\(texts)",
+        ].joined(separator: ";")
+    }
+}
+
+/**
+ Builds compact reader accessibility snapshots for My Notes and StudyPad document state.
+
+ `BibleReaderController` owns the live reader state and SWORD ordinal resolution. This factory owns
+ only the deterministic export assembly so tests and UI automation tokens do not remain embedded in
+ the controller's bridge/navigation responsibilities.
+ */
+struct BibleReaderAccessibilitySnapshotFactory {
+    /// Resolves the current chapter's ordinal range using the reader's active versification.
+    typealias ChapterOrdinalRangeResolver = () -> (start: Int, end: Int, verseCount: Int)?
+
+    /// Resolves a persisted bookmark ordinal into a chapter/verse reference.
+    typealias VerseReferenceResolver = (_ book: String, _ ordinal: Int) -> VerseKeyReference?
+
+    private let bookmarkService: BookmarkService?
+    private let currentBook: String
+    private let currentChapter: Int
+    private let showingMyNotes: Bool
+    private let showingStudyPad: Bool
+    private let editingInWebView: Bool
+    private let myNotesMutationRevision: Int
+    private let studyPadMutationRevision: Int
+    private let activeStudyPadLabelId: UUID?
+    private let activeStudyPadLabelName: String?
+    private let rowLimit: Int
+    private let chapterOrdinalRange: ChapterOrdinalRangeResolver
+    private let verseReference: VerseReferenceResolver
+
+    /**
+     Creates a snapshot factory from the controller state needed for compact exports.
+    
+     - Parameters:
+       - bookmarkService: Bookmark service supplying notes and StudyPad entries.
+       - currentBook: Current reader book name used for note lookup and reference tokens.
+       - currentChapter: Current reader chapter used when ordinal resolution falls back.
+       - showingMyNotes: Whether the visible document is My Notes.
+       - showingStudyPad: Whether the visible document is StudyPad.
+       - editingInWebView: Whether the Vue editor is active.
+       - myNotesMutationRevision: Mutation revision for My Notes state.
+       - studyPadMutationRevision: Mutation revision for StudyPad state.
+       - activeStudyPadLabelId: Active StudyPad label id, if any.
+       - activeStudyPadLabelName: Active StudyPad label name, if any.
+       - rowLimit: Maximum detailed rows exported for UI tests.
+       - chapterOrdinalRange: Closure that resolves the visible chapter ordinal range.
+       - verseReference: Closure that resolves ordinals using the active reader versification.
+     - Side effects: None during initialization.
+     - Failure modes: Missing services or failed ordinal resolution produce empty snapshots rather
+       than throwing so UI automation exports stay safe in no-module states.
+     */
+    init(
+        bookmarkService: BookmarkService?,
+        currentBook: String,
+        currentChapter: Int,
+        showingMyNotes: Bool,
+        showingStudyPad: Bool,
+        editingInWebView: Bool,
+        myNotesMutationRevision: Int,
+        studyPadMutationRevision: Int,
+        activeStudyPadLabelId: UUID?,
+        activeStudyPadLabelName: String?,
+        rowLimit: Int = UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit,
+        chapterOrdinalRange: @escaping ChapterOrdinalRangeResolver,
+        verseReference: @escaping VerseReferenceResolver
+    ) {
+        self.bookmarkService = bookmarkService
+        self.currentBook = currentBook
+        self.currentChapter = currentChapter
+        self.showingMyNotes = showingMyNotes
+        self.showingStudyPad = showingStudyPad
+        self.editingInWebView = editingInWebView
+        self.myNotesMutationRevision = myNotesMutationRevision
+        self.studyPadMutationRevision = studyPadMutationRevision
+        self.activeStudyPadLabelId = activeStudyPadLabelId
+        self.activeStudyPadLabelName = activeStudyPadLabelName
+        self.rowLimit = rowLimit
+        self.chapterOrdinalRange = chapterOrdinalRange
+        self.verseReference = verseReference
+    }
+
+    /**
+     Builds the compact My Notes snapshot for the current reader chapter.
+    
+     - Returns: Snapshot containing visibility, editor state, revision, full note count, and limited
+       detailed note tokens.
+     - Side effects: Reads bookmarks from `BookmarkService`.
+     - Failure modes: Missing service or unresolved chapter range returns an empty note list while
+       preserving visibility and revision state.
+     */
+    func myNotesAccessibilitySnapshot() -> MyNotesAccessibilitySnapshot {
+        let bookmarks = currentChapterMyNotesBookmarks()
+        let exportedBookmarks = bookmarks.prefix(rowLimit)
+        let noteTokens = exportedBookmarks.map { bookmark in
+            MyNotesAccessibilityNoteToken(
+                referenceToken: myNotesReferenceToken(for: bookmark),
+                noteToken: BibleReaderRenderedContentState.token(bookmark.notes?.notes)
+            )
+        }
+        return MyNotesAccessibilitySnapshot(
+            isVisible: showingMyNotes,
+            isEditing: editingInWebView,
+            revision: myNotesMutationRevision,
+            totalCount: bookmarks.count,
+            rowReferenceTokens: noteTokens.map(\.referenceToken),
+            noteTokens: noteTokens
+        )
+    }
+
+    /**
+     Builds the compact StudyPad snapshot for the active StudyPad label.
+    
+     - Returns: Snapshot containing visibility, editor state, revision, active label, full text-entry
+       count, and limited detailed text tokens.
+     - Side effects: Reads StudyPad entries from `BookmarkService`.
+     - Failure modes: Missing label or service returns an empty text-entry list while preserving
+       visibility and label state.
+     */
+    func studyPadAccessibilitySnapshot() -> StudyPadAccessibilitySnapshot {
+        guard showingStudyPad,
+              let labelId = activeStudyPadLabelId,
+              let service = bookmarkService else {
+            return StudyPadAccessibilitySnapshot(
+                isVisible: showingStudyPad,
+                isEditing: editingInWebView,
+                revision: studyPadMutationRevision,
+                labelToken: BibleReaderRenderedContentState.token(activeStudyPadLabelName),
+                textEntryCount: 0,
+                textTokens: []
+            )
+        }
+
+        let entries = service.studyPadEntries(labelId: labelId)
+        let exportedEntries = entries.prefix(rowLimit)
+        let textTokens = exportedEntries.map { entry in
+            StudyPadAccessibilityTextToken(
+                orderNumber: entry.orderNumber,
+                textToken: BibleReaderRenderedContentState.token(entry.textEntry?.text)
+            )
+        }
+        return StudyPadAccessibilitySnapshot(
+            isVisible: showingStudyPad,
+            isEditing: editingInWebView,
+            revision: studyPadMutationRevision,
+            labelToken: BibleReaderRenderedContentState.token(activeStudyPadLabelName),
+            textEntryCount: entries.count,
+            textTokens: textTokens
+        )
+    }
+
+    /**
+     Returns notes with non-empty payloads that belong to the currently visible chapter.
+    
+     - Returns: Sorted Bible bookmarks with non-empty note content for the current chapter.
+     - Side effects: Reads bookmarks from `BookmarkService`.
+     - Failure modes: Missing service or unresolved chapter range returns an empty list.
+     */
+    func currentChapterMyNotesBookmarks() -> [BibleBookmark] {
+        guard let service = bookmarkService,
+              let range = chapterOrdinalRange() else { return [] }
+        return service.bookmarks(for: range.start, endOrdinal: range.end, book: currentBook)
+            .filter { bookmark in
+                guard let note = bookmark.notes?.notes else { return false }
+                return !note.isEmpty
+            }
+            .sorted {
+                if $0.ordinalStart != $1.ordinalStart {
+                    return $0.ordinalStart < $1.ordinalStart
+                }
+                return $0.createdAt < $1.createdAt
+            }
+    }
+
+    /// Stable row token for the My Notes accessibility export.
+    private func myNotesReferenceToken(for bookmark: BibleBookmark) -> String {
+        let startReference = verseReference(currentBook, bookmark.ordinalStart)
+        let endReference = verseReference(currentBook, bookmark.ordinalEnd)
+        let startVerse = startReference?.verse ?? 1
+        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
+        let verseToken = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)_\(endVerse)"
+        let chapter = startReference?.chapter ?? currentChapter
+        return "\(BibleReaderRenderedContentState.token(currentBook))_\(chapter)_\(verseToken)"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -13,85 +13,6 @@ import AppKit
 
 private let logger = Logger(subsystem: "org.andbible", category: "BibleReaderController")
 
-struct MyNotesAccessibilityNoteToken: Equatable {
-    let referenceToken: String
-    let noteToken: String
-
-    var encodedValue: String {
-        "|\(referenceToken)=\(noteToken)|"
-    }
-}
-
-struct MyNotesAccessibilitySnapshot: Equatable {
-    let isVisible: Bool
-    let isEditing: Bool
-    let revision: Int
-    let totalCount: Int
-    let rowReferenceTokens: [String]
-    let noteTokens: [MyNotesAccessibilityNoteToken]
-
-    static let empty = MyNotesAccessibilitySnapshot(
-        isVisible: false,
-        isEditing: false,
-        revision: 0,
-        totalCount: 0,
-        rowReferenceTokens: [],
-        noteTokens: []
-    )
-
-    var encodedValue: String {
-        let rowTokens = rowReferenceTokens.map { "|\($0)|" }.joined(separator: ",")
-        let notes = noteTokens.map(\.encodedValue).joined(separator: ",")
-        return [
-            "myNotesVisible=\(isVisible)",
-            "myNotesEditing=\(isEditing)",
-            "myNotesRevision=\(revision)",
-            "myNotesCount=\(totalCount)",
-            "myNotesRows=\(rowTokens)",
-            "myNotesNotes=\(notes)",
-        ].joined(separator: ";")
-    }
-}
-
-struct StudyPadAccessibilityTextToken: Equatable {
-    let orderNumber: Int
-    let textToken: String
-
-    var encodedValue: String {
-        "|\(orderNumber)=\(textToken)|"
-    }
-}
-
-struct StudyPadAccessibilitySnapshot: Equatable {
-    let isVisible: Bool
-    let isEditing: Bool
-    let revision: Int
-    let labelToken: String
-    let textEntryCount: Int
-    let textTokens: [StudyPadAccessibilityTextToken]
-
-    static let empty = StudyPadAccessibilitySnapshot(
-        isVisible: false,
-        isEditing: false,
-        revision: 0,
-        labelToken: "none",
-        textEntryCount: 0,
-        textTokens: []
-    )
-
-    var encodedValue: String {
-        let texts = textTokens.map(\.encodedValue).joined(separator: ",")
-        return [
-            "studyPadVisible=\(isVisible)",
-            "studyPadEditing=\(isEditing)",
-            "studyPadRevision=\(revision)",
-            "studyPadLabel=\(labelToken)",
-            "studyPadTextEntryCount=\(textEntryCount)",
-            "studyPadTexts=\(texts)",
-        ].joined(separator: ";")
-    }
-}
-
 /**
  Coordinates BibleView bridge events, SWORD content loading, and native presentation callbacks.
 
@@ -201,7 +122,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var currentEpubTitle: String?
 
     /// Stable summary of the last content payload emitted to the reader WebView.
-    static let emptyRenderedContentState = "category=none;module=none;book=none;chapter=none;key=none"
+    static let emptyRenderedContentState = BibleReaderRenderedContentState.empty.encodedValue
     private static let issueTrackerURLString = "https://github.com/AndBible/and-bible/issues"
     private(set) var renderedContentState: String = BibleReaderController.emptyRenderedContentState
     /// Transient document that should be replayed once the Vue client has finished bootstrapping.
@@ -248,16 +169,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
         /// Optional rendered module token.
         let renderedModuleName: String?
-    }
-
-    /// Escapes semantically important content-state tokens for accessibility export and tests.
-    private static func contentStateToken(_ raw: String?) -> String {
-        (raw ?? "none")
-            .replacingOccurrences(of: ";", with: "_")
-            .replacingOccurrences(of: ",", with: "_")
-            .replacingOccurrences(of: "|", with: "_")
-            .replacingOccurrences(of: "=", with: "_")
-            .replacingOccurrences(of: "\n", with: " ")
     }
 
     /**
@@ -380,52 +291,36 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         chapterOrdinalRange(book: currentBook, chapter: currentChapter)
     }
 
-    /// Notes with non-empty payloads that belong to the currently visible chapter.
-    private func currentChapterMyNotesBookmarks() -> [BibleBookmark] {
-        guard let service = bookmarkService,
-              let range = currentChapterOrdinalRange() else { return [] }
-        return service.bookmarks(for: range.start, endOrdinal: range.end, book: currentBook)
-            .filter { bookmark in
-                guard let note = bookmark.notes?.notes else { return false }
-                return !note.isEmpty
+    /// Snapshot factory that owns compact UI-test state assembly while the controller supplies state.
+    private func accessibilitySnapshotFactory() -> BibleReaderAccessibilitySnapshotFactory {
+        BibleReaderAccessibilitySnapshotFactory(
+            bookmarkService: bookmarkService,
+            currentBook: currentBook,
+            currentChapter: currentChapter,
+            showingMyNotes: showingMyNotes,
+            showingStudyPad: showingStudyPad,
+            editingInWebView: editingInWebView,
+            myNotesMutationRevision: myNotesMutationRevision,
+            studyPadMutationRevision: studyPadMutationRevision,
+            activeStudyPadLabelId: activeStudyPadLabelId,
+            activeStudyPadLabelName: activeStudyPadLabelName,
+            chapterOrdinalRange: { [self] in
+                currentChapterOrdinalRange()
+            },
+            verseReference: { [self] book, ordinal in
+                verseReference(book: book, ordinal: ordinal)
             }
-            .sorted {
-                if $0.ordinalStart != $1.ordinalStart {
-                    return $0.ordinalStart < $1.ordinalStart
-                }
-                return $0.createdAt < $1.createdAt
-            }
+        )
     }
 
-    /// Stable row token for the My Notes accessibility export.
-    private func myNotesReferenceToken(for bookmark: BibleBookmark) -> String {
-        let startReference = verseReference(book: currentBook, ordinal: bookmark.ordinalStart)
-        let endReference = verseReference(book: currentBook, ordinal: bookmark.ordinalEnd)
-        let startVerse = startReference?.verse ?? 1
-        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
-        let verseToken = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)_\(endVerse)"
-        let chapter = startReference?.chapter ?? currentChapter
-        return "\(Self.contentStateToken(currentBook))_\(chapter)_\(verseToken)"
+    /// Notes with non-empty payloads that belong to the currently visible chapter.
+    private func currentChapterMyNotesBookmarks() -> [BibleBookmark] {
+        accessibilitySnapshotFactory().currentChapterMyNotesBookmarks()
     }
 
     /// Typed My Notes state used to produce compact UI-test accessibility exports.
     var myNotesAccessibilitySnapshot: MyNotesAccessibilitySnapshot {
-        let bookmarks = currentChapterMyNotesBookmarks()
-        let exportedBookmarks = bookmarks.prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit)
-        let noteTokens = exportedBookmarks.map { bookmark in
-            MyNotesAccessibilityNoteToken(
-                referenceToken: myNotesReferenceToken(for: bookmark),
-                noteToken: Self.contentStateToken(bookmark.notes?.notes)
-            )
-        }
-        return MyNotesAccessibilitySnapshot(
-            isVisible: showingMyNotes,
-            isEditing: editingInWebView,
-            revision: myNotesMutationRevision,
-            totalCount: bookmarks.count,
-            rowReferenceTokens: noteTokens.map(\.referenceToken),
-            noteTokens: noteTokens
-        )
+        accessibilitySnapshotFactory().myNotesAccessibilitySnapshot()
     }
 
     /// Compact My Notes state used by UI tests after opening the real visible My Notes document.
@@ -435,35 +330,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Typed StudyPad state used to produce compact UI-test accessibility exports.
     var studyPadAccessibilitySnapshot: StudyPadAccessibilitySnapshot {
-        guard showingStudyPad,
-              let labelId = activeStudyPadLabelId,
-              let service = bookmarkService else {
-            return StudyPadAccessibilitySnapshot(
-                isVisible: showingStudyPad,
-                isEditing: editingInWebView,
-                revision: studyPadMutationRevision,
-                labelToken: Self.contentStateToken(activeStudyPadLabelName),
-                textEntryCount: 0,
-                textTokens: []
-            )
-        }
-
-        let entries = service.studyPadEntries(labelId: labelId)
-        let exportedEntries = entries.prefix(UITestRuntimeConfiguration.detailedAccessibilityRowTokenLimit)
-        let textTokens = exportedEntries.map { entry in
-            StudyPadAccessibilityTextToken(
-                orderNumber: entry.orderNumber,
-                textToken: Self.contentStateToken(entry.textEntry?.text)
-            )
-        }
-        return StudyPadAccessibilitySnapshot(
-            isVisible: showingStudyPad,
-            isEditing: editingInWebView,
-            revision: studyPadMutationRevision,
-            labelToken: Self.contentStateToken(activeStudyPadLabelName),
-            textEntryCount: entries.count,
-            textTokens: textTokens
-        )
+        accessibilitySnapshotFactory().studyPadAccessibilitySnapshot()
     }
 
     /// Compact StudyPad state used by UI tests after opening the real visible StudyPad document.
@@ -483,13 +350,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             activeMyDocumentBookInitials = nil
             activeMyDocumentPageKey = nil
         }
-        renderedContentState = [
-            "category=\(category.pageManagerKey)",
-            "module=\(Self.contentStateToken(moduleName))",
-            "book=\(Self.contentStateToken(book))",
-            "chapter=\(chapter.map(String.init) ?? "none")",
-            "key=\(Self.contentStateToken(key))",
-        ].joined(separator: ";")
+        renderedContentState = BibleReaderRenderedContentState(
+            category: category,
+            moduleName: moduleName,
+            book: book,
+            chapter: chapter,
+            key: key
+        ).encodedValue
     }
 
     /// Whether the current module has Strong's numbers (matching Android CurrentPageManager.hasStrongs).
@@ -2028,13 +1895,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Side effects: None.
      */
     private func renderedContentStateTokens() -> [String: String] {
-        Dictionary(uniqueKeysWithValues: renderedContentState
-            .split(separator: ";")
-            .compactMap { part -> (String, String)? in
-                let pieces = part.split(separator: "=", maxSplits: 1).map(String.init)
-                guard pieces.count == 2 else { return nil }
-                return (pieces[0], pieces[1])
-            })
+        BibleReaderRenderedContentState.tokens(from: renderedContentState)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
@@ -301,13 +301,7 @@ struct WindowTabBar: View {
      */
     private func renderedContentTabState(for window: Window) -> RenderedContentTabState? {
         guard let ctrl = windowManager.controllers[window.id] as? BibleReaderController else { return nil }
-        let tokens = Dictionary(uniqueKeysWithValues: ctrl.renderedContentState
-            .split(separator: ";")
-            .compactMap { part -> (String, String)? in
-                let pieces = part.split(separator: "=", maxSplits: 1).map(String.init)
-                guard pieces.count == 2 else { return nil }
-                return (pieces[0], pieces[1])
-            })
+        let tokens = BibleReaderRenderedContentState.tokens(from: ctrl.renderedContentState)
 
         guard let category = tokens["category"],
               category != "none",


### PR DESCRIPTION
## Summary

- Extracts rendered-content token encoding/parsing and compact My Notes/StudyPad accessibility state assembly out of BibleReaderController.
- Keeps BibleReaderController as the reader orchestration boundary while preserving the existing public renderedContentState, myNotesAccessibilityState, and studyPadAccessibilityState contracts.
- Reuses the shared rendered-content parser in WindowTabBar so tab labels and controller exports stay aligned.

## Scope

- In: rendered-content state token construction/parsing, My Notes accessibility snapshots, StudyPad accessibility snapshots, bottom-tab rendered-content token parsing, focused unit coverage.
- Out: navigation behavior, module switching, SWORD initialization, bridge delegate routing, document rendering semantics, and any user-facing behavior change.

## Contract references

- Issue #146: incrementally decompose BibleReaderController into focused collaborators without thin file splitting.
- Existing reader rendered-content token contract: category, module, book, chapter, key.
- Existing UI-test state export contracts for My Notes and StudyPad.
- Android parity: no Android-facing reader behavior changes; this is ownership extraction only.

## Change details

- Added BibleReaderAccessibilityState to own rendered-content tokens plus My Notes and StudyPad accessibility snapshot DTOs/factory.
- Rewired BibleReaderController to create the snapshot factory from current state and delegate compact state assembly.
- Left controller-owned note loading behavior intact through a wrapper over the factory note-list query.
- Replaced duplicate rendered-content token parsing in WindowTabBar with the shared parser.
- Added tests for shared token encoding/parsing and factory-built My Notes/StudyPad snapshots.

## Validation evidence

- python3 scripts/check_repo_standards.py docblocks --all-files
- git diff --check on staged source and test files
- Targeted new tests on iPhone 17 simulator: testRenderedContentStateBuildsAndParsesSharedTokens, testAccessibilitySnapshotFactoryBuildsMyNotesAndStudyPadState
- Affected reader/bookmark rendered-state tests on iPhone 17 simulator
- Full unit target on iPhone 17 simulator: 452 tests, 0 failures
- python3 scripts/check_repo_standards.py all --rev-range HEAD^..HEAD
- GitNexus detect_changes on staged diff: low risk, no affected execution flows

## Risks/follow-ups

- Runtime risk is limited to compact UI-test exports and non-Bible bottom tab labels.
- BibleReaderController remains large at about 8,040 lines; #146 still needs further slices for navigation, module/category switching, SWORD initialization, and bridge delegate routing.
- Local worktree has unrelated unstaged instruction/artifact files that are intentionally excluded from this PR.

## Issue closure reference

Refs #146. This PR intentionally does not close #146 because it handles one remaining responsibility boundary only.
