### PR TITLE
feat(passage-selector): align chooser with Android parity

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
+		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -89,6 +90,7 @@
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidModuleBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
+		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
+				B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -509,6 +512,7 @@
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
+				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -40,6 +40,34 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies KJVA verse ordinal lookup uses cached JSword-derived offsets.
+
+     The passage chooser progress bars resolve KJVA ranges for many visible cells. The values must
+     still match Android/JSword exactly, but lookup should not repeatedly walk the full KJVA table
+     while SwiftUI renders book, chapter, and verse grids.
+     */
+    func testJSwordKJVAVersificationUsesPrecomputedOrdinalIndexForProgressRendering() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repoRoot.appendingPathComponent(
+            "Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let ordinalFunctionStart = try XCTUnwrap(source.range(of: "public static func verseOrdinal("))
+        let ordinalFunctionEnd = try XCTUnwrap(
+            source.range(of: "public static func verseOrdinalRange(osisId: String, chapter: Int)", range: ordinalFunctionStart.upperBound..<source.endIndex)
+        )
+        let ordinalFunctionSource = source[ordinalFunctionStart.lowerBound..<ordinalFunctionEnd.lowerBound]
+
+        XCTAssertTrue(source.contains("private static let ordinalIndexByBookIndex"))
+        XCTAssertFalse(ordinalFunctionSource.contains("JSwordKJVAVersificationData.bookTable.enumerated()"))
+        XCTAssertEqual(JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 1), 4)
+        XCTAssertEqual(JSwordKJVAVersification.verseOrdinal(osisId: "Rev", chapter: 22, verse: 21), 38_272)
+    }
+
+    /**
      Verifies that iOS reads Android `.abdb.zip` archives by database file discovery and exposes
      both restorable and unsupported database sections.
 

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -925,7 +925,8 @@ extension AndBibleTests {
     func testReaderSideDrawerOverlayBuildsWithInjectedContent() {
         let view = ReaderSideDrawerOverlay(
             colorScheme: ColorScheme.light,
-            dismissAreaIdentifier: "testDismissArea"
+            dismissAreaIdentifier: "testDismissArea",
+            onDismiss: {}
         ) { width in
             Text("Drawer \(Int(width))")
         }

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -957,7 +957,28 @@ extension AndBibleTests {
 
         XCTAssertTrue(overlaySource.contains("ReaderPassageChooserOverlay"))
         XCTAssertFalse(overlaySource.contains("ReaderSideDrawerOverlay"))
-        XCTAssertTrue(overlaySource.contains("onCancel: dismissBookChooser"))
+        XCTAssertFalse(overlaySource.contains("onCancel: dismissBookChooser"))
+    }
+
+    /**
+     Verifies the passage chooser overlay does not expose an unused cancellation API.
+
+     Dismissal belongs to `BookChooserView` through its explicit back button callback. Keeping a dead
+     `onCancel` parameter on the overlay makes the reader shell look like it handles cancellation
+     while the value is never read, so future call sites can drift into false safety.
+     */
+    func testReaderPassageChooserOverlayDoesNotExposeDeadCancellationAPI() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let overlayURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Bible/ReaderPassageChooserOverlay.swift"
+        )
+
+        let source = try String(contentsOf: overlayURL, encoding: .utf8)
+
+        XCTAssertFalse(source.contains("onCancel"))
     }
 
     /**
@@ -1013,11 +1034,12 @@ extension AndBibleTests {
     }
 
     /**
-     Verifies reader-hosted passage choosers capture progress snapshots once per presentation.
+     Verifies reader-hosted passage choosers store progress snapshots once per presentation.
 
      Reading and memorization snapshots decode persisted store payloads. The chooser progress
-     closures run for many grid cells, so they should close over a prebuilt progress context instead
-     of re-reading those snapshots from `BibleReaderView` on every cell render.
+     closures run for many grid cells, and `BibleReaderView` can re-render while a chooser is open.
+     The reader should therefore store a captured context at presentation time instead of rebuilding
+     it from computed properties during unrelated renders.
      */
     func testReaderPassageChooserProgressProvidersCaptureSnapshotsOnce() throws {
         let testFileURL = URL(fileURLWithPath: #filePath)
@@ -1030,8 +1052,14 @@ extension AndBibleTests {
 
         let source = try String(contentsOf: readerViewURL, encoding: .utf8)
         let contextOccurrences = source.components(separatedBy: "let progressContext = passageChooserProgressContext").count - 1
+        let captureOccurrences = source.components(separatedBy: "passageChooserProgressContext = makePassageChooserProgressContext()").count - 1
 
+        XCTAssertTrue(source.contains("@State private var passageChooserProgressContext = PassageChooserProgressContext.empty"))
+        XCTAssertTrue(source.contains("private func makePassageChooserProgressContext() -> PassageChooserProgressContext"))
+        XCTAssertFalse(source.contains("private var passageChooserProgressContext: PassageChooserProgressContext"))
         XCTAssertEqual(contextOccurrences, 2)
+        XCTAssertEqual(captureOccurrences, 2)
+        XCTAssertTrue(source.contains("passageChooserProgressContext = .empty"))
         XCTAssertFalse(source.contains("passageBookProgress(for: book)"))
         XCTAssertFalse(source.contains("passageChapterProgress(for: book, chapter: chapter)"))
         XCTAssertFalse(source.contains("passageVerseProgress(for: book, chapter: chapter, verse: verse)"))

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -984,14 +984,14 @@ extension AndBibleTests {
     }
 
     /**
-     Verifies the drawer-hosted passage chooser restores its own navigation bar.
+     Verifies the drawer-hosted passage chooser does not depend on native navigation bars.
 
-     `BibleReaderView` hides the reader navigation bar so the custom Android-style header can own
-     the reading screen chrome. The passage chooser is now hosted as a child drawer in that same
-     hierarchy, so it must explicitly make its nested navigation bar visible or the Android chooser
-     title and Cancel action disappear. Failure means the drawer can slide in with only the grid.
+     Android's chooser activity owns its visible app bar as chooser content. `BibleReaderView`
+     hides native navigation chrome for the reader, so the reader-hosted chooser must not try to
+     recover by forcing a nested SwiftUI navigation bar visible. Failure means the app can regress
+     to a brittle host-level toolbar that disappears under the reader shell.
      */
-    func testPassageChooserDrawerMakesNavigationBarVisibleInsideReader() throws {
+    func testPassageChooserDrawerDoesNotDependOnNativeNavigationBarInsideReader() throws {
         let testFileURL = URL(fileURLWithPath: #filePath)
         let repoRoot = testFileURL
             .deletingLastPathComponent()
@@ -1008,7 +1008,8 @@ extension AndBibleTests {
 
         let drawerSource = source[drawerStart.lowerBound..<nextSection.lowerBound]
 
-        XCTAssertTrue(drawerSource.contains(".toolbar(.visible, for: .navigationBar)"))
+        XCTAssertTrue(drawerSource.contains("BookChooserView("))
+        XCTAssertFalse(drawerSource.contains(".toolbar(.visible, for: .navigationBar)"))
     }
 
     #if os(iOS)

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1012,6 +1012,31 @@ extension AndBibleTests {
         XCTAssertFalse(drawerSource.contains(".toolbar(.visible, for: .navigationBar)"))
     }
 
+    /**
+     Verifies reader-hosted passage choosers capture progress snapshots once per presentation.
+
+     Reading and memorization snapshots decode persisted store payloads. The chooser progress
+     closures run for many grid cells, so they should close over a prebuilt progress context instead
+     of re-reading those snapshots from `BibleReaderView` on every cell render.
+     */
+    func testReaderPassageChooserProgressProvidersCaptureSnapshotsOnce() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let readerViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift"
+        )
+
+        let source = try String(contentsOf: readerViewURL, encoding: .utf8)
+        let contextOccurrences = source.components(separatedBy: "let progressContext = passageChooserProgressContext").count - 1
+
+        XCTAssertEqual(contextOccurrences, 2)
+        XCTAssertFalse(source.contains("passageBookProgress(for: book)"))
+        XCTAssertFalse(source.contains("passageChapterProgress(for: book, chapter: chapter)"))
+        XCTAssertFalse(source.contains("passageVerseProgress(for: book, chapter: chapter, verse: verse)"))
+    }
+
     #if os(iOS)
     func testWindowingControlPolicyUsesMinimalStyleOnlyOnIPad() {
         XCTAssertTrue(

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -21,7 +21,7 @@ import struct SwiftUI.Color
 extension AndBibleTests {
     func testAppPreferenceRegistryHasDefinitionForAllKeys() {
         let keys = AppPreferenceKey.allCases
-        XCTAssertEqual(keys.count, 36)
+        XCTAssertEqual(keys.count, 40)
         XCTAssertEqual(Set(keys).count, keys.count)
         XCTAssertEqual(AppPreferenceRegistry.definitions.count, keys.count)
 
@@ -39,6 +39,10 @@ extension AndBibleTests {
         XCTAssertEqual(AppPreferenceRegistry.intRange(for: .fontSizeMultiplier), 10...500)
         XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .openLinksInSpecialWindowPref), true)
         XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .enableBluetoothPref), true)
+        XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .bookGridLeftToRight), false)
+        XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .bookGridGroupByCategory), false)
+        XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .bookGridShowLongName), false)
+        XCTAssertEqual(AppPreferenceRegistry.boolDefault(for: .bookGridShowProgress), true)
     }
 
     func testNotesContentTypeNormalizerUsesAndroidSupportedValues() {
@@ -912,12 +916,11 @@ extension AndBibleTests {
     }
 
     /**
-     Verifies reader side drawers are hosted by one shared slide-out presentation shell.
+     Verifies the reader navigation drawer is hosted by the shared slide-out presentation shell.
 
-     Android uses a drawer-like transition for left-side reader surfaces. The iOS main menu and
-     passage chooser should therefore share the same dimmer, width calculation, and move transition
-     instead of maintaining separate one-off overlays. Failure indicates a new drawer surface may
-     drift from the hamburger drawer behavior.
+     Android's hamburger menu remains a narrow left drawer over a dimmed reader. Passage selection
+     is a separate full-screen chooser activity, so this shared shell should be reserved for the
+     hamburger drawer and similar left navigation surfaces only.
      */
     func testReaderSideDrawerOverlayBuildsWithInjectedContent() {
         let view = ReaderSideDrawerOverlay(
@@ -931,13 +934,13 @@ extension AndBibleTests {
     }
 
     /**
-     Verifies the passage chooser drawer owns cancellation instead of relying on sheet dismissal.
+     Verifies the passage chooser uses its Android-style full-screen shell.
 
-     SwiftUI's environment dismiss action closed the old modal sheet, but a custom reader drawer
-     needs an explicit callback back into `BibleReaderView`. Failure means the visible Cancel action
-     can become inert after the Android-style drawer presentation replaces the sheet.
+     Android presents book/chapter/verse selection as a full-screen dark chooser with its own
+     toolbar, not as the narrow hamburger drawer. Failure means iOS is artificially preserving a
+     platform-specific presentation that hides part of the picker behind the reader surface.
      */
-    func testPassageChooserDrawerPassesExplicitCancelHandler() throws {
+    func testPassageChooserUsesFullScreenChooserShell() throws {
         let testFileURL = URL(fileURLWithPath: #filePath)
         let repoRoot = testFileURL
             .deletingLastPathComponent()
@@ -947,8 +950,13 @@ extension AndBibleTests {
         )
 
         let source = try String(contentsOf: readerViewURL, encoding: .utf8)
+        let overlayStart = try XCTUnwrap(source.range(of: "private var bookChooserDrawerOverlay"))
+        let overlayEnd = try XCTUnwrap(source[overlayStart.lowerBound...].range(of: "private func dismissReaderNavigationDrawer"))
+        let overlaySource = String(source[overlayStart.lowerBound..<overlayEnd.lowerBound])
 
-        XCTAssertTrue(source.contains("onCancel: dismissBookChooser"))
+        XCTAssertTrue(overlaySource.contains("ReaderPassageChooserOverlay"))
+        XCTAssertFalse(overlaySource.contains("ReaderSideDrawerOverlay"))
+        XCTAssertTrue(overlaySource.contains("onCancel: dismissBookChooser"))
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -11,6 +11,7 @@ import struct SwiftUI.Binding
 import enum SwiftUI.ColorScheme
 import struct SwiftUI.EdgeInsets
 import struct SwiftUI.EmptyView
+import struct SwiftUI.Text
 #if os(iOS)
 import UIKit
 import WebKit
@@ -908,6 +909,97 @@ extension AndBibleTests {
         )
 
         XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderNavigationDrawer"))
+    }
+
+    /**
+     Verifies reader side drawers are hosted by one shared slide-out presentation shell.
+
+     Android uses a drawer-like transition for left-side reader surfaces. The iOS main menu and
+     passage chooser should therefore share the same dimmer, width calculation, and move transition
+     instead of maintaining separate one-off overlays. Failure indicates a new drawer surface may
+     drift from the hamburger drawer behavior.
+     */
+    func testReaderSideDrawerOverlayBuildsWithInjectedContent() {
+        let view = ReaderSideDrawerOverlay(
+            colorScheme: ColorScheme.light,
+            dismissAreaIdentifier: "testDismissArea"
+        ) { width in
+            Text("Drawer \(Int(width))")
+        }
+
+        XCTAssertTrue(String(describing: type(of: view)).contains("ReaderSideDrawerOverlay"))
+    }
+
+    /**
+     Verifies the passage chooser drawer owns cancellation instead of relying on sheet dismissal.
+
+     SwiftUI's environment dismiss action closed the old modal sheet, but a custom reader drawer
+     needs an explicit callback back into `BibleReaderView`. Failure means the visible Cancel action
+     can become inert after the Android-style drawer presentation replaces the sheet.
+     */
+    func testPassageChooserDrawerPassesExplicitCancelHandler() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let readerViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift"
+        )
+
+        let source = try String(contentsOf: readerViewURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("onCancel: dismissBookChooser"))
+    }
+
+    /**
+     Verifies all reader-hosted passage chooser entry points carry the active workspace title.
+
+     Android appends `SharedActivityState.currentWorkspaceName` to the book chooser activity title.
+     The SwiftUI chooser should receive the same workspace context from `BibleReaderView` wherever
+     that chooser is hosted, rather than only for one visible entry point. Failure means a caller can
+     drift back to an iOS-only title that hides the target workspace.
+     */
+    func testReaderPassageChooserCallSitesUseSharedWorkspaceTitleSource() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let readerViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift"
+        )
+
+        let source = try String(contentsOf: readerViewURL, encoding: .utf8)
+        let occurrences = source.components(separatedBy: "workspaceName: activePassageChooserWorkspaceName").count - 1
+
+        XCTAssertEqual(occurrences, 2)
+    }
+
+    /**
+     Verifies the drawer-hosted passage chooser restores its own navigation bar.
+
+     `BibleReaderView` hides the reader navigation bar so the custom Android-style header can own
+     the reading screen chrome. The passage chooser is now hosted as a child drawer in that same
+     hierarchy, so it must explicitly make its nested navigation bar visible or the Android chooser
+     title and Cancel action disappear. Failure means the drawer can slide in with only the grid.
+     */
+    func testPassageChooserDrawerMakesNavigationBarVisibleInsideReader() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let readerViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift"
+        )
+
+        let source = try String(contentsOf: readerViewURL, encoding: .utf8)
+        guard let drawerStart = source.range(of: "private var bookChooserDrawerContent"),
+              let nextSection = source.range(of: "/// Search sheet", range: drawerStart.upperBound..<source.endIndex) else {
+            return XCTFail("Could not locate book chooser drawer content in BibleReaderView.swift")
+        }
+
+        let drawerSource = source[drawerStart.lowerBound..<nextSection.lowerBound]
+
+        XCTAssertTrue(drawerSource.contains(".toolbar(.visible, for: .navigationBar)"))
     }
 
     #if os(iOS)

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -341,6 +341,39 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies chooser grids apply their shared outer inset horizontally only.
+
+     `PassageGridMetrics.horizontalPadding` is part of the square-cell width calculation. Applying
+     it to every edge adds unrelated vertical spacing and makes the metric contract misleading, so
+     each Android-style chooser grid should use it only for leading and trailing padding.
+     */
+    func testPassageGridViewsApplyHorizontalOnlyOuterPadding() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let relativePaths = [
+            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift",
+            "Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift",
+            "Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift"
+        ]
+
+        for relativePath in relativePaths {
+            let sourceURL = repoRoot.appendingPathComponent(relativePath)
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+            XCTAssertTrue(
+                source.contains(".padding(.horizontal, PassageGridMetrics.horizontalPadding)"),
+                relativePath
+            )
+            XCTAssertFalse(
+                source.contains(".padding(PassageGridMetrics.horizontalPadding)"),
+                relativePath
+            )
+        }
+    }
+
+    /**
      Verifies the book chooser title follows Android's activity-title workspace suffix.
 
      Android `GridChoosePassageBook.onCreate` appends `SharedActivityState.currentWorkspaceName` to

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -79,6 +79,27 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies checkable passage chooser menu rows expose their state to accessibility.
+
+     The Android-style overflow popup renders checkbox rows visually. iOS VoiceOver and UI tests
+     need the same state as an accessibility value, using the existing app convention for checkable
+     menu rows: `on` when checked and `off` when unchecked.
+     */
+    func testPassageChooserMenuRowsExposeCheckedStateAccessibilityValue() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        )
+
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains(".accessibilityValue(isChecked(entry.option) ? \"on\" : \"off\")"))
+    }
+
+    /**
      Verifies iOS uses Android/JSword short book labels instead of SWORD abbreviations.
 
      The Android chooser calls `versification.getShortName(book)`, producing labels like `2 Ki`,

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -360,6 +360,30 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the Android chooser app bar is owned by the chooser content itself.
+
+     `BibleReaderView` hides native navigation chrome for the custom reader toolbar, and iOS can fail
+     to render a nested native `NavigationStack` toolbar from the reader overlay. Android's chooser
+     activity owns a visible app bar containing the back button, title, and top-right overflow menu,
+     so iOS must render that app bar explicitly inside `BookChooserView`.
+     */
+    func testPassageChooserOwnsExplicitAndroidAppBar() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let chooserViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        )
+
+        let source = try String(contentsOf: chooserViewURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("PassageChooserAppBar("))
+        XCTAssertTrue(source.contains(".toolbar(.hidden, for: .navigationBar)"))
+        XCTAssertFalse(source.contains("ToolbarItem(placement: .navigation)"))
+    }
+
+    /**
      Verifies chooser progress fractions follow Android's JSword KJVA semantics.
 
      Android computes book reading progress from distinct read KJVA chapters in the active cycle,

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import BibleUI
+@testable import SwordKit
+
+extension AndBibleTests {
+    /**
+     Verifies that the 66-book portrait grid follows Android's default column-major layout.
+
+     Android's `ButtonGrid` uses an 11-by-6 portrait matrix for the standard Protestant canon and
+     fills columns before rows unless the row-order preference is enabled. The iOS selector must
+     therefore render Genesis through 1 Kings down the first column, then continue with 2 Kings at
+     the top of the second column.
+     */
+    func testPassageBookGridUsesAndroidColumnMajorPortraitOrderForStandardCanon() {
+        let layout = PassageGridLayout.androidDefault(
+            itemCount: BibleReaderController.defaultBooks.count,
+            kind: .book,
+            orientation: .portrait
+        )
+        let slots = layout.displaySlots(for: BibleReaderController.defaultBooks)
+
+        XCTAssertEqual(layout.rows, 11)
+        XCTAssertEqual(layout.columns, 6)
+        XCTAssertTrue(layout.usesColumnMajorOrder)
+        XCTAssertEqual(slots[0]?.osisId, "Gen")
+        XCTAssertEqual(slots[6]?.osisId, "Exod")
+        XCTAssertEqual(slots[60]?.osisId, "1Kgs")
+        XCTAssertEqual(slots[1]?.osisId, "2Kgs")
+    }
+
+    /**
+     Verifies Android's row-order option can be represented without changing the shared grid.
+
+     The preference is not the default Android behavior, but the layout primitive must support it so
+     the iOS chooser can add the user-facing option without another layout rewrite.
+     */
+    func testPassageBookGridCanUseAndroidRowOrderPreference() {
+        let layout = PassageGridLayout.androidDefault(
+            itemCount: BibleReaderController.defaultBooks.count,
+            kind: .book,
+            orientation: .portrait,
+            rowOrder: true
+        )
+        let slots = layout.displaySlots(for: BibleReaderController.defaultBooks)
+
+        XCTAssertFalse(layout.usesColumnMajorOrder)
+        XCTAssertEqual(slots[0]?.osisId, "Gen")
+        XCTAssertEqual(slots[1]?.osisId, "Exod")
+    }
+
+    /**
+     Protects Android's category color boundaries for representative canonical books.
+
+     These colors come from Android `GridChoosePassageBook.getBookColorAndGroup` and should not drift
+     into iOS-specific palette choices.
+     */
+    func testPassageBookCategoryColorsMirrorAndroidBoundaries() {
+        let expectations: [(osisId: String, color: PassageGridRGBColor)] = [
+            ("Gen", .pentateuch),
+            ("Josh", .history),
+            ("Ps", .wisdom),
+            ("Isa", .majorProphets),
+            ("Mal", .minorProphets),
+            ("Matt", .gospel),
+            ("Rom", .pauline),
+            ("Jas", .generalEpistles),
+            ("Rev", .revelation),
+        ]
+
+        for expectation in expectations {
+            XCTAssertEqual(
+                PassageBookCategory.category(forOsisId: expectation.osisId).color,
+                expectation.color,
+                expectation.osisId
+            )
+        }
+    }
+
+    /**
+     Verifies the highlighted current book uses Android's selected-button palette.
+
+     Android paints the current book with its category color as the tint and dark gray text, while
+     non-current books keep the category color as text over the testament tint.
+     */
+    func testPassageBookCellPaletteMirrorsAndroidCurrentAndNormalStates() {
+        let current = PassageGridCellPalette.bookPalette(
+            for: BookInfo(name: "Matthew", osisId: "Matt", abbreviation: "Matt", chapterCount: 28, testament: 2),
+            currentOsisId: "Matt"
+        )
+        let oldTestamentNormal = PassageGridCellPalette.bookPalette(
+            for: BookInfo(name: "Genesis", osisId: "Gen", abbreviation: "Gen", chapterCount: 50, testament: 1),
+            currentOsisId: "Matt"
+        )
+        let newTestamentNormal = PassageGridCellPalette.bookPalette(
+            for: BookInfo(name: "Romans", osisId: "Rom", abbreviation: "Rom", chapterCount: 16, testament: 2),
+            currentOsisId: "Matt"
+        )
+
+        XCTAssertEqual(current.background, .gospel)
+        XCTAssertEqual(current.foreground, .darkGray)
+        XCTAssertEqual(oldTestamentNormal.background, .oldTestamentTint)
+        XCTAssertEqual(oldTestamentNormal.foreground, .pentateuch)
+        XCTAssertEqual(newTestamentNormal.background, .newTestamentTint)
+        XCTAssertEqual(newTestamentNormal.foreground, .pauline)
+    }
+
+    /**
+     Verifies chapter and verse grids share Android's selected-number palette.
+
+     Android uses the selected book category color for the current chapter and current verse instead
+     of inventing a separate iOS highlight treatment.
+     */
+    func testPassageNumberCellPaletteUsesBookCategoryForCurrentChapterAndVerse() {
+        let current = PassageGridCellPalette.numberPalette(
+            number: 3,
+            currentNumber: 3,
+            categoryColor: .gospel
+        )
+        let normal = PassageGridCellPalette.numberPalette(
+            number: 4,
+            currentNumber: 3,
+            categoryColor: .gospel
+        )
+
+        XCTAssertEqual(current.background, .gospel)
+        XCTAssertEqual(current.foreground, .darkGray)
+        XCTAssertEqual(normal.background, .oldTestamentTint)
+        XCTAssertEqual(normal.foreground, .white)
+    }
+
+    /**
+     Verifies expanded module canons keep all books and use Android's dynamic non-66 layout.
+
+     Modules with additional books must continue to use `BookInfo` as the data source. A 67-book
+     module should not be forced into the 66-book 11-by-6 matrix or drop the extra book.
+     */
+    func testPassageBookGridUsesDynamicAndroidLayoutForExpandedCanons() {
+        let expandedBooks = BibleReaderController.defaultBooks + [
+            BookInfo(name: "Tobit", osisId: "Tob", abbreviation: "Tob", chapterCount: 14, testament: 1),
+        ]
+        let layout = PassageGridLayout.androidDefault(
+            itemCount: expandedBooks.count,
+            kind: .book,
+            orientation: .portrait
+        )
+        let slots = layout.displaySlots(for: expandedBooks)
+
+        XCTAssertEqual(layout.rows, 10)
+        XCTAssertEqual(layout.columns, 7)
+        XCTAssertTrue(slots.contains { $0?.osisId == "Tob" })
+        XCTAssertEqual(PassageBookCategory.category(forOsisId: "Tob").color, .other)
+    }
+}

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -442,4 +442,35 @@ extension AndBibleTests {
         XCTAssertEqual(verseProgress.readingFraction, 1.0, accuracy: 0.0001)
         XCTAssertEqual(verseProgress.memorizationFraction, 1.0, accuracy: 0.0001)
     }
+
+    /**
+     Verifies memorization progress counts unique KJVA ordinals from merged Android ranges.
+
+     Android memorization data can contain overlapping neutral and module-scoped ranges. The grid
+     should count their union, ignore other modules, and avoid treating repeated ordinals as extra
+     progress.
+     */
+    func testPassageGridProgressMergesOverlappingMemorizationRanges() throws {
+        let genesis = try XCTUnwrap(BibleReaderController.defaultBooks.first { $0.osisId == "Gen" })
+        let genesisStart = try XCTUnwrap(JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 1))
+
+        let memorizationSnapshot = MemorizationProgressSnapshot(
+            memorizedRanges: [
+                MemorizationProgressRange(bookInitials: "", startOrdinal: genesisStart, endOrdinal: genesisStart + 9),
+                MemorizationProgressRange(bookInitials: "KJV", startOrdinal: genesisStart + 4, endOrdinal: genesisStart + 14),
+                MemorizationProgressRange(bookInitials: "KJV", startOrdinal: genesisStart + 15, endOrdinal: genesisStart + 19),
+                MemorizationProgressRange(bookInitials: "ESV", startOrdinal: genesisStart + 20, endOrdinal: genesisStart + 30),
+            ]
+        )
+
+        let chapterProgress = PassageGridProgressCalculator.chapterProgress(
+            book: genesis,
+            chapter: 1,
+            readingSnapshot: nil,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: "KJV"
+        )
+
+        XCTAssertEqual(chapterProgress.memorizationFraction, 20.0 / 31.0, accuracy: 0.0001)
+    }
 }

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -468,6 +468,33 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies book reading progress aggregates read chapters in one pass.
+
+     Android progress is chapter-based for book cells. SwiftUI can re-render visible cells often, so
+     the iOS calculator should preserve the same distinct-chapter behavior without allocating
+     filter/map intermediates before building the chapter set.
+     */
+    func testPassageGridBookProgressUsesSinglePassReadingChapterAggregation() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let bookProgressStart = try XCTUnwrap(source.range(of: "static func bookProgress("))
+        let bookProgressEnd = try XCTUnwrap(
+            source.range(of: "static func chapterProgress(", range: bookProgressStart.upperBound..<source.endIndex)
+        )
+        let bookProgressSource = source[bookProgressStart.lowerBound..<bookProgressEnd.lowerBound]
+
+        XCTAssertTrue(bookProgressSource.contains("var readChapters = Set<Int>()"))
+        XCTAssertFalse(bookProgressSource.contains(".filter { row in"))
+        XCTAssertFalse(bookProgressSource.contains(".map(\\.chapter)"))
+    }
+
+    /**
      Verifies memorization progress counts unique KJVA ordinals from merged Android ranges.
 
      Android memorization data can contain overlapping neutral and module-scoped ranges. The grid

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -150,4 +150,42 @@ extension AndBibleTests {
         XCTAssertTrue(slots.contains { $0?.osisId == "Tob" })
         XCTAssertEqual(PassageBookCategory.category(forOsisId: "Tob").color, .other)
     }
+
+    /**
+     Verifies iOS derives square cell dimensions from Android's matrix columns.
+
+     Android gives every `TableRow` and every cell the same weighted width/height within the
+     calculated matrix. The SwiftUI grid should therefore size each button with the same width and
+     height instead of keeping Android rows/columns but rendering wide rectangular buttons.
+     */
+    func testPassageGridMetricsDeriveSquareCellSideFromAvailableWidth() {
+        let metrics = PassageGridMetrics.squareCells(
+            availableWidth: 393,
+            columns: 6,
+            spacing: 4,
+            horizontalPadding: 12
+        )
+
+        XCTAssertEqual(metrics.cellSide, 58.166, accuracy: 0.001)
+        XCTAssertEqual(metrics.gridWidth, 369, accuracy: 0.001)
+    }
+
+    /**
+     Verifies the book chooser title follows Android's activity-title workspace suffix.
+
+     Android `GridChoosePassageBook.onCreate` appends `SharedActivityState.currentWorkspaceName` to
+     the chooser title. The iOS picker should use the same user-facing contract and omit the suffix
+     only when there is no usable workspace name. Failure means the drawer may no longer identify
+     which workspace the navigation target belongs to.
+     */
+    func testPassageChooserTitleAppendsWorkspaceNameLikeAndroid() {
+        XCTAssertEqual(
+            PassageChooserTitle.bookSelectionTitle(baseTitle: "Choose Book", workspaceName: "Workspace 1"),
+            "Choose Book (Workspace 1)"
+        )
+        XCTAssertEqual(
+            PassageChooserTitle.bookSelectionTitle(baseTitle: "Choose Book", workspaceName: "   "),
+            "Choose Book"
+        )
+    }
 }

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -1,8 +1,113 @@
 import XCTest
+@testable import BibleCore
 @testable import BibleUI
 @testable import SwordKit
 
 extension AndBibleTests {
+    /**
+     Verifies the chooser option state machine mirrors Android's overflow-menu behavior.
+
+     Android's `GridChoosePassageBook` persists the row-order, category grouping, long-name, and
+     progress options under `book_grid_*` keys. Grouping forces Bible-book order and row order,
+     while alphabetical and row-order changes clear grouping without resetting unrelated options.
+     Failure means the iOS menu is only cosmetically similar and will drift from Android behavior.
+     */
+    func testPassageChooserOptionsMirrorAndroidMenuStateTransitions() {
+        var options = PassageChooserOptions.androidDefault
+
+        XCTAssertFalse(options.alphabeticalOrder)
+        XCTAssertFalse(options.rowOrder)
+        XCTAssertFalse(options.groupByCategory)
+        XCTAssertFalse(options.showLongBookName)
+        XCTAssertTrue(options.showProgressBars)
+
+        options.apply(.groupByCategory)
+        XCTAssertFalse(options.alphabeticalOrder)
+        XCTAssertTrue(options.rowOrder)
+        XCTAssertTrue(options.groupByCategory)
+
+        options.apply(.alphabeticalOrder)
+        XCTAssertTrue(options.alphabeticalOrder)
+        XCTAssertTrue(options.rowOrder)
+        XCTAssertFalse(options.groupByCategory)
+
+        options.apply(.rowOrder)
+        XCTAssertTrue(options.alphabeticalOrder)
+        XCTAssertFalse(options.rowOrder)
+        XCTAssertFalse(options.groupByCategory)
+
+        options.apply(.showLongBookName)
+        options.apply(.showProgressBars)
+        XCTAssertTrue(options.showLongBookName)
+        XCTAssertFalse(options.showProgressBars)
+    }
+
+    /**
+     Verifies iOS exposes Android's full passage-chooser overflow menu contract.
+
+     Android's top-right chooser menu includes sorting, row ordering, category grouping, long/short
+     book names, and progress bars in this order. Failure means the iOS popup may look present while
+     still omitting or reordering Android-visible behavior.
+     */
+    func testPassageChooserMenuEntriesMirrorAndroidOrderAndLabels() {
+        let entries = PassageChooserMenuEntry.androidBookChooserOrder
+
+        XCTAssertEqual(
+            entries.map(\.option),
+            [.alphabeticalOrder, .rowOrder, .groupByCategory, .showLongBookName, .showProgressBars]
+        )
+        XCTAssertEqual(
+            entries.map(\.localizationKey),
+            [
+                "sort_by_alphabetical",
+                "book_menu_sort_row_opt",
+                "book_menu_group_by_category",
+                "book_menu_show_long_book_name",
+                "book_menu_show_progress_bars",
+            ]
+        )
+        XCTAssertEqual(
+            entries.map(\.defaultTitle),
+            [
+                "Alphabetical order",
+                "Order books horizontally",
+                "Group books by category",
+                "Show long book name",
+                "Show progress bars",
+            ]
+        )
+    }
+
+    /**
+     Verifies iOS uses Android/JSword short book labels instead of SWORD abbreviations.
+
+     The Android chooser calls `versification.getShortName(book)`, producing labels like `2 Ki`,
+     `Psa`, `Act`, and `Phile`. The previous iOS grid used module abbreviations such as `2Kgs`,
+     `Ps`, `Acts`, and `Phlm`, so the two platforms did not present the same picker. Long-name mode
+     should follow Android's uppercase short-name plus description format.
+     */
+    func testPassageBookDisplayNamesMirrorAndroidShortAndLongNames() {
+        let expectations: [(osisId: String, shortName: String)] = [
+            ("2Kgs", "2 Ki"),
+            ("1Chr", "1 Ch"),
+            ("Ps", "Psa"),
+            ("Acts", "Act"),
+            ("Phil", "Phili"),
+            ("Phlm", "Phile"),
+            ("Jas", "Jam"),
+            ("1Pet", "1 Pe"),
+        ]
+
+        for expectation in expectations {
+            let book = try! XCTUnwrap(BibleReaderController.defaultBooks.first { $0.osisId == expectation.osisId })
+            XCTAssertEqual(PassageBookDisplayName.shortName(for: book), expectation.shortName, expectation.osisId)
+        }
+
+        let genesis = try! XCTUnwrap(BibleReaderController.defaultBooks.first { $0.osisId == "Gen" })
+        XCTAssertEqual(PassageBookDisplayName.title(for: genesis, showLongName: false), "Gen")
+        XCTAssertEqual(PassageBookDisplayName.title(for: genesis, showLongName: true), "GEN\nGenesis")
+    }
+
     /**
      Verifies that the 66-book portrait grid follows Android's default column-major layout.
 
@@ -46,6 +151,57 @@ extension AndBibleTests {
         XCTAssertFalse(layout.usesColumnMajorOrder)
         XCTAssertEqual(slots[0]?.osisId, "Gen")
         XCTAssertEqual(slots[1]?.osisId, "Exod")
+    }
+
+    /**
+     Verifies book ordering is driven by the Android overflow-menu options.
+
+     Android defaults to Bible-book order with portrait column-major placement. Alphabetical mode
+     sorts the source books but still uses the current row-order setting for visual placement. The
+     row-order option fills the visual row left-to-right, and category grouping inserts spacer cells
+     when the Android `GroupB` bucket changes. Failure means menu state is not actually controlling
+     the rendered grid, even if the menu rows appear.
+     */
+    func testPassageBookOrderingOptionsMirrorAndroidMenu() {
+        var defaultOptions = PassageChooserOptions.androidDefault
+        var slots = PassageBookOrdering.displaySlots(
+            for: BibleReaderController.defaultBooks,
+            options: defaultOptions,
+            orientation: .portrait
+        )
+        XCTAssertEqual(slots[0]?.osisId, "Gen")
+        XCTAssertEqual(slots[1]?.osisId, "2Kgs")
+        XCTAssertEqual(slots[6]?.osisId, "Exod")
+
+        defaultOptions.apply(.rowOrder)
+        slots = PassageBookOrdering.displaySlots(
+            for: BibleReaderController.defaultBooks,
+            options: defaultOptions,
+            orientation: .portrait
+        )
+        XCTAssertEqual(slots[0]?.osisId, "Gen")
+        XCTAssertEqual(slots[1]?.osisId, "Exod")
+
+        var groupedOptions = PassageChooserOptions.androidDefault
+        groupedOptions.apply(.groupByCategory)
+        let groupedSlots = PassageBookOrdering.displaySlots(
+            for: BibleReaderController.defaultBooks,
+            options: groupedOptions,
+            orientation: .portrait
+        )
+        XCTAssertEqual(groupedSlots.prefix(6).map { $0?.osisId }, ["Gen", "Exod", "Lev", "Num", "Deut", nil])
+        XCTAssertEqual(groupedSlots[6]?.osisId, "Josh")
+
+        var alphabeticalOptions = PassageChooserOptions.androidDefault
+        alphabeticalOptions.apply(.alphabeticalOrder)
+        let alphabeticalSlots = PassageBookOrdering.displaySlots(
+            for: BibleReaderController.defaultBooks,
+            options: alphabeticalOptions,
+            orientation: .portrait
+        )
+        XCTAssertEqual(alphabeticalSlots[0]?.osisId, "Acts")
+        XCTAssertEqual(alphabeticalSlots[6]?.osisId, "Amos")
+        XCTAssertEqual(alphabeticalSlots[1]?.osisId, "Esth")
     }
 
     /**
@@ -152,6 +308,20 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies the passage chooser uses Android's fixed dark activity palette.
+
+     Android's chooser sets `allowThemeChange = false` and uses `GridChoosePassageTheme`, so the
+     picker remains a dark full-screen surface even when the reader itself is in day mode. Failure
+     means iOS can accidentally inherit the reader theme and diverge from the Android screenshots.
+     */
+    func testPassageChooserSurfacePaletteMirrorsAndroidFixedDarkTheme() {
+        XCTAssertEqual(PassageChooserSurfacePalette.background, PassageGridRGBColor(red: 0x30, green: 0x30, blue: 0x30))
+        XCTAssertEqual(PassageChooserSurfacePalette.toolbarBackground, PassageGridRGBColor(red: 0x00, green: 0x00, blue: 0x00))
+        XCTAssertEqual(PassageGridProgress.readingColor, PassageGridRGBColor(red: 0x4C, green: 0xAF, blue: 0x50))
+        XCTAssertEqual(PassageGridProgress.memorizationColor, PassageGridRGBColor(red: 0xFF, green: 0xD7, blue: 0x00))
+    }
+
+    /**
      Verifies iOS derives square cell dimensions from Android's matrix columns.
 
      Android gives every `TableRow` and every cell the same weighted width/height within the
@@ -187,5 +357,89 @@ extension AndBibleTests {
             PassageChooserTitle.bookSelectionTitle(baseTitle: "Choose Book", workspaceName: "   "),
             "Choose Book"
         )
+    }
+
+    /**
+     Verifies chooser progress fractions follow Android's JSword KJVA semantics.
+
+     Android computes book reading progress from distinct read KJVA chapters in the active cycle,
+     book memorization progress from memorized KJVA verse ordinals across the book, chapter progress
+     from the selected chapter's KJVA verse range, and verse progress as one full bar for a
+     memorized verse. Failure means the progress bars are decorative or tied to an iOS-only address
+     space rather than Android's `ProgressControl` behavior.
+     */
+    func testPassageGridProgressUsesAndroidKJVARanges() throws {
+        let genesis = try XCTUnwrap(BibleReaderController.defaultBooks.first { $0.osisId == "Gen" })
+        let genesisOrdinal = try XCTUnwrap(JSwordKJVAVersification.bibleBookOrdinal(forOsisId: "Gen"))
+        let genesisStart = try XCTUnwrap(JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 1))
+        let genesisChapterOneEnd = try XCTUnwrap(JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 31))
+
+        let readingSnapshot = ReadingProgressSnapshot(
+            history: [
+                ReadingProgressHistoryRow(
+                    bookInitials: "KJV",
+                    startOrdinal: genesisStart,
+                    kjvBookOrdinal: genesisOrdinal,
+                    chapter: 1,
+                    cycle: 3,
+                    readAt: 1,
+                    source: .manual
+                ),
+                ReadingProgressHistoryRow(
+                    bookInitials: "KJV",
+                    startOrdinal: genesisChapterOneEnd + 1,
+                    kjvBookOrdinal: genesisOrdinal,
+                    chapter: 2,
+                    cycle: 3,
+                    readAt: 2,
+                    source: .manual
+                ),
+                ReadingProgressHistoryRow(
+                    bookInitials: "KJV",
+                    startOrdinal: genesisStart,
+                    kjvBookOrdinal: genesisOrdinal,
+                    chapter: 1,
+                    cycle: 2,
+                    readAt: 3,
+                    source: .manual
+                ),
+            ],
+            settings: ReadingProgressSettingsSnapshot(activeCycle: 3)
+        )
+        let memorizationSnapshot = MemorizationProgressSnapshot(
+            memorizedRanges: [
+                MemorizationProgressRange(bookInitials: "", startOrdinal: genesisStart, endOrdinal: genesisStart + 2),
+            ]
+        )
+
+        let bookProgress = PassageGridProgressCalculator.bookProgress(
+            book: genesis,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: "KJV"
+        )
+        XCTAssertEqual(bookProgress.readingFraction, 2.0 / 50.0, accuracy: 0.0001)
+        XCTAssertEqual(bookProgress.memorizationFraction, 3.0 / 1533.0, accuracy: 0.0001)
+
+        let chapterProgress = PassageGridProgressCalculator.chapterProgress(
+            book: genesis,
+            chapter: 1,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: "KJV"
+        )
+        XCTAssertEqual(chapterProgress.readingFraction, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(chapterProgress.memorizationFraction, 3.0 / 31.0, accuracy: 0.0001)
+
+        let verseProgress = PassageGridProgressCalculator.verseProgress(
+            book: genesis,
+            chapter: 1,
+            verse: 1,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: "KJV"
+        )
+        XCTAssertEqual(verseProgress.readingFraction, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(verseProgress.memorizationFraction, 1.0, accuracy: 0.0001)
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/AppPreferenceRegistry.swift
@@ -25,6 +25,10 @@ public enum AppPreferenceKey: String, CaseIterable, Sendable {
     case disableTwoStepBookmarking = "disable_two_step_bookmarking"
     case bibleViewSwipeMode = "bible_view_swipe_mode"
     case volumeKeysScroll = "volume_keys_scroll"
+    case bookGridLeftToRight = "book_grid_ltr"
+    case bookGridGroupByCategory = "book_grid_group_by_category"
+    case bookGridShowLongName = "book_grid_show_long_name"
+    case bookGridShowProgress = "book_grid_show_progress"
 
     // Look & feel
     case nightModePref3 = "night_mode_pref3"
@@ -297,6 +301,34 @@ public enum AppPreferenceRegistry {
             valueType: .bool,
             defaultValue: "true",
             androidReference: "settings.xml:104"
+        ),
+        .bookGridLeftToRight: .init(
+            key: .bookGridLeftToRight,
+            storage: .swiftData,
+            valueType: .bool,
+            defaultValue: "false",
+            androidReference: "GridChoosePassageBook.kt:147,192-200,349"
+        ),
+        .bookGridGroupByCategory: .init(
+            key: .bookGridGroupByCategory,
+            storage: .swiftData,
+            valueType: .bool,
+            defaultValue: "false",
+            androidReference: "GridChoosePassageBook.kt:148,203-212,350"
+        ),
+        .bookGridShowLongName: .init(
+            key: .bookGridShowLongName,
+            storage: .swiftData,
+            valueType: .bool,
+            defaultValue: "false",
+            androidReference: "GridChoosePassageBook.kt:149,215-221,351"
+        ),
+        .bookGridShowProgress: .init(
+            key: .bookGridShowProgress,
+            storage: .swiftData,
+            valueType: .bool,
+            defaultValue: "true",
+            androidReference: "GridChoosePassageBook.kt:95-100,171,224-230,352"
         ),
         .nightModePref3: .init(
             key: .nightModePref3,

--- a/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
@@ -63,6 +63,36 @@ public enum JSwordKJVAVersification {
         return result
     }()
 
+    /// Cached KJVA ordinal offsets by source table index.
+    private static let ordinalIndexByBookIndex: [Int: JSwordKJVAOrdinalBookIndex] = {
+        var result: [Int: JSwordKJVAOrdinalBookIndex] = [:]
+        var ordinal = 0
+        ordinal += 1 // INTRO_OT book-introduction ordinal.
+
+        for (index, book) in JSwordKJVAVersificationData.bookTable.enumerated() {
+            if index == firstNewTestamentTableIndex {
+                ordinal += 1 // INTRO_NT book-introduction ordinal.
+            }
+
+            ordinal += 1 // Current book chapter-0 introduction ordinal.
+            var chapterStartOrdinals: [Int] = []
+            chapterStartOrdinals.reserveCapacity(book.chapterVerseCounts.count)
+
+            for lastVerse in book.chapterVerseCounts {
+                ordinal += 1 // Current chapter verse-0 introduction ordinal.
+                chapterStartOrdinals.append(ordinal + 1)
+                ordinal += lastVerse
+            }
+
+            result[index] = JSwordKJVAOrdinalBookIndex(
+                book: book,
+                chapterStartOrdinals: chapterStartOrdinals
+            )
+        }
+
+        return result
+    }()
+
     /**
      Checks whether an ordinal is addressable by JSword `SystemKJVA`.
 
@@ -177,35 +207,17 @@ public enum JSwordKJVAVersification {
     public static func verseOrdinal(osisId: String, chapter: Int, verse: Int) -> Int? {
         guard chapter > 0,
               verse > 0,
-              let targetIndex = bookIndexByOsisId[osisId] else {
+              let targetIndex = bookIndexByOsisId[osisId],
+              let ordinalIndex = ordinalIndexByBookIndex[targetIndex],
+              chapter <= ordinalIndex.book.chapterVerseCounts.count else {
             return nil
         }
 
-        var ordinal = 0
-        ordinal += 1 // INTRO_OT book-introduction ordinal.
-
-        for (index, book) in JSwordKJVAVersificationData.bookTable.enumerated() {
-            if index == firstNewTestamentTableIndex {
-                ordinal += 1 // INTRO_NT book-introduction ordinal.
-            }
-
-            ordinal += 1 // Current book chapter-0 introduction ordinal.
-
-            for (chapterIndex, lastVerse) in book.chapterVerseCounts.enumerated() {
-                ordinal += 1 // Current chapter verse-0 introduction ordinal.
-
-                if index == targetIndex, chapterIndex + 1 == chapter {
-                    guard verse <= lastVerse else {
-                        return nil
-                    }
-                    return ordinal + verse
-                }
-
-                ordinal += lastVerse
-            }
+        let lastVerse = ordinalIndex.book.chapterVerseCounts[chapter - 1]
+        guard verse <= lastVerse else {
+            return nil
         }
-
-        return nil
+        return ordinalIndex.chapterStartOrdinals[chapter - 1] + verse - 1
     }
 
     /**
@@ -219,11 +231,15 @@ public enum JSwordKJVAVersification {
      - Failure modes: Unknown ids and out-of-range chapters return `nil`.
      */
     public static func verseOrdinalRange(osisId: String, chapter: Int) -> ClosedRange<Int>? {
-        guard let lastVerse = verseCount(osisId: osisId, chapter: chapter),
-              let start = verseOrdinal(osisId: osisId, chapter: chapter, verse: 1),
-              let end = verseOrdinal(osisId: osisId, chapter: chapter, verse: lastVerse) else {
+        guard chapter > 0,
+              let targetIndex = bookIndexByOsisId[osisId],
+              let ordinalIndex = ordinalIndexByBookIndex[targetIndex],
+              chapter <= ordinalIndex.book.chapterVerseCounts.count else {
             return nil
         }
+        let lastVerse = ordinalIndex.book.chapterVerseCounts[chapter - 1]
+        let start = ordinalIndex.chapterStartOrdinals[chapter - 1]
+        let end = start + lastVerse - 1
         return start...end
     }
 
@@ -236,12 +252,14 @@ public enum JSwordKJVAVersification {
      - Failure modes: Unknown ids or books without chapters return `nil`.
      */
     public static func verseOrdinalRange(osisId: String) -> ClosedRange<Int>? {
-        guard let lastChapter = lastChapter(osisId: osisId),
-              let lastVerse = verseCount(osisId: osisId, chapter: lastChapter),
-              let start = verseOrdinal(osisId: osisId, chapter: 1, verse: 1),
-              let end = verseOrdinal(osisId: osisId, chapter: lastChapter, verse: lastVerse) else {
+        guard let targetIndex = bookIndexByOsisId[osisId],
+              let ordinalIndex = ordinalIndexByBookIndex[targetIndex],
+              let start = ordinalIndex.chapterStartOrdinals.first,
+              let lastChapterStart = ordinalIndex.chapterStartOrdinals.last,
+              let lastVerse = ordinalIndex.book.chapterVerseCounts.last else {
             return nil
         }
+        let end = lastChapterStart + lastVerse - 1
         return start...end
     }
 
@@ -259,4 +277,13 @@ public enum JSwordKJVAVersification {
         }
         return JSwordKJVAVersificationData.bookTable[index]
     }
+}
+
+/// Cached per-book KJVA ordinal offsets derived from JSword's `SystemKJVA` table.
+private struct JSwordKJVAOrdinalBookIndex: Sendable {
+    /// Source book row used for chapter and verse bounds checks.
+    let book: JSwordKJVABookData
+
+    /// One-based verse-1 ordinal for each real chapter in the book.
+    let chapterStartOrdinals: [Int]
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
@@ -16,36 +16,52 @@
  - Side effects: none.
  - Failure modes: none.
  */
-enum JSwordKJVAVersification {
+public enum JSwordKJVAVersification {
     /// Android and JSword name for this versification.
-    static let name = "KJVA"
+    public static let name = "KJVA"
 
     /// Real books in JSword `SystemKJVA`, including deuterocanonical books.
-    static let canonicalBookCount = 80
+    public static let canonicalBookCount = 80
 
     /// JSword book-list entries after adding Bible, OT, and NT introduction pseudo-books.
-    static let bookCount = canonicalBookCount + 3
+    public static let bookCount = canonicalBookCount + 3
 
     /// Real chapters in JSword `SystemKJVA`, excluding chapter 0 introductions.
-    static let chapterCount = 1_371
+    public static let chapterCount = 1_371
 
     /// Real verses in JSword `SystemKJVA`, excluding introduction ordinals.
-    static let verseCount = 36_819
+    public static let verseCount = 36_819
 
     /// JSword introduction ordinals contributed by book chapter 0 and real chapter verse 0.
-    static let introductionOrdinalCount = bookCount + chapterCount
+    public static let introductionOrdinalCount = bookCount + chapterCount
 
     /// Addressable JSword ordinals, including ordinal 0 for the Bible introduction.
-    static let addressableOrdinalCount = verseCount + introductionOrdinalCount
+    public static let addressableOrdinalCount = verseCount + introductionOrdinalCount
 
     /// Highest ordinal returned by JSword `Versification.maximumOrdinal()` for `SystemKJVA`.
-    static let maximumOrdinal = addressableOrdinalCount - 1
+    public static let maximumOrdinal = addressableOrdinalCount - 1
 
     /// Full JSword KJVA ordinal domain, including the Bible introduction at ordinal 0.
-    static let ordinalRange = 0...maximumOrdinal
+    public static let ordinalRange = 0...maximumOrdinal
 
     /// Android progress rows normally store verse/range ordinals, not the Bible intro sentinel 0.
-    static let progressOrdinalRange = 1...maximumOrdinal
+    public static let progressOrdinalRange = 1...maximumOrdinal
+
+    /// First KJVA table index that belongs to the New Testament, before which JSword inserts `INTRO_NT`.
+    private static let firstNewTestamentTableIndex = 53
+
+    /// Lookup from canonical or accepted alias OSIS id to the KJVA table index.
+    private static let bookIndexByOsisId: [String: Int] = {
+        var result = Dictionary(
+            uniqueKeysWithValues: JSwordKJVAVersificationData.bookTable.enumerated().map { index, book in
+                (book.osisId, index)
+            }
+        )
+        for (alias, canonical) in JSwordKJVAVersificationData.canonicalOsisAliases {
+            result[alias] = result[canonical]
+        }
+        return result
+    }()
 
     /**
      Checks whether an ordinal is addressable by JSword `SystemKJVA`.
@@ -55,7 +71,7 @@ enum JSwordKJVAVersification {
      - Side effects: none.
      - Failure modes: none.
      */
-    static func containsOrdinal(_ ordinal: Int) -> Bool {
+    public static func containsOrdinal(_ ordinal: Int) -> Bool {
         ordinalRange.contains(ordinal)
     }
 
@@ -70,7 +86,177 @@ enum JSwordKJVAVersification {
      - Side effects: none.
      - Failure modes: none.
      */
-    static func containsProgressOrdinal(_ ordinal: Int) -> Bool {
+    public static func containsProgressOrdinal(_ ordinal: Int) -> Bool {
         progressOrdinalRange.contains(ordinal)
+    }
+
+    /**
+     Returns JSword's `BibleBook.ordinal()` value for an OSIS id.
+
+     Android stores this ordinal on chapter-reading rows independently from the KJVA verse ordinal
+     address space. The deuterocanonical `BibleBook` enum order differs from `SystemKJVA` book
+     order, so callers must use this explicit lookup rather than deriving the value from table
+     position.
+
+     - Parameter osisId: Canonical OSIS id or supported alias such as `WisSol`.
+     - Returns: JSword `BibleBook.ordinal()` or `nil` when the id is outside `SystemKJVA`.
+     - Side effects: none.
+     - Failure modes: Unknown ids return `nil`.
+     */
+    public static func bibleBookOrdinal(forOsisId osisId: String) -> Int? {
+        if let aliasOrdinal = JSwordKJVAVersificationData.bibleBookOrdinalAliases[osisId] {
+            return aliasOrdinal
+        }
+        guard let index = bookIndexByOsisId[osisId] else {
+            return nil
+        }
+        return JSwordKJVAVersificationData.bookTable[index].bibleBookOrdinal
+    }
+
+    /**
+     Returns the last one-based chapter number for a KJVA book.
+
+     - Parameter osisId: Canonical OSIS id or supported alias.
+     - Returns: Chapter count for the book, or `nil` for unsupported ids.
+     - Side effects: none.
+     - Failure modes: Unknown ids return `nil`.
+     */
+    public static func lastChapter(osisId: String) -> Int? {
+        book(forOsisId: osisId)?.chapterVerseCounts.count
+    }
+
+    /**
+     Returns the last one-based verse number for a KJVA chapter.
+
+     - Parameters:
+       - osisId: Canonical OSIS id or supported alias.
+       - chapter: One-based chapter number.
+     - Returns: Last verse number for the chapter, or `nil` for unsupported ids/chapters.
+     - Side effects: none.
+     - Failure modes: Unknown ids and out-of-range chapters return `nil`.
+     */
+    public static func verseCount(osisId: String, chapter: Int) -> Int? {
+        guard chapter > 0,
+              let book = book(forOsisId: osisId),
+              chapter <= book.chapterVerseCounts.count else {
+            return nil
+        }
+        return book.chapterVerseCounts[chapter - 1]
+    }
+
+    /**
+     Returns the number of real verses in a KJVA book.
+
+     Android book-level memorization progress divides memorized verse ordinals by this count.
+
+     - Parameter osisId: Canonical OSIS id or supported alias.
+     - Returns: Sum of all chapter verse counts, or `nil` for unsupported ids.
+     - Side effects: none.
+     - Failure modes: Unknown ids return `nil`.
+     */
+    public static func bookVerseCount(osisId: String) -> Int? {
+        book(forOsisId: osisId)?.chapterVerseCounts.reduce(0, +)
+    }
+
+    /**
+     Computes JSword's KJVA ordinal for a verse reference.
+
+     JSword reserves ordinal `0` for `INTRO_BIBLE`, inserts `INTRO_OT` before Genesis, inserts
+     `INTRO_NT` before Matthew, gives every real book a chapter-0 introduction ordinal, and gives
+     every real chapter a verse-0 introduction ordinal. Real verse ordinals are then counted in
+     `SystemKJVA` book order.
+
+     - Parameters:
+       - osisId: Canonical OSIS id or supported alias.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: JSword KJVA ordinal for the verse, or `nil` when the reference is invalid.
+     - Side effects: none.
+     - Failure modes: Unknown ids and out-of-range chapters/verses return `nil`.
+     */
+    public static func verseOrdinal(osisId: String, chapter: Int, verse: Int) -> Int? {
+        guard chapter > 0,
+              verse > 0,
+              let targetIndex = bookIndexByOsisId[osisId] else {
+            return nil
+        }
+
+        var ordinal = 0
+        ordinal += 1 // INTRO_OT book-introduction ordinal.
+
+        for (index, book) in JSwordKJVAVersificationData.bookTable.enumerated() {
+            if index == firstNewTestamentTableIndex {
+                ordinal += 1 // INTRO_NT book-introduction ordinal.
+            }
+
+            ordinal += 1 // Current book chapter-0 introduction ordinal.
+
+            for (chapterIndex, lastVerse) in book.chapterVerseCounts.enumerated() {
+                ordinal += 1 // Current chapter verse-0 introduction ordinal.
+
+                if index == targetIndex, chapterIndex + 1 == chapter {
+                    guard verse <= lastVerse else {
+                        return nil
+                    }
+                    return ordinal + verse
+                }
+
+                ordinal += lastVerse
+            }
+        }
+
+        return nil
+    }
+
+    /**
+     Computes the JSword KJVA ordinal range for a chapter's real verses.
+
+     - Parameters:
+       - osisId: Canonical OSIS id or supported alias.
+       - chapter: One-based chapter number.
+     - Returns: Closed range from verse 1 through the chapter's last verse, or `nil` when invalid.
+     - Side effects: none.
+     - Failure modes: Unknown ids and out-of-range chapters return `nil`.
+     */
+    public static func verseOrdinalRange(osisId: String, chapter: Int) -> ClosedRange<Int>? {
+        guard let lastVerse = verseCount(osisId: osisId, chapter: chapter),
+              let start = verseOrdinal(osisId: osisId, chapter: chapter, verse: 1),
+              let end = verseOrdinal(osisId: osisId, chapter: chapter, verse: lastVerse) else {
+            return nil
+        }
+        return start...end
+    }
+
+    /**
+     Computes the JSword KJVA ordinal range for a whole book's real verses.
+
+     - Parameter osisId: Canonical OSIS id or supported alias.
+     - Returns: Closed range from the first verse through the last verse, or `nil` when invalid.
+     - Side effects: none.
+     - Failure modes: Unknown ids or books without chapters return `nil`.
+     */
+    public static func verseOrdinalRange(osisId: String) -> ClosedRange<Int>? {
+        guard let lastChapter = lastChapter(osisId: osisId),
+              let lastVerse = verseCount(osisId: osisId, chapter: lastChapter),
+              let start = verseOrdinal(osisId: osisId, chapter: 1, verse: 1),
+              let end = verseOrdinal(osisId: osisId, chapter: lastChapter, verse: lastVerse) else {
+            return nil
+        }
+        return start...end
+    }
+
+    /**
+     Resolves a source-derived KJVA book entry.
+
+     - Parameter osisId: Canonical OSIS id or supported alias.
+     - Returns: KJVA table row, or `nil` when unsupported.
+     - Side effects: none.
+     - Failure modes: Unknown ids return `nil`.
+     */
+    private static func book(forOsisId osisId: String) -> JSwordKJVABookData? {
+        guard let index = bookIndexByOsisId[osisId] else {
+            return nil
+        }
+        return JSwordKJVAVersificationData.bookTable[index]
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersificationData.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersificationData.swift
@@ -1,0 +1,123 @@
+// JSwordKJVAVersificationData.swift - Source-derived JSword KJVA chapter table
+
+/**
+ One JSword `SystemKJVA` book entry used for Android-compatible ordinal calculations.
+
+ `bibleBookOrdinal` is JSword `BibleBook.ordinal()`, while `chapterVerseCounts` follows
+ `SystemKJVA` versification order. The two orders differ for deuterocanonical books, so both
+ values are stored explicitly instead of deriving one from the other.
+*/
+struct JSwordKJVABookData: Equatable, Sendable {
+    /// OSIS identifier used by SWORD, JSword, and imported Android progress rows.
+    let osisId: String
+
+    /// JSword `BibleBook.ordinal()` value persisted by Android reading-progress rows.
+    let bibleBookOrdinal: Int
+
+    /// Last verse number for each one-based chapter in this KJVA book.
+    let chapterVerseCounts: [Int]
+}
+
+/**
+ Source-derived table for JSword `SystemKJVA`.
+
+ The data is generated from the local JSword source tree used for Android parity and mirrors
+ `SystemKJVA` book order: KJV Old Testament, deuterocanonical books, then New Testament.
+ It has no runtime side effects; callers use it only for deterministic ordinal math.
+*/
+enum JSwordKJVAVersificationData {
+    /// Canonical OSIS aliases accepted by Android import and progress compatibility code.
+    static let canonicalOsisAliases: [String: String] = [
+        "WisSol": "Wis",
+    ]
+
+    /// JSword `BibleBook.ordinal()` aliases for books not represented as standalone KJVA table entries.
+    static let bibleBookOrdinalAliases: [String: Int] = [
+        "EpJer": 75,
+        "WisSol": 72,
+    ]
+
+    /// `SystemKJVA` book table in versification order.
+    static let bookTable: [JSwordKJVABookData] = [
+        JSwordKJVABookData(osisId: "Gen", bibleBookOrdinal: 2, chapterVerseCounts: [31, 25, 24, 26, 32, 22, 24, 22, 29, 32, 32, 20, 18, 24, 21, 16, 27, 33, 38, 18, 34, 24, 20, 67, 34, 35, 46, 22, 35, 43, 55, 32, 20, 31, 29, 43, 36, 30, 23, 23, 57, 38, 34, 34, 28, 34, 31, 22, 33, 26]),
+        JSwordKJVABookData(osisId: "Exod", bibleBookOrdinal: 3, chapterVerseCounts: [22, 25, 22, 31, 23, 30, 25, 32, 35, 29, 10, 51, 22, 31, 27, 36, 16, 27, 25, 26, 36, 31, 33, 18, 40, 37, 21, 43, 46, 38, 18, 35, 23, 35, 35, 38, 29, 31, 43, 38]),
+        JSwordKJVABookData(osisId: "Lev", bibleBookOrdinal: 4, chapterVerseCounts: [17, 16, 17, 35, 19, 30, 38, 36, 24, 20, 47, 8, 59, 57, 33, 34, 16, 30, 37, 27, 24, 33, 44, 23, 55, 46, 34]),
+        JSwordKJVABookData(osisId: "Num", bibleBookOrdinal: 5, chapterVerseCounts: [54, 34, 51, 49, 31, 27, 89, 26, 23, 36, 35, 16, 33, 45, 41, 50, 13, 32, 22, 29, 35, 41, 30, 25, 18, 65, 23, 31, 40, 16, 54, 42, 56, 29, 34, 13]),
+        JSwordKJVABookData(osisId: "Deut", bibleBookOrdinal: 6, chapterVerseCounts: [46, 37, 29, 49, 33, 25, 26, 20, 29, 22, 32, 32, 18, 29, 23, 22, 20, 22, 21, 20, 23, 30, 25, 22, 19, 19, 26, 68, 29, 20, 30, 52, 29, 12]),
+        JSwordKJVABookData(osisId: "Josh", bibleBookOrdinal: 7, chapterVerseCounts: [18, 24, 17, 24, 15, 27, 26, 35, 27, 43, 23, 24, 33, 15, 63, 10, 18, 28, 51, 9, 45, 34, 16, 33]),
+        JSwordKJVABookData(osisId: "Judg", bibleBookOrdinal: 8, chapterVerseCounts: [36, 23, 31, 24, 31, 40, 25, 35, 57, 18, 40, 15, 25, 20, 20, 31, 13, 31, 30, 48, 25]),
+        JSwordKJVABookData(osisId: "Ruth", bibleBookOrdinal: 9, chapterVerseCounts: [22, 23, 18, 22]),
+        JSwordKJVABookData(osisId: "1Sam", bibleBookOrdinal: 10, chapterVerseCounts: [28, 36, 21, 22, 12, 21, 17, 22, 27, 27, 15, 25, 23, 52, 35, 23, 58, 30, 24, 42, 15, 23, 29, 22, 44, 25, 12, 25, 11, 31, 13]),
+        JSwordKJVABookData(osisId: "2Sam", bibleBookOrdinal: 11, chapterVerseCounts: [27, 32, 39, 12, 25, 23, 29, 18, 13, 19, 27, 31, 39, 33, 37, 23, 29, 33, 43, 26, 22, 51, 39, 25]),
+        JSwordKJVABookData(osisId: "1Kgs", bibleBookOrdinal: 12, chapterVerseCounts: [53, 46, 28, 34, 18, 38, 51, 66, 28, 29, 43, 33, 34, 31, 34, 34, 24, 46, 21, 43, 29, 53]),
+        JSwordKJVABookData(osisId: "2Kgs", bibleBookOrdinal: 13, chapterVerseCounts: [18, 25, 27, 44, 27, 33, 20, 29, 37, 36, 21, 21, 25, 29, 38, 20, 41, 37, 37, 21, 26, 20, 37, 20, 30]),
+        JSwordKJVABookData(osisId: "1Chr", bibleBookOrdinal: 14, chapterVerseCounts: [54, 55, 24, 43, 26, 81, 40, 40, 44, 14, 47, 40, 14, 17, 29, 43, 27, 17, 19, 8, 30, 19, 32, 31, 31, 32, 34, 21, 30]),
+        JSwordKJVABookData(osisId: "2Chr", bibleBookOrdinal: 15, chapterVerseCounts: [17, 18, 17, 22, 14, 42, 22, 18, 31, 19, 23, 16, 22, 15, 19, 14, 19, 34, 11, 37, 20, 12, 21, 27, 28, 23, 9, 27, 36, 27, 21, 33, 25, 33, 27, 23]),
+        JSwordKJVABookData(osisId: "Ezra", bibleBookOrdinal: 16, chapterVerseCounts: [11, 70, 13, 24, 17, 22, 28, 36, 15, 44]),
+        JSwordKJVABookData(osisId: "Neh", bibleBookOrdinal: 17, chapterVerseCounts: [11, 20, 32, 23, 19, 19, 73, 18, 38, 39, 36, 47, 31]),
+        JSwordKJVABookData(osisId: "Esth", bibleBookOrdinal: 18, chapterVerseCounts: [22, 23, 15, 17, 14, 14, 10, 17, 32, 3]),
+        JSwordKJVABookData(osisId: "Job", bibleBookOrdinal: 19, chapterVerseCounts: [22, 13, 26, 21, 27, 30, 21, 22, 35, 22, 20, 25, 28, 22, 35, 22, 16, 21, 29, 29, 34, 30, 17, 25, 6, 14, 23, 28, 25, 31, 40, 22, 33, 37, 16, 33, 24, 41, 30, 24, 34, 17]),
+        JSwordKJVABookData(osisId: "Ps", bibleBookOrdinal: 20, chapterVerseCounts: [6, 12, 8, 8, 12, 10, 17, 9, 20, 18, 7, 8, 6, 7, 5, 11, 15, 50, 14, 9, 13, 31, 6, 10, 22, 12, 14, 9, 11, 12, 24, 11, 22, 22, 28, 12, 40, 22, 13, 17, 13, 11, 5, 26, 17, 11, 9, 14, 20, 23, 19, 9, 6, 7, 23, 13, 11, 11, 17, 12, 8, 12, 11, 10, 13, 20, 7, 35, 36, 5, 24, 20, 28, 23, 10, 12, 20, 72, 13, 19, 16, 8, 18, 12, 13, 17, 7, 18, 52, 17, 16, 15, 5, 23, 11, 13, 12, 9, 9, 5, 8, 28, 22, 35, 45, 48, 43, 13, 31, 7, 10, 10, 9, 8, 18, 19, 2, 29, 176, 7, 8, 9, 4, 8, 5, 6, 5, 6, 8, 8, 3, 18, 3, 3, 21, 26, 9, 8, 24, 13, 10, 7, 12, 15, 21, 10, 20, 14, 9, 6]),
+        JSwordKJVABookData(osisId: "Prov", bibleBookOrdinal: 21, chapterVerseCounts: [33, 22, 35, 27, 23, 35, 27, 36, 18, 32, 31, 28, 25, 35, 33, 33, 28, 24, 29, 30, 31, 29, 35, 34, 28, 28, 27, 28, 27, 33, 31]),
+        JSwordKJVABookData(osisId: "Eccl", bibleBookOrdinal: 22, chapterVerseCounts: [18, 26, 22, 16, 20, 12, 29, 17, 18, 20, 10, 14]),
+        JSwordKJVABookData(osisId: "Song", bibleBookOrdinal: 23, chapterVerseCounts: [17, 17, 11, 16, 16, 13, 13, 14]),
+        JSwordKJVABookData(osisId: "Isa", bibleBookOrdinal: 24, chapterVerseCounts: [31, 22, 26, 6, 30, 13, 25, 22, 21, 34, 16, 6, 22, 32, 9, 14, 14, 7, 25, 6, 17, 25, 18, 23, 12, 21, 13, 29, 24, 33, 9, 20, 24, 17, 10, 22, 38, 22, 8, 31, 29, 25, 28, 28, 25, 13, 15, 22, 26, 11, 23, 15, 12, 17, 13, 12, 21, 14, 21, 22, 11, 12, 19, 12, 25, 24]),
+        JSwordKJVABookData(osisId: "Jer", bibleBookOrdinal: 25, chapterVerseCounts: [19, 37, 25, 31, 31, 30, 34, 22, 26, 25, 23, 17, 27, 22, 21, 21, 27, 23, 15, 18, 14, 30, 40, 10, 38, 24, 22, 17, 32, 24, 40, 44, 26, 22, 19, 32, 21, 28, 18, 16, 18, 22, 13, 30, 5, 28, 7, 47, 39, 46, 64, 34]),
+        JSwordKJVABookData(osisId: "Lam", bibleBookOrdinal: 26, chapterVerseCounts: [22, 22, 66, 22, 22]),
+        JSwordKJVABookData(osisId: "Ezek", bibleBookOrdinal: 27, chapterVerseCounts: [28, 10, 27, 17, 17, 14, 27, 18, 11, 22, 25, 28, 23, 23, 8, 63, 24, 32, 14, 49, 32, 31, 49, 27, 17, 21, 36, 26, 21, 26, 18, 32, 33, 31, 15, 38, 28, 23, 29, 49, 26, 20, 27, 31, 25, 24, 23, 35]),
+        JSwordKJVABookData(osisId: "Dan", bibleBookOrdinal: 28, chapterVerseCounts: [21, 49, 30, 37, 31, 28, 28, 27, 27, 21, 45, 13]),
+        JSwordKJVABookData(osisId: "Hos", bibleBookOrdinal: 29, chapterVerseCounts: [11, 23, 5, 19, 15, 11, 16, 14, 17, 15, 12, 14, 16, 9]),
+        JSwordKJVABookData(osisId: "Joel", bibleBookOrdinal: 30, chapterVerseCounts: [20, 32, 21]),
+        JSwordKJVABookData(osisId: "Amos", bibleBookOrdinal: 31, chapterVerseCounts: [15, 16, 15, 13, 27, 14, 17, 14, 15]),
+        JSwordKJVABookData(osisId: "Obad", bibleBookOrdinal: 32, chapterVerseCounts: [21]),
+        JSwordKJVABookData(osisId: "Jonah", bibleBookOrdinal: 33, chapterVerseCounts: [17, 10, 10, 11]),
+        JSwordKJVABookData(osisId: "Mic", bibleBookOrdinal: 34, chapterVerseCounts: [16, 13, 12, 13, 15, 16, 20]),
+        JSwordKJVABookData(osisId: "Nah", bibleBookOrdinal: 35, chapterVerseCounts: [15, 13, 19]),
+        JSwordKJVABookData(osisId: "Hab", bibleBookOrdinal: 36, chapterVerseCounts: [17, 20, 19]),
+        JSwordKJVABookData(osisId: "Zeph", bibleBookOrdinal: 37, chapterVerseCounts: [18, 15, 20]),
+        JSwordKJVABookData(osisId: "Hag", bibleBookOrdinal: 38, chapterVerseCounts: [15, 23]),
+        JSwordKJVABookData(osisId: "Zech", bibleBookOrdinal: 39, chapterVerseCounts: [21, 13, 10, 14, 11, 15, 14, 23, 17, 12, 17, 14, 9, 21]),
+        JSwordKJVABookData(osisId: "Mal", bibleBookOrdinal: 40, chapterVerseCounts: [14, 17, 18, 6]),
+        JSwordKJVABookData(osisId: "1Esd", bibleBookOrdinal: 84, chapterVerseCounts: [58, 30, 24, 63, 73, 34, 15, 96, 55]),
+        JSwordKJVABookData(osisId: "2Esd", bibleBookOrdinal: 85, chapterVerseCounts: [40, 48, 36, 52, 56, 59, 70, 63, 47, 59, 46, 51, 58, 48, 63, 78]),
+        JSwordKJVABookData(osisId: "Tob", bibleBookOrdinal: 69, chapterVerseCounts: [22, 14, 17, 21, 22, 17, 18, 21, 6, 12, 19, 22, 18, 15]),
+        JSwordKJVABookData(osisId: "Jdt", bibleBookOrdinal: 70, chapterVerseCounts: [16, 28, 10, 15, 24, 21, 32, 36, 14, 23, 23, 20, 20, 19, 13, 25]),
+        JSwordKJVABookData(osisId: "AddEsth", bibleBookOrdinal: 71, chapterVerseCounts: [1, 1, 1, 1, 1, 1, 1, 1, 1, 13, 12, 6, 18, 19, 16, 24]),
+        JSwordKJVABookData(osisId: "Wis", bibleBookOrdinal: 72, chapterVerseCounts: [16, 24, 19, 20, 23, 25, 30, 21, 18, 21, 26, 27, 19, 31, 19, 29, 21, 25, 22]),
+        JSwordKJVABookData(osisId: "Sir", bibleBookOrdinal: 73, chapterVerseCounts: [30, 18, 31, 31, 15, 37, 36, 19, 18, 31, 34, 18, 26, 27, 20, 30, 32, 33, 30, 32, 28, 27, 28, 34, 26, 29, 30, 26, 28, 25, 31, 24, 31, 26, 20, 26, 31, 34, 35, 30, 24, 25, 33, 22, 26, 20, 25, 25, 16, 29, 30]),
+        JSwordKJVABookData(osisId: "Bar", bibleBookOrdinal: 74, chapterVerseCounts: [22, 35, 37, 37, 9, 73]),
+        JSwordKJVABookData(osisId: "PrAzar", bibleBookOrdinal: 76, chapterVerseCounts: [68]),
+        JSwordKJVABookData(osisId: "Sus", bibleBookOrdinal: 77, chapterVerseCounts: [64]),
+        JSwordKJVABookData(osisId: "Bel", bibleBookOrdinal: 78, chapterVerseCounts: [42]),
+        JSwordKJVABookData(osisId: "PrMan", bibleBookOrdinal: 83, chapterVerseCounts: [1]),
+        JSwordKJVABookData(osisId: "1Macc", bibleBookOrdinal: 79, chapterVerseCounts: [64, 70, 60, 61, 68, 63, 50, 32, 73, 89, 74, 53, 53, 49, 41, 24]),
+        JSwordKJVABookData(osisId: "2Macc", bibleBookOrdinal: 80, chapterVerseCounts: [36, 32, 40, 50, 27, 31, 42, 36, 29, 38, 38, 45, 26, 46, 39]),
+        JSwordKJVABookData(osisId: "Matt", bibleBookOrdinal: 42, chapterVerseCounts: [25, 23, 17, 25, 48, 34, 29, 34, 38, 42, 30, 50, 58, 36, 39, 28, 27, 35, 30, 34, 46, 46, 39, 51, 46, 75, 66, 20]),
+        JSwordKJVABookData(osisId: "Mark", bibleBookOrdinal: 43, chapterVerseCounts: [45, 28, 35, 41, 43, 56, 37, 38, 50, 52, 33, 44, 37, 72, 47, 20]),
+        JSwordKJVABookData(osisId: "Luke", bibleBookOrdinal: 44, chapterVerseCounts: [80, 52, 38, 44, 39, 49, 50, 56, 62, 42, 54, 59, 35, 35, 32, 31, 37, 43, 48, 47, 38, 71, 56, 53]),
+        JSwordKJVABookData(osisId: "John", bibleBookOrdinal: 45, chapterVerseCounts: [51, 25, 36, 54, 47, 71, 53, 59, 41, 42, 57, 50, 38, 31, 27, 33, 26, 40, 42, 31, 25]),
+        JSwordKJVABookData(osisId: "Acts", bibleBookOrdinal: 46, chapterVerseCounts: [26, 47, 26, 37, 42, 15, 60, 40, 43, 48, 30, 25, 52, 28, 41, 40, 34, 28, 41, 38, 40, 30, 35, 27, 27, 32, 44, 31]),
+        JSwordKJVABookData(osisId: "Rom", bibleBookOrdinal: 47, chapterVerseCounts: [32, 29, 31, 25, 21, 23, 25, 39, 33, 21, 36, 21, 14, 23, 33, 27]),
+        JSwordKJVABookData(osisId: "1Cor", bibleBookOrdinal: 48, chapterVerseCounts: [31, 16, 23, 21, 13, 20, 40, 13, 27, 33, 34, 31, 13, 40, 58, 24]),
+        JSwordKJVABookData(osisId: "2Cor", bibleBookOrdinal: 49, chapterVerseCounts: [24, 17, 18, 18, 21, 18, 16, 24, 15, 18, 33, 21, 14]),
+        JSwordKJVABookData(osisId: "Gal", bibleBookOrdinal: 50, chapterVerseCounts: [24, 21, 29, 31, 26, 18]),
+        JSwordKJVABookData(osisId: "Eph", bibleBookOrdinal: 51, chapterVerseCounts: [23, 22, 21, 32, 33, 24]),
+        JSwordKJVABookData(osisId: "Phil", bibleBookOrdinal: 52, chapterVerseCounts: [30, 30, 21, 23]),
+        JSwordKJVABookData(osisId: "Col", bibleBookOrdinal: 53, chapterVerseCounts: [29, 23, 25, 18]),
+        JSwordKJVABookData(osisId: "1Thess", bibleBookOrdinal: 54, chapterVerseCounts: [10, 20, 13, 18, 28]),
+        JSwordKJVABookData(osisId: "2Thess", bibleBookOrdinal: 55, chapterVerseCounts: [12, 17, 18]),
+        JSwordKJVABookData(osisId: "1Tim", bibleBookOrdinal: 56, chapterVerseCounts: [20, 15, 16, 16, 25, 21]),
+        JSwordKJVABookData(osisId: "2Tim", bibleBookOrdinal: 57, chapterVerseCounts: [18, 26, 17, 22]),
+        JSwordKJVABookData(osisId: "Titus", bibleBookOrdinal: 58, chapterVerseCounts: [16, 15, 15]),
+        JSwordKJVABookData(osisId: "Phlm", bibleBookOrdinal: 59, chapterVerseCounts: [25]),
+        JSwordKJVABookData(osisId: "Heb", bibleBookOrdinal: 60, chapterVerseCounts: [14, 18, 19, 16, 14, 20, 28, 13, 28, 39, 40, 29, 25]),
+        JSwordKJVABookData(osisId: "Jas", bibleBookOrdinal: 61, chapterVerseCounts: [27, 26, 18, 17, 20]),
+        JSwordKJVABookData(osisId: "1Pet", bibleBookOrdinal: 62, chapterVerseCounts: [25, 25, 22, 19, 14]),
+        JSwordKJVABookData(osisId: "2Pet", bibleBookOrdinal: 63, chapterVerseCounts: [21, 22, 18]),
+        JSwordKJVABookData(osisId: "1John", bibleBookOrdinal: 64, chapterVerseCounts: [10, 29, 24, 21, 21]),
+        JSwordKJVABookData(osisId: "2John", bibleBookOrdinal: 65, chapterVerseCounts: [13]),
+        JSwordKJVABookData(osisId: "3John", bibleBookOrdinal: 66, chapterVerseCounts: [14]),
+        JSwordKJVABookData(osisId: "Jude", bibleBookOrdinal: 67, chapterVerseCounts: [25]),
+        JSwordKJVABookData(osisId: "Rev", bibleBookOrdinal: 68, chapterVerseCounts: [20, 29, 22, 11, 14, 17, 17, 13, 21, 11, 19, 17, 18, 20, 8, 21, 18, 24, 21, 15, 27, 21]),
+    ]
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -811,6 +811,9 @@ public struct BibleReaderView: View {
             BookChooserView(
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
                 navigateToVerse: navigateToVersePref,
+                currentBook: panePresentationController?.currentBook,
+                currentChapter: panePresentationController?.currentChapter,
+                currentVerse: panePresentationController?.currentVerse,
                 verseCountProvider: { book, chapter in
                     guard let panePresentationController else {
                         return BibleReaderController.verseCount(for: book.name, chapter: chapter)
@@ -1006,7 +1009,12 @@ public struct BibleReaderView: View {
     /// Reference chooser sheet used by web-modal callbacks.
     private var refChooserSheetContent: some View {
         NavigationStack {
-            BookChooserView(books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks) { book, chapter, _ in
+            BookChooserView(
+                books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
+                currentBook: panePresentationController?.currentBook,
+                currentChapter: panePresentationController?.currentChapter,
+                currentVerse: panePresentationController?.currentVerse
+            ) { book, chapter, _ in
                 showRefChooser = false
                 let osisId = panePresentationController?.osisBookId(for: book) ?? BibleReaderController.osisBookId(for: book)
                 refChooserCompletion?("\(osisId).\(chapter)")

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -811,65 +811,6 @@ public struct BibleReaderView: View {
         panePresentationTargetWindow?.workspace?.name ?? windowManager.activeWorkspace?.name
     }
 
-    /**
-     Computes Android-compatible book progress for the passage chooser.
-
-     - Parameter book: Visible book cell from the active module's book list.
-     - Returns: Reading and memorization fractions derived from active pane snapshots.
-     - Side effects: Reads local progress stores through the active pane controller.
-     - Failure modes: Missing controller/store data produces empty progress.
-     */
-    private func passageBookProgress(for book: BookInfo) -> PassageGridProgress {
-        PassageGridProgressCalculator.bookProgress(
-            book: book,
-            readingSnapshot: passageReadingProgressSnapshot,
-            memorizationSnapshot: passageMemorizationProgressSnapshot,
-            activeBookInitials: passageProgressBookInitials
-        )
-    }
-
-    /**
-     Computes Android-compatible chapter progress for the passage chooser.
-
-     - Parameters:
-       - book: Selected book from the active module's book list.
-       - chapter: One-based chapter number.
-     - Returns: Reading and memorization fractions derived from active pane snapshots.
-     - Side effects: Reads local progress stores through the active pane controller.
-     - Failure modes: Missing controller/store data produces empty progress.
-     */
-    private func passageChapterProgress(for book: BookInfo, chapter: Int) -> PassageGridProgress {
-        PassageGridProgressCalculator.chapterProgress(
-            book: book,
-            chapter: chapter,
-            readingSnapshot: passageReadingProgressSnapshot,
-            memorizationSnapshot: passageMemorizationProgressSnapshot,
-            activeBookInitials: passageProgressBookInitials
-        )
-    }
-
-    /**
-     Computes Android-compatible verse progress for the passage chooser.
-
-     - Parameters:
-       - book: Selected book from the active module's book list.
-       - chapter: One-based chapter number.
-       - verse: One-based verse number.
-     - Returns: Reading and memorization fractions derived from active pane snapshots.
-     - Side effects: Reads local progress stores through the active pane controller.
-     - Failure modes: Missing controller/store data produces empty progress.
-     */
-    private func passageVerseProgress(for book: BookInfo, chapter: Int, verse: Int) -> PassageGridProgress {
-        PassageGridProgressCalculator.verseProgress(
-            book: book,
-            chapter: chapter,
-            verse: verse,
-            readingSnapshot: passageReadingProgressSnapshot,
-            memorizationSnapshot: passageMemorizationProgressSnapshot,
-            activeBookInitials: passageProgressBookInitials
-        )
-    }
-
     /// Active module initials used to match Android/iOS memorization progress ranges.
     private var passageProgressBookInitials: String {
         panePresentationController?.activeModuleName ?? ""
@@ -885,9 +826,26 @@ public struct BibleReaderView: View {
         panePresentationController?.memorizationProgressStore?.snapshot()
     }
 
+    /**
+     Creates the immutable progress context used by one passage chooser presentation.
+
+     - Returns: Snapshot-backed progress calculator inputs for the active pane.
+     - Side effects: Reads the active pane's reading and memorization progress stores once.
+     - Failure modes: Missing controller/store data is represented by `nil` snapshots.
+     */
+    private var passageChooserProgressContext: PassageChooserProgressContext {
+        PassageChooserProgressContext(
+            readingSnapshot: passageReadingProgressSnapshot,
+            memorizationSnapshot: passageMemorizationProgressSnapshot,
+            activeBookInitials: passageProgressBookInitials
+        )
+    }
+
     /// Book chooser content used by toolbar and tab-bar navigation commands.
     private var bookChooserDrawerContent: some View {
-        NavigationStack {
+        let progressContext = passageChooserProgressContext
+
+        return NavigationStack {
             BookChooserView(
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
                 navigateToVerse: navigateToVersePref,
@@ -905,13 +863,13 @@ public struct BibleReaderView: View {
                     )
                 },
                 bookProgressProvider: { book in
-                    passageBookProgress(for: book)
+                    progressContext.bookProgress(for: book)
                 },
                 chapterProgressProvider: { book, chapter in
-                    passageChapterProgress(for: book, chapter: chapter)
+                    progressContext.chapterProgress(for: book, chapter: chapter)
                 },
                 verseProgressProvider: { book, chapter, verse in
-                    passageVerseProgress(for: book, chapter: chapter, verse: verse)
+                    progressContext.verseProgress(for: book, chapter: chapter, verse: verse)
                 },
                 onCancel: dismissBookChooser
             ) { book, chapter, verse in
@@ -1101,7 +1059,9 @@ public struct BibleReaderView: View {
 
     /// Reference chooser sheet used by web-modal callbacks.
     private var refChooserSheetContent: some View {
-        NavigationStack {
+        let progressContext = passageChooserProgressContext
+
+        return NavigationStack {
             BookChooserView(
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
                 currentBook: panePresentationController?.currentBook,
@@ -1118,13 +1078,13 @@ public struct BibleReaderView: View {
                     )
                 },
                 bookProgressProvider: { book in
-                    passageBookProgress(for: book)
+                    progressContext.bookProgress(for: book)
                 },
                 chapterProgressProvider: { book, chapter in
-                    passageChapterProgress(for: book, chapter: chapter)
+                    progressContext.chapterProgress(for: book, chapter: chapter)
                 },
                 verseProgressProvider: { book, chapter, verse in
-                    passageVerseProgress(for: book, chapter: chapter, verse: verse)
+                    progressContext.verseProgress(for: book, chapter: chapter, verse: verse)
                 }
             ) { book, chapter, _ in
                 showRefChooser = false
@@ -3359,6 +3319,84 @@ public struct BibleReaderView: View {
         tiltScrollService.start()
     }
     #endif
+}
+
+/**
+ Snapshot-backed passage chooser progress context.
+
+ `BibleReaderView` builds this once when presenting Android-style passage chooser content. The grid
+ may ask for progress many times while SwiftUI renders or re-renders cells, so this type keeps the
+ persisted reading and memorization snapshots stable for that presentation and delegates the actual
+ Android-compatible calculations to `PassageGridProgressCalculator`.
+ */
+private struct PassageChooserProgressContext {
+    /// Current reading progress snapshot for the active pane, if available.
+    let readingSnapshot: ReadingProgressSnapshot?
+
+    /// Current memorization progress snapshot for the active pane, if available.
+    let memorizationSnapshot: MemorizationProgressSnapshot?
+
+    /// Active module initials used to match Android/iOS memorization rows.
+    let activeBookInitials: String
+
+    /**
+     Computes book-level progress from the captured snapshots.
+
+     - Parameter book: Visible book cell from the active module's book list.
+     - Returns: Android-compatible reading and memorization progress.
+     - Side effects: none.
+     - Failure modes: Missing snapshots or unsupported books produce empty progress.
+     */
+    func bookProgress(for book: BookInfo) -> PassageGridProgress {
+        PassageGridProgressCalculator.bookProgress(
+            book: book,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        )
+    }
+
+    /**
+     Computes chapter-level progress from the captured snapshots.
+
+     - Parameters:
+       - book: Selected book from the active module's book list.
+       - chapter: One-based chapter number.
+     - Returns: Android-compatible reading and memorization progress.
+     - Side effects: none.
+     - Failure modes: Missing snapshots or unsupported chapters produce empty progress.
+     */
+    func chapterProgress(for book: BookInfo, chapter: Int) -> PassageGridProgress {
+        PassageGridProgressCalculator.chapterProgress(
+            book: book,
+            chapter: chapter,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        )
+    }
+
+    /**
+     Computes verse-level progress from the captured snapshots.
+
+     - Parameters:
+       - book: Selected book from the active module's book list.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: Android-compatible reading and memorization progress.
+     - Side effects: none.
+     - Failure modes: Missing snapshots or unsupported verses produce empty progress.
+     */
+    func verseProgress(for book: BookInfo, chapter: Int, verse: Int) -> PassageGridProgress {
+        PassageGridProgressCalculator.verseProgress(
+            book: book,
+            chapter: chapter,
+            verse: verse,
+            readingSnapshot: readingSnapshot,
+            memorizationSnapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        )
+    }
 }
 
 /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -178,6 +178,9 @@ public struct BibleReaderView: View {
     /// Presents the book/chapter/verse chooser flow for the focused controller.
     @State private var showBookChooser = false
 
+    /// Snapshot-backed chooser progress context captured when the chooser is presented.
+    @State private var passageChooserProgressContext = PassageChooserProgressContext.empty
+
     /// Presents the full-text search sheet for the focused module.
     @State private var showSearch = false
 
@@ -715,7 +718,7 @@ public struct BibleReaderView: View {
         )) {
             crossReferenceSheetContent
         }
-        .sheet(isPresented: $showRefChooser) {
+        .sheet(isPresented: $showRefChooser, onDismiss: resetPassageChooserProgressContext) {
             refChooserSheetContent
         }
         // MARK: - Keyboard Shortcuts (iPad/Mac)
@@ -833,7 +836,7 @@ public struct BibleReaderView: View {
      - Side effects: Reads the active pane's reading and memorization progress stores once.
      - Failure modes: Missing controller/store data is represented by `nil` snapshots.
      */
-    private var passageChooserProgressContext: PassageChooserProgressContext {
+    private func makePassageChooserProgressContext() -> PassageChooserProgressContext {
         PassageChooserProgressContext(
             readingSnapshot: passageReadingProgressSnapshot,
             memorizationSnapshot: passageMemorizationProgressSnapshot,
@@ -1428,6 +1431,7 @@ public struct BibleReaderView: View {
     /// Presents the book chooser for the pane that initiated the navigation.
     private func presentBookChooser(from windowId: UUID? = nil) {
         setPanePresentationTarget(windowId)
+        passageChooserProgressContext = makePassageChooserProgressContext()
         showReaderNavigationDrawer = false
         showReaderOverflowMenu = false
         showBookChooser = true
@@ -1436,6 +1440,12 @@ public struct BibleReaderView: View {
     /// Closes the book chooser without changing the current pane target.
     private func dismissBookChooser() {
         showBookChooser = false
+        resetPassageChooserProgressContext()
+    }
+
+    /// Releases stored chooser progress snapshots after the passage chooser closes.
+    private func resetPassageChooserProgressContext() {
+        passageChooserProgressContext = .empty
     }
 
     // MARK: - Modal Routing
@@ -2014,6 +2024,7 @@ public struct BibleReaderView: View {
             onRefChooserDialog: { completion in
                 // Present book chooser and return OSIS ref
                 setPanePresentationTarget(window.id)
+                passageChooserProgressContext = makePassageChooserProgressContext()
                 refChooserCompletion = completion
                 showRefChooser = true
             },
@@ -2271,7 +2282,7 @@ public struct BibleReaderView: View {
 
     /// Full-screen dark chooser panel for Android-style passage selection.
     private var bookChooserDrawerOverlay: some View {
-        ReaderPassageChooserOverlay(onCancel: dismissBookChooser) {
+        ReaderPassageChooserOverlay {
             bookChooserDrawerContent
                 .accessibilityIdentifier("passageChooserDrawer")
         }
@@ -3330,6 +3341,13 @@ public struct BibleReaderView: View {
  Android-compatible calculations to `PassageGridProgressCalculator`.
  */
 private struct PassageChooserProgressContext {
+    /// Empty context used before a chooser presentation captures active pane snapshots.
+    static let empty = PassageChooserProgressContext(
+        readingSnapshot: nil,
+        memorizationSnapshot: nil,
+        activeBookInitials: ""
+    )
+
     /// Current reading progress snapshot for the active pane, if available.
     let readingSnapshot: ReadingProgressSnapshot?
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -919,12 +919,6 @@ public struct BibleReaderView: View {
                 panePresentationController?.navigateTo(book: book, chapter: chapter, verse: verse)
             }
         }
-        #if os(iOS)
-        .toolbar(.visible, for: .navigationBar)
-        .toolbarBackground(PassageChooserSurfacePalette.toolbarBackground.swiftUIColor, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbarColorScheme(.dark, for: .navigationBar)
-        #endif
         .preferredColorScheme(.dark)
         .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
     }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -811,6 +811,80 @@ public struct BibleReaderView: View {
         panePresentationTargetWindow?.workspace?.name ?? windowManager.activeWorkspace?.name
     }
 
+    /**
+     Computes Android-compatible book progress for the passage chooser.
+
+     - Parameter book: Visible book cell from the active module's book list.
+     - Returns: Reading and memorization fractions derived from active pane snapshots.
+     - Side effects: Reads local progress stores through the active pane controller.
+     - Failure modes: Missing controller/store data produces empty progress.
+     */
+    private func passageBookProgress(for book: BookInfo) -> PassageGridProgress {
+        PassageGridProgressCalculator.bookProgress(
+            book: book,
+            readingSnapshot: passageReadingProgressSnapshot,
+            memorizationSnapshot: passageMemorizationProgressSnapshot,
+            activeBookInitials: passageProgressBookInitials
+        )
+    }
+
+    /**
+     Computes Android-compatible chapter progress for the passage chooser.
+
+     - Parameters:
+       - book: Selected book from the active module's book list.
+       - chapter: One-based chapter number.
+     - Returns: Reading and memorization fractions derived from active pane snapshots.
+     - Side effects: Reads local progress stores through the active pane controller.
+     - Failure modes: Missing controller/store data produces empty progress.
+     */
+    private func passageChapterProgress(for book: BookInfo, chapter: Int) -> PassageGridProgress {
+        PassageGridProgressCalculator.chapterProgress(
+            book: book,
+            chapter: chapter,
+            readingSnapshot: passageReadingProgressSnapshot,
+            memorizationSnapshot: passageMemorizationProgressSnapshot,
+            activeBookInitials: passageProgressBookInitials
+        )
+    }
+
+    /**
+     Computes Android-compatible verse progress for the passage chooser.
+
+     - Parameters:
+       - book: Selected book from the active module's book list.
+       - chapter: One-based chapter number.
+       - verse: One-based verse number.
+     - Returns: Reading and memorization fractions derived from active pane snapshots.
+     - Side effects: Reads local progress stores through the active pane controller.
+     - Failure modes: Missing controller/store data produces empty progress.
+     */
+    private func passageVerseProgress(for book: BookInfo, chapter: Int, verse: Int) -> PassageGridProgress {
+        PassageGridProgressCalculator.verseProgress(
+            book: book,
+            chapter: chapter,
+            verse: verse,
+            readingSnapshot: passageReadingProgressSnapshot,
+            memorizationSnapshot: passageMemorizationProgressSnapshot,
+            activeBookInitials: passageProgressBookInitials
+        )
+    }
+
+    /// Active module initials used to match Android/iOS memorization progress ranges.
+    private var passageProgressBookInitials: String {
+        panePresentationController?.activeModuleName ?? ""
+    }
+
+    /// Snapshot of active pane reading progress for chooser progress bars.
+    private var passageReadingProgressSnapshot: ReadingProgressSnapshot? {
+        panePresentationController?.readingProgressStore?.snapshot()
+    }
+
+    /// Snapshot of active pane memorization progress for chooser progress bars.
+    private var passageMemorizationProgressSnapshot: MemorizationProgressSnapshot? {
+        panePresentationController?.memorizationProgressStore?.snapshot()
+    }
+
     /// Book chooser content used by toolbar and tab-bar navigation commands.
     private var bookChooserDrawerContent: some View {
         NavigationStack {
@@ -830,6 +904,15 @@ public struct BibleReaderView: View {
                         chapter: chapter
                     )
                 },
+                bookProgressProvider: { book in
+                    passageBookProgress(for: book)
+                },
+                chapterProgressProvider: { book, chapter in
+                    passageChapterProgress(for: book, chapter: chapter)
+                },
+                verseProgressProvider: { book, chapter, verse in
+                    passageVerseProgress(for: book, chapter: chapter, verse: verse)
+                },
                 onCancel: dismissBookChooser
             ) { book, chapter, verse in
                 dismissBookChooser()
@@ -838,7 +921,12 @@ public struct BibleReaderView: View {
         }
         #if os(iOS)
         .toolbar(.visible, for: .navigationBar)
+        .toolbarBackground(PassageChooserSurfacePalette.toolbarBackground.swiftUIColor, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         #endif
+        .preferredColorScheme(.dark)
+        .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
     }
 
     /// Search sheet seeded from toolbar, keyboard, or Android-compatible link routing.
@@ -2209,13 +2297,9 @@ public struct BibleReaderView: View {
         }
     }
 
-    /// Full-screen dimmer plus left drawer panel for Android-style passage selection.
+    /// Full-screen dark chooser panel for Android-style passage selection.
     private var bookChooserDrawerOverlay: some View {
-        ReaderSideDrawerOverlay(
-            colorScheme: colorScheme,
-            dismissAreaIdentifier: "passageChooserDrawerDismissArea",
-            onDismiss: dismissBookChooser
-        ) { _ in
+        ReaderPassageChooserOverlay(onCancel: dismissBookChooser) {
             bookChooserDrawerContent
                 .accessibilityIdentifier("passageChooserDrawer")
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1113,7 +1113,25 @@ public struct BibleReaderView: View {
                 currentBook: panePresentationController?.currentBook,
                 currentChapter: panePresentationController?.currentChapter,
                 currentVerse: panePresentationController?.currentVerse,
-                workspaceName: activePassageChooserWorkspaceName
+                workspaceName: activePassageChooserWorkspaceName,
+                verseCountProvider: { book, chapter in
+                    guard let panePresentationController else {
+                        return BibleReaderController.verseCount(for: book.name, chapter: chapter)
+                    }
+                    return panePresentationController.verseCountForActiveModule(
+                        book: book.name,
+                        chapter: chapter
+                    )
+                },
+                bookProgressProvider: { book in
+                    passageBookProgress(for: book)
+                },
+                chapterProgressProvider: { book, chapter in
+                    passageChapterProgress(for: book, chapter: chapter)
+                },
+                verseProgressProvider: { book, chapter, verse in
+                    passageVerseProgress(for: book, chapter: chapter, verse: verse)
+                }
             ) { book, chapter, _ in
                 showRefChooser = false
                 let osisId = panePresentationController?.osisBookId(for: book) ?? BibleReaderController.osisBookId(for: book)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -598,6 +598,9 @@ public struct BibleReaderView: View {
             if showReaderNavigationDrawer {
                 readerNavigationDrawerOverlay
             }
+            if showBookChooser {
+                bookChooserDrawerOverlay
+            }
         }
         .overlayPreferenceValue(ReaderOverflowButtonBoundsPreferenceKey.self) { anchor in
             if showReaderOverflowMenu {
@@ -606,6 +609,7 @@ public struct BibleReaderView: View {
         }
         .animation(.easeInOut(duration: 0.25), value: toastMessage)
         .animation(.easeInOut(duration: 0.2), value: showReaderNavigationDrawer)
+        .animation(.easeInOut(duration: 0.2), value: showBookChooser)
         .animation(.easeInOut(duration: 0.16), value: showReaderOverflowMenu)
         .background {
             readerSceneMetricsBackground
@@ -634,9 +638,6 @@ public struct BibleReaderView: View {
         }
         #endif
         .preferredColorScheme(preferredColorSchemeOverride)
-        .sheet(isPresented: $showBookChooser) {
-            bookChooserSheetContent
-        }
         .sheet(isPresented: $showSearch, onDismiss: { searchInitialQuery = "" }) {
             searchSheetContent
         }
@@ -805,8 +806,13 @@ public struct BibleReaderView: View {
         }
     }
 
-    /// Book chooser sheet used by toolbar and tab-bar navigation commands.
-    private var bookChooserSheetContent: some View {
+    /// Workspace name shown in reader-hosted passage chooser titles.
+    private var activePassageChooserWorkspaceName: String? {
+        panePresentationTargetWindow?.workspace?.name ?? windowManager.activeWorkspace?.name
+    }
+
+    /// Book chooser content used by toolbar and tab-bar navigation commands.
+    private var bookChooserDrawerContent: some View {
         NavigationStack {
             BookChooserView(
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
@@ -814,6 +820,7 @@ public struct BibleReaderView: View {
                 currentBook: panePresentationController?.currentBook,
                 currentChapter: panePresentationController?.currentChapter,
                 currentVerse: panePresentationController?.currentVerse,
+                workspaceName: activePassageChooserWorkspaceName,
                 verseCountProvider: { book, chapter in
                     guard let panePresentationController else {
                         return BibleReaderController.verseCount(for: book.name, chapter: chapter)
@@ -822,12 +829,16 @@ public struct BibleReaderView: View {
                         book: book.name,
                         chapter: chapter
                     )
-                }
+                },
+                onCancel: dismissBookChooser
             ) { book, chapter, verse in
                 dismissBookChooser()
                 panePresentationController?.navigateTo(book: book, chapter: chapter, verse: verse)
             }
         }
+        #if os(iOS)
+        .toolbar(.visible, for: .navigationBar)
+        #endif
     }
 
     /// Search sheet seeded from toolbar, keyboard, or Android-compatible link routing.
@@ -1013,7 +1024,8 @@ public struct BibleReaderView: View {
                 books: panePresentationController?.bookList ?? BibleReaderController.defaultBooks,
                 currentBook: panePresentationController?.currentBook,
                 currentChapter: panePresentationController?.currentChapter,
-                currentVerse: panePresentationController?.currentVerse
+                currentVerse: panePresentationController?.currentVerse,
+                workspaceName: activePassageChooserWorkspaceName
             ) { book, chapter, _ in
                 showRefChooser = false
                 let osisId = panePresentationController?.osisBookId(for: book) ?? BibleReaderController.osisBookId(for: book)
@@ -1356,6 +1368,8 @@ public struct BibleReaderView: View {
     /// Presents the book chooser for the pane that initiated the navigation.
     private func presentBookChooser(from windowId: UUID? = nil) {
         setPanePresentationTarget(windowId)
+        showReaderNavigationDrawer = false
+        showReaderOverflowMenu = false
         showBookChooser = true
     }
 
@@ -2181,22 +2195,29 @@ public struct BibleReaderView: View {
 
     /// Full-screen dimmer plus left drawer panel mirroring Android's main navigation drawer.
     private var readerNavigationDrawerOverlay: some View {
-        GeometryReader { proxy in
-            ZStack(alignment: .leading) {
-                Color.black.opacity(0.28)
-                    .ignoresSafeArea()
-                    .contentShape(Rectangle())
-                    .onTapGesture { dismissReaderNavigationDrawer() }
-                    .accessibilityIdentifier("readerNavigationDrawerDismissArea")
+        ReaderSideDrawerOverlay(
+            colorScheme: colorScheme,
+            dismissAreaIdentifier: "readerNavigationDrawerDismissArea",
+            onDismiss: dismissReaderNavigationDrawer
+        ) { width in
+            BibleReaderNavigationDrawer(
+                width: width,
+                colorScheme: colorScheme,
+                versionText: readerNavigationDrawerVersionText,
+                onAction: handleReaderNavigationDrawerAction
+            )
+        }
+    }
 
-                BibleReaderNavigationDrawer(
-                    width: min(306, max(252, proxy.size.width * 0.756)),
-                    colorScheme: colorScheme,
-                    versionText: readerNavigationDrawerVersionText,
-                    onAction: handleReaderNavigationDrawerAction
-                )
-                    .transition(.move(edge: .leading))
-            }
+    /// Full-screen dimmer plus left drawer panel for Android-style passage selection.
+    private var bookChooserDrawerOverlay: some View {
+        ReaderSideDrawerOverlay(
+            colorScheme: colorScheme,
+            dismissAreaIdentifier: "passageChooserDrawerDismissArea",
+            onDismiss: dismissBookChooser
+        ) { _ in
+            bookChooserDrawerContent
+                .accessibilityIdentifier("passageChooserDrawer")
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderPassageChooserOverlay.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderPassageChooserOverlay.swift
@@ -9,26 +9,19 @@ import SwiftUI
  menu actions, and dismissal.
  */
 struct ReaderPassageChooserOverlay<ChooserContent: View>: View {
-    /// Action retained for parity with other reader overlays and source-level presentation tests.
-    let onCancel: () -> Void
-
     /// Chooser content, normally a `NavigationStack` hosting `BookChooserView`.
     let chooserContent: () -> ChooserContent
 
     /**
      Creates a full-screen passage chooser overlay.
 
-     - Parameters:
-       - onCancel: Callback the hosted chooser uses to close reader-owned presentation state.
-       - chooserContent: Full-screen chooser content.
+     - Parameter chooserContent: Full-screen chooser content.
      - Side effects: none. Dismissal is driven by hosted controls.
      - Failure modes: none.
      */
     init(
-        onCancel: @escaping () -> Void = {},
         @ViewBuilder chooserContent: @escaping () -> ChooserContent
     ) {
-        self.onCancel = onCancel
         self.chooserContent = chooserContent
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderPassageChooserOverlay.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderPassageChooserOverlay.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/**
+ Full-screen reader-owned shell for Android-style passage selection.
+
+ Android opens book/chapter/verse selection as a dark full-screen chooser activity with its own
+ toolbar. The reader still owns presentation state on iOS, so this shell supplies only the
+ full-screen surface, background, and transition while `BookChooserView` owns internal navigation,
+ menu actions, and dismissal.
+ */
+struct ReaderPassageChooserOverlay<ChooserContent: View>: View {
+    /// Action retained for parity with other reader overlays and source-level presentation tests.
+    let onCancel: () -> Void
+
+    /// Chooser content, normally a `NavigationStack` hosting `BookChooserView`.
+    let chooserContent: () -> ChooserContent
+
+    /**
+     Creates a full-screen passage chooser overlay.
+
+     - Parameters:
+       - onCancel: Callback the hosted chooser uses to close reader-owned presentation state.
+       - chooserContent: Full-screen chooser content.
+     - Side effects: none. Dismissal is driven by hosted controls.
+     - Failure modes: none.
+     */
+    init(
+        onCancel: @escaping () -> Void = {},
+        @ViewBuilder chooserContent: @escaping () -> ChooserContent
+    ) {
+        self.onCancel = onCancel
+        self.chooserContent = chooserContent
+    }
+
+    /// Renders the full-screen dark chooser surface.
+    var body: some View {
+        chooserContent()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
+            .transition(.move(edge: .leading))
+            .accessibilityIdentifier("passageChooserFullScreenSurface")
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/**
+ Shared left-side drawer presentation shell for reader-owned drawer surfaces.
+
+ Android presents the main reader drawer as a left-origin drawer with a dimmed reading surface.
+ Passage selection is also a reader-owned navigation surface, so `BibleReaderView` uses this shell
+ for both the hamburger drawer and the passage chooser instead of maintaining separate dimmer,
+ width, background, and transition behavior. The shell owns presentation chrome and dismissal;
+ caller content remains responsible for internal navigation and actions.
+ */
+struct ReaderSideDrawerOverlay<DrawerContent: View>: View {
+    /// System color scheme available to callers that need scheme-aware drawer content.
+    let colorScheme: ColorScheme
+
+    /// Accessibility identifier applied to the dimmed dismiss target.
+    let dismissAreaIdentifier: String
+
+    /// Action invoked when the user taps outside the drawer.
+    let onDismiss: () -> Void
+
+    /// Drawer content builder receiving the Android-compatible drawer width.
+    let drawerContent: (CGFloat) -> DrawerContent
+
+    /**
+     Creates a shared reader side-drawer overlay.
+
+     - Parameters:
+       - colorScheme: Current color scheme. Stored so all reader drawer surfaces receive the same
+         environmental input used by the hamburger drawer.
+       - dismissAreaIdentifier: Stable identifier for UI tests and accessibility debugging.
+       - onDismiss: Callback for dismissing the owning presentation state.
+       - drawerContent: Content builder that receives the computed drawer width.
+     */
+    init(
+        colorScheme: ColorScheme,
+        dismissAreaIdentifier: String,
+        onDismiss: @escaping () -> Void = {},
+        @ViewBuilder drawerContent: @escaping (CGFloat) -> DrawerContent
+    ) {
+        self.colorScheme = colorScheme
+        self.dismissAreaIdentifier = dismissAreaIdentifier
+        self.onDismiss = onDismiss
+        self.drawerContent = drawerContent
+    }
+
+    /// Builds the dimmed full-screen overlay and left drawer content.
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Color.black.opacity(0.28)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { onDismiss() }
+                    .accessibilityIdentifier(dismissAreaIdentifier)
+
+                let drawerWidth = Self.drawerWidth(for: proxy.size.width)
+
+                drawerContent(drawerWidth)
+                    .frame(width: drawerWidth, alignment: .topLeading)
+                    .frame(maxHeight: .infinity, alignment: .topLeading)
+                    .background(drawerBackground)
+                    .transition(.move(edge: .leading))
+            }
+        }
+    }
+
+    /// Reader drawer background aligned with Android's drawer surface and current app theme.
+    private var drawerBackground: Color {
+        #if os(iOS)
+        return colorScheme == .dark
+            ? Color(red: 48.0 / 255.0, green: 48.0 / 255.0, blue: 48.0 / 255.0)
+            : Color(uiColor: .systemBackground)
+        #elseif os(macOS)
+        return Color(nsColor: .windowBackgroundColor)
+        #endif
+    }
+
+    /**
+     Computes the reader drawer width used by Android-style left drawer surfaces.
+
+     - Parameter availableWidth: Full reader surface width.
+     - Returns: Width clamped to the existing hamburger-drawer range.
+     */
+    static func drawerWidth(for availableWidth: CGFloat) -> CGFloat {
+        min(306, max(252, availableWidth * 0.756))
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
@@ -3,11 +3,10 @@ import SwiftUI
 /**
  Shared left-side drawer presentation shell for reader-owned drawer surfaces.
 
- Android presents the main reader drawer as a left-origin drawer with a dimmed reading surface.
- Passage selection is also a reader-owned navigation surface, so `BibleReaderView` uses this shell
- for both the hamburger drawer and the passage chooser instead of maintaining separate dimmer,
- width, background, and transition behavior. The shell owns presentation chrome and dismissal;
- caller content remains responsible for internal navigation and actions.
+ Android presents the main reader drawer as a left-origin drawer with a dimmed reading surface. The
+ passage chooser is a separate full-screen Android activity and uses `ReaderPassageChooserOverlay`
+ instead. This shell owns hamburger-drawer chrome and dismissal; caller content remains responsible
+ for internal navigation and actions.
  */
 struct ReaderSideDrawerOverlay<DrawerContent: View>: View {
     /// System color scheme available to callers that need scheme-aware drawer content.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderSideDrawerOverlay.swift
@@ -34,7 +34,7 @@ struct ReaderSideDrawerOverlay<DrawerContent: View>: View {
     init(
         colorScheme: ColorScheme,
         dismissAreaIdentifier: String,
-        onDismiss: @escaping () -> Void = {},
+        onDismiss: @escaping () -> Void,
         @ViewBuilder drawerContent: @escaping (CGFloat) -> DrawerContent
     ) {
         self.colorScheme = colorScheme

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -10,8 +10,14 @@ import SwordKit
  expanded canons surface their additional books automatically. Depending on `navigateToVerse`, the
  flow ends after chapter selection or adds a verse-selection step.
 
+ The grid layout and colors mirror Android's `GridChoosePassageBook` and `ButtonGrid` defaults:
+ standard 66-book canons render in a dense column-major portrait matrix, expanded canons use
+ Android's dynamic matrix, and the current passage is highlighted with its book category color.
+
  Data dependencies:
  - `books` is the module-specific canon and chapter metadata provided by the caller
+ - `currentBook`, `currentChapter`, and `currentVerse` are the reader's active location used only
+   for Android-compatible highlighting
  - `verseCountProvider` supplies module-specific `Versification.getLastVerse` equivalents when
    the chooser drills into verse selection; `nil` means the active module could not resolve the
    selected chapter and no synthetic verse list should be shown
@@ -28,6 +34,15 @@ public struct BookChooserView: View {
 
     /// Whether the flow should include a verse chooser after chapter selection.
     let navigateToVerse: Bool
+
+    /// Current reader book name, used to highlight the active book.
+    let currentBook: String?
+
+    /// Current reader chapter, used to highlight the active chapter in the active book.
+    let currentChapter: Int?
+
+    /// Current reader verse, used to highlight the active verse in the active chapter.
+    let currentVerse: Int?
 
     /// Provides the last verse number for a selected book/chapter.
     let verseCountProvider: (BookInfo, Int) -> Int?
@@ -50,6 +65,9 @@ public struct BookChooserView: View {
      - Parameters:
        - books: Book list from the active module's versification.
        - navigateToVerse: Whether the flow should include verse selection.
+       - currentBook: Current reader book name, used only for selector highlighting.
+       - currentChapter: Current reader chapter, used only for selector highlighting.
+       - currentVerse: Current reader verse, used only for selector highlighting.
        - verseCountProvider: Optional provider for module-specific chapter verse counts. A missing
          provider keeps existing no-module callers functional by falling back to the static
          compatibility table.
@@ -58,25 +76,21 @@ public struct BookChooserView: View {
     public init(
         books: [BookInfo],
         navigateToVerse: Bool = false,
+        currentBook: String? = nil,
+        currentChapter: Int? = nil,
+        currentVerse: Int? = nil,
         verseCountProvider: ((BookInfo, Int) -> Int?)? = nil,
         onSelect: @escaping (String, Int, Int?) -> Void
     ) {
         self.books = books
         self.navigateToVerse = navigateToVerse
+        self.currentBook = currentBook
+        self.currentChapter = currentChapter
+        self.currentVerse = currentVerse
         self.verseCountProvider = verseCountProvider ?? { book, chapter in
             BibleReaderController.verseCount(for: book.name, chapter: chapter)
         }
         self.onSelect = onSelect
-    }
-
-    /// Books tagged as Old Testament in the module-provided canon.
-    private var oldTestamentBooks: [BookInfo] {
-        books.filter { $0.testament == 1 }
-    }
-
-    /// Books tagged as New Testament in the module-provided canon.
-    private var newTestamentBooks: [BookInfo] {
-        books.filter { $0.testament == 2 }
     }
 
     /**
@@ -88,13 +102,20 @@ public struct BookChooserView: View {
                 if navigateToVerse, let chapter = selectedChapter {
                     VerseChooserView(
                         bookName: book.name,
+                        osisBookId: book.osisId,
                         chapter: chapter,
-                        verseCount: verseCountProvider(book, chapter) ?? 0
+                        verseCount: verseCountProvider(book, chapter) ?? 0,
+                        currentVerse: currentVerseForSelectedContext(book: book, chapter: chapter)
                     ) { verse in
                         onSelect(book.name, chapter, verse)
                     }
                 } else {
-                    ChapterChooserView(bookName: book.name, chapterCount: book.chapterCount) { chapter in
+                    ChapterChooserView(
+                        bookName: book.name,
+                        osisBookId: book.osisId,
+                        chapterCount: book.chapterCount,
+                        currentChapter: currentChapterForSelectedBook(book)
+                    ) { chapter in
                         if navigateToVerse {
                             selectedChapter = chapter
                         } else {
@@ -139,47 +160,91 @@ public struct BookChooserView: View {
         return selectedBook?.name ?? String(localized: "choose_book")
     }
 
-    /// Scrollable container for the testament-grouped book grid.
+    /// Scrollable container for the Android-aligned book grid.
     private var bookGrid: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 16) {
-                if !oldTestamentBooks.isEmpty {
-                    Section(String(localized: "old_testament")) {
-                        bookGridSection(books: oldTestamentBooks)
+        GeometryReader { proxy in
+            let orientation = PassageGridOrientation(size: proxy.size)
+            let layout = PassageGridLayout.androidDefault(
+                itemCount: books.count,
+                kind: .book,
+                orientation: orientation
+            )
+            let slots = layout.displaySlots(for: books)
+            let columns = Array(
+                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
+                count: max(layout.columns, 1)
+            )
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 4) {
+                    ForEach(Array(slots.enumerated()), id: \.offset) { _, book in
+                        if let book {
+                            PassageGridButton(
+                                title: book.abbreviation,
+                                accessibilityLabel: book.name,
+                                accessibilityIdentifier: "passageBookCell.\(book.osisId)",
+                                palette: PassageGridCellPalette.bookPalette(
+                                    for: book,
+                                    currentOsisId: currentOsisBookId
+                                ),
+                                font: .subheadline.weight(.semibold),
+                                minHeight: 34
+                            ) {
+                                selectedBook = book
+                                selectedChapter = nil
+                            }
+                        } else {
+                            Color.clear
+                                .frame(minHeight: 34)
+                                .accessibilityHidden(true)
+                        }
                     }
                 }
-                if !newTestamentBooks.isEmpty {
-                    Section(String(localized: "new_testament")) {
-                        bookGridSection(books: newTestamentBooks)
-                    }
-                }
+                .padding(12)
             }
-            .padding()
         }
     }
 
     /**
-     Builds one adaptive grid section for the provided books.
+     Resolves the current reader OSIS id against the active module's book list.
 
-     - Parameter books: Books to render in this testament section.
+     - Returns: Current book OSIS id if it exists in the active module or static fallback table.
      */
-    private func bookGridSection(books: [BookInfo]) -> some View {
-        let columns = [GridItem(.adaptive(minimum: 100), spacing: 8)]
-        return LazyVGrid(columns: columns, spacing: 8) {
-            ForEach(books) { book in
-                Button(action: {
-                    selectedBook = book
-                    selectedChapter = nil
-                }) {
-                    Text(book.abbreviation)
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                        .background(.quaternary)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
-                .buttonStyle(.plain)
-            }
+    private var currentOsisBookId: String? {
+        guard let currentBook else {
+            return nil
         }
+        if let book = books.first(where: { $0.name == currentBook || $0.osisId == currentBook }) {
+            return book.osisId
+        }
+        return BibleReaderController.osisBookId(for: currentBook)
+    }
+
+    /**
+     Returns the current chapter when the selected book matches the active reader book.
+
+     - Parameter book: Book currently selected in the chooser flow.
+     - Returns: Current chapter for matching books; otherwise `nil`.
+     */
+    private func currentChapterForSelectedBook(_ book: BookInfo) -> Int? {
+        guard book.osisId == currentOsisBookId else {
+            return nil
+        }
+        return currentChapter
+    }
+
+    /**
+     Returns the current verse when the selected book and chapter match the active reader context.
+
+     - Parameters:
+       - book: Book currently selected in the chooser flow.
+       - chapter: Chapter currently selected in the chooser flow.
+     - Returns: Current verse for matching book/chapter contexts; otherwise `nil`.
+     */
+    private func currentVerseForSelectedContext(book: BookInfo, chapter: Int) -> Int? {
+        guard book.osisId == currentOsisBookId, chapter == currentChapter else {
+            return nil
+        }
+        return currentVerse
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -384,7 +384,7 @@ public struct BookChooserView: View {
                     }
                 }
                 .frame(width: metrics.gridWidth)
-                .padding(PassageGridMetrics.horizontalPadding)
+                .padding(.horizontal, PassageGridMetrics.horizontalPadding)
                 .frame(maxWidth: .infinity)
             }
         }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -143,55 +143,21 @@ public struct BookChooserView: View {
     }
 
     /**
-     Builds the current chooser step: book grid, chapter grid, or verse grid.
+     Builds the Android-style chooser shell and current selection step.
      */
     public var body: some View {
-        Group {
-            if let book = selectedBook {
-                if navigateToVerse, let chapter = selectedChapter {
-                    VerseChooserView(
-                        bookName: book.name,
-                        osisBookId: book.osisId,
-                        chapter: chapter,
-                        verseCount: verseCountProvider(book, chapter) ?? 0,
-                        currentVerse: currentVerseForSelectedContext(book: book, chapter: chapter),
-                        rowOrder: chooserOptions.rowOrder,
-                        progressProvider: { verse in
-                            chooserOptions.showProgressBars
-                                ? verseProgressProvider(book, chapter, verse)
-                                : .none
-                        }
-                    ) { verse in
-                        onSelect(book.name, chapter, verse)
-                    }
-                } else {
-                    ChapterChooserView(
-                        bookName: book.name,
-                        osisBookId: book.osisId,
-                        chapterCount: book.chapterCount,
-                        currentChapter: currentChapterForSelectedBook(book),
-                        rowOrder: chooserOptions.rowOrder,
-                        progressProvider: { chapter in
-                            chooserOptions.showProgressBars
-                                ? chapterProgressProvider(book, chapter)
-                                : .none
-                        }
-                    ) { chapter in
-                        if navigateToVerse {
-                            selectedChapter = chapter
-                        } else {
-                            onSelect(book.name, chapter, nil)
-                        }
-                    }
+        VStack(spacing: 0) {
+            PassageChooserAppBar(
+                title: navigationTitle,
+                showsOverflowButton: selectedBook == nil,
+                onBack: navigateBackOrCancel,
+                onOverflow: {
+                    isChooserMenuPresented.toggle()
                 }
-            } else {
-                bookGrid
-            }
+            )
+
+            chooserStep
         }
-        .navigationTitle(navigationTitle)
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
         .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
         .preferredColorScheme(.dark)
         .tint(.white)
@@ -199,25 +165,56 @@ public struct BookChooserView: View {
         .overlay(alignment: .topTrailing) {
             chooserOptionsPopupOverlay
         }
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button(action: navigateBackOrCancel) {
-                    Image(systemName: "chevron.left")
-                        .font(.title3.weight(.semibold))
-                }
-                .accessibilityLabel(String(localized: "back", defaultValue: "Back"))
-            }
-            if selectedBook == nil {
-                ToolbarItem(placement: .primaryAction) {
-                    chooserOptionsMenuButton
-                }
-            }
-        }
         #if os(iOS)
-        .toolbarBackground(PassageChooserSurfacePalette.toolbarBackground.swiftUIColor, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar(.hidden, for: .navigationBar)
         #endif
+    }
+
+    /**
+     Builds the current chooser step: book grid, chapter grid, or verse grid.
+     */
+    @ViewBuilder
+    private var chooserStep: some View {
+        if let book = selectedBook {
+            if navigateToVerse, let chapter = selectedChapter {
+                VerseChooserView(
+                    bookName: book.name,
+                    osisBookId: book.osisId,
+                    chapter: chapter,
+                    verseCount: verseCountProvider(book, chapter) ?? 0,
+                    currentVerse: currentVerseForSelectedContext(book: book, chapter: chapter),
+                    rowOrder: chooserOptions.rowOrder,
+                    progressProvider: { verse in
+                        chooserOptions.showProgressBars
+                            ? verseProgressProvider(book, chapter, verse)
+                            : .none
+                    }
+                ) { verse in
+                    onSelect(book.name, chapter, verse)
+                }
+            } else {
+                ChapterChooserView(
+                    bookName: book.name,
+                    osisBookId: book.osisId,
+                    chapterCount: book.chapterCount,
+                    currentChapter: currentChapterForSelectedBook(book),
+                    rowOrder: chooserOptions.rowOrder,
+                    progressProvider: { chapter in
+                        chooserOptions.showProgressBars
+                            ? chapterProgressProvider(book, chapter)
+                            : .none
+                    }
+                ) { chapter in
+                    if navigateToVerse {
+                        selectedChapter = chapter
+                    } else {
+                        onSelect(book.name, chapter, nil)
+                    }
+                }
+            }
+        } else {
+            bookGrid
+        }
     }
 
     /**
@@ -255,19 +252,6 @@ public struct BookChooserView: View {
         }
     }
 
-    /// Android overflow button for chooser ordering, labels, grouping, and progress options.
-    private var chooserOptionsMenuButton: some View {
-        Button {
-            isChooserMenuPresented.toggle()
-        } label: {
-            Image(systemName: "ellipsis")
-                .rotationEffect(.degrees(90))
-                .font(.title3.weight(.semibold))
-        }
-        .accessibilityLabel(String(localized: "more_options", defaultValue: "More options"))
-        .accessibilityIdentifier("passageChooserOverflowButton")
-    }
-
     /**
      Draws Android's dark popup menu over the book grid.
 
@@ -291,7 +275,7 @@ public struct BookChooserView: View {
                         isChooserMenuPresented = false
                     }
                     .frame(width: min(max(proxy.size.width - 16, 260), 340))
-                    .padding(.top, 8)
+                    .padding(.top, PassageChooserAppBar.height + 8)
                     .padding(.trailing, 8)
                 }
             }
@@ -447,6 +431,75 @@ public struct BookChooserView: View {
             return nil
         }
         return currentVerse
+    }
+}
+
+/**
+ Android-style app bar owned by the passage chooser content.
+
+ Android's book/chapter/verse chooser uses activity-owned chrome with a back arrow, changing title,
+ and a top-right menu only on the book grid. Rendering this as chooser content avoids depending on
+ iOS navigation bars that the reader shell intentionally hides for its custom toolbar.
+ */
+private struct PassageChooserAppBar: View {
+    /// Fixed Material toolbar height used by Android's passage chooser activity.
+    static let height: CGFloat = 56
+
+    /// Current chooser title, including workspace suffix on the book step.
+    let title: String
+
+    /// Whether the Android overflow menu should be available for the current chooser step.
+    let showsOverflowButton: Bool
+
+    /// Back action for stepping back within the chooser or closing it from the book grid.
+    let onBack: () -> Void
+
+    /// Action that toggles Android's chooser option popup.
+    let onOverflow: () -> Void
+
+    /// Renders the chooser-owned app bar.
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: onBack) {
+                Image(systemName: "arrow.left")
+                    .font(.system(size: 24, weight: .semibold))
+                    .frame(width: 52, height: Self.height)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "back", defaultValue: "Back"))
+            .accessibilityIdentifier("passageChooserBackButton")
+
+            Text(title)
+                .font(.system(size: 24, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier("passageChooserTitle")
+
+            if showsOverflowButton {
+                Button(action: onOverflow) {
+                    Image(systemName: "ellipsis")
+                        .rotationEffect(.degrees(90))
+                        .font(.system(size: 24, weight: .semibold))
+                        .frame(width: 52, height: Self.height)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "more_options", defaultValue: "More options"))
+                .accessibilityIdentifier("passageChooserOverflowButton")
+            } else {
+                Color.clear
+                    .frame(width: 52, height: Self.height)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(height: Self.height)
+        .foregroundStyle(Color.white)
+        .background(PassageChooserSurfacePalette.toolbarBackground.swiftUIColor)
+        .accessibilityIdentifier("passageChooserAppBar")
     }
 }
 

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -550,6 +550,7 @@ private struct PassageChooserOverflowMenuPopup: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(localizedTitle(for: entry))
+                .accessibilityValue(isChecked(entry.option) ? "on" : "off")
                 .accessibilityIdentifier("passageChooserMenu.\(entry.localizationKey)")
             }
         }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -1,6 +1,8 @@
 // BookChooserView.swift — Book selection grid
 
 import SwiftUI
+import BibleCore
+import SwiftData
 import SwordKit
 
 /**
@@ -22,6 +24,8 @@ import SwordKit
  - `verseCountProvider` supplies module-specific `Versification.getLastVerse` equivalents when
    the chooser drills into verse selection; `nil` means the active module could not resolve the
    selected chapter and no synthetic verse list should be shown
+ - `SettingsStore` supplies Android `BibleBookSortOrder` and `book_grid_*` option state
+ - progress providers supply Android KJVA reading/memorization fractions for visible grid cells
  - `onCancel` lets custom drawer presenters close their own presentation state; without it the view
    falls back to SwiftUI's environment dismiss action for sheet/navigation-stack hosts
 
@@ -29,6 +33,7 @@ import SwordKit
  - tapping a book mutates local selection state to advance to the chapter step
  - tapping a chapter may either complete the flow or advance to the verse step
  - tapping toolbar back actions resets the local step state without dismissing the chooser
+ - tapping overflow-menu rows persists Android-compatible chooser options in `SettingsStore`
  */
 public struct BookChooserView: View {
     /// Dynamic book list derived from the active module's versification.
@@ -52,6 +57,15 @@ public struct BookChooserView: View {
     /// Provides the last verse number for a selected book/chapter.
     let verseCountProvider: (BookInfo, Int) -> Int?
 
+    /// Provides Android KJVA progress for a book cell.
+    let bookProgressProvider: (BookInfo) -> PassageGridProgress
+
+    /// Provides Android KJVA progress for a chapter cell.
+    let chapterProgressProvider: (BookInfo, Int) -> PassageGridProgress
+
+    /// Provides Android KJVA progress for a verse cell.
+    let verseProgressProvider: (BookInfo, Int, Int) -> PassageGridProgress
+
     /// Optional explicit cancellation callback for non-sheet presentations.
     let onCancel: (() -> Void)?
 
@@ -64,8 +78,20 @@ public struct BookChooserView: View {
     /// Currently selected chapter when the verse step is active.
     @State private var selectedChapter: Int?
 
+    /// Android chooser overflow-menu state loaded from `SettingsStore`.
+    @State private var chooserOptions = PassageChooserOptions.androidDefault
+
+    /// Tracks first appearance so option state is not reloaded after in-view menu changes.
+    @State private var hasLoadedChooserOptions = false
+
+    /// Whether Android's book-chooser overflow popup is visible.
+    @State private var isChooserMenuPresented = false
+
     /// Dismiss action for canceling the chooser flow.
     @Environment(\.dismiss) private var dismiss
+
+    /// SwiftData context backing Android-compatible chooser option persistence.
+    @Environment(\.modelContext) private var modelContext
 
     /**
      Creates a book chooser for a specific module canon.
@@ -80,6 +106,9 @@ public struct BookChooserView: View {
        - verseCountProvider: Optional provider for module-specific chapter verse counts. A missing
          provider keeps existing no-module callers functional by falling back to the static
          compatibility table.
+       - bookProgressProvider: Optional provider for Android KJVA book-cell progress.
+       - chapterProgressProvider: Optional provider for Android KJVA chapter-cell progress.
+       - verseProgressProvider: Optional provider for Android KJVA verse-cell progress.
        - onCancel: Optional callback used by custom drawer hosts to close their presentation state.
        - onSelect: Callback receiving `(bookName, chapter, verse?)` when selection completes.
      */
@@ -91,6 +120,9 @@ public struct BookChooserView: View {
         currentVerse: Int? = nil,
         workspaceName: String? = nil,
         verseCountProvider: ((BookInfo, Int) -> Int?)? = nil,
+        bookProgressProvider: ((BookInfo) -> PassageGridProgress)? = nil,
+        chapterProgressProvider: ((BookInfo, Int) -> PassageGridProgress)? = nil,
+        verseProgressProvider: ((BookInfo, Int, Int) -> PassageGridProgress)? = nil,
         onCancel: (() -> Void)? = nil,
         onSelect: @escaping (String, Int, Int?) -> Void
     ) {
@@ -103,6 +135,9 @@ public struct BookChooserView: View {
         self.verseCountProvider = verseCountProvider ?? { book, chapter in
             BibleReaderController.verseCount(for: book.name, chapter: chapter)
         }
+        self.bookProgressProvider = bookProgressProvider ?? { _ in .none }
+        self.chapterProgressProvider = chapterProgressProvider ?? { _, _ in .none }
+        self.verseProgressProvider = verseProgressProvider ?? { _, _, _ in .none }
         self.onCancel = onCancel
         self.onSelect = onSelect
     }
@@ -119,7 +154,13 @@ public struct BookChooserView: View {
                         osisBookId: book.osisId,
                         chapter: chapter,
                         verseCount: verseCountProvider(book, chapter) ?? 0,
-                        currentVerse: currentVerseForSelectedContext(book: book, chapter: chapter)
+                        currentVerse: currentVerseForSelectedContext(book: book, chapter: chapter),
+                        rowOrder: chooserOptions.rowOrder,
+                        progressProvider: { verse in
+                            chooserOptions.showProgressBars
+                                ? verseProgressProvider(book, chapter, verse)
+                                : .none
+                        }
                     ) { verse in
                         onSelect(book.name, chapter, verse)
                     }
@@ -128,7 +169,13 @@ public struct BookChooserView: View {
                         bookName: book.name,
                         osisBookId: book.osisId,
                         chapterCount: book.chapterCount,
-                        currentChapter: currentChapterForSelectedBook(book)
+                        currentChapter: currentChapterForSelectedBook(book),
+                        rowOrder: chooserOptions.rowOrder,
+                        progressProvider: { chapter in
+                            chooserOptions.showProgressBars
+                                ? chapterProgressProvider(book, chapter)
+                                : .none
+                        }
                     ) { chapter in
                         if navigateToVerse {
                             selectedChapter = chapter
@@ -145,25 +192,32 @@ public struct BookChooserView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
+        .preferredColorScheme(.dark)
+        .tint(.white)
+        .onAppear { loadChooserOptionsIfNeeded() }
+        .overlay(alignment: .topTrailing) {
+            chooserOptionsPopupOverlay
+        }
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(String(localized: "cancel")) { cancelChooser() }
-            }
-            if selectedChapter != nil {
-                ToolbarItem(placement: .navigation) {
-                    Button(String(localized: "choose_chapter", defaultValue: "Choose Chapter")) {
-                        selectedChapter = nil
-                    }
+            ToolbarItem(placement: .navigation) {
+                Button(action: navigateBackOrCancel) {
+                    Image(systemName: "chevron.left")
+                        .font(.title3.weight(.semibold))
                 }
-            } else if selectedBook != nil {
-                ToolbarItem(placement: .navigation) {
-                    Button(String(localized: "books")) {
-                        selectedBook = nil
-                        selectedChapter = nil
-                    }
+                .accessibilityLabel(String(localized: "back", defaultValue: "Back"))
+            }
+            if selectedBook == nil {
+                ToolbarItem(placement: .primaryAction) {
+                    chooserOptionsMenuButton
                 }
             }
         }
+        #if os(iOS)
+        .toolbarBackground(PassageChooserSurfacePalette.toolbarBackground.swiftUIColor, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        #endif
     }
 
     /**
@@ -179,6 +233,97 @@ public struct BookChooserView: View {
         } else {
             dismiss()
         }
+    }
+
+    /**
+     Navigates backward within the chooser or closes it from the first step.
+
+     Android's chooser surfaces use a toolbar back arrow. Within this SwiftUI-hosted flow, the same
+     affordance returns from verse to chapter, from chapter to book, and finally dismisses the
+     reader-owned chooser presentation.
+     */
+    private func navigateBackOrCancel() {
+        if isChooserMenuPresented {
+            isChooserMenuPresented = false
+        } else if selectedChapter != nil {
+            selectedChapter = nil
+        } else if selectedBook != nil {
+            selectedBook = nil
+            selectedChapter = nil
+        } else {
+            cancelChooser()
+        }
+    }
+
+    /// Android overflow button for chooser ordering, labels, grouping, and progress options.
+    private var chooserOptionsMenuButton: some View {
+        Button {
+            isChooserMenuPresented.toggle()
+        } label: {
+            Image(systemName: "ellipsis")
+                .rotationEffect(.degrees(90))
+                .font(.title3.weight(.semibold))
+        }
+        .accessibilityLabel(String(localized: "more_options", defaultValue: "More options"))
+        .accessibilityIdentifier("passageChooserOverflowButton")
+    }
+
+    /**
+     Draws Android's dark popup menu over the book grid.
+
+     Android's chooser menu is a popup anchored near the top-right toolbar button, not an iOS
+     command menu. The transparent hit target lets taps outside the popup dismiss it without
+     changing chooser state.
+     */
+    @ViewBuilder
+    private var chooserOptionsPopupOverlay: some View {
+        if selectedBook == nil, isChooserMenuPresented {
+            GeometryReader { proxy in
+                ZStack(alignment: .topTrailing) {
+                    Color.black.opacity(0.42)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            isChooserMenuPresented = false
+                        }
+
+                    PassageChooserOverflowMenuPopup(options: chooserOptions) { option in
+                        applyChooserOption(option)
+                        isChooserMenuPresented = false
+                    }
+                    .frame(width: min(max(proxy.size.width - 16, 260), 340))
+                    .padding(.top, 8)
+                    .padding(.trailing, 8)
+                }
+            }
+            .transition(.opacity)
+            .zIndex(10)
+        }
+    }
+
+    /**
+     Applies and persists one Android chooser-menu option.
+
+     - Parameter option: Menu option selected by the user.
+     - Side effects: Mutates local option state and writes Android-compatible settings.
+     - Failure modes: SwiftData save errors are swallowed by `SettingsStore`.
+     */
+    private func applyChooserOption(_ option: PassageChooserMenuOption) {
+        chooserOptions.apply(option)
+        chooserOptions.persist(to: SettingsStore(modelContext: modelContext))
+    }
+
+    /**
+     Loads persisted chooser options on first appearance.
+
+     - Side effects: Reads SwiftData through `SettingsStore` once per view lifetime.
+     - Failure modes: Missing settings use Android defaults.
+     */
+    private func loadChooserOptionsIfNeeded() {
+        guard !hasLoadedChooserOptions else {
+            return
+        }
+        chooserOptions = PassageChooserOptions.from(settingsStore: SettingsStore(modelContext: modelContext))
+        hasLoadedChooserOptions = true
     }
 
     /// Navigation title reflecting the current chooser step.
@@ -200,13 +345,19 @@ public struct BookChooserView: View {
     private var bookGrid: some View {
         GeometryReader { proxy in
             let orientation = PassageGridOrientation(size: proxy.size)
-            let layout = PassageGridLayout.androidDefault(
-                itemCount: books.count,
-                kind: .book,
+            let slots = PassageBookOrdering.displaySlots(
+                for: books,
+                options: chooserOptions,
                 orientation: orientation
             )
-            let slots = layout.displaySlots(for: books)
-            let columnCount = max(layout.columns, 1)
+            let columnCount = max(
+                PassageBookOrdering.columnCount(
+                    itemCount: books.count,
+                    options: chooserOptions,
+                    orientation: orientation
+                ),
+                1
+            )
             let metrics = PassageGridMetrics.squareCells(
                 availableWidth: proxy.size.width,
                 columns: columnCount
@@ -221,7 +372,10 @@ public struct BookChooserView: View {
                     ForEach(Array(slots.enumerated()), id: \.offset) { _, book in
                         if let book {
                             PassageGridButton(
-                                title: book.abbreviation,
+                                title: PassageBookDisplayName.title(
+                                    for: book,
+                                    showLongName: chooserOptions.showLongBookName
+                                ),
                                 accessibilityLabel: book.name,
                                 accessibilityIdentifier: "passageBookCell.\(book.osisId)",
                                 palette: PassageGridCellPalette.bookPalette(
@@ -229,8 +383,12 @@ public struct BookChooserView: View {
                                     currentOsisId: currentOsisBookId
                                 ),
                                 font: .subheadline.weight(.semibold),
+                                progress: chooserOptions.showProgressBars
+                                    ? bookProgressProvider(book)
+                                    : .none,
                                 cellSide: metrics.cellSide
                             ) {
+                                isChooserMenuPresented = false
                                 selectedBook = book
                                 selectedChapter = nil
                             }
@@ -289,5 +447,92 @@ public struct BookChooserView: View {
             return nil
         }
         return currentVerse
+    }
+}
+
+/**
+ Android-style popup surface for passage book chooser menu actions.
+
+ The Android chooser uses a dark overflow popup with text on the left and checkboxes on the right.
+ SwiftUI's native `Menu` renders platform command rows and left-side symbols, so this view keeps
+ the passage selector visually aligned with Android while delegating all behavior to
+ `PassageChooserOptions`.
+ */
+private struct PassageChooserOverflowMenuPopup: View {
+    /// Current Android chooser option state used to render row checkmarks.
+    let options: PassageChooserOptions
+
+    /// Callback invoked with the selected Android menu option.
+    let onSelect: (PassageChooserMenuOption) -> Void
+
+    /// Android-like active checkbox tint used by Material dark menus.
+    private let checkedTint = Color(red: 0x80 / 255.0, green: 0xCB / 255.0, blue: 0xC4 / 255.0)
+
+    /**
+     Renders Android's passage chooser overflow popup.
+     */
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(PassageChooserMenuEntry.androidBookChooserOrder) { entry in
+                Button {
+                    onSelect(entry.option)
+                } label: {
+                    HStack(spacing: 18) {
+                        Text(localizedTitle(for: entry))
+                            .font(.system(size: 19, weight: .regular))
+                            .foregroundStyle(Color.white)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+
+                        Spacer(minLength: 12)
+
+                        Image(systemName: isChecked(entry.option) ? "checkmark.square.fill" : "square")
+                            .font(.system(size: 24, weight: .regular))
+                            .foregroundStyle(isChecked(entry.option) ? checkedTint : Color.white)
+                    }
+                    .frame(height: 58)
+                    .padding(.leading, 24)
+                    .padding(.trailing, 18)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(localizedTitle(for: entry))
+                .accessibilityIdentifier("passageChooserMenu.\(entry.localizationKey)")
+            }
+        }
+        .background(PassageChooserSurfacePalette.background.swiftUIColor)
+        .shadow(color: Color.black.opacity(0.45), radius: 10, x: 0, y: 6)
+        .accessibilityIdentifier("passageChooserOverflowPopup")
+    }
+
+    /**
+     Resolves localized text for an Android menu row.
+
+     - Parameter entry: Android menu row metadata.
+     - Returns: Localized menu title or the Android English fallback.
+     */
+    private func localizedTitle(for entry: PassageChooserMenuEntry) -> String {
+        NSLocalizedString(entry.localizationKey, value: entry.defaultTitle, comment: "")
+    }
+
+    /**
+     Returns whether one Android menu option is enabled.
+
+     - Parameter option: Android chooser option represented by a popup row.
+     - Returns: Current checked state for the row.
+     */
+    private func isChecked(_ option: PassageChooserMenuOption) -> Bool {
+        switch option {
+        case .alphabeticalOrder:
+            return options.alphabeticalOrder
+        case .rowOrder:
+            return options.rowOrder
+        case .groupByCategory:
+            return options.groupByCategory
+        case .showLongBookName:
+            return options.showLongBookName
+        case .showProgressBars:
+            return options.showProgressBars
+        }
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -18,15 +18,17 @@ import SwordKit
  - `books` is the module-specific canon and chapter metadata provided by the caller
  - `currentBook`, `currentChapter`, and `currentVerse` are the reader's active location used only
    for Android-compatible highlighting
+ - `workspaceName` is shown on the first chooser step to mirror Android's activity title context
  - `verseCountProvider` supplies module-specific `Versification.getLastVerse` equivalents when
    the chooser drills into verse selection; `nil` means the active module could not resolve the
    selected chapter and no synthetic verse list should be shown
- - `dismiss` closes the chooser when the user cancels the flow
+ - `onCancel` lets custom drawer presenters close their own presentation state; without it the view
+   falls back to SwiftUI's environment dismiss action for sheet/navigation-stack hosts
 
  Side effects:
  - tapping a book mutates local selection state to advance to the chapter step
  - tapping a chapter may either complete the flow or advance to the verse step
- - tapping toolbar back actions resets the local step state without dismissing the sheet
+ - tapping toolbar back actions resets the local step state without dismissing the chooser
  */
 public struct BookChooserView: View {
     /// Dynamic book list derived from the active module's versification.
@@ -44,8 +46,14 @@ public struct BookChooserView: View {
     /// Current reader verse, used to highlight the active verse in the active chapter.
     let currentVerse: Int?
 
+    /// Active workspace name appended to the first-step title for Android parity.
+    let workspaceName: String?
+
     /// Provides the last verse number for a selected book/chapter.
     let verseCountProvider: (BookInfo, Int) -> Int?
+
+    /// Optional explicit cancellation callback for non-sheet presentations.
+    let onCancel: (() -> Void)?
 
     /// Callback invoked when the user has completed the selection flow.
     let onSelect: (String, Int, Int?) -> Void
@@ -68,9 +76,11 @@ public struct BookChooserView: View {
        - currentBook: Current reader book name, used only for selector highlighting.
        - currentChapter: Current reader chapter, used only for selector highlighting.
        - currentVerse: Current reader verse, used only for selector highlighting.
+       - workspaceName: Active workspace name appended to the first-step chooser title.
        - verseCountProvider: Optional provider for module-specific chapter verse counts. A missing
          provider keeps existing no-module callers functional by falling back to the static
          compatibility table.
+       - onCancel: Optional callback used by custom drawer hosts to close their presentation state.
        - onSelect: Callback receiving `(bookName, chapter, verse?)` when selection completes.
      */
     public init(
@@ -79,7 +89,9 @@ public struct BookChooserView: View {
         currentBook: String? = nil,
         currentChapter: Int? = nil,
         currentVerse: Int? = nil,
+        workspaceName: String? = nil,
         verseCountProvider: ((BookInfo, Int) -> Int?)? = nil,
+        onCancel: (() -> Void)? = nil,
         onSelect: @escaping (String, Int, Int?) -> Void
     ) {
         self.books = books
@@ -87,9 +99,11 @@ public struct BookChooserView: View {
         self.currentBook = currentBook
         self.currentChapter = currentChapter
         self.currentVerse = currentVerse
+        self.workspaceName = workspaceName
         self.verseCountProvider = verseCountProvider ?? { book, chapter in
             BibleReaderController.verseCount(for: book.name, chapter: chapter)
         }
+        self.onCancel = onCancel
         self.onSelect = onSelect
     }
 
@@ -133,7 +147,7 @@ public struct BookChooserView: View {
         #endif
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(String(localized: "cancel")) { dismiss() }
+                Button(String(localized: "cancel")) { cancelChooser() }
             }
             if selectedChapter != nil {
                 ToolbarItem(placement: .navigation) {
@@ -152,12 +166,34 @@ public struct BookChooserView: View {
         }
     }
 
+    /**
+     Cancels the chooser through the host-provided callback when present.
+
+     Custom drawer presentation is owned by `BibleReaderView`, so SwiftUI's environment dismiss
+     action is not sufficient there. Sheet-based callers keep the legacy path by omitting
+     `onCancel`, which delegates to the environment dismiss action.
+     */
+    private func cancelChooser() {
+        if let onCancel {
+            onCancel()
+        } else {
+            dismiss()
+        }
+    }
+
     /// Navigation title reflecting the current chooser step.
     private var navigationTitle: String {
         if let book = selectedBook, let chapter = selectedChapter {
             return "\(book.name) \(chapter)"
         }
-        return selectedBook?.name ?? String(localized: "choose_book")
+        if let selectedBook {
+            return selectedBook.name
+        }
+
+        return PassageChooserTitle.bookSelectionTitle(
+            baseTitle: String(localized: "choose_book"),
+            workspaceName: workspaceName
+        )
     }
 
     /// Scrollable container for the Android-aligned book grid.
@@ -170,13 +206,18 @@ public struct BookChooserView: View {
                 orientation: orientation
             )
             let slots = layout.displaySlots(for: books)
+            let columnCount = max(layout.columns, 1)
+            let metrics = PassageGridMetrics.squareCells(
+                availableWidth: proxy.size.width,
+                columns: columnCount
+            )
             let columns = Array(
-                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
-                count: max(layout.columns, 1)
+                repeating: GridItem(.fixed(metrics.cellSide), spacing: PassageGridMetrics.spacing),
+                count: columnCount
             )
 
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 4) {
+                LazyVGrid(columns: columns, spacing: PassageGridMetrics.spacing) {
                     ForEach(Array(slots.enumerated()), id: \.offset) { _, book in
                         if let book {
                             PassageGridButton(
@@ -188,19 +229,21 @@ public struct BookChooserView: View {
                                     currentOsisId: currentOsisBookId
                                 ),
                                 font: .subheadline.weight(.semibold),
-                                minHeight: 34
+                                cellSide: metrics.cellSide
                             ) {
                                 selectedBook = book
                                 selectedChapter = nil
                             }
                         } else {
                             Color.clear
-                                .frame(minHeight: 34)
+                                .frame(width: metrics.cellSide, height: metrics.cellSide)
                                 .accessibilityHidden(true)
                         }
                     }
                 }
-                .padding(12)
+                .frame(width: metrics.gridWidth)
+                .padding(PassageGridMetrics.horizontalPadding)
+                .frame(maxWidth: .infinity)
             }
         }
     }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
@@ -7,13 +7,20 @@ import SwiftUI
 
  The chapter count is supplied by the parent chooser from the active module's versification data,
  so chapter availability matches the selected module rather than a static canon table.
+ The grid layout and current-chapter highlight mirror Android `GridChoosePassageChapter`.
  */
 public struct ChapterChooserView: View {
     /// User-visible book name shown in the navigation title.
     let bookName: String
 
+    /// OSIS id for the selected book, used to resolve Android category color.
+    let osisBookId: String?
+
     /// Number of chapters available for this book in the active module; zero renders no choices.
     let chapterCount: Int
+
+    /// Current reader chapter if this chooser is showing the active book.
+    let currentChapter: Int?
 
     /// Callback invoked with the chosen one-based chapter number.
     let onSelect: (Int) -> Void
@@ -23,36 +30,75 @@ public struct ChapterChooserView: View {
 
      - Parameters:
        - bookName: Book name displayed in the navigation title.
+       - osisBookId: OSIS id for Android category color; falls back to static resolution by name.
        - chapterCount: Number of chapters available in the active module.
+       - currentChapter: Current reader chapter to highlight when the active book is selected.
        - onSelect: Callback receiving the selected one-based chapter number.
      */
-    public init(bookName: String, chapterCount: Int, onSelect: @escaping (Int) -> Void) {
+    public init(
+        bookName: String,
+        osisBookId: String? = nil,
+        chapterCount: Int,
+        currentChapter: Int? = nil,
+        onSelect: @escaping (Int) -> Void
+    ) {
         self.bookName = bookName
+        self.osisBookId = osisBookId
         self.chapterCount = chapterCount
+        self.currentChapter = currentChapter
         self.onSelect = onSelect
     }
 
-    /// Builds the adaptive chapter grid.
+    /// Builds the Android-aligned chapter grid.
     public var body: some View {
-        ScrollView {
-            let columns = [GridItem(.adaptive(minimum: 50), spacing: 8)]
-            LazyVGrid(columns: columns, spacing: 8) {
-                if chapterCount > 0 {
-                    ForEach(1...chapterCount, id: \.self) { chapter in
-                        Button(action: { onSelect(chapter) }) {
-                            Text("\(chapter)")
-                                .font(.body.monospacedDigit())
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 12)
-                                .background(.quaternary)
-                                .clipShape(RoundedRectangle(cornerRadius: 6))
+        GeometryReader { proxy in
+            let chapters = chapterCount > 0 ? Array(1...chapterCount) : []
+            let orientation = PassageGridOrientation(size: proxy.size)
+            let layout = PassageGridLayout.androidDefault(
+                itemCount: chapters.count,
+                kind: .number,
+                orientation: orientation
+            )
+            let slots = layout.displaySlots(for: chapters)
+            let columns = Array(
+                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
+                count: max(layout.columns, 1)
+            )
+            let categoryColor = PassageBookCategory.category(forOsisId: resolvedOsisBookId).color
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 4) {
+                    ForEach(Array(slots.enumerated()), id: \.offset) { _, chapter in
+                        if let chapter {
+                            PassageGridButton(
+                                title: "\(chapter)",
+                                accessibilityLabel: "\(bookName) \(chapter)",
+                                accessibilityIdentifier: "passageChapterCell.\(chapter)",
+                                palette: PassageGridCellPalette.numberPalette(
+                                    number: chapter,
+                                    currentNumber: currentChapter,
+                                    categoryColor: categoryColor
+                                ),
+                                font: .body.monospacedDigit().weight(.semibold),
+                                minHeight: 36
+                            ) {
+                                onSelect(chapter)
+                            }
+                        } else {
+                            Color.clear
+                                .frame(minHeight: 36)
+                                .accessibilityHidden(true)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
+                .padding(12)
             }
-            .padding()
         }
         .navigationTitle(bookName)
+    }
+
+    /// OSIS id used for Android category color resolution.
+    private var resolvedOsisBookId: String {
+        osisBookId ?? BibleReaderController.osisBookId(for: bookName)
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
@@ -112,7 +112,7 @@ public struct ChapterChooserView: View {
                     }
                 }
                 .frame(width: metrics.gridWidth)
-                .padding(PassageGridMetrics.horizontalPadding)
+                .padding(.horizontal, PassageGridMetrics.horizontalPadding)
                 .frame(maxWidth: .infinity)
             }
         }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
@@ -60,14 +60,19 @@ public struct ChapterChooserView: View {
                 orientation: orientation
             )
             let slots = layout.displaySlots(for: chapters)
+            let columnCount = max(layout.columns, 1)
+            let metrics = PassageGridMetrics.squareCells(
+                availableWidth: proxy.size.width,
+                columns: columnCount
+            )
             let columns = Array(
-                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
-                count: max(layout.columns, 1)
+                repeating: GridItem(.fixed(metrics.cellSide), spacing: PassageGridMetrics.spacing),
+                count: columnCount
             )
             let categoryColor = PassageBookCategory.category(forOsisId: resolvedOsisBookId).color
 
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 4) {
+                LazyVGrid(columns: columns, spacing: PassageGridMetrics.spacing) {
                     ForEach(Array(slots.enumerated()), id: \.offset) { _, chapter in
                         if let chapter {
                             PassageGridButton(
@@ -80,18 +85,20 @@ public struct ChapterChooserView: View {
                                     categoryColor: categoryColor
                                 ),
                                 font: .body.monospacedDigit().weight(.semibold),
-                                minHeight: 36
+                                cellSide: metrics.cellSide
                             ) {
                                 onSelect(chapter)
                             }
                         } else {
                             Color.clear
-                                .frame(minHeight: 36)
+                                .frame(width: metrics.cellSide, height: metrics.cellSide)
                                 .accessibilityHidden(true)
                         }
                     }
                 }
-                .padding(12)
+                .frame(width: metrics.gridWidth)
+                .padding(PassageGridMetrics.horizontalPadding)
+                .frame(maxWidth: .infinity)
             }
         }
         .navigationTitle(bookName)

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift
@@ -7,7 +7,8 @@ import SwiftUI
 
  The chapter count is supplied by the parent chooser from the active module's versification data,
  so chapter availability matches the selected module rather than a static canon table.
- The grid layout and current-chapter highlight mirror Android `GridChoosePassageChapter`.
+ The grid layout, row-order preference, progress overlays, and current-chapter highlight mirror
+ Android `GridChoosePassageChapter`.
  */
 public struct ChapterChooserView: View {
     /// User-visible book name shown in the navigation title.
@@ -22,6 +23,12 @@ public struct ChapterChooserView: View {
     /// Current reader chapter if this chooser is showing the active book.
     let currentChapter: Int?
 
+    /// Android row-order option shared with the book chooser menu.
+    let rowOrder: Bool
+
+    /// Provides Android KJVA progress for a one-based chapter.
+    let progressProvider: (Int) -> PassageGridProgress
+
     /// Callback invoked with the chosen one-based chapter number.
     let onSelect: (Int) -> Void
 
@@ -33,6 +40,8 @@ public struct ChapterChooserView: View {
        - osisBookId: OSIS id for Android category color; falls back to static resolution by name.
        - chapterCount: Number of chapters available in the active module.
        - currentChapter: Current reader chapter to highlight when the active book is selected.
+       - rowOrder: Android row-order option shared with book chooser settings.
+       - progressProvider: Optional Android KJVA progress provider for chapter cells.
        - onSelect: Callback receiving the selected one-based chapter number.
      */
     public init(
@@ -40,12 +49,16 @@ public struct ChapterChooserView: View {
         osisBookId: String? = nil,
         chapterCount: Int,
         currentChapter: Int? = nil,
+        rowOrder: Bool = false,
+        progressProvider: ((Int) -> PassageGridProgress)? = nil,
         onSelect: @escaping (Int) -> Void
     ) {
         self.bookName = bookName
         self.osisBookId = osisBookId
         self.chapterCount = chapterCount
         self.currentChapter = currentChapter
+        self.rowOrder = rowOrder
+        self.progressProvider = progressProvider ?? { _ in .none }
         self.onSelect = onSelect
     }
 
@@ -57,7 +70,8 @@ public struct ChapterChooserView: View {
             let layout = PassageGridLayout.androidDefault(
                 itemCount: chapters.count,
                 kind: .number,
-                orientation: orientation
+                orientation: orientation,
+                rowOrder: rowOrder
             )
             let slots = layout.displaySlots(for: chapters)
             let columnCount = max(layout.columns, 1)
@@ -85,6 +99,7 @@ public struct ChapterChooserView: View {
                                     categoryColor: categoryColor
                                 ),
                                 font: .body.monospacedDigit().weight(.semibold),
+                                progress: progressProvider(chapter),
                                 cellSide: metrics.cellSide
                             ) {
                                 onSelect(chapter)
@@ -102,6 +117,7 @@ public struct ChapterChooserView: View {
             }
         }
         .navigationTitle(bookName)
+        .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
     }
 
     /// OSIS id used for Android category color resolution.

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -1022,18 +1022,46 @@ enum PassageGridProgressCalculator {
             return 0
         }
 
-        var ordinals = Set<Int>()
+        var intersections: [ClosedRange<Int>] = []
         for range in snapshot.memorizedRanges where matches(range, activeBookInitials: activeBookInitials) {
             let start = max(range.startOrdinal, queryRange.lowerBound)
             let end = min(range.endOrdinal, queryRange.upperBound)
             guard start <= end else {
                 continue
             }
-            for ordinal in start...end {
-                ordinals.insert(ordinal)
+            intersections.append(start...end)
+        }
+        return mergedOrdinalCount(in: intersections)
+    }
+
+    /**
+     Counts unique ordinals represented by possibly overlapping or adjacent ranges.
+
+     Android stores memorized passages as ranges, so progress can be counted from merged intervals
+     without allocating one value per verse ordinal. Adjacent ranges are merged because their covered
+     ordinal count is equivalent and avoids unnecessary segment churn.
+    */
+    private static func mergedOrdinalCount(in ranges: [ClosedRange<Int>]) -> Int {
+        let sortedRanges = ranges.sorted(by: { $0.lowerBound < $1.lowerBound })
+        guard let first = sortedRanges.first else {
+            return 0
+        }
+
+        var count = 0
+        var currentStart = first.lowerBound
+        var currentEnd = first.upperBound
+
+        for range in sortedRanges.dropFirst() {
+            if range.lowerBound <= currentEnd + 1 {
+                currentEnd = max(currentEnd, range.upperBound)
+            } else {
+                count += currentEnd - currentStart + 1
+                currentStart = range.lowerBound
+                currentEnd = range.upperBound
             }
         }
-        return ordinals.count
+
+        return count + currentEnd - currentStart + 1
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -1,6 +1,7 @@
 // PassageGrid.swift - Android-aligned passage selector layout and palette
 
 import SwiftUI
+import BibleCore
 import SwordKit
 
 /**
@@ -47,18 +48,34 @@ enum PassageGridOrientation: Equatable, Sendable {
  SwiftUI `Color` is not equatable, so tests assert against this value type while views convert it
  to `Color` only at render time.
  */
-struct PassageGridRGBColor: Equatable, Sendable {
+public struct PassageGridRGBColor: Equatable, Sendable {
     /// Red component in the Android 0...255 range.
-    let red: Int
+    public let red: Int
 
     /// Green component in the Android 0...255 range.
-    let green: Int
+    public let green: Int
 
     /// Blue component in the Android 0...255 range.
-    let blue: Int
+    public let blue: Int
+
+    /**
+     Creates an RGB color token.
+
+     - Parameters:
+       - red: Red component in `0...255`.
+       - green: Green component in `0...255`.
+       - blue: Blue component in `0...255`.
+     - Side effects: none.
+     - Failure modes: Components are not clamped; callers should pass Android source values.
+     */
+    public init(red: Int, green: Int, blue: Int) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
 
     /// SwiftUI color used by the rendered selector cell.
-    var swiftUIColor: Color {
+    public var swiftUIColor: Color {
         Color(
             red: Double(red) / 255.0,
             green: Double(green) / 255.0,
@@ -68,6 +85,9 @@ struct PassageGridRGBColor: Equatable, Sendable {
 
     /// Android `Color.DKGRAY`.
     static let darkGray = PassageGridRGBColor(red: 0x44, green: 0x44, blue: 0x44)
+
+    /// Android black toolbar tint used by the fixed passage-chooser activity theme.
+    static let black = PassageGridRGBColor(red: 0x00, green: 0x00, blue: 0x00)
 
     /// Android default text color for unselected chapter and verse buttons.
     static let white = PassageGridRGBColor(red: 0xFF, green: 0xFF, blue: 0xFF)
@@ -110,6 +130,203 @@ struct PassageGridRGBColor: Equatable, Sendable {
 
     /// Android fallback color for books outside the canonical category ranges.
     static let other = acts
+
+    /// Android passage chooser activity background.
+    static let passageChooserBackground = PassageGridRGBColor(red: 0x30, green: 0x30, blue: 0x30)
+}
+
+/**
+ Fixed Android passage-chooser surface palette.
+
+ Android disables normal theme switching for `GridChoosePassageBook`, `GridChoosePassageChapter`,
+ and `GridChoosePassageVerse`; those activities keep a dark grid surface and black toolbar in both
+ day and night reader modes. The iOS chooser consumes this palette directly so it does not inherit
+ the surrounding reader theme.
+ */
+enum PassageChooserSurfacePalette {
+    /// Android `GridChoosePassageTheme` content background.
+    static let background = PassageGridRGBColor.passageChooserBackground
+
+    /// Android chooser action-bar background.
+    static let toolbarBackground = PassageGridRGBColor.black
+}
+
+/**
+ Android overflow-menu actions supported by the book chooser.
+
+ Each case corresponds to a checkable item in Android `choose_passage_book_menu.xml`. The enum is
+ intentionally separate from SwiftUI `Menu` construction so tests can verify Android state
+ transitions without rendering a platform menu.
+ */
+enum PassageChooserMenuOption: Hashable, Sendable {
+    /// Toggle alphabetical sort order.
+    case alphabeticalOrder
+
+    /// Toggle left-to-right row ordering.
+    case rowOrder
+
+    /// Toggle category grouping.
+    case groupByCategory
+
+    /// Toggle uppercase short name plus long description labels.
+    case showLongBookName
+
+    /// Toggle reading/memorization progress bars.
+    case showProgressBars
+}
+
+/**
+ Android book-chooser overflow menu row metadata.
+
+ Android defines the passage-chooser popup in `choose_passage_book_menu.xml`. Keeping the row order,
+ localization key, and fallback title as data lets the SwiftUI surface render an Android-style menu
+ without duplicating the menu contract in tests and view code.
+ */
+struct PassageChooserMenuEntry: Equatable, Identifiable, Sendable {
+    /// Android menu action represented by this row.
+    let option: PassageChooserMenuOption
+
+    /// Localization key shared with the Android preference/menu label.
+    let localizationKey: String
+
+    /// English fallback title used when no localized string is present.
+    let defaultTitle: String
+
+    /// Stable identity for SwiftUI row rendering.
+    var id: PassageChooserMenuOption {
+        option
+    }
+
+    /// Android `choose_passage_book_menu.xml` row order.
+    static let androidBookChooserOrder: [PassageChooserMenuEntry] = [
+        PassageChooserMenuEntry(
+            option: .alphabeticalOrder,
+            localizationKey: "sort_by_alphabetical",
+            defaultTitle: "Alphabetical order"
+        ),
+        PassageChooserMenuEntry(
+            option: .rowOrder,
+            localizationKey: "book_menu_sort_row_opt",
+            defaultTitle: "Order books horizontally"
+        ),
+        PassageChooserMenuEntry(
+            option: .groupByCategory,
+            localizationKey: "book_menu_group_by_category",
+            defaultTitle: "Group books by category"
+        ),
+        PassageChooserMenuEntry(
+            option: .showLongBookName,
+            localizationKey: "book_menu_show_long_book_name",
+            defaultTitle: "Show long book name"
+        ),
+        PassageChooserMenuEntry(
+            option: .showProgressBars,
+            localizationKey: "book_menu_show_progress_bars",
+            defaultTitle: "Show progress bars"
+        ),
+    ]
+}
+
+/**
+ Durable passage-chooser option state mirrored from Android `book_grid_*` settings.
+
+ Android persists these flags globally and applies additional state transitions when certain menu
+ rows are tapped. In particular, category grouping forces Bible-book order and horizontal row
+ order; alphabetical and row-order changes clear grouping without resetting long-name or progress
+ choices.
+ */
+struct PassageChooserOptions: Equatable, Sendable {
+    /// Android `NavigationControl.BIBLE_BOOK_SORT_ORDER` shared preference key.
+    private static let bibleBookSortOrderKey = "BibleBookSortOrder"
+
+    /// Whether books are sorted alphabetically before grid placement.
+    var alphabeticalOrder: Bool
+
+    /// Whether grid source items fill rows left-to-right instead of Android's portrait column order.
+    var rowOrder: Bool
+
+    /// Whether books are grouped by Android's broad category buckets with spacer cells between groups.
+    var groupByCategory: Bool
+
+    /// Whether book cells show Android's long-name two-line label.
+    var showLongBookName: Bool
+
+    /// Whether reading and memorization progress bars are drawn at the bottom of grid cells.
+    var showProgressBars: Bool
+
+    /// Android defaults from `GridChoosePassageBook`: row/order/category/long-name off, progress on.
+    static let androidDefault = PassageChooserOptions(
+        alphabeticalOrder: false,
+        rowOrder: false,
+        groupByCategory: false,
+        showLongBookName: false,
+        showProgressBars: true
+    )
+
+    /**
+     Loads passage chooser options from Android parity settings.
+
+     - Parameter settingsStore: Settings source bound to the current SwiftData context.
+     - Returns: Stored chooser options or Android defaults when no values have been persisted.
+     - Side effects: Reads SwiftData through `SettingsStore`.
+     - Failure modes: Missing or malformed booleans fall back through `AppPreferenceRegistry`.
+     */
+    static func from(settingsStore: SettingsStore) -> PassageChooserOptions {
+        PassageChooserOptions(
+            alphabeticalOrder: settingsStore.getString(Self.bibleBookSortOrderKey) == "ALPHABETICAL",
+            rowOrder: settingsStore.getBool(.bookGridLeftToRight),
+            groupByCategory: settingsStore.getBool(.bookGridGroupByCategory),
+            showLongBookName: settingsStore.getBool(.bookGridShowLongName),
+            showProgressBars: settingsStore.getBool(.bookGridShowProgress)
+        )
+    }
+
+    /**
+     Applies one Android overflow-menu action to the option state.
+
+     - Parameter option: Menu row selected by the user.
+     - Side effects: Mutates this value only; persistence is handled by `persist(to:)`.
+     - Failure modes: none.
+     */
+    mutating func apply(_ option: PassageChooserMenuOption) {
+        switch option {
+        case .alphabeticalOrder:
+            groupByCategory = false
+            alphabeticalOrder.toggle()
+        case .rowOrder:
+            groupByCategory = false
+            rowOrder.toggle()
+        case .groupByCategory:
+            alphabeticalOrder = false
+            rowOrder = true
+            groupByCategory.toggle()
+        case .showLongBookName:
+            showLongBookName.toggle()
+        case .showProgressBars:
+            showProgressBars.toggle()
+        }
+    }
+
+    /**
+     Persists options through Android-compatible `book_grid_*` keys.
+
+     Android stores alphabetical order in `NavigationControl.BIBLE_BOOK_SORT_ORDER`, while the
+     other chooser flags use `book_grid_*` keys. iOS writes the same durable keys so relaunches and
+     reset/import behavior are not tied to view-local state.
+     - Parameter settingsStore: Store receiving the durable option values.
+     - Side effects: Writes SwiftData via `SettingsStore`.
+     - Failure modes: `SettingsStore` save errors are swallowed by the store.
+     */
+    func persist(to settingsStore: SettingsStore) {
+        settingsStore.setString(
+            Self.bibleBookSortOrderKey,
+            value: alphabeticalOrder ? "ALPHABETICAL" : "BIBLE_BOOK"
+        )
+        settingsStore.setBool(.bookGridLeftToRight, value: rowOrder)
+        settingsStore.setBool(.bookGridGroupByCategory, value: groupByCategory)
+        settingsStore.setBool(.bookGridShowLongName, value: showLongBookName)
+        settingsStore.setBool(.bookGridShowProgress, value: showProgressBars)
+    }
 }
 
 /**
@@ -120,8 +337,11 @@ struct PassageGridRGBColor: Equatable, Sendable {
  the active module exposes.
  */
 struct PassageBookCategory: Equatable, Sendable {
-    /// Android group id for category sorting and future option support.
+    /// Android fine-grained `GroupA` id for category coloring.
     let group: Int
+
+    /// Android broad `GroupB` id used by the grouped-grid menu option.
+    let groupingBucket: Int
 
     /// Android category color.
     let color: PassageGridRGBColor
@@ -135,28 +355,206 @@ struct PassageBookCategory: Equatable, Sendable {
     static func category(forOsisId osisId: String) -> PassageBookCategory {
         switch osisId {
         case "Gen", "Exod", "Lev", "Num", "Deut":
-            PassageBookCategory(group: 0, color: .pentateuch)
+            PassageBookCategory(group: 0, groupingBucket: 1, color: .pentateuch)
         case "Josh", "Judg", "Ruth", "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh", "Esth":
-            PassageBookCategory(group: 1, color: .history)
+            PassageBookCategory(group: 1, groupingBucket: 2, color: .history)
         case "Job", "Ps", "Prov", "Eccl", "Song":
-            PassageBookCategory(group: 2, color: .wisdom)
+            PassageBookCategory(group: 2, groupingBucket: 3, color: .wisdom)
         case "Isa", "Jer", "Lam", "Ezek", "Dan":
-            PassageBookCategory(group: 3, color: .majorProphets)
+            PassageBookCategory(group: 3, groupingBucket: 4, color: .majorProphets)
         case "Hos", "Joel", "Amos", "Obad", "Jonah", "Mic", "Nah", "Hab", "Zeph", "Hag", "Zech", "Mal":
-            PassageBookCategory(group: 4, color: .minorProphets)
+            PassageBookCategory(group: 4, groupingBucket: 5, color: .minorProphets)
         case "Matt", "Mark", "Luke", "John":
-            PassageBookCategory(group: 5, color: .gospel)
+            PassageBookCategory(group: 5, groupingBucket: 6, color: .gospel)
         case "Acts":
-            PassageBookCategory(group: 6, color: .acts)
+            PassageBookCategory(group: 6, groupingBucket: 6, color: .acts)
         case "Rom", "1Cor", "2Cor", "Gal", "Eph", "Phil", "Col", "1Thess", "2Thess", "1Tim", "2Tim", "Titus", "Phlm":
-            PassageBookCategory(group: 7, color: .pauline)
+            PassageBookCategory(group: 7, groupingBucket: 7, color: .pauline)
         case "Heb", "Jas", "1Pet", "2Pet", "1John", "2John", "3John", "Jude":
-            PassageBookCategory(group: 8, color: .generalEpistles)
+            PassageBookCategory(group: 8, groupingBucket: 8, color: .generalEpistles)
         case "Rev":
-            PassageBookCategory(group: 9, color: .revelation)
+            PassageBookCategory(group: 9, groupingBucket: 8, color: .revelation)
         default:
-            PassageBookCategory(group: 10, color: .other)
+            PassageBookCategory(group: 10, groupingBucket: 9, color: .other)
         }
+    }
+}
+
+/**
+ Android JSword book-label formatter.
+
+ Android renders `versification.getShortName(book)` in the grid, which differs from SWORD module
+ abbreviations for several books (`2 Ki`, `Psa`, `Act`, `Phile`, and similar labels). Long-name
+ mode uses the uppercase short name on the first line and the book description on the second line.
+ */
+enum PassageBookDisplayName {
+    /// Source-derived JSword short names by OSIS id.
+    private static let shortNamesByOsisId: [String: String] = [
+        "Gen": "Gen", "Exod": "Exo", "Lev": "Lev", "Num": "Num", "Deut": "Deu",
+        "Josh": "Jos", "Judg": "Judg", "Ruth": "Rut", "1Sam": "1 Sa", "2Sam": "2 Sa",
+        "1Kgs": "1 Ki", "2Kgs": "2 Ki", "1Chr": "1 Ch", "2Chr": "2 Ch", "Ezra": "Ezr",
+        "Neh": "Neh", "Esth": "Est", "Job": "Job", "Ps": "Psa", "Prov": "Pro",
+        "Eccl": "Ecc", "Song": "Song", "Isa": "Isa", "Jer": "Jer", "Lam": "Lam",
+        "Ezek": "Eze", "Dan": "Dan", "Hos": "Hos", "Joel": "Joe", "Amos": "Amo",
+        "Obad": "Obd", "Jonah": "Jon", "Mic": "Mic", "Nah": "Nah", "Hab": "Hab",
+        "Zeph": "Zep", "Hag": "Hag", "Zech": "Zec", "Mal": "Mal", "Matt": "Mat",
+        "Mark": "Mar", "Luke": "Luk", "John": "Joh", "Acts": "Act", "Rom": "Rom",
+        "1Cor": "1 Cor", "2Cor": "2 Cor", "Gal": "Gal", "Eph": "Eph", "Phil": "Phili",
+        "Col": "Col", "1Thess": "1 Th", "2Thess": "2 Th", "1Tim": "1 Tim",
+        "2Tim": "2 Tim", "Titus": "Tit", "Phlm": "Phile", "Heb": "Heb", "Jas": "Jam",
+        "1Pet": "1 Pe", "2Pet": "2 Pe", "1John": "1 Jo", "2John": "2 Jo",
+        "3John": "3 Jo", "Jude": "Jude", "Rev": "Rev",
+    ]
+
+    /**
+     Returns Android's short chooser label for a book.
+
+     - Parameter book: Module-provided book metadata.
+     - Returns: JSword short name when known, otherwise the module abbreviation as a safe fallback.
+     - Side effects: none.
+     - Failure modes: Unknown ids fall back to `book.abbreviation`.
+     */
+    static func shortName(for book: BookInfo) -> String {
+        shortNamesByOsisId[book.osisId] ?? book.abbreviation
+    }
+
+    /**
+     Returns the visible cell title for Android short-name or long-name mode.
+
+     - Parameters:
+       - book: Module-provided book metadata.
+       - showLongName: Whether Android's "Show long book name" option is enabled.
+     - Returns: One-line short label or two-line uppercase-short plus book name.
+     - Side effects: none.
+     - Failure modes: Unknown ids still render through the fallback abbreviation.
+     */
+    static func title(for book: BookInfo, showLongName: Bool) -> String {
+        let shortName = shortName(for: book)
+        guard showLongName else {
+            return shortName
+        }
+        return "\(shortName.uppercased())\n\(book.name)"
+    }
+}
+
+/**
+ Android book-ordering coordinator for the chooser grid.
+
+ The underlying `PassageGridLayout` knows Android's row/column matrix. This helper owns the
+ additional book-menu ordering options: alphabetical sorting, row ordering, and broad category
+ grouping with spacer cells at group boundaries.
+ */
+enum PassageBookOrdering {
+    /// Android grouped-grid maximum column count.
+    static let groupedColumnCount = 6
+
+    /**
+     Produces visual slots for the book grid under the active Android chooser options.
+
+     - Parameters:
+       - books: Module-provided book list in Bible-book order.
+       - options: Current persisted/session chooser options.
+       - orientation: Current visual orientation used by Android layout rules.
+     - Returns: Row-major visual slots, with `nil` placeholders for empty cells/spacers.
+     - Side effects: none.
+     - Failure modes: Empty input returns an empty array.
+     */
+    static func displaySlots(
+        for books: [BookInfo],
+        options: PassageChooserOptions,
+        orientation: PassageGridOrientation
+    ) -> [BookInfo?] {
+        guard !books.isEmpty else {
+            return []
+        }
+
+        if options.groupByCategory {
+            return groupedSlots(for: books)
+        }
+
+        let sortedBooks = options.alphabeticalOrder
+            ? books.sorted { lhs, rhs in
+                androidAlphabeticalSortKey(lhs) < androidAlphabeticalSortKey(rhs)
+            }
+            : books
+        let layout = PassageGridLayout.androidDefault(
+            itemCount: sortedBooks.count,
+            kind: .book,
+            orientation: orientation,
+            rowOrder: options.rowOrder
+        )
+        return layout.displaySlots(for: sortedBooks)
+    }
+
+    /**
+     Resolves the column count the rendered grid should use for the active options.
+
+     - Parameters:
+       - itemCount: Number of source books.
+       - options: Current chooser options.
+       - orientation: Current visual orientation.
+     - Returns: Android grouped-grid column count or the layout-derived count.
+     - Side effects: none.
+     - Failure modes: Counts below one are clamped by callers.
+     */
+    static func columnCount(
+        itemCount: Int,
+        options: PassageChooserOptions,
+        orientation: PassageGridOrientation
+    ) -> Int {
+        if options.groupByCategory {
+            return groupedColumnCount
+        }
+        return PassageGridLayout.androidDefault(
+            itemCount: itemCount,
+            kind: .book,
+            orientation: orientation,
+            rowOrder: options.rowOrder
+        ).columns
+    }
+
+    /**
+     Groups canonical books by Android `GroupB`, inserting spacer cells between groups.
+
+     Android's `ButtonGrid.addGroupedButtons` fills rows left-to-right, starts a new row when the
+     broad category changes, and pads the current row with empty cells before beginning the next
+     group.
+     */
+    private static func groupedSlots(for books: [BookInfo]) -> [BookInfo?] {
+        var slots: [BookInfo?] = []
+        var currentBucket: Int?
+
+        for book in books {
+            let bucket = PassageBookCategory.category(forOsisId: book.osisId).groupingBucket
+            if let currentBucket, currentBucket != bucket {
+                while !slots.count.isMultiple(of: groupedColumnCount) {
+                    slots.append(nil)
+                }
+            }
+            currentBucket = bucket
+            slots.append(book)
+        }
+
+        while !slots.count.isMultiple(of: groupedColumnCount) {
+            slots.append(nil)
+        }
+        return slots
+    }
+
+    /**
+     Builds Android's alphabetical comparator key.
+
+     Android sorts by localized JSword short names and moves leading digits to the end so `1 Cor`
+     sorts with Corinthians instead of before Acts. This mirrors that behavior with the current
+     locale-independent short labels available to iOS.
+     */
+    private static func androidAlphabeticalSortKey(_ book: BookInfo) -> String {
+        let name = PassageBookDisplayName.shortName(for: book).lowercased()
+        let nonDigits = name
+            .filter { !$0.isNumber }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = name.filter(\.isNumber)
+        return nonDigits + String(digits)
     }
 }
 
@@ -354,6 +752,306 @@ struct PassageGridMetrics: Equatable, Sendable {
 }
 
 /**
+ Android passage-grid progress fractions for one cell.
+
+ Android overlays reading progress in green and memorization progress in gold at the bottom of
+ book, chapter, and verse buttons. This value carries normalized fractions only; rendering remains
+ in `PassageGridButton` so tests can verify progress semantics without a UI surface.
+ */
+public struct PassageGridProgress: Equatable, Sendable {
+    /// Fraction of reading progress in `0...1`.
+    public let readingFraction: Double
+
+    /// Fraction of memorization progress in `0...1`.
+    public let memorizationFraction: Double
+
+    /// Android reading progress bar color without alpha.
+    public static let readingColor = PassageGridRGBColor(red: 0x4C, green: 0xAF, blue: 0x50)
+
+    /// Android memorization progress bar color without alpha.
+    public static let memorizationColor = PassageGridRGBColor(red: 0xFF, green: 0xD7, blue: 0x00)
+
+    /// Empty progress state used when progress bars are disabled or unavailable.
+    public static let none = PassageGridProgress(readingFraction: 0, memorizationFraction: 0)
+
+    /**
+     Creates clamped progress fractions.
+
+     - Parameters:
+       - readingFraction: Raw reading fraction; values outside `0...1` are clamped.
+       - memorizationFraction: Raw memorization fraction; values outside `0...1` are clamped.
+     - Returns: Normalized progress state.
+     - Side effects: none.
+     - Failure modes: Non-finite values are treated as zero.
+     */
+    public init(readingFraction: Double = 0, memorizationFraction: Double = 0) {
+        self.readingFraction = Self.clamped(readingFraction)
+        self.memorizationFraction = Self.clamped(memorizationFraction)
+    }
+
+    /// Whether either Android progress bar should be visible.
+    var hasProgress: Bool {
+        readingFraction > 0 || memorizationFraction > 0
+    }
+
+    /**
+     Clamps a raw fraction into Android progress-bar bounds.
+
+     - Parameter value: Candidate fraction.
+     - Returns: A finite value in `0...1`.
+     - Side effects: none.
+     - Failure modes: Non-finite values return zero.
+     */
+    private static func clamped(_ value: Double) -> Double {
+        guard value.isFinite else {
+            return 0
+        }
+        return min(1, max(0, value))
+    }
+}
+
+/**
+ Android KJVA-backed progress calculator for passage-grid cells.
+
+ `ProgressControl` on Android normalizes reading progress by JSword `BibleBook.ordinal()` and
+ memorization progress by JSword KJVA verse ordinals. This calculator mirrors those rules against
+ the iOS snapshots so rendered bars are not decorative or tied to SWORD's separate address space.
+ */
+enum PassageGridProgressCalculator {
+    /**
+     Computes book-level reading and memorization progress.
+
+     - Parameters:
+       - book: Module-provided book metadata.
+       - readingSnapshot: Current reading progress snapshot, if available.
+       - memorizationSnapshot: Current memorization progress snapshot, if available.
+       - activeBookInitials: Active module initials used to match module-scoped memorization rows.
+     - Returns: Android-compatible progress fractions for the book cell.
+     - Side effects: none.
+     - Failure modes: Unsupported books return `.none`.
+     */
+    static func bookProgress(
+        book: BookInfo,
+        readingSnapshot: ReadingProgressSnapshot?,
+        memorizationSnapshot: MemorizationProgressSnapshot?,
+        activeBookInitials: String
+    ) -> PassageGridProgress {
+        guard let kjvBookOrdinal = JSwordKJVAVersification.bibleBookOrdinal(forOsisId: book.osisId),
+              let chapterCount = JSwordKJVAVersification.lastChapter(osisId: book.osisId),
+              let verseCount = JSwordKJVAVersification.bookVerseCount(osisId: book.osisId),
+              let bookRange = JSwordKJVAVersification.verseOrdinalRange(osisId: book.osisId) else {
+            return .none
+        }
+
+        let readingFraction: Double
+        if let readingSnapshot, chapterCount > 0 {
+            let cycle = currentReadingCycle(in: readingSnapshot)
+            let readChapters = Set(
+                readingSnapshot.history
+                    .filter { row in
+                        row.kjvBookOrdinal == kjvBookOrdinal &&
+                            row.cycle == cycle &&
+                            row.chapter > 0 &&
+                            row.chapter <= chapterCount
+                    }
+                    .map(\.chapter)
+            )
+            readingFraction = Double(readChapters.count) / Double(chapterCount)
+        } else {
+            readingFraction = 0
+        }
+
+        let memorizationFraction = fractionOfMemorizedOrdinals(
+            in: bookRange,
+            verseCount: verseCount,
+            snapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        )
+        return PassageGridProgress(
+            readingFraction: readingFraction,
+            memorizationFraction: memorizationFraction
+        )
+    }
+
+    /**
+     Computes chapter-level reading and memorization progress.
+
+     Android marks a chapter as fully read when the active reading cycle has at least one matching
+     row and divides memorized ordinals by the KJVA verse count in that chapter.
+     */
+    static func chapterProgress(
+        book: BookInfo,
+        chapter: Int,
+        readingSnapshot: ReadingProgressSnapshot?,
+        memorizationSnapshot: MemorizationProgressSnapshot?,
+        activeBookInitials: String
+    ) -> PassageGridProgress {
+        guard let kjvBookOrdinal = JSwordKJVAVersification.bibleBookOrdinal(forOsisId: book.osisId),
+              let verseCount = JSwordKJVAVersification.verseCount(osisId: book.osisId, chapter: chapter),
+              let chapterRange = JSwordKJVAVersification.verseOrdinalRange(osisId: book.osisId, chapter: chapter) else {
+            return .none
+        }
+
+        let readingFraction: Double
+        if let readingSnapshot {
+            let cycle = currentReadingCycle(in: readingSnapshot)
+            readingFraction = readingSnapshot.history.contains { row in
+                row.kjvBookOrdinal == kjvBookOrdinal &&
+                    row.chapter == chapter &&
+                    row.cycle == cycle
+            } ? 1 : 0
+        } else {
+            readingFraction = 0
+        }
+
+        let memorizationFraction = fractionOfMemorizedOrdinals(
+            in: chapterRange,
+            verseCount: verseCount,
+            snapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        )
+        return PassageGridProgress(
+            readingFraction: readingFraction,
+            memorizationFraction: memorizationFraction
+        )
+    }
+
+    /**
+     Computes verse-level reading and memorization progress.
+
+     Android shows a full reading bar for every verse in a read chapter and a full memorization bar
+     when the exact KJVA verse ordinal is present in memorized ranges.
+     */
+    static func verseProgress(
+        book: BookInfo,
+        chapter: Int,
+        verse: Int,
+        readingSnapshot: ReadingProgressSnapshot?,
+        memorizationSnapshot: MemorizationProgressSnapshot?,
+        activeBookInitials: String
+    ) -> PassageGridProgress {
+        guard let kjvBookOrdinal = JSwordKJVAVersification.bibleBookOrdinal(forOsisId: book.osisId),
+              let ordinal = JSwordKJVAVersification.verseOrdinal(
+                osisId: book.osisId,
+                chapter: chapter,
+                verse: verse
+              ) else {
+            return .none
+        }
+
+        let readingFraction: Double
+        if let readingSnapshot {
+            let cycle = currentReadingCycle(in: readingSnapshot)
+            readingFraction = readingSnapshot.history.contains { row in
+                row.kjvBookOrdinal == kjvBookOrdinal &&
+                    row.chapter == chapter &&
+                    row.cycle == cycle
+            } ? 1 : 0
+        } else {
+            readingFraction = 0
+        }
+
+        let memorizationFraction = memorizedOrdinalCount(
+            in: ordinal...ordinal,
+            snapshot: memorizationSnapshot,
+            activeBookInitials: activeBookInitials
+        ) > 0 ? 1.0 : 0.0
+        return PassageGridProgress(
+            readingFraction: readingFraction,
+            memorizationFraction: memorizationFraction
+        )
+    }
+
+    /**
+     Resolves Android's active reading cycle fallback.
+
+     - Parameter snapshot: Reading progress snapshot.
+     - Returns: Explicit active cycle when set; otherwise the latest stored cycle or Android's `1`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func currentReadingCycle(in snapshot: ReadingProgressSnapshot) -> Int {
+        if snapshot.settings.activeCycle > 0 {
+            return snapshot.settings.activeCycle
+        }
+        return snapshot.history.map(\.cycle).max() ?? 1
+    }
+
+    /**
+     Converts memorized ordinal membership into a normalized progress fraction.
+
+     - Parameters:
+       - range: KJVA verse ordinal range being measured.
+       - verseCount: Number of real verses represented by the range.
+       - snapshot: Current memorization snapshot.
+       - activeBookInitials: Module initials used for module-scoped ranges.
+     - Returns: Memorized count divided by `verseCount`.
+     - Side effects: none.
+     - Failure modes: Missing snapshots or invalid counts return zero.
+     */
+    private static func fractionOfMemorizedOrdinals(
+        in range: ClosedRange<Int>,
+        verseCount: Int,
+        snapshot: MemorizationProgressSnapshot?,
+        activeBookInitials: String
+    ) -> Double {
+        guard verseCount > 0 else {
+            return 0
+        }
+        return Double(
+            memorizedOrdinalCount(
+                in: range,
+                snapshot: snapshot,
+                activeBookInitials: activeBookInitials
+            )
+        ) / Double(verseCount)
+    }
+
+    /**
+     Counts unique memorized KJVA ordinals that intersect a query range.
+
+     Android imports can store module-neutral ranges, while existing iOS bridge writes are
+     module-scoped. Matching accepts both empty `bookInitials` and the active module initials.
+     */
+    private static func memorizedOrdinalCount(
+        in queryRange: ClosedRange<Int>,
+        snapshot: MemorizationProgressSnapshot?,
+        activeBookInitials: String
+    ) -> Int {
+        guard let snapshot else {
+            return 0
+        }
+
+        var ordinals = Set<Int>()
+        for range in snapshot.memorizedRanges where matches(range, activeBookInitials: activeBookInitials) {
+            let start = max(range.startOrdinal, queryRange.lowerBound)
+            let end = min(range.endOrdinal, queryRange.upperBound)
+            guard start <= end else {
+                continue
+            }
+            for ordinal in start...end {
+                ordinals.insert(ordinal)
+            }
+        }
+        return ordinals.count
+    }
+
+    /**
+     Checks whether a stored memorization range applies to the active module.
+
+     - Parameters:
+       - range: Persisted memorization range.
+       - activeBookInitials: Active module initials.
+     - Returns: `true` for Android-imported module-neutral ranges and matching module-scoped rows.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func matches(_ range: MemorizationProgressRange, activeBookInitials: String) -> Bool {
+        range.bookInitials.isEmpty || range.bookInitials == activeBookInitials
+    }
+}
+
+/**
  Android-compatible title formatting for the passage chooser.
 
  `GridChoosePassageBook` appends `SharedActivityState.currentWorkspaceName` to the activity title,
@@ -402,29 +1100,95 @@ struct PassageGridButton: View {
     /// Label font tuned by selector type.
     let font: Font
 
+    /// Android reading/memorization progress fractions for this cell.
+    let progress: PassageGridProgress
+
     /// Fixed square width and height for the button.
     let cellSide: CGFloat
 
     /// Action invoked when the button is tapped.
     let action: () -> Void
 
+    /**
+     Creates a fixed-size Android passage-grid button.
+
+     - Parameters:
+       - title: Visible text, either one-line short label or two-line long-name label.
+       - accessibilityLabel: VoiceOver label for the represented book/chapter/verse.
+       - accessibilityIdentifier: Stable UI-test identifier.
+       - palette: Android foreground/background colors.
+       - font: Text style for the selector type.
+       - progress: Optional Android reading/memorization progress overlays.
+       - cellSide: Fixed square side derived from the Android grid matrix.
+       - action: Tap handler.
+     - Side effects: none; the action is invoked only when the button is tapped.
+     - Failure modes: none.
+     */
+    init(
+        title: String,
+        accessibilityLabel: String,
+        accessibilityIdentifier: String,
+        palette: PassageGridCellPalette,
+        font: Font,
+        progress: PassageGridProgress = .none,
+        cellSide: CGFloat,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.palette = palette
+        self.font = font
+        self.progress = progress
+        self.cellSide = cellSide
+        self.action = action
+    }
+
     /// Renders the Android-style selector button.
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .font(font)
-                .lineLimit(1)
-                .minimumScaleFactor(0.65)
-                .padding(.horizontal, 2)
-                .frame(width: cellSide, height: cellSide)
-                .background(
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(palette.background.swiftUIColor)
-                )
-                .foregroundStyle(palette.foreground.swiftUIColor)
+            ZStack(alignment: .bottomLeading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(palette.background.swiftUIColor)
+
+                if progress.hasProgress {
+                    progressBars
+                }
+
+                Text(title)
+                    .font(font)
+                    .lineLimit(title.contains("\n") ? 2 : 1)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.55)
+                    .padding(.horizontal, 2)
+                    .frame(width: cellSide, height: cellSide)
+                    .foregroundStyle(palette.foreground.swiftUIColor)
+            }
+            .frame(width: cellSide, height: cellSide)
+            .clipShape(RoundedRectangle(cornerRadius: 3))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    /// Android-style progress overlays anchored to the bottom of the button cell.
+    @ViewBuilder
+    private var progressBars: some View {
+        let barHeight: CGFloat = 4
+        let gap: CGFloat = 3
+
+        if progress.memorizationFraction > 0 {
+            Rectangle()
+                .fill(PassageGridProgress.memorizationColor.swiftUIColor.opacity(0.8))
+                .frame(width: cellSide * progress.memorizationFraction, height: barHeight)
+        }
+
+        if progress.readingFraction > 0 {
+            Rectangle()
+                .fill(PassageGridProgress.readingColor.swiftUIColor.opacity(0.8))
+                .frame(width: cellSide * progress.readingFraction, height: barHeight)
+                .padding(.bottom, progress.memorizationFraction > 0 ? barHeight + gap : 0)
+        }
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -306,11 +306,85 @@ struct PassageGridLayout: Equatable, Sendable {
 }
 
 /**
+ Android-compatible sizing metrics for passage selector cells.
+
+ Android `ButtonGrid` gives each table row and each cell equal weight, so a visible cell occupies
+ the same width and height inside the calculated matrix. SwiftUI grids do not infer that contract
+ from row/column counts, so callers use this value object to derive a fixed square side from the
+ available drawer or sheet width.
+ */
+struct PassageGridMetrics: Equatable, Sendable {
+    /// Width and height for every rendered grid cell.
+    let cellSide: CGFloat
+
+    /// Total width occupied by all fixed-width columns and inter-column spacing.
+    let gridWidth: CGFloat
+
+    /// Android-compatible spacing between cells.
+    static let spacing: CGFloat = 4
+
+    /// Horizontal inset around the grid, matching the existing selector padding.
+    static let horizontalPadding: CGFloat = 12
+
+    /**
+     Derives fixed square cell dimensions from an available container width.
+
+     - Parameters:
+       - availableWidth: Width available to the selector content before grid padding is applied.
+       - columns: Android layout column count. Values below one are clamped to one.
+       - spacing: Space between neighboring cells.
+       - horizontalPadding: Leading and trailing padding reserved around the grid.
+     - Returns: Square cell side and total grid width. Widths clamp at zero when the container is
+       too small, so SwiftUI never receives negative frame dimensions.
+     */
+    static func squareCells(
+        availableWidth: CGFloat,
+        columns: Int,
+        spacing: CGFloat = Self.spacing,
+        horizontalPadding: CGFloat = Self.horizontalPadding
+    ) -> PassageGridMetrics {
+        let columnCount = max(columns, 1)
+        let availableGridWidth = max(0, availableWidth - (horizontalPadding * 2))
+        let totalSpacing = spacing * CGFloat(max(columnCount - 1, 0))
+        let cellSide = max(0, (availableGridWidth - totalSpacing) / CGFloat(columnCount))
+        let gridWidth = (cellSide * CGFloat(columnCount)) + totalSpacing
+
+        return PassageGridMetrics(cellSide: cellSide, gridWidth: gridWidth)
+    }
+}
+
+/**
+ Android-compatible title formatting for the passage chooser.
+
+ `GridChoosePassageBook` appends `SharedActivityState.currentWorkspaceName` to the activity title,
+ while chapter and verse steps use the selected book/chapter titles. Keeping the formatter separate
+ from SwiftUI view state makes the Android parity rule testable without rendering a navigation bar.
+ */
+enum PassageChooserTitle {
+    /**
+     Builds the book-selection title used for the first chooser step.
+
+     - Parameters:
+       - baseTitle: Localized base title, usually Android/iOS "Choose Book".
+       - workspaceName: Active workspace name. Whitespace-only values are ignored.
+     - Returns: `baseTitle (workspaceName)` when a workspace is known, otherwise `baseTitle`.
+     */
+    static func bookSelectionTitle(baseTitle: String, workspaceName: String?) -> String {
+        guard let workspaceName = workspaceName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !workspaceName.isEmpty else {
+            return baseTitle
+        }
+
+        return "\(baseTitle) (\(workspaceName))"
+    }
+}
+
+/**
  Shared passage-grid button with Android colors and stable accessibility metadata.
 
- The view is deliberately small and rectangular like Android's selector buttons; it avoids
- platform-specific card styling while still using SwiftUI text sizing to keep abbreviations and
- numbers readable across compact iPhone and iPad sheet sizes.
+ The view is deliberately plain like Android's selector buttons; it avoids platform-specific card
+ styling while using a fixed square frame derived from Android's row/column matrix so book,
+ chapter, and verse cells do not drift into iOS-specific rectangular controls.
  */
 struct PassageGridButton: View {
     /// Visible label rendered in the button.
@@ -328,8 +402,8 @@ struct PassageGridButton: View {
     /// Label font tuned by selector type.
     let font: Font
 
-    /// Minimum button height in points.
-    let minHeight: CGFloat
+    /// Fixed square width and height for the button.
+    let cellSide: CGFloat
 
     /// Action invoked when the button is tapped.
     let action: () -> Void
@@ -341,8 +415,8 @@ struct PassageGridButton: View {
                 .font(font)
                 .lineLimit(1)
                 .minimumScaleFactor(0.65)
-                .frame(maxWidth: .infinity, minHeight: minHeight)
                 .padding(.horizontal, 2)
+                .frame(width: cellSide, height: cellSide)
                 .background(
                     RoundedRectangle(cornerRadius: 3)
                         .fill(palette.background.swiftUIColor)

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -1,0 +1,356 @@
+// PassageGrid.swift - Android-aligned passage selector layout and palette
+
+import SwiftUI
+import SwordKit
+
+/**
+ Android-compatible selector item kind used by the shared passage grid layout.
+
+ The book selector has a fixed 66-book standard layout on Android. Chapter and verse selectors,
+ plus non-standard book lists, use Android's dynamic row calculation.
+ */
+enum PassageGridItemKind: Equatable, Sendable {
+    /// Book selector grid.
+    case book
+
+    /// Chapter or verse selector grid.
+    case number
+}
+
+/**
+ Orientation used by Android's `LayoutDesigner` passage-grid rules.
+
+ The value is intentionally derived from the available chooser size instead of device orientation
+ so iPad split views and resizable windows can choose the same portrait or landscape matrix Android
+ would choose for the visible grid shape.
+ */
+enum PassageGridOrientation: Equatable, Sendable {
+    /// Taller-than-wide passage chooser.
+    case portrait
+
+    /// Wider-than-tall passage chooser.
+    case landscape
+
+    /**
+     Creates an orientation from a SwiftUI geometry size.
+
+     - Parameter size: Available grid container size.
+     */
+    init(size: CGSize) {
+        self = size.width > size.height ? .landscape : .portrait
+    }
+}
+
+/**
+ RGB color token copied from Android's passage selector constants.
+
+ SwiftUI `Color` is not equatable, so tests assert against this value type while views convert it
+ to `Color` only at render time.
+ */
+struct PassageGridRGBColor: Equatable, Sendable {
+    /// Red component in the Android 0...255 range.
+    let red: Int
+
+    /// Green component in the Android 0...255 range.
+    let green: Int
+
+    /// Blue component in the Android 0...255 range.
+    let blue: Int
+
+    /// SwiftUI color used by the rendered selector cell.
+    var swiftUIColor: Color {
+        Color(
+            red: Double(red) / 255.0,
+            green: Double(green) / 255.0,
+            blue: Double(blue) / 255.0
+        )
+    }
+
+    /// Android `Color.DKGRAY`.
+    static let darkGray = PassageGridRGBColor(red: 0x44, green: 0x44, blue: 0x44)
+
+    /// Android default text color for unselected chapter and verse buttons.
+    static let white = PassageGridRGBColor(red: 0xFF, green: 0xFF, blue: 0xFF)
+
+    /// Android Old Testament button tint.
+    static let oldTestamentTint = darkGray
+
+    /// Android New Testament button tint.
+    static let newTestamentTint = PassageGridRGBColor(red: 0x50, green: 0x50, blue: 0x50)
+
+    /// Android Pentateuch category color.
+    static let pentateuch = PassageGridRGBColor(red: 0xCC, green: 0xCC, blue: 0xFE)
+
+    /// Android history category color.
+    static let history = PassageGridRGBColor(red: 0xFE, green: 0xCC, blue: 0x9B)
+
+    /// Android wisdom category color.
+    static let wisdom = PassageGridRGBColor(red: 0x99, green: 0xFF, blue: 0x99)
+
+    /// Android major-prophets category color.
+    static let majorProphets = PassageGridRGBColor(red: 0xFF, green: 0x99, blue: 0xFF)
+
+    /// Android minor-prophets category color.
+    static let minorProphets = PassageGridRGBColor(red: 0xFF, green: 0xFE, blue: 0xCD)
+
+    /// Android gospel category color.
+    static let gospel = PassageGridRGBColor(red: 0xFF, green: 0x97, blue: 0x03)
+
+    /// Android Acts category color.
+    static let acts = PassageGridRGBColor(red: 0x00, green: 0x99, blue: 0xFF)
+
+    /// Android Pauline epistles category color.
+    static let pauline = PassageGridRGBColor(red: 0xFF, green: 0xFF, blue: 0x31)
+
+    /// Android general epistles category color.
+    static let generalEpistles = PassageGridRGBColor(red: 0x67, green: 0xCC, blue: 0x66)
+
+    /// Android Revelation category color.
+    static let revelation = PassageGridRGBColor(red: 0xFE, green: 0x33, blue: 0xFF)
+
+    /// Android fallback color for books outside the canonical category ranges.
+    static let other = acts
+}
+
+/**
+ Book category resolved with Android's `GridChoosePassageBook.getBookColorAndGroup` boundaries.
+
+ The category map is not used as a canon source; the chooser still renders the module-provided
+ `BookInfo` list. This type only supplies Android's color and grouping semantics for whatever books
+ the active module exposes.
+ */
+struct PassageBookCategory: Equatable, Sendable {
+    /// Android group id for category sorting and future option support.
+    let group: Int
+
+    /// Android category color.
+    let color: PassageGridRGBColor
+
+    /**
+     Resolves the Android category for an OSIS book id.
+
+     - Parameter osisId: OSIS identifier from `BookInfo`.
+     - Returns: Android category color and group, or `.other` for unsupported/deuterocanonical ids.
+     */
+    static func category(forOsisId osisId: String) -> PassageBookCategory {
+        switch osisId {
+        case "Gen", "Exod", "Lev", "Num", "Deut":
+            PassageBookCategory(group: 0, color: .pentateuch)
+        case "Josh", "Judg", "Ruth", "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh", "Esth":
+            PassageBookCategory(group: 1, color: .history)
+        case "Job", "Ps", "Prov", "Eccl", "Song":
+            PassageBookCategory(group: 2, color: .wisdom)
+        case "Isa", "Jer", "Lam", "Ezek", "Dan":
+            PassageBookCategory(group: 3, color: .majorProphets)
+        case "Hos", "Joel", "Amos", "Obad", "Jonah", "Mic", "Nah", "Hab", "Zeph", "Hag", "Zech", "Mal":
+            PassageBookCategory(group: 4, color: .minorProphets)
+        case "Matt", "Mark", "Luke", "John":
+            PassageBookCategory(group: 5, color: .gospel)
+        case "Acts":
+            PassageBookCategory(group: 6, color: .acts)
+        case "Rom", "1Cor", "2Cor", "Gal", "Eph", "Phil", "Col", "1Thess", "2Thess", "1Tim", "2Tim", "Titus", "Phlm":
+            PassageBookCategory(group: 7, color: .pauline)
+        case "Heb", "Jas", "1Pet", "2Pet", "1John", "2John", "3John", "Jude":
+            PassageBookCategory(group: 8, color: .generalEpistles)
+        case "Rev":
+            PassageBookCategory(group: 9, color: .revelation)
+        default:
+            PassageBookCategory(group: 10, color: .other)
+        }
+    }
+}
+
+/**
+ Foreground/background pair used by Android passage selector buttons.
+
+ Book buttons use category text over testament tint unless selected. Chapter and verse buttons use
+ white text over dark tint unless selected. Selected buttons use the book category as background
+ with Android dark-gray text.
+ */
+struct PassageGridCellPalette: Equatable, Sendable {
+    /// Text color for the cell label.
+    let foreground: PassageGridRGBColor
+
+    /// Fill color for the cell background.
+    let background: PassageGridRGBColor
+
+    /**
+     Builds the Android palette for a book button.
+
+     - Parameters:
+       - book: Module-provided book metadata.
+       - currentOsisId: Current reader book OSIS id, if available.
+     - Returns: Android selected or normal book palette.
+     */
+    static func bookPalette(for book: BookInfo, currentOsisId: String?) -> PassageGridCellPalette {
+        let category = PassageBookCategory.category(forOsisId: book.osisId)
+        guard book.osisId != currentOsisId else {
+            return PassageGridCellPalette(foreground: .darkGray, background: category.color)
+        }
+        return PassageGridCellPalette(
+            foreground: category.color,
+            background: book.isNewTestament ? .newTestamentTint : .oldTestamentTint
+        )
+    }
+
+    /**
+     Builds the Android palette for a chapter or verse button.
+
+     - Parameters:
+       - number: One-based chapter or verse number.
+       - currentNumber: Current reader chapter or verse number in the selected book context.
+       - categoryColor: Selected book category color.
+     - Returns: Android selected or normal numeric-button palette.
+     */
+    static func numberPalette(
+        number: Int,
+        currentNumber: Int?,
+        categoryColor: PassageGridRGBColor
+    ) -> PassageGridCellPalette {
+        guard number != currentNumber else {
+            return PassageGridCellPalette(foreground: .darkGray, background: categoryColor)
+        }
+        return PassageGridCellPalette(foreground: .white, background: .oldTestamentTint)
+    }
+}
+
+/**
+ Android passage selector matrix.
+
+ The layout mirrors Android `LayoutDesigner` and `ButtonGrid`: standard 66-book canons use a fixed
+ 11-by-6 portrait or 6-by-11 landscape matrix; all other counts use Android's dynamic rows and
+ minimum columns. In portrait, the default ordering fills columns first unless row order is enabled.
+ */
+struct PassageGridLayout: Equatable, Sendable {
+    /// Number of visual rows in the grid.
+    let rows: Int
+
+    /// Number of visual columns in the grid.
+    let columns: Int
+
+    /// Whether source items fill down columns before moving right.
+    let usesColumnMajorOrder: Bool
+
+    /**
+     Creates Android's passage-grid layout for a selector item count.
+
+     - Parameters:
+       - itemCount: Number of module-provided books, chapters, or verses.
+       - kind: Book grids get Android's fixed 66-book layout when applicable.
+       - orientation: Current visual orientation of the chooser.
+       - rowOrder: Android row-order preference; default `false` preserves Android's default column order.
+     - Returns: Rows, columns, and ordering semantics for rendering the grid.
+     */
+    static func androidDefault(
+        itemCount: Int,
+        kind: PassageGridItemKind,
+        orientation: PassageGridOrientation,
+        rowOrder: Bool = false
+    ) -> PassageGridLayout {
+        guard itemCount > 0 else {
+            return PassageGridLayout(rows: 0, columns: 0, usesColumnMajorOrder: false)
+        }
+
+        let isPortrait = orientation == .portrait
+        let rows: Int
+        let columns: Int
+
+        if kind == .book, itemCount == 66 {
+            rows = isPortrait ? 11 : 6
+            columns = isPortrait ? 6 : 11
+        } else {
+            if itemCount <= 50 {
+                rows = isPortrait ? 10 : 5
+            } else if itemCount <= 100 {
+                rows = 10
+            } else {
+                rows = isPortrait ? 15 : 10
+            }
+            let calculatedColumns = Int(ceil(Double(itemCount) / Double(rows)))
+            columns = max(isPortrait ? 5 : 8, calculatedColumns)
+        }
+
+        return PassageGridLayout(
+            rows: rows,
+            columns: columns,
+            usesColumnMajorOrder: isPortrait && !rowOrder
+        )
+    }
+
+    /**
+     Converts source items into the visual slot order used by SwiftUI `LazyVGrid`.
+
+     SwiftUI fills rows first, so this method precomputes visual slots from Android's source index
+     calculation and includes `nil` placeholders for unused matrix cells.
+     */
+    func displaySlots<Item>(for items: [Item]) -> [Item?] {
+        guard rows > 0, columns > 0 else {
+            return []
+        }
+
+        return (0..<(rows * columns)).map { slot in
+            let row = slot / columns
+            let column = slot % columns
+            let sourceIndex: Int
+            if usesColumnMajorOrder {
+                sourceIndex = column * rows + row
+            } else {
+                sourceIndex = row * columns + column
+            }
+            guard sourceIndex < items.count else {
+                return nil
+            }
+            return items[sourceIndex]
+        }
+    }
+}
+
+/**
+ Shared passage-grid button with Android colors and stable accessibility metadata.
+
+ The view is deliberately small and rectangular like Android's selector buttons; it avoids
+ platform-specific card styling while still using SwiftUI text sizing to keep abbreviations and
+ numbers readable across compact iPhone and iPad sheet sizes.
+ */
+struct PassageGridButton: View {
+    /// Visible label rendered in the button.
+    let title: String
+
+    /// Accessibility label announced for the button.
+    let accessibilityLabel: String
+
+    /// Stable UI-test identifier for this button.
+    let accessibilityIdentifier: String
+
+    /// Android foreground/background colors.
+    let palette: PassageGridCellPalette
+
+    /// Label font tuned by selector type.
+    let font: Font
+
+    /// Minimum button height in points.
+    let minHeight: CGFloat
+
+    /// Action invoked when the button is tapped.
+    let action: () -> Void
+
+    /// Renders the Android-style selector button.
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(font)
+                .lineLimit(1)
+                .minimumScaleFactor(0.65)
+                .frame(maxWidth: .infinity, minHeight: minHeight)
+                .padding(.horizontal, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(palette.background.swiftUIColor)
+                )
+                .foregroundStyle(palette.foreground.swiftUIColor)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -846,16 +846,14 @@ enum PassageGridProgressCalculator {
         let readingFraction: Double
         if let readingSnapshot, chapterCount > 0 {
             let cycle = currentReadingCycle(in: readingSnapshot)
-            let readChapters = Set(
-                readingSnapshot.history
-                    .filter { row in
-                        row.kjvBookOrdinal == kjvBookOrdinal &&
-                            row.cycle == cycle &&
-                            row.chapter > 0 &&
-                            row.chapter <= chapterCount
-                    }
-                    .map(\.chapter)
-            )
+            var readChapters = Set<Int>()
+            for row in readingSnapshot.history
+                where row.kjvBookOrdinal == kjvBookOrdinal &&
+                row.cycle == cycle &&
+                row.chapter > 0 &&
+                row.chapter <= chapterCount {
+                readChapters.insert(row.chapter)
+            }
             readingFraction = Double(readChapters.count) / Double(chapterCount)
         } else {
             readingFraction = 0

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
@@ -66,14 +66,19 @@ public struct VerseChooserView: View {
                 orientation: orientation
             )
             let slots = layout.displaySlots(for: verses)
+            let columnCount = max(layout.columns, 1)
+            let metrics = PassageGridMetrics.squareCells(
+                availableWidth: proxy.size.width,
+                columns: columnCount
+            )
             let columns = Array(
-                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
-                count: max(layout.columns, 1)
+                repeating: GridItem(.fixed(metrics.cellSide), spacing: PassageGridMetrics.spacing),
+                count: columnCount
             )
             let categoryColor = PassageBookCategory.category(forOsisId: resolvedOsisBookId).color
 
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 4) {
+                LazyVGrid(columns: columns, spacing: PassageGridMetrics.spacing) {
                     ForEach(Array(slots.enumerated()), id: \.offset) { _, verse in
                         if let verse {
                             PassageGridButton(
@@ -86,18 +91,20 @@ public struct VerseChooserView: View {
                                     categoryColor: categoryColor
                                 ),
                                 font: .callout.monospacedDigit().weight(.semibold),
-                                minHeight: 34
+                                cellSide: metrics.cellSide
                             ) {
                                 onSelect(verse)
                             }
                         } else {
                             Color.clear
-                                .frame(minHeight: 34)
+                                .frame(width: metrics.cellSide, height: metrics.cellSide)
                                 .accessibilityHidden(true)
                         }
                     }
                 }
-                .padding(12)
+                .frame(width: metrics.gridWidth)
+                .padding(PassageGridMetrics.horizontalPadding)
+                .frame(maxWidth: .infinity)
             }
         }
         .navigationTitle("\(bookName) \(chapter)")

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
@@ -6,17 +6,24 @@ import SwiftUI
  Grid-based chooser for selecting a specific verse after book and chapter selection.
 
  The verse count is supplied by the parent chooser and reflects the currently selected book and
- chapter in the active module.
+ chapter in the active module. The grid layout and current-verse highlight mirror Android
+ `GridChoosePassageVerse`.
  */
 public struct VerseChooserView: View {
     /// User-visible book name shown in the navigation title.
     let bookName: String
+
+    /// OSIS id for the selected book, used to resolve Android category color.
+    let osisBookId: String?
 
     /// One-based chapter number currently being selected within.
     let chapter: Int
 
     /// Number of verses available for this chapter in the active module; zero renders no choices.
     let verseCount: Int
+
+    /// Current reader verse if this chooser is showing the active book and chapter.
+    let currentVerse: Int?
 
     /// Callback invoked with the chosen one-based verse number.
     let onSelect: (Int) -> Void
@@ -26,38 +33,78 @@ public struct VerseChooserView: View {
 
      - Parameters:
        - bookName: Book name displayed in the navigation title.
+       - osisBookId: OSIS id for Android category color; falls back to static resolution by name.
        - chapter: One-based chapter number for the current selection flow.
        - verseCount: Number of verses available in this chapter.
+       - currentVerse: Current reader verse to highlight when the active chapter is selected.
        - onSelect: Callback receiving the selected one-based verse number.
      */
-    public init(bookName: String, chapter: Int, verseCount: Int, onSelect: @escaping (Int) -> Void) {
+    public init(
+        bookName: String,
+        osisBookId: String? = nil,
+        chapter: Int,
+        verseCount: Int,
+        currentVerse: Int? = nil,
+        onSelect: @escaping (Int) -> Void
+    ) {
         self.bookName = bookName
+        self.osisBookId = osisBookId
         self.chapter = chapter
         self.verseCount = verseCount
+        self.currentVerse = currentVerse
         self.onSelect = onSelect
     }
 
-    /// Builds the adaptive verse grid.
+    /// Builds the Android-aligned verse grid.
     public var body: some View {
-        ScrollView {
-            let columns = [GridItem(.adaptive(minimum: 44), spacing: 6)]
-            LazyVGrid(columns: columns, spacing: 6) {
-                if verseCount > 0 {
-                    ForEach(1...verseCount, id: \.self) { verse in
-                        Button(action: { onSelect(verse) }) {
-                            Text("\(verse)")
-                                .font(.callout.monospacedDigit())
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 10)
-                                .background(.quaternary)
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
+        GeometryReader { proxy in
+            let verses = verseCount > 0 ? Array(1...verseCount) : []
+            let orientation = PassageGridOrientation(size: proxy.size)
+            let layout = PassageGridLayout.androidDefault(
+                itemCount: verses.count,
+                kind: .number,
+                orientation: orientation
+            )
+            let slots = layout.displaySlots(for: verses)
+            let columns = Array(
+                repeating: GridItem(.flexible(minimum: 0), spacing: 4),
+                count: max(layout.columns, 1)
+            )
+            let categoryColor = PassageBookCategory.category(forOsisId: resolvedOsisBookId).color
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 4) {
+                    ForEach(Array(slots.enumerated()), id: \.offset) { _, verse in
+                        if let verse {
+                            PassageGridButton(
+                                title: "\(verse)",
+                                accessibilityLabel: "\(bookName) \(chapter):\(verse)",
+                                accessibilityIdentifier: "passageVerseCell.\(verse)",
+                                palette: PassageGridCellPalette.numberPalette(
+                                    number: verse,
+                                    currentNumber: currentVerse,
+                                    categoryColor: categoryColor
+                                ),
+                                font: .callout.monospacedDigit().weight(.semibold),
+                                minHeight: 34
+                            ) {
+                                onSelect(verse)
+                            }
+                        } else {
+                            Color.clear
+                                .frame(minHeight: 34)
+                                .accessibilityHidden(true)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
+                .padding(12)
             }
-            .padding()
         }
         .navigationTitle("\(bookName) \(chapter)")
+    }
+
+    /// OSIS id used for Android category color resolution.
+    private var resolvedOsisBookId: String {
+        osisBookId ?? BibleReaderController.osisBookId(for: bookName)
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
@@ -117,7 +117,7 @@ public struct VerseChooserView: View {
                     }
                 }
                 .frame(width: metrics.gridWidth)
-                .padding(PassageGridMetrics.horizontalPadding)
+                .padding(.horizontal, PassageGridMetrics.horizontalPadding)
                 .frame(maxWidth: .infinity)
             }
         }

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/VerseChooserView.swift
@@ -6,8 +6,8 @@ import SwiftUI
  Grid-based chooser for selecting a specific verse after book and chapter selection.
 
  The verse count is supplied by the parent chooser and reflects the currently selected book and
- chapter in the active module. The grid layout and current-verse highlight mirror Android
- `GridChoosePassageVerse`.
+ chapter in the active module. The grid layout, row-order preference, progress overlays, and
+ current-verse highlight mirror Android `GridChoosePassageVerse`.
  */
 public struct VerseChooserView: View {
     /// User-visible book name shown in the navigation title.
@@ -25,6 +25,12 @@ public struct VerseChooserView: View {
     /// Current reader verse if this chooser is showing the active book and chapter.
     let currentVerse: Int?
 
+    /// Android row-order option shared with the book chooser menu.
+    let rowOrder: Bool
+
+    /// Provides Android KJVA progress for a one-based verse.
+    let progressProvider: (Int) -> PassageGridProgress
+
     /// Callback invoked with the chosen one-based verse number.
     let onSelect: (Int) -> Void
 
@@ -37,6 +43,8 @@ public struct VerseChooserView: View {
        - chapter: One-based chapter number for the current selection flow.
        - verseCount: Number of verses available in this chapter.
        - currentVerse: Current reader verse to highlight when the active chapter is selected.
+       - rowOrder: Android row-order option shared with book chooser settings.
+       - progressProvider: Optional Android KJVA progress provider for verse cells.
        - onSelect: Callback receiving the selected one-based verse number.
      */
     public init(
@@ -45,6 +53,8 @@ public struct VerseChooserView: View {
         chapter: Int,
         verseCount: Int,
         currentVerse: Int? = nil,
+        rowOrder: Bool = false,
+        progressProvider: ((Int) -> PassageGridProgress)? = nil,
         onSelect: @escaping (Int) -> Void
     ) {
         self.bookName = bookName
@@ -52,6 +62,8 @@ public struct VerseChooserView: View {
         self.chapter = chapter
         self.verseCount = verseCount
         self.currentVerse = currentVerse
+        self.rowOrder = rowOrder
+        self.progressProvider = progressProvider ?? { _ in .none }
         self.onSelect = onSelect
     }
 
@@ -63,7 +75,8 @@ public struct VerseChooserView: View {
             let layout = PassageGridLayout.androidDefault(
                 itemCount: verses.count,
                 kind: .number,
-                orientation: orientation
+                orientation: orientation,
+                rowOrder: rowOrder
             )
             let slots = layout.displaySlots(for: verses)
             let columnCount = max(layout.columns, 1)
@@ -91,6 +104,7 @@ public struct VerseChooserView: View {
                                     categoryColor: categoryColor
                                 ),
                                 font: .callout.monospacedDigit().weight(.semibold),
+                                progress: progressProvider(verse),
                                 cellSide: metrics.cellSide
                             ) {
                                 onSelect(verse)
@@ -108,6 +122,7 @@ public struct VerseChooserView: View {
             }
         }
         .navigationTitle("\(bookName) \(chapter)")
+        .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
     }
 
     /// OSIS id used for Android category color resolution.


### PR DESCRIPTION
## Summary
Aligns the iOS book/chapter/verse selector with Android's passage chooser behavior. The chooser now uses Android's fixed dark full-screen surface, dense square grids, category colors, selected-cell highlighting, workspace-aware title, overflow menu options, JSword short book labels, and reading/memorization progress bars.

## Scope
In scope:
- Replace the iOS-specific passage picker presentation with Android's full-screen dark chooser activity model.
- Keep the active module's `BookInfo` list as the data source while applying Android's grid layout, ordering, grouping, labels, and color semantics.
- Add the Android top-right chooser menu: alphabetical order, horizontal ordering, category grouping, long book names, and progress bars.
- Persist Android-compatible `book_grid_*` chooser settings and `BibleBookSortOrder` behavior.
- Compute chooser progress bars from Android-compatible JSword KJVA book/chapter/verse semantics.

Out of scope:
- none for #206's passage selector parity slice.

## Contract References
- #206
- Android references: `GridChoosePassageBook.kt`, `GridChoosePassageChapter.kt`, `GridChoosePassageVerse.kt`, `ButtonGrid.kt`, `LayoutDesigner.kt`, `choose_passage_book_menu.xml`, `ProgressControl.kt`, JSword `SystemKJVA`
- Repository commit, docblock, and parity guardrails

## Change Details
- Added shared Android-aligned passage grid layout, palette, cell metrics, menu option state, book ordering, JSword short-name labels, and progress rendering.
- Added a full-screen `ReaderPassageChooserOverlay` and stopped routing passage selection through the hamburger drawer shell.
- Added Android chooser preference keys to `AppPreferenceRegistry` with Android defaults.
- Added JSword KJVA-derived verse/chapter/book ordinal data for Android-compatible progress calculations.
- Threaded active reader progress snapshots into book, chapter, and verse chooser cells.
- Added parity tests for menu state, menu entries, Android labels, ordering/grouping, fixed dark palette, KJVA progress, full-screen presentation, square grid cells, and registry defaults.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath .derived/issue-206-passage-selector-parity-merged -only-testing:AndBibleTests`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main --head-ref HEAD`
- `python3 scripts/check_repo_standards.py docblocks --base-ref origin/main --head-ref HEAD --all-files`
- `python3 scripts/check_bridge_parity_inventory.py`
- `git diff --cached --check`
- GitNexus staged worktree analysis reported high risk across 12 staged Swift/test files, with reader-navigation processes flagged as the affected area.

## Risks / Follow-ups
- Risk is concentrated in reader passage selection presentation and progress display.
- Visual parity should still be checked in Simulator before merge because the custom popup intentionally mirrors Android instead of using a native iOS menu.

## Screenshots

| Old | New |
| --- | --- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-19 at 15 16 37" src="https://github.com/user-attachments/assets/bbcda4c7-4ed8-4ee6-9ff1-7bd1857dee5f" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-20 at 10 31 03" src="https://github.com/user-attachments/assets/aa4c2b90-c429-4bd3-b1fe-0bc6cad1cd91" /> |

## Closes
Closes #206
