### PR TITLE
test(ui): reduce seeded search readiness wait

### DIFF
--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -10,6 +10,12 @@ private let seededSearchFixtureScenarios: Set<String> = [
     "search-multi-translation",
 ]
 
+/// Maximum Search readiness wait for fixture-seeded Search UI tests.
+private let seededSearchReadinessTimeout: TimeInterval = 20
+
+/// Maximum Search readiness wait for workflows that intentionally create an index at runtime.
+private let runtimeSearchIndexReadinessTimeout: TimeInterval = 120
+
 extension AndBibleUITests {
     /**
      Opens Search and waits for it to become interactive under the current fixture contract.
@@ -47,14 +53,18 @@ extension AndBibleUITests {
         let isSeededSearchFixtureScenario = fixtureScenario.map {
             seededSearchFixtureScenarios.contains($0)
         } ?? false
+        let allowsRuntimeIndexCreation = !isSeededSearchFixtureScenario
+        let readinessTimeout = searchReadinessTimeout(
+            allowsRuntimeIndexCreation: allowsRuntimeIndexCreation
+        )
 
         if app.launchArguments.contains("-UITEST_SEARCH_QUERY"),
            let prePresentedSearch = waitForSearchScreenIfAlreadySeeded(in: app, timeout: 10) {
             waitForSearchInteractionReady(
                 on: prePresentedSearch,
                 in: app,
-                timeout: 120,
-                allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario,
+                timeout: readinessTimeout,
+                allowsRuntimeIndexCreation: allowsRuntimeIndexCreation,
                 file: file,
                 line: line
             )
@@ -66,12 +76,32 @@ extension AndBibleUITests {
         waitForSearchInteractionReady(
             on: searchScreen,
             in: app,
-            timeout: 120,
-            allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario,
+            timeout: readinessTimeout,
+            allowsRuntimeIndexCreation: allowsRuntimeIndexCreation,
             file: file,
             line: line
         )
         return searchScreen
+    }
+
+    /**
+     Selects the Search readiness budget for the current index lifecycle contract.
+
+     Normal Search UI tests launch with seeded `search-indexed` fixtures and should only need the
+     same short readiness budget used by the follow-up Search assertions. A longer budget remains
+     available for explicit runtime index-creation coverage so that fixture-backed tests do not hide
+     regressions behind Android-incompatible automatic indexing.
+
+     - Parameter allowsRuntimeIndexCreation: Whether the current workflow may create a missing
+       Search index at runtime.
+     - Returns: The readiness timeout to pass to `waitForSearchInteractionReady`.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    func searchReadinessTimeout(allowsRuntimeIndexCreation: Bool) -> TimeInterval {
+        allowsRuntimeIndexCreation
+            ? runtimeSearchIndexReadinessTimeout
+            : seededSearchReadinessTimeout
     }
 
     /// Reuses a Search sheet that the app auto-presented from a launch-seeded UI-test query.
@@ -200,6 +230,45 @@ extension AndBibleUITests {
     }
 
     /**
+     Waits for the compact Search state export through the shared semantic-state waiter.
+
+     Search publishes a deterministic `searchStateExport` value for UI tests. This helper keeps
+     Search-specific callers on one observation path while preserving each caller's predicate and
+     failure wording.
+
+     - Parameters:
+       - app: Running application under test.
+       - timeout: Maximum time to wait before failing.
+       - success: Predicate that must match the exported Search state.
+       - failureDescription: Closure that formats the failure message from the final observed
+         Search state.
+       - file: Source file used for XCTest failure attribution.
+       - line: Source line used for XCTest failure attribution.
+     - Side effects:
+       - polls the shared Search accessibility export through `waitForResolvedSemanticState`
+     - Failure modes:
+       - records an XCTest failure with the final Search state when the predicate never matches
+     */
+    func waitForSearchSemanticState(
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        success: (String) -> Bool,
+        failureDescription: (String) -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        waitForResolvedSemanticState(
+            named: "searchStateExport",
+            timeout: timeout,
+            valueProvider: { resolvedSearchStateValue(in: app) },
+            success: success,
+            failureDescription: failureDescription,
+            file: file,
+            line: line
+        )
+    }
+
+    /**
      Waits for Search to become interactive and optionally triggers runtime index creation.
      *
      * - Parameters:
@@ -233,10 +302,12 @@ extension AndBibleUITests {
         var observedNeedsIndex = lastState.contains("state=needsIndex")
         var observedCreatePrompt = false
         func failSeededFixtureReadiness() {
+            let indexCreationRequested = observedNeedsIndex || observedCreatePrompt
             XCTFail(
                 "Expected seeded Search fixture to be ready without runtime index creation; "
                     + "last Search state was '\(lastState)'; "
                     + "state=needsIndex observed=\(observedNeedsIndex); "
+                    + "index creation requested=\(indexCreationRequested); "
                     + "Create-index prompt observed=\(observedCreatePrompt).",
                 file: file,
                 line: line
@@ -278,10 +349,12 @@ extension AndBibleUITests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         }
 
+        let indexCreationRequested = observedNeedsIndex || observedCreatePrompt
         XCTFail(
             "Expected Search to become interactive within \(timeout) seconds; "
                 + "last Search state was '\(lastState)'; "
                 + "state=needsIndex observed=\(observedNeedsIndex); "
+                + "index creation requested=\(indexCreationRequested); "
                 + "Create-index prompt observed=\(observedCreatePrompt).",
             file: file,
             line: line
@@ -308,28 +381,17 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        func matches(_ value: String) -> Bool {
-            value.contains("state=ready")
-                && value.contains("searching=false")
-                && value.contains(token)
-        }
-
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if searchStateCandidateValues(in: app).contains(where: matches) {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
-        } while Date() < deadline
-
-        let finalValues = searchStateCandidateValues(in: app)
-        if finalValues.contains(where: matches) {
-            return
-        }
-
-        let lastValue = finalValues.isEmpty ? "nil" : finalValues.joined(separator: " || ")
-        XCTFail(
-            "Expected Search state to contain '\(token)' within \(timeout) seconds; last value was '\(lastValue)'.",
+        waitForSearchSemanticState(
+            in: app,
+            timeout: timeout,
+            success: {
+                $0.contains("state=ready")
+                    && $0.contains("searching=false")
+                    && $0.contains(token)
+            },
+            failureDescription: {
+                "Expected Search state to contain '\(token)' within \(timeout) seconds; last value was '\($0)'."
+            },
             file: file,
             line: line
         )
@@ -353,21 +415,17 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let value = resolvedSearchStateValue(in: app),
-               value.contains("state=ready"),
-               value.contains("searching=false"),
-               let count = searchResultCount(from: value),
-               count >= minimumCount {
-                return
+        waitForSearchSemanticState(
+            in: app,
+            timeout: timeout,
+            success: {
+                $0.contains("state=ready")
+                    && $0.contains("searching=false")
+                    && (searchResultCount(from: $0) ?? -1) >= minimumCount
+            },
+            failureDescription: {
+                "Expected Search to report at least \(minimumCount) results within \(timeout) seconds; last value was '\($0)'."
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
-        } while Date() < deadline
-
-        let lastValue = resolvedSearchStateValue(in: app) ?? "nil"
-        XCTFail(
-            "Expected Search to report at least \(minimumCount) results within \(timeout) seconds; last value was '\(lastValue)'."
         )
     }
 
@@ -400,21 +458,17 @@ extension AndBibleUITests {
         line: UInt = #line,
         predicate: (Set<String>) -> Bool
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let value = resolvedSearchStateValue(in: app),
-               value.contains("state=ready"),
-               value.contains("searching=false"),
-               let modules = searchSelectedModules(from: value),
-               predicate(modules) {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
-        } while Date() < deadline
-
-        let lastValue = resolvedSearchStateValue(in: app) ?? "nil"
-        XCTFail(
-            "Expected Search selected modules to match \(description) within \(timeout) seconds; last value was '\(lastValue)'.",
+        waitForSearchSemanticState(
+            in: app,
+            timeout: timeout,
+            success: {
+                $0.contains("state=ready")
+                    && $0.contains("searching=false")
+                    && searchSelectedModules(from: $0).map(predicate) == true
+            },
+            failureDescription: {
+                "Expected Search selected modules to match \(description) within \(timeout) seconds; last value was '\($0)'."
+            },
             file: file,
             line: line
         )
@@ -1372,24 +1426,18 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
         let rowToken = "|\(identifier)|"
-
-        repeat {
-            if let value = resolvedSearchStateValue(in: app),
-               value.contains("state=ready"),
-               value.contains("searching=false"),
-               value.contains(rowToken) == shouldExist {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalValue = resolvedSearchStateValue(in: app) ?? ""
-        XCTAssertEqual(
-            finalValue.contains(rowToken),
-            shouldExist,
-            "Expected Search result '\(identifier)' existence to become \(shouldExist) within \(timeout) seconds. Final Search state: '\(finalValue)'.",
+        waitForSearchSemanticState(
+            in: app,
+            timeout: timeout,
+            success: {
+                $0.contains("state=ready")
+                    && $0.contains("searching=false")
+                    && $0.contains(rowToken) == shouldExist
+            },
+            failureDescription: {
+                "Expected Search result '\(identifier)' existence to become \(shouldExist) within \(timeout) seconds. Final Search state: '\($0)'."
+            },
             file: file,
             line: line
         )

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -714,7 +714,8 @@ extension AndBibleUITests {
      * - Side effects:
      *   - polls a dedicated state export on the main run loop until the predicate succeeds
      * - Failure modes:
-     *   - records an XCTest failure if the predicate never succeeds before the timeout expires
+     *   - records an XCTest failure if the predicate never succeeds before the timeout expires,
+     *     after one final state read for deadline-edge updates
      */
     func waitForResolvedSemanticState(
         named name: String,
@@ -738,8 +739,16 @@ extension AndBibleUITests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        let finalValue = valueProvider() ?? "<missing \(name)>"
-        XCTFail(failureDescription(finalValue), file: file, line: line)
+        if let finalValue = valueProvider() {
+            if success(finalValue) {
+                return
+            }
+            XCTFail(failureDescription(finalValue), file: file, line: line)
+        } else if missingCountsAsSuccess {
+            return
+        } else {
+            XCTFail(failureDescription("<missing \(name)>"), file: file, line: line)
+        }
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -540,9 +540,10 @@ extension AndBibleUITests {
      *
      * - Side effects:
      *   - launches the app directly into Search with one deterministic Strong's query
-     *   - lets Search create the bundled KJV index when missing, then waits for non-zero results
+     *   - uses the seeded `search-indexed` fixture so normal Search coverage does not create an
+     *     index at runtime
      * - Failure modes:
-     *   - fails if Search never reaches the ready state for the Strong's query after index setup
+     *   - fails if Search never reaches the ready state for the seeded Strong's query
      *   - fails if the bundled Strong's-capable Bible still reports zero indexed lexical matches
      */
     func testSearchDirectLaunchStrongsQueryReturnsBundledResults() {

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -11,6 +11,29 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SEEDED_SEARCH_FIXTURES = {"search-indexed", "search-multi-translation"}
 
 
+def swift_function_body(source: str, name: str) -> str:
+    """Return a Swift function body from a source string for contract checks."""
+    match = re.search(rf"\bfunc\s+{re.escape(name)}\b", source)
+    if match is None:
+        raise AssertionError(f"Expected Swift function {name} to exist.")
+
+    brace_index = source.find("{", match.end())
+    if brace_index == -1:
+        raise AssertionError(f"Expected Swift function {name} to have a body.")
+
+    depth = 0
+    for index in range(brace_index, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_index + 1 : index]
+
+    raise AssertionError(f"Expected Swift function {name} body to close.")
+
+
 class SearchFixtureGuardrailsTests(unittest.TestCase):
     """Protects Search UI tests from silently falling back to runtime index creation."""
 
@@ -54,7 +77,8 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
         self.assertIn("seededSearchFixtureScenarios", support_source)
         for scenario in SEEDED_SEARCH_FIXTURES:
             self.assertIn(f'"{scenario}"', support_source)
-        self.assertIn("allowsRuntimeIndexCreation: !isSeededSearchFixtureScenario", support_source)
+        self.assertIn("let allowsRuntimeIndexCreation = !isSeededSearchFixtureScenario", support_source)
+        self.assertIn("allowsRuntimeIndexCreation: allowsRuntimeIndexCreation", support_source)
 
     def test_search_open_path_preserves_call_site_failure_attribution(self) -> None:
         """Ensure seeded fixture failures point at the invoking Search UI test."""
@@ -82,11 +106,70 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
 
         readiness_calls = re.findall(
             r"waitForSearchInteractionReady\([\s\S]*?"
-            r"allowsRuntimeIndexCreation:\s*!isSeededSearchFixtureScenario,\s*"
+            r"allowsRuntimeIndexCreation:\s*allowsRuntimeIndexCreation,\s*"
             r"file:\s*file,\s*line:\s*line\s*\)",
             support_source,
         )
         self.assertEqual(2, len(readiness_calls))
+
+    def test_seeded_open_search_readiness_uses_reduced_budget(self) -> None:
+        """Ensure normal seeded Search tests no longer inherit index-creation timeouts."""
+        support_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("seededSearchReadinessTimeout", support_source)
+        self.assertIn("runtimeSearchIndexReadinessTimeout", support_source)
+        self.assertRegex(
+            support_source,
+            re.compile(r"seededSearchReadinessTimeout:\s*TimeInterval\s*=\s*20\b"),
+        )
+        self.assertRegex(
+            support_source,
+            re.compile(r"runtimeSearchIndexReadinessTimeout:\s*TimeInterval\s*=\s*120\b"),
+        )
+
+        open_search_body = swift_function_body(support_source, "openSearch")
+        normalized_open_search_body = re.sub(r"\s+", " ", open_search_body)
+        self.assertIn(
+            "let allowsRuntimeIndexCreation = !isSeededSearchFixtureScenario",
+            normalized_open_search_body,
+        )
+        self.assertIn(
+            "let readinessTimeout = searchReadinessTimeout( "
+            "allowsRuntimeIndexCreation: allowsRuntimeIndexCreation "
+            ")",
+            normalized_open_search_body,
+        )
+        self.assertNotRegex(open_search_body, re.compile(r"timeout:\s*120\b"))
+        readiness_calls = re.findall(
+            r"waitForSearchInteractionReady\([\s\S]*?"
+            r"timeout:\s*readinessTimeout,[\s\S]*?"
+            r"allowsRuntimeIndexCreation:\s*allowsRuntimeIndexCreation,\s*"
+            r"file:\s*file,\s*line:\s*line\s*\)",
+            open_search_body,
+        )
+        self.assertEqual(2, len(readiness_calls))
+
+    def test_search_state_waits_use_shared_semantic_wait_helper(self) -> None:
+        """Keep Search's pure state waits on one shared diagnostic helper."""
+        support_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("func waitForSearchSemanticState", support_source)
+        for function_name in [
+            "waitForSearchState",
+            "waitForSearchResultCount",
+            "waitForSearchSelectedModules",
+            "waitForSearchResultRow",
+        ]:
+            body = swift_function_body(support_source, function_name)
+            self.assertIn(
+                "waitForSearchSemanticState",
+                body,
+                f"{function_name} must use the shared Search state waiter.",
+            )
 
     def test_search_readiness_failure_reports_final_state_and_needs_index_history(self) -> None:
         """Keep readiness failures actionable when seeded indexes are missing or stale."""
@@ -97,6 +180,7 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
         self.assertIn("observedNeedsIndex", support_source)
         self.assertIn("last Search state", support_source)
         self.assertIn("state=needsIndex observed", support_source)
+        self.assertIn("index creation requested", support_source)
         self.assertIn("Create-index prompt observed", support_source)
 
         needs_index_branch = re.search(


### PR DESCRIPTION
## Summary
Reduce normal Search UI readiness waits now that seeded fixtures verify the index is already available, while preserving the long wait only for workflows that explicitly allow runtime index creation.

## Scope
- Search UI-test readiness helper behavior.
- Shared semantic-state waiting for pure Search state assertions.
- Python guardrails protecting seeded timeout, shared Search wait usage, and readiness diagnostics.
- No production Search behavior changes.

## Contract references
- Issue #202 acceptance criteria.
- Android parity: missing-index search routes through SearchIndex instead of hiding runtime index creation inside normal Search readiness.
- Existing seeded scenarios: search-indexed and search-multi-translation.

## Change details
- Added separate 20 second seeded Search readiness and 120 second runtime index-creation readiness budgets.
- Routed Search state waits for ready state, result count, selected modules, and result-row existence through one shared semantic-state helper.
- Preserved deadline-edge final state reads in the shared resolved semantic-state waiter.
- Added diagnostics that report final Search state plus whether index creation was requested.
- Updated guardrail tests to prevent regressions back to broad 120 second seeded waits or duplicated Search state polling.

## Validation evidence
- python3 -m unittest scripts.test_search_fixture_guardrails
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -derivedDataPath .derivedData-issue-202 -resultBundlePath .artifacts/AndBibleBuild-issue-202-final.xcresult build-for-testing -quiet
- Search indexed UI group passed locally with .artifacts/AndBibleTests-issue-202-search-group-01-search-indexed.xcresult.
- Search multi-translation UI test passed locally on a fresh simulator with .artifacts/AndBibleTests-issue-202-search-multi-fresh.xcresult.
- swift test --list-tests is blocked locally by the existing macOS SwiftPM UIUserInterfaceIdiom compile issue.

## Risks/follow-ups
- The active reused simulator had many locally installed module configs and made the multi-translation picker row unreachable; the same test passed on a fresh simulator. CI should run with controlled simulator state.
- No custom event bridge or new fixture infrastructure was added.

## Issue closure
Closes #202