### PR TITLE
test(ui): consolidate semantic state waits

### DIFF
--- a/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -896,7 +896,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected My Notes state to contain '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -919,7 +919,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { $0.contains("myNotesVisible=true") && $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected visible My Notes state to contain '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -942,7 +942,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { state in
                 state.contains("myNotesVisible=true")
                     && (state.contains("myNotesEditing=true") || state.contains(marker))
@@ -1058,7 +1058,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { !$0.contains(token) },
             failureDescription: { finalValue in
                 "Expected My Notes state to stop containing '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -1081,7 +1081,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { $0.contains("myNotesVisible=true") && !$0.contains(token) },
             failureDescription: { finalValue in
                 "Expected visible My Notes state to stop containing '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -1257,7 +1257,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readerRenderedContentState",
             timeout: timeout,
-            valueProvider: { readerRenderedContentStateValue(in: app) },
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
             success: { $0.contains("studyPadVisible=true") && $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected visible StudyPad state to contain '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -310,7 +310,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "bookmarkListStateExport",
             timeout: timeout,
-            valueProvider: { resolvedBookmarkListStateValue(in: app) },
+            valueProvider: { self.resolvedBookmarkListStateValue(in: app) },
             success: { $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected element 'bookmarkListStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -338,7 +338,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "bookmarkListStateExport",
             timeout: timeout,
-            valueProvider: { resolvedBookmarkListStateValue(in: app) },
+            valueProvider: { self.resolvedBookmarkListStateValue(in: app) },
             success: { !$0.contains(token) },
             missingCountsAsSuccess: true,
             failureDescription: { _ in
@@ -368,7 +368,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readingPlanListStateExport",
             timeout: timeout,
-            valueProvider: { resolvedReadingPlanListStateValue(in: app) },
+            valueProvider: { self.resolvedReadingPlanListStateValue(in: app) },
             success: { $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected element 'readingPlanListStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -385,7 +385,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "readingPlanListStateExport",
             timeout: timeout,
-            valueProvider: { resolvedReadingPlanListStateValue(in: app) },
+            valueProvider: { self.resolvedReadingPlanListStateValue(in: app) },
             success: { !$0.contains(token) },
             missingCountsAsSuccess: true,
             failureDescription: { _ in
@@ -403,7 +403,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "availablePlansStateExport",
             timeout: timeout,
-            valueProvider: { resolvedAvailablePlansStateValue(in: app) },
+            valueProvider: { self.resolvedAvailablePlansStateValue(in: app) },
             success: { $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected element 'availablePlansStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -504,7 +504,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "labelManagerStateExport",
             timeout: timeout,
-            valueProvider: { resolvedLabelManagerStateValue(in: app) },
+            valueProvider: { self.resolvedLabelManagerStateValue(in: app) },
             success: { $0.contains(token) },
             failureDescription: { finalValue in
                 "Expected element 'labelManagerStateExport' to contain token '\(token)' within \(timeout) seconds. Final value: '\(finalValue)'."
@@ -521,7 +521,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "labelManagerStateExport",
             timeout: timeout,
-            valueProvider: { resolvedLabelManagerStateValue(in: app) },
+            valueProvider: { self.resolvedLabelManagerStateValue(in: app) },
             success: { !$0.contains(token) },
             missingCountsAsSuccess: true,
             failureDescription: { _ in
@@ -541,8 +541,8 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - polls the bookmark-list accessibility export until all requested row tokens appear in
-     *     the requested sequence
+     *   - samples the bookmark-list accessibility export through the shared semantic-state waiter
+     *     until all requested row tokens appear in the requested sequence
      * - Failure modes:
      *   - records an XCTest failure if the bookmark-list export never reaches the requested order
      */
@@ -554,18 +554,14 @@ extension AndBibleUITests {
         line: UInt = #line
     ) {
         let orderedTokens = orderedReferenceTokens.map(bookmarkListRowStateToken)
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let state = resolvedBookmarkListStateValue(in: app),
-               bookmarkListRowsAppearInOrder(orderedTokens, within: state) {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalState = resolvedBookmarkListStateValue(in: app) ?? "nil"
-        XCTFail(
-            "Expected bookmark-list rows \(orderedReferenceTokens) to appear in order within \(timeout) seconds; last state was '\(finalState)'.",
+        waitForResolvedSemanticState(
+            named: "bookmarkListStateExport",
+            timeout: timeout,
+            valueProvider: { self.resolvedBookmarkListStateValue(in: app) },
+            success: { self.bookmarkListRowsAppearInOrder(orderedTokens, within: $0) },
+            failureDescription: { finalState in
+                "Expected bookmark-list rows \(orderedReferenceTokens) to appear in order within \(timeout) seconds; last state was '\(finalState)'."
+            },
             file: file,
             line: line
         )

--- a/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -33,7 +33,7 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - repeatedly re-queries the live XCUI hierarchy for the requested identifier
+     *   - samples the live accessibility value through the shared semantic-state waiter
      *   - records an XCTest failure when the value never reaches the expected state before timeout
      * - Failure modes:
      *   - fails when the element disappears or its accessibility value never reaches the requested
@@ -47,21 +47,14 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let currentValue = resolvedElementSemanticText(identifier, in: app),
-               currentValue == expectedValue
-            {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalValue = resolvedElementSemanticText(identifier, in: app) ?? "<missing>"
-        XCTAssertEqual(
-            finalValue,
-            expectedValue,
-            "Expected element '\(identifier)' to reach value '\(expectedValue)' within \(timeout) seconds.",
+        waitForResolvedSemanticState(
+            named: identifier,
+            timeout: timeout,
+            valueProvider: { self.resolvedElementSemanticText(identifier, in: app) },
+            success: { $0 == expectedValue },
+            failureDescription: { finalValue in
+                "Expected element '\(identifier)' to reach value '\(expectedValue)' within \(timeout) seconds. Final value: '\(finalValue)'."
+            },
             file: file,
             line: line
         )
@@ -78,8 +71,7 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - repeatedly re-queries the live XCUI hierarchy until the requested token appears in the
-     *     element value or label
+     *   - samples the live accessibility value through the shared semantic-state waiter
      * - Failure modes:
      *   - fails when the element disappears or never reports the requested token before timeout
      */
@@ -91,20 +83,14 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let currentValue = resolvedElementSemanticText(identifier, in: app),
-               currentValue.contains(expectedToken)
-            {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalValue = resolvedElementSemanticText(identifier, in: app) ?? "<missing>"
-        XCTAssertTrue(
-            finalValue.contains(expectedToken),
-            "Expected element '\(identifier)' to contain token '\(expectedToken)' within \(timeout) seconds. Final value: '\(finalValue)'.",
+        waitForResolvedSemanticState(
+            named: identifier,
+            timeout: timeout,
+            valueProvider: { self.resolvedElementSemanticText(identifier, in: app) },
+            success: { $0.contains(expectedToken) },
+            failureDescription: { finalValue in
+                "Expected element '\(identifier)' to contain token '\(expectedToken)' within \(timeout) seconds. Final value: '\(finalValue)'."
+            },
             file: file,
             line: line
         )
@@ -121,8 +107,7 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - repeatedly re-queries the live XCUI hierarchy until the requested token disappears from
-     *     the element value and label
+     *   - samples the live accessibility value through the shared semantic-state waiter
      * - Failure modes:
      *   - fails when the element disappears or keeps reporting the token after the timeout
      */
@@ -134,22 +119,15 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let currentValue = resolvedElementSemanticText(identifier, in: app) {
-                if !currentValue.contains(unexpectedToken) {
-                    return
-                }
-            } else {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalValue = resolvedElementSemanticText(identifier, in: app) ?? "<missing>"
-        XCTAssertFalse(
-            finalValue.contains(unexpectedToken),
-            "Expected element '\(identifier)' to stop containing '\(unexpectedToken)' within \(timeout) seconds.",
+        waitForResolvedSemanticState(
+            named: identifier,
+            timeout: timeout,
+            valueProvider: { self.resolvedElementSemanticText(identifier, in: app) },
+            success: { !$0.contains(unexpectedToken) },
+            missingCountsAsSuccess: true,
+            failureDescription: { finalValue in
+                "Expected element '\(identifier)' to stop containing '\(unexpectedToken)' within \(timeout) seconds. Final value: '\(finalValue)'."
+            },
             file: file,
             line: line
         )

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -252,7 +252,7 @@ extension AndBibleUITests {
     func waitForSearchSemanticState(
         in app: XCUIApplication,
         timeout: TimeInterval,
-        success: (String) -> Bool,
+        success: @escaping (String) -> Bool,
         failureDescription: (String) -> String,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -260,7 +260,7 @@ extension AndBibleUITests {
         waitForResolvedSemanticState(
             named: "searchStateExport",
             timeout: timeout,
-            valueProvider: { resolvedSearchStateValue(in: app) },
+            valueProvider: { self.resolvedSearchStateValue(in: app) },
             success: success,
             failureDescription: failureDescription,
             file: file,
@@ -421,7 +421,7 @@ extension AndBibleUITests {
             success: {
                 $0.contains("state=ready")
                     && $0.contains("searching=false")
-                    && (searchResultCount(from: $0) ?? -1) >= minimumCount
+                    && (self.searchResultCount(from: $0) ?? -1) >= minimumCount
             },
             failureDescription: {
                 "Expected Search to report at least \(minimumCount) results within \(timeout) seconds; last value was '\($0)'."
@@ -456,7 +456,7 @@ extension AndBibleUITests {
         description: String,
         file: StaticString = #filePath,
         line: UInt = #line,
-        predicate: (Set<String>) -> Bool
+        predicate: @escaping (Set<String>) -> Bool
     ) {
         waitForSearchSemanticState(
             in: app,
@@ -464,7 +464,7 @@ extension AndBibleUITests {
             success: {
                 $0.contains("state=ready")
                     && $0.contains("searching=false")
-                    && searchSelectedModules(from: $0).map(predicate) == true
+                    && self.searchSelectedModules(from: $0).map(predicate) == true
             },
             failureDescription: {
                 "Expected Search selected modules to match \(description) within \(timeout) seconds; last value was '\($0)'."

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -712,42 +712,70 @@ extension AndBibleUITests {
      *   - missingCountsAsSuccess: When true, treats a missing export as success.
      *   - failureDescription: Closure that formats the final failure message from the last value.
      * - Side effects:
-     *   - polls a dedicated state export on the main run loop until the predicate succeeds
+     *   - evaluates a dedicated state export through `XCTNSPredicateExpectation` and `XCTWaiter`
+     *     until the predicate succeeds
      * - Failure modes:
-     *   - records an XCTest failure if the predicate never succeeds before the timeout expires,
-     *     after one final state read for deadline-edge updates
+     *   - records an XCTest failure with elapsed wait time, final observed state, and last observed
+     *     state if the predicate never succeeds before the timeout expires
      */
     func waitForResolvedSemanticState(
         named name: String,
         timeout: TimeInterval,
-        valueProvider: () -> String?,
-        success: (String) -> Bool,
+        valueProvider: @escaping () -> String?,
+        success: @escaping (String) -> Bool,
         missingCountsAsSuccess: Bool = false,
         failureDescription: (String) -> String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
+        let startedAt = Date()
+        var lastObservedValue: String?
+        let predicate = NSPredicate(block: { _, _ in
             if let currentValue = valueProvider() {
+                lastObservedValue = currentValue
                 if success(currentValue) {
-                    return
+                    return true
                 }
             } else if missingCountsAsSuccess {
-                return
+                return true
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+            return false
+        })
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        expectation.expectationDescription = "Wait for \(name) semantic state"
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+
+        if result == .completed {
+            return
+        }
 
         if let finalValue = valueProvider() {
+            lastObservedValue = finalValue
             if success(finalValue) {
                 return
             }
-            XCTFail(failureDescription(finalValue), file: file, line: line)
+            let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
+            let lastObservedState = lastObservedValue ?? "<none>"
+            XCTFail(
+                "\(failureDescription(finalValue)) Semantic wait '\(name)' ended with \(result) "
+                    + "after elapsed=\(elapsed)s; final observed state='\(finalValue)'; "
+                    + "last observed state='\(lastObservedState)'.",
+                file: file,
+                line: line
+            )
         } else if missingCountsAsSuccess {
             return
         } else {
-            XCTFail(failureDescription("<missing \(name)>"), file: file, line: line)
+            let missingValue = "<missing \(name)>"
+            let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
+            let lastObservedState = lastObservedValue ?? "<none>"
+            XCTFail(
+                "\(failureDescription(missingValue)) Semantic wait '\(name)' ended with \(result) "
+                    + "after elapsed=\(elapsed)s; final observed state='\(missingValue)'; "
+                    + "last observed state='\(lastObservedState)'.",
+                file: file,
+                line: line
+            )
         }
     }
 

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -749,13 +749,13 @@ extension AndBibleUITests {
             return
         }
 
+        let lastObservedBeforeFinalRead = lastObservedValue
         if let finalValue = valueProvider() {
-            lastObservedValue = finalValue
             if success(finalValue) {
                 return
             }
             let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
-            let lastObservedState = lastObservedValue ?? "<none>"
+            let lastObservedState = lastObservedBeforeFinalRead ?? "<none>"
             XCTFail(
                 "\(failureDescription(finalValue)) Semantic wait '\(name)' ended with \(result) "
                     + "after elapsed=\(elapsed)s; final observed state='\(finalValue)'; "
@@ -768,7 +768,7 @@ extension AndBibleUITests {
         } else {
             let missingValue = "<missing \(name)>"
             let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
-            let lastObservedState = lastObservedValue ?? "<none>"
+            let lastObservedState = lastObservedBeforeFinalRead ?? "<none>"
             XCTFail(
                 "\(failureDescription(missingValue)) Semantic wait '\(name)' ended with \(result) "
                     + "after elapsed=\(elapsed)s; final observed state='\(missingValue)'; "

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -93,6 +93,20 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertIn("final observed state", body)
         self.assertIn("last observed state", body)
         self.assertRegex(body, re.compile(r"valueProvider\(\)[\s\S]*success\(finalValue\)"))
+        self.assertRegex(
+            body,
+            re.compile(
+                r"let\s+lastObservedBeforeFinalRead\s*=\s*lastObservedValue"
+                r"[\s\S]*if\s+let\s+finalValue\s*=\s*valueProvider\(\)"
+            ),
+        )
+        self.assertRegex(
+            body,
+            re.compile(
+                r"let\s+lastObservedState\s*=\s*lastObservedBeforeFinalRead\s*\?\?\s*\"<none>\""
+            ),
+        )
+        self.assertNotIn("lastObservedValue = finalValue", body)
 
     def test_representative_pure_observation_waits_use_shared_helper(self) -> None:
         """Keep migrated value/state waits on the shared XCTest-backed helper."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -1,0 +1,116 @@
+"""Guardrails for shared UI-test semantic state waiting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def swift_function_body(source: str, name: str) -> str:
+    """Return the Swift function body for focused source-contract checks."""
+    match = re.search(rf"\bfunc\s+{re.escape(name)}\b", source)
+    if match is None:
+        raise AssertionError(f"Expected Swift function {name} to exist.")
+
+    brace_index = source.find("{", match.end())
+    if brace_index == -1:
+        raise AssertionError(f"Expected Swift function {name} to have a body.")
+
+    depth = 0
+    for index in range(brace_index, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_index + 1 : index]
+
+    raise AssertionError(f"Expected Swift function {name} body to close.")
+
+
+def swift_function_bodies(source: str, name: str) -> list[str]:
+    """Return every Swift function body with a matching overloaded function name."""
+    bodies: list[str] = []
+    search_start = 0
+    while True:
+        match = re.search(rf"\bfunc\s+{re.escape(name)}\b", source[search_start:])
+        if match is None:
+            break
+        absolute_match_start = search_start + match.start()
+        brace_index = source.find("{", search_start + match.end())
+        if brace_index == -1:
+            raise AssertionError(f"Expected Swift function {name} to have a body.")
+
+        depth = 0
+        for index in range(brace_index, len(source)):
+            char = source[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    bodies.append(source[brace_index + 1 : index])
+                    search_start = index + 1
+                    break
+        else:
+            raise AssertionError(f"Expected Swift function {name} body to close.")
+
+        if search_start <= absolute_match_start:
+            raise AssertionError(f"Parser did not advance after Swift function {name}.")
+
+    if not bodies:
+        raise AssertionError(f"Expected Swift function {name} to exist.")
+    return bodies
+
+
+class SemanticWaitGuardrailsTests(unittest.TestCase):
+    """Protects pure semantic-state waits from regressing to ad hoc run-loop polling."""
+
+    def test_resolved_semantic_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
+        """Ensure the shared pure-observation wait is backed by XCTest wait primitives."""
+        state_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestStateSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(state_source, "waitForResolvedSemanticState")
+
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_resolved_semantic_wait_failure_reports_elapsed_and_final_state(self) -> None:
+        """Keep timeout failures actionable without reintroducing custom polling loops."""
+        state_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestStateSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(state_source, "waitForResolvedSemanticState")
+
+        self.assertIn("elapsed", body)
+        self.assertIn("final observed state", body)
+        self.assertIn("last observed state", body)
+        self.assertRegex(body, re.compile(r"valueProvider\(\)[\s\S]*success\(finalValue\)"))
+
+    def test_representative_pure_observation_waits_use_shared_helper(self) -> None:
+        """Keep migrated value/state waits on the shared XCTest-backed helper."""
+        reader_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestReaderSupport.swift"
+        ).read_text(encoding="utf-8")
+        list_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestListSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        for body in swift_function_bodies(reader_source, "waitForElementValue"):
+            self.assertIn("waitForResolvedSemanticState", body)
+            self.assertNotIn("RunLoop.current.run", body)
+
+        bookmark_rows_body = swift_function_body(list_source, "waitForBookmarkListRows")
+        self.assertIn("waitForResolvedSemanticState", bookmark_rows_body)
+        self.assertNotIn("RunLoop.current.run", bookmark_rows_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR consolidates pure UI-test semantic state waits onto the shared XCTest-backed waiter requested by issue #201.

It replaces representative ad hoc `RunLoop.current.run` polling in state/value observation helpers with `XCTNSPredicateExpectation` + `XCTWaiter`, while preserving the existing accessibility-state contracts, timeout budgets, and Android-parity behavioral assertions covered by the UI tests.

## Scope
In scope:
- Rework `waitForResolvedSemanticState` to use XCTest waiting primitives with elapsed-time, final observed state, and last observed state diagnostics.
- Route representative reader value waits and bookmark row-order waits through the shared helper.
- Keep existing semantic export contracts and timeout values unchanged.
- Add guardrail tests to prevent the shared waiter and migrated representative waits from regressing to local run-loop polling.

Out of scope:
- No production app behavior changes.
- No global timeout reduction.
- No fixture seeding or host setup refactor.
- No custom cross-process event bridge.
- No action, retry, or bootstrap loop rewrites beyond the representative pure-observation waits.

## Contract References
- Closes #201
- Android parity constraint: this changes UI-test wait mechanics only and does not alter production behavior or expected app semantics.
- XCTest/XCUITest wait contract: predicate expectations and `XCTWaiter` are used for pure state observation.
- Existing accessibility/state export contracts in `AndBibleUITests/*Support.swift`.

## Change Details
- `AndBibleUITestStateSupport.swift`: `waitForResolvedSemanticState` now uses `XCTNSPredicateExpectation` and `XCTWaiter`; failures include elapsed wait time, final observed state, last observed state, and the waiter result.
- `AndBibleUITestReaderSupport.swift`: the `waitForElementValue` equality, contains, and not-contains helpers now delegate to the shared semantic-state waiter.
- `AndBibleUITestListSupport.swift`: bookmark row-order observation now delegates to the shared semantic-state waiter.
- `AndBibleUITestSearchSupport.swift` and `AndBibleUITestInteractionSupport.swift`: escaping closure call sites now use explicit `self` where required by the shared waiter signature.
- `scripts/test_semantic_wait_guardrails.py`: adds focused guardrails for the XCTest-backed waiter contract and representative migrations.

Before:
- Reader value and bookmark row-order waits built a local deadline, repeatedly sampled accessibility state, and called `RunLoop.current.run` between observations.
- Timeout failures only reported each caller's final value message.

After:
- Those waits call `waitForResolvedSemanticState`, which uses `XCTNSPredicateExpectation` and `XCTWaiter` for observation.
- Timeout failures preserve caller-specific messages and append elapsed time, final observed state, last observed state, and the waiter result.

## Validation Evidence
- `python3 scripts/test_semantic_wait_guardrails.py`
- `python3 -m unittest scripts.test_search_fixture_guardrails`
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path . --product UITestFixtureTool`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -derivedDataPath .derivedData-issue-201 -resultBundlePath .artifacts/AndBibleBuild-issue-201-r5.xcresult build-for-testing -quiet`
- Focused UI slice passed on iPhone 16 simulator iOS 18.6:
  - `AndBibleUITests/testBookmarkListSortMenuReordersRows`
  - `AndBibleUITests/testSettingsBackupRestoreDatabaseBackupPresentsDestinationChoice`
  - `AndBibleUITests/testAllTextOptionsOpensReaderTextDisplaySurface`

## Risks / Follow-ups
- Risk is limited to UI-test waiting behavior. The wait predicate still performs a final state read after timeout so deadline-edge updates retain the previous success path.
- CI shard coverage remains the source of truth for broader UI-test timing behavior.

## Screenshots
none

## Closes
Closes #201