### PR TITLE
fix(reader): align Bible quick selector with Android

### DIFF
--- a/AndBibleTests/AndBibleTestSupport.swift
+++ b/AndBibleTests/AndBibleTestSupport.swift
@@ -405,6 +405,67 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Seeds an additional Bible module identity that reuses the bundled KJV fixture payload.
+
+     Quick-selector parity tests need multiple installed Bible module initials so they can exercise
+     Android's direct-switch and popup contracts through `SwordManager` and `BibleReaderController`.
+     The alias keeps the canonical KJV data files untouched and only writes a separate `.conf`
+     module descriptor with a different abbreviation, description, and language code.
+
+     - Parameters:
+       - moduleName: SWORD module initials to publish in `mods.d`.
+       - description: Human-readable module name stored in the alias descriptor.
+       - language: ISO language code used by quick-selector ordering and labels.
+       - modulePath: Temporary SWORD root returned by `makeTemporaryBundledSwordPath()`.
+     - Side effects: Writes a `.conf` file under `modulePath/mods.d`.
+     - Failure modes: Propagates filesystem read/write errors, including a missing bundled KJV
+       descriptor in the temporary fixture.
+     */
+    func seedBibleAliasModule(
+        named moduleName: String,
+        description: String,
+        language: String = "en",
+        in modulePath: String
+    ) throws {
+        let moduleRoot = URL(fileURLWithPath: modulePath, isDirectory: true)
+        let modsDURL = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let kjvConfigURL = modsDURL.appendingPathComponent("kjv.conf", isDirectory: false)
+        var config = try String(contentsOf: kjvConfigURL, encoding: .utf8)
+        config = config.replacingOccurrences(of: "[KJV]", with: "[\(moduleName)]")
+        config = replaceConfigLine(named: "Description", with: description, in: config)
+        config = replaceConfigLine(named: "Lang", with: language, in: config)
+
+        try config.write(
+            to: modsDURL.appendingPathComponent("\(moduleName.lowercased()).conf", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /**
+     Replaces one SWORD `.conf` key/value line while preserving the rest of the descriptor.
+
+     - Parameters:
+       - key: Configuration key to replace.
+       - value: Replacement value written after the equals sign.
+       - config: Full descriptor text.
+     - Returns: The updated descriptor, or the original descriptor with a new line appended when the
+       key was absent.
+     - Side effects: none.
+     - Failure modes: none; malformed input simply receives an appended key/value line.
+     */
+    private func replaceConfigLine(named key: String, with value: String, in config: String) -> String {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        let pattern = #"(?m)^\#(escapedKey)=.*$"#
+        guard let range = config.range(of: pattern, options: .regularExpression) else {
+            return config + "\n\(key)=\(value)\n"
+        }
+        var updatedConfig = config
+        updatedConfig.replaceSubrange(range, with: "\(key)=\(value)")
+        return updatedConfig
+    }
+
     func copyDirectoryContents(from source: URL, to destination: URL) throws {
         let fm = FileManager.default
         try fm.createDirectory(at: destination, withIntermediateDirectories: true)

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1222,6 +1222,7 @@ extension AndBibleTests {
      Bible category on the pane's `PageManager`, rather than maintaining separate quick-selector
      state.
      */
+    @MainActor
     func testBibleQuickModuleSelectorSelectionUsesControllerSwitchPathAndPersistsPaneDocument() throws {
         let (bridge, _) = makeRecordingBridge()
         let modulePath = try makeTemporaryBundledSwordPath()
@@ -1312,6 +1313,7 @@ extension AndBibleTests {
      unchanged. A failure means an accidental non-Bible caller can corrupt pane state by forcing the
      reader into Bible mode with a commentary/dictionary module name.
      */
+    @MainActor
     func testBibleDocumentSwitchRejectsNonBibleModulesWithoutStateMutation() throws {
         let (bridge, _) = makeRecordingBridge()
         let modulePath = try makeTemporaryBundledSwordPath()

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -471,6 +471,44 @@ extension AndBibleTests {
         XCTAssertEqual(placement.offset.width + popupWidth, 797, accuracy: 0.001)
     }
 
+    /**
+     Verifies toolbar popup width calculation cannot feed negative dimensions into SwiftUI layout.
+
+     SwiftUI may report transient zero-width geometry during popup presentation or device rotation.
+     The reader uses the bounded width for both placement and `.frame(width:)`, so the shared width
+     helper must clamp undersized containers to zero while preserving normal Android-style popup
+     sizing when enough space exists.
+     */
+    func testReaderToolbarPopupWidthClampHandlesTransientNarrowGeometry() {
+        XCTAssertEqual(
+            ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: 0,
+                preferredWidth: 236,
+                maximumWidth: 236
+            ),
+            0,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: 8,
+                preferredWidth: 236,
+                maximumWidth: 236
+            ),
+            0,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: 393,
+                preferredWidth: max(CGFloat(393) * 0.42, 156),
+                maximumWidth: 232
+            ),
+            CGFloat(165.06),
+            accuracy: 0.001
+        )
+    }
+
     func testBibleReaderOverflowMenuBuildsWithBibleDisplayOptions() {
         let state = BibleReaderOverflowMenuState(
             isFullScreen: false,

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1045,7 +1045,7 @@ extension AndBibleTests {
      that can scroll; the SwiftUI parity renderer must likewise be backed by a scroll container so
      all available modules can be reached without falling back to the full iOS sheet.
      */
-    func testBibleQuickModuleSelectorUsesScrollContainerForLongInstalledModuleLists() {
+    func testBibleQuickModuleSelectorUsesScrollContainerForLongInstalledModuleLists() throws {
         let rows = (0..<60).map { index in
             BibleReaderQuickModuleSelectorPresentation.Row(
                 module: ModuleInfo(
@@ -1065,6 +1065,12 @@ extension AndBibleTests {
         )
 
         XCTAssertTrue(String(describing: type(of: view.body)).contains("ScrollView"))
+        let selectorSource = try bibleUISource(named: "BibleReaderQuickModuleSelector.swift")
+        XCTAssertTrue(selectorSource.contains("LazyVStack(alignment: .leading, spacing: 0)"))
+        XCTAssertTrue(selectorSource.contains(".onTapGesture"))
+        XCTAssertTrue(selectorSource.contains(".accessibilityAddTraits(.isButton)"))
+        XCTAssertTrue(selectorSource.contains(".accessibilityAction"))
+        XCTAssertFalse(selectorSource.contains("Button {"))
     }
 
     /**
@@ -1320,7 +1326,7 @@ extension AndBibleTests {
                 ".anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self"
             )
         )
-        XCTAssertTrue(toolbarSource.contains(".allowsHitTesting(moduleActionsEnabled)"))
+        XCTAssertTrue(toolbarSource.contains(".disabled(!moduleActionsEnabled)"))
         XCTAssertEqual(
             toolbarSource.components(separatedBy: ".accessibilityHidden(!moduleActionsEnabled)")
                 .count - 1,

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1067,10 +1067,10 @@ extension AndBibleTests {
         XCTAssertTrue(String(describing: type(of: view.body)).contains("ScrollView"))
         let selectorSource = try bibleUISource(named: "BibleReaderQuickModuleSelector.swift")
         XCTAssertTrue(selectorSource.contains("LazyVStack(alignment: .leading, spacing: 0)"))
-        XCTAssertTrue(selectorSource.contains(".onTapGesture"))
-        XCTAssertTrue(selectorSource.contains(".accessibilityAddTraits(.isButton)"))
-        XCTAssertTrue(selectorSource.contains(".accessibilityAction"))
-        XCTAssertFalse(selectorSource.contains("Button {"))
+        XCTAssertTrue(selectorSource.contains("Button {"))
+        XCTAssertTrue(selectorSource.contains(".buttonStyle(.plain)"))
+        XCTAssertTrue(selectorSource.contains(".disabled(!row.isEnabled)"))
+        XCTAssertFalse(selectorSource.contains("            VStack(alignment: .leading, spacing: 0)"))
     }
 
     /**
@@ -1298,9 +1298,12 @@ extension AndBibleTests {
      quick-selector rows into the popup, the toolbar button must publish anchor geometry for an
      in-reader popup, and module actions must be disabled until the focused pane controller exists,
      including accessibility exposure. Row selection must also dismiss the popup before checking
-     whether the captured controller still exists. A failure means the user-visible selector likely
-     drifted back toward the old full-sheet behavior, can accept taps before the Android-equivalent
-     document state is available, or can leave a stale popup onscreen after pane teardown.
+     whether the captured controller still exists. Bible/commentary toolbar gestures must dispatch
+     tap or long-press exclusively so Android's quick-menu and full-chooser paths cannot both fire
+     for one press. A failure means the user-visible selector likely drifted back toward the old
+     full-sheet behavior, can accept taps before the Android-equivalent document state is available,
+     can leave a stale popup onscreen after pane teardown, or can fire both selector paths from one
+     toolbar gesture.
      */
     func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
         let readerSource = try bibleUISource(named: "BibleReaderView.swift")
@@ -1318,7 +1321,12 @@ extension AndBibleTests {
         XCTAssertTrue(menuActionSource.contains("presentBibleQuickSelector(controller, rows: rows)"))
         XCTAssertFalse(menuActionSource.contains("performBibleChooserAction()"))
         XCTAssertTrue(readerSource.contains("@State private var bibleQuickModuleSelectorRows"))
+        XCTAssertTrue(readerSource.contains("@State private var bibleQuickModuleSelectorTargetWindowId"))
+        XCTAssertTrue(readerSource.contains("bibleQuickModuleSelectorTargetWindowId = resolvedTargetWindowId"))
+        XCTAssertTrue(readerSource.contains("bibleQuickModuleSelectorTargetWindowId = nil"))
         XCTAssertTrue(readerSource.contains("let rows = bibleQuickModuleSelectorRows"))
+        XCTAssertTrue(readerSource.contains("let targetWindowId = bibleQuickModuleSelectorTargetWindowId"))
+        XCTAssertTrue(readerSource.contains("selectBibleQuickModule(module, targetWindowId: targetWindowId)"))
         XCTAssertTrue(readerSource.contains("moduleActionsEnabled: controller != nil"))
         XCTAssertTrue(readerSource.contains("ReaderBibleToolbarButtonBoundsPreferenceKey"))
         XCTAssertTrue(
@@ -1327,14 +1335,16 @@ extension AndBibleTests {
             )
         )
         XCTAssertTrue(toolbarSource.contains(".disabled(!moduleActionsEnabled)"))
-        XCTAssertEqual(
-            toolbarSource.components(separatedBy: ".accessibilityHidden(!moduleActionsEnabled)")
-                .count - 1,
-            2
-        )
+        XCTAssertFalse(toolbarSource.contains(".simultaneousGesture(LongPressGesture"))
+        XCTAssertTrue(toolbarSource.contains("LongPressGesture().exclusively(before: TapGesture())"))
+        XCTAssertFalse(readerSource.contains("suppressBibleTapAfterLongPress"))
+        XCTAssertFalse(readerSource.contains("suppressCommentaryTapAfterLongPress"))
+        XCTAssertEqual(toolbarSource.components(separatedBy: "moduleToolbarAction(").count - 1, 2)
+        XCTAssertTrue(toolbarSource.contains(".accessibilityHidden(!moduleActionsEnabled)"))
+        XCTAssertTrue(selectionSource.contains("let controller = controller(for: targetWindowId)"))
+        let resolveIndex = try XCTUnwrap(selectionSource.range(of: "let controller = controller(for: targetWindowId)")?.lowerBound)
         let dismissIndex = try XCTUnwrap(selectionSource.range(of: "dismissBibleQuickSelector()")?.lowerBound)
-        let guardIndex = try XCTUnwrap(selectionSource.range(of: "guard let controller else { return }")?.lowerBound)
-        XCTAssertLessThan(dismissIndex, guardIndex)
+        XCTAssertLessThan(resolveIndex, dismissIndex)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1006,6 +1006,39 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the quick-selector row equality contract used by presentation tests.
+
+     Row equality should cover only visible and behavior-significant fields: selected module name,
+     rendered title, and enabled state. Metadata such as description, category, or language is
+     normalized into the title before rendering and should not make tests fail when behavior is
+     unchanged.
+     */
+    func testBibleQuickModuleSelectorRowEqualityIgnoresNonVisibleModuleMetadata() {
+        let lhs = BibleReaderQuickModuleSelectorPresentation.Row(
+            module: ModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en"
+            ),
+            title: "KJV (en)",
+            isEnabled: true
+        )
+        let rhs = BibleReaderQuickModuleSelectorPresentation.Row(
+            module: ModuleInfo(
+                name: "KJV",
+                description: "Different catalog description",
+                category: .commentary,
+                language: "fi"
+            ),
+            title: "KJV (en)",
+            isEnabled: true
+        )
+
+        XCTAssertEqual(lhs, rhs)
+    }
+
+    /**
      Protects long quick-selector lists from becoming unscrollable off-screen stacks.
 
      Users can install dozens of Bible modules. Android renders those entries through a popup menu

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1248,6 +1248,43 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the controller-level Bible switch API from accepting non-Bible modules.
+
+     The quick selector and module picker currently pass Bible-filtered rows, but
+     `BibleReaderController.switchBibleDocument(to:)` is public controller API and mirrors Android's
+     current-document transition only for Bible documents. A non-Bible SWORD module must therefore
+     leave the active Bible, document category, PageManager state, and persistence callbacks
+     unchanged. A failure means an accidental non-Bible caller can corrupt pane state by forcing the
+     reader into Bible mode with a commentary/dictionary module name.
+     */
+    func testBibleDocumentSwitchRejectsNonBibleModulesWithoutStateMutation() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawCommentaryModule(in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        controller.switchCategory(to: .commentary)
+        let baselineCategory = controller.currentCategory
+        let baselineBibleModuleName = controller.activeModuleName
+        let baselineBibleDocument = pageManager.bibleDocument
+        let baselineCategoryName = pageManager.currentCategoryName
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchBibleDocument(to: "UITestComm")
+
+        XCTAssertEqual(controller.currentCategory, baselineCategory)
+        XCTAssertEqual(controller.activeModuleName, baselineBibleModuleName)
+        XCTAssertEqual(pageManager.bibleDocument, baselineBibleDocument)
+        XCTAssertEqual(pageManager.currentCategoryName, baselineCategoryName)
+        XCTAssertEqual(persistCount, 0)
+    }
+
+    /**
      Guards the reader coordinator against regressing to the iOS sheet for the quick-menu path.
 
      The coordinator state is intentionally private, so this source-level test checks the routing

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -889,6 +889,252 @@ extension AndBibleTests {
         XCTAssertNil(BibleReaderModulePicker.documentCategory(for: .unknown))
     }
 
+    /**
+     Protects Android `MainBibleActivity.menuForDocs` parity for the Bible toolbar quick menu.
+
+     Android sorts quick-menu entries by language code and then book abbreviation, renders labels as
+     abbreviation plus language code in parentheses, and disables the current document instead of
+     re-selecting it. This test uses the pure presentation contract so future UI refactors cannot
+     accidentally restore the old iOS full-sheet semantics or sort by localized description.
+     */
+    func testBibleQuickModuleSelectorRowsMirrorAndroidOrderingLabelsAndDisabledCurrentDocument() {
+        let modules = [
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en"),
+            ModuleInfo(name: "FinRK", description: "Finnish Revised Version", category: .bible, language: "fi"),
+            ModuleInfo(name: "AB", description: "Another Bible", category: .bible, language: "en")
+        ]
+
+        let rows = BibleReaderQuickModuleSelectorPresentation.rows(
+            for: modules,
+            activeModuleName: "WEB"
+        )
+
+        XCTAssertEqual(rows.map(\.module.name), ["AB", "WEB", "FinRK"])
+        XCTAssertEqual(rows.map(\.title), ["AB (en)", "WEB (en)", "FinRK (fi)"])
+        XCTAssertEqual(rows.map(\.isEnabled), [true, false, true])
+    }
+
+    /**
+     Protects Android's exactly-two-document shortcut in `menuForDocs`.
+
+     When only two Bible modules are available, Android switches directly to the other document and
+     does not show a popup. The iOS toolbar action must keep that shortcut while replacing only the
+     three-or-more path with the compact quick selector.
+     */
+    func testBibleQuickModuleSelectorActionMirrorsAndroidTwoDocumentShortcut() {
+        let modules = [
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en"),
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en")
+        ]
+
+        let action = BibleReaderQuickModuleSelectorPresentation.action(
+            for: modules,
+            activeModuleName: "KJV"
+        )
+
+        XCTAssertEqual(action, .switchDirectly("WEB"))
+    }
+
+    /**
+     Protects Android's popup threshold in `menuForDocs`.
+
+     Three or more Bible modules must show the compact anchored quick selector, not the full
+     document picker sheet. The sorted rows are part of the action payload so the UI layer cannot
+     accidentally diverge from Android ordering while still showing a popup.
+     */
+    func testBibleQuickModuleSelectorActionShowsPopupForMoreThanTwoModules() {
+        let modules = [
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en"),
+            ModuleInfo(name: "FinRK", description: "Finnish Revised Version", category: .bible, language: "fi"),
+            ModuleInfo(name: "AB", description: "Another Bible", category: .bible, language: "en")
+        ]
+
+        let action = BibleReaderQuickModuleSelectorPresentation.action(
+            for: modules,
+            activeModuleName: "WEB"
+        )
+
+        XCTAssertEqual(
+            action,
+            .showPopup([
+                BibleReaderQuickModuleSelectorPresentation.Row(
+                    module: modules[2],
+                    title: "AB (en)",
+                    isEnabled: true
+                ),
+                BibleReaderQuickModuleSelectorPresentation.Row(
+                    module: modules[0],
+                    title: "WEB (en)",
+                    isEnabled: false
+                ),
+                BibleReaderQuickModuleSelectorPresentation.Row(
+                    module: modules[1],
+                    title: "FinRK (fi)",
+                    isEnabled: true
+                )
+            ])
+        )
+    }
+
+    /**
+     Protects Android's non-two-document popup rule for single available Bible modules.
+
+     Android only special-cases exactly two documents. With one available Bible it still shows the
+     popup, and if the current document is not that Bible then the row remains enabled so the toolbar
+     can switch from commentary or another category back to Bible mode.
+     */
+    func testBibleQuickModuleSelectorActionShowsPopupForSingleModuleWhenBibleIsNotCurrentDocument() {
+        let modules = [
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en")
+        ]
+
+        let action = BibleReaderQuickModuleSelectorPresentation.action(
+            for: modules,
+            activeModuleName: nil
+        )
+
+        XCTAssertEqual(
+            action,
+            .showPopup([
+                BibleReaderQuickModuleSelectorPresentation.Row(
+                    module: modules[0],
+                    title: "KJV (en)",
+                    isEnabled: true
+                )
+            ])
+        )
+    }
+
+    /**
+     Protects the quick selector's selected-row side effect contract.
+
+     Android's popup selection calls the same current-document switch path used elsewhere in the
+     reader. iOS should likewise route selected quick-menu modules through
+     `BibleReaderController.switchModule(to:)` and persist the chosen Bible document on the pane's
+     `PageManager`, rather than maintaining separate quick-selector state.
+     */
+    func testBibleQuickModuleSelectorSelectionUsesControllerSwitchPathAndPersistsPaneDocument() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedBibleAliasModule(
+            named: "WEB",
+            description: "World English Bible",
+            in: modulePath
+        )
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+
+        let action = BibleReaderQuickModuleSelectorPresentation.action(
+            for: controller.installedBibleModules,
+            activeModuleName: controller.activeModuleName
+        )
+        guard case .switchDirectly(let selectedModuleName) = action else {
+            XCTFail("Expected Android's exactly-two-module shortcut to select the alternate Bible.")
+            return
+        }
+
+        controller.switchModule(to: selectedModuleName)
+        controller.switchCategory(to: .bible)
+
+        XCTAssertEqual(controller.activeModuleName, "WEB")
+        XCTAssertEqual(pageManager.bibleDocument, "WEB")
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+    }
+
+    /**
+     Guards the reader coordinator against regressing to the iOS sheet for the quick-menu path.
+
+     The coordinator state is intentionally private, so this source-level test checks the routing
+     contract at the function boundary: Android's `menuForDocs` equivalent must route to the quick
+     selector and the toolbar button must publish anchor geometry for an in-reader popup. A failure
+     means the user-visible selector likely drifted back toward the old full-sheet behavior.
+     */
+    func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
+        let readerSource = try bibleUISource(named: "BibleReaderView.swift")
+        let toolbarSource = try bibleUISource(named: "BibleReaderToolbarActions.swift")
+        let menuActionSource = try extractFunction(
+            named: "performBibleMenuAction",
+            from: readerSource
+        )
+
+        XCTAssertTrue(menuActionSource.contains("presentBibleQuickSelector(controller)"))
+        XCTAssertFalse(menuActionSource.contains("performBibleChooserAction()"))
+        XCTAssertTrue(readerSource.contains("ReaderBibleToolbarButtonBoundsPreferenceKey"))
+        XCTAssertTrue(
+            toolbarSource.contains(
+                ".anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self"
+            )
+        )
+    }
+
+    /**
+     Loads a Bible reader UI source file for source-level contract tests.
+
+     Source assertions are used only where SwiftUI coordinator state is intentionally private and a
+     pure behavior test cannot observe the routing boundary. The helper derives the path from the
+     current test bundle so it works in local and CI checkouts without hard-coded absolute paths.
+     */
+    private func bibleUISource(named fileName: String) throws -> String {
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let repositoryRoot = testsDirectory.deletingLastPathComponent()
+        let sourceURL = repositoryRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("BibleUI")
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("BibleUI")
+            .appendingPathComponent("Bible")
+            .appendingPathComponent(fileName)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+
+    /**
+     Extracts one Swift function body from a source file for a focused source-contract assertion.
+
+     The scanner balances braces after the named function declaration instead of checking arbitrary
+     file-wide fragments, which keeps the tests tied to the specific behavior boundary they protect.
+     */
+    private func extractFunction(named functionName: String, from source: String) throws -> String {
+        guard let functionRange = source.range(of: "func \(functionName)") else {
+            throw NSError(
+                domain: "AndBibleTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Function \(functionName) not found"]
+            )
+        }
+        guard let openingBrace = source[functionRange.lowerBound...].firstIndex(of: "{") else {
+            throw NSError(
+                domain: "AndBibleTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Function \(functionName) has no body"]
+            )
+        }
+
+        var depth = 0
+        var current = openingBrace
+        while current < source.endIndex {
+            let character = source[current]
+            if character == "{" {
+                depth += 1
+            } else if character == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(source[functionRange.lowerBound...current])
+                }
+            }
+            current = source.index(after: current)
+        }
+
+        throw NSError(
+            domain: "AndBibleTests",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Function \(functionName) body was not balanced"]
+        )
+    }
+
     func testBibleReaderSpeakMiniPlayerBuildsWithSpeakService() {
         let view = BibleReaderSpeakMiniPlayer(
             speakService: SpeakService(),

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -476,8 +476,9 @@ extension AndBibleTests {
 
      SwiftUI may report transient zero-width geometry during popup presentation or device rotation.
      The reader uses the bounded width for both placement and `.frame(width:)`, so the shared width
-     helper must clamp undersized containers to zero while preserving normal Android-style popup
-     sizing when enough space exists.
+     helper must clamp undersized containers to zero, account for safe-area insets before SwiftUI
+     receives a frame width, and preserve normal Android-style popup sizing when enough space
+     exists.
      */
     func testReaderToolbarPopupWidthClampHandlesTransientNarrowGeometry() {
         XCTAssertEqual(
@@ -505,6 +506,16 @@ extension AndBibleTests {
                 maximumWidth: 232
             ),
             CGFloat(165.06),
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: 200,
+                safeAreaInsets: EdgeInsets(top: 0, leading: 80, bottom: 0, trailing: 80),
+                preferredWidth: 236,
+                maximumWidth: 236
+            ),
+            24,
             accuracy: 0.001
         )
     }

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -446,6 +446,31 @@ extension AndBibleTests {
         XCTAssertEqual(placement.maximumHeight, 600, accuracy: 0.001)
     }
 
+    /**
+     Verifies toolbar popup placement stays inside horizontal safe areas.
+
+     Android anchors popup menus to app-bar controls that are already laid out inside system insets.
+     The iOS shared popup placement therefore needs to include horizontal safe-area insets when
+     computing the trailing rail, especially in landscape where notches and system regions can
+     consume non-zero leading or trailing space.
+     */
+    func testReaderToolbarPopupPlacementRespectsHorizontalSafeAreas() {
+        let containerSize = CGSize(width: 852, height: 393)
+        let safeAreaInsets = EdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 47)
+        let trigger = CGRect(x: 760, y: 42, width: 24, height: 22)
+        let popupWidth: CGFloat = 236
+
+        let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+            containerSize: containerSize,
+            safeAreaInsets: safeAreaInsets,
+            triggerRect: trigger,
+            popupWidth: popupWidth
+        )
+
+        XCTAssertEqual(placement.offset.width, 561, accuracy: 0.001)
+        XCTAssertEqual(placement.offset.width + popupWidth, 797, accuracy: 0.001)
+    }
+
     func testBibleReaderOverflowMenuBuildsWithBibleDisplayOptions() {
         let state = BibleReaderOverflowMenuState(
             isFullScreen: false,

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1253,9 +1253,10 @@ extension AndBibleTests {
      The coordinator state is intentionally private, so this source-level test checks the routing
      contract at the function boundary: Android's `menuForDocs` equivalent must route to the quick
      selector, the toolbar button must publish anchor geometry for an in-reader popup, and module
-     actions must be disabled until the focused pane controller exists. A failure means the
-     user-visible selector likely drifted back toward the old full-sheet behavior or can accept taps
-     before the Android-equivalent document state is available.
+     actions must be disabled until the focused pane controller exists, including accessibility
+     exposure. A failure means the user-visible selector likely drifted back toward the old
+     full-sheet behavior or can accept taps before the Android-equivalent document state is
+     available.
      */
     func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
         let readerSource = try bibleUISource(named: "BibleReaderView.swift")
@@ -1275,6 +1276,11 @@ extension AndBibleTests {
             )
         )
         XCTAssertTrue(toolbarSource.contains(".allowsHitTesting(moduleActionsEnabled)"))
+        XCTAssertEqual(
+            toolbarSource.components(separatedBy: ".accessibilityHidden(!moduleActionsEnabled)")
+                .count - 1,
+            2
+        )
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -424,6 +424,28 @@ extension AndBibleTests {
         XCTAssertEqual(quickPlacement.offset.height, bibleTrigger.maxY + 6, accuracy: 0.001)
     }
 
+    /**
+     Verifies toolbar popups expose a bounded viewport height for long Android-style menus.
+
+     Android's `PopupMenu` remains scrollable when many installed modules are available. The iOS
+     quick selector must therefore receive a finite height between the toolbar trigger and the
+     bottom safe area instead of expanding its full row stack off-screen.
+     */
+    func testReaderToolbarPopupPlacementBoundsQuickSelectorHeightToVisibleViewport() {
+        let containerSize = CGSize(width: 393, height: 852)
+        let safeAreaInsets = EdgeInsets(top: 59, leading: 0, bottom: 34, trailing: 0)
+        let bibleTrigger = CGRect(x: 292, y: 182, width: 24, height: 22)
+
+        let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+            containerSize: containerSize,
+            safeAreaInsets: safeAreaInsets,
+            triggerRect: bibleTrigger,
+            popupWidth: 232
+        )
+
+        XCTAssertEqual(placement.maximumHeight, 600, accuracy: 0.001)
+    }
+
     func testBibleReaderOverflowMenuBuildsWithBibleDisplayOptions() {
         let state = BibleReaderOverflowMenuState(
             isFullScreen: false,
@@ -956,6 +978,35 @@ extension AndBibleTests {
         XCTAssertEqual(rows.map(\.module.name), ["AB", "WEB", "FinRK"])
         XCTAssertEqual(rows.map(\.title), ["AB (en)", "WEB (en)", "FinRK (fi)"])
         XCTAssertEqual(rows.map(\.isEnabled), [true, false, true])
+    }
+
+    /**
+     Protects long quick-selector lists from becoming unscrollable off-screen stacks.
+
+     Users can install dozens of Bible modules. Android renders those entries through a popup menu
+     that can scroll; the SwiftUI parity renderer must likewise be backed by a scroll container so
+     all available modules can be reached without falling back to the full iOS sheet.
+     */
+    func testBibleQuickModuleSelectorUsesScrollContainerForLongInstalledModuleLists() {
+        let rows = (0..<60).map { index in
+            BibleReaderQuickModuleSelectorPresentation.Row(
+                module: ModuleInfo(
+                    name: String(format: "MOD%02d", index),
+                    description: "Module \(index)",
+                    category: .bible,
+                    language: "en"
+                ),
+                title: String(format: "MOD%02d (en)", index),
+                isEnabled: true
+            )
+        }
+        let view = BibleReaderQuickModuleSelector(
+            rows: rows,
+            colorScheme: .light,
+            onSelect: { _ in }
+        )
+
+        XCTAssertTrue(String(describing: type(of: view.body)).contains("ScrollView"))
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -381,6 +381,44 @@ extension AndBibleTests {
         XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderToolbarActions"))
     }
 
+    /**
+     Verifies Android-style toolbar popups share the same trailing menu rail.
+
+     The Bible quick selector is triggered by the Bible toolbar icon, but Android presents toolbar
+     popup menus from the trailing app-bar region. The selector therefore uses the trigger for
+     vertical placement only and pins its right edge to the same trailing rail as the overflow menu.
+     A failure means the selector can drift toward the middle of the reader on compact screens.
+     */
+    func testReaderToolbarPopupPlacementPinsQuickSelectorToTrailingMenuRail() {
+        let containerSize = CGSize(width: 393, height: 852)
+        let safeAreaInsets = EdgeInsets(top: 59, leading: 0, bottom: 34, trailing: 0)
+        let bibleTrigger = CGRect(x: 292, y: 182, width: 24, height: 22)
+        let overflowTrigger = CGRect(x: 360, y: 182, width: 24, height: 22)
+        let quickSelectorWidth: CGFloat = 232
+        let overflowMenuWidth: CGFloat = 236
+
+        let quickPlacement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+            containerSize: containerSize,
+            safeAreaInsets: safeAreaInsets,
+            triggerRect: bibleTrigger,
+            popupWidth: quickSelectorWidth
+        )
+        let overflowPlacement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+            containerSize: containerSize,
+            safeAreaInsets: safeAreaInsets,
+            triggerRect: overflowTrigger,
+            popupWidth: overflowMenuWidth
+        )
+
+        XCTAssertEqual(quickPlacement.offset.width + quickSelectorWidth, 385, accuracy: 0.001)
+        XCTAssertEqual(
+            quickPlacement.offset.width + quickSelectorWidth,
+            overflowPlacement.offset.width + overflowMenuWidth,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(quickPlacement.offset.height, bibleTrigger.maxY + 6, accuracy: 0.001)
+    }
+
     func testBibleReaderOverflowMenuBuildsWithBibleDisplayOptions() {
         let state = BibleReaderOverflowMenuState(
             isFullScreen: false,

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1251,12 +1251,12 @@ extension AndBibleTests {
      Guards the reader coordinator against regressing to the iOS sheet for the quick-menu path.
 
      The coordinator state is intentionally private, so this source-level test checks the routing
-     contract at the function boundary: Android's `menuForDocs` equivalent must route to the quick
-     selector, the toolbar button must publish anchor geometry for an in-reader popup, and module
-     actions must be disabled until the focused pane controller exists, including accessibility
-     exposure. A failure means the user-visible selector likely drifted back toward the old
-     full-sheet behavior or can accept taps before the Android-equivalent document state is
-     available.
+     contract at the function boundary: Android's `menuForDocs` equivalent must route the resolved
+     quick-selector rows into the popup, the toolbar button must publish anchor geometry for an
+     in-reader popup, and module actions must be disabled until the focused pane controller exists,
+     including accessibility exposure. A failure means the user-visible selector likely drifted back
+     toward the old full-sheet behavior or can accept taps before the Android-equivalent document
+     state is available.
      */
     func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
         let readerSource = try bibleUISource(named: "BibleReaderView.swift")
@@ -1266,8 +1266,11 @@ extension AndBibleTests {
             from: readerSource
         )
 
-        XCTAssertTrue(menuActionSource.contains("presentBibleQuickSelector(controller)"))
+        XCTAssertTrue(menuActionSource.contains("case .showPopup(let rows):"))
+        XCTAssertTrue(menuActionSource.contains("presentBibleQuickSelector(controller, rows: rows)"))
         XCTAssertFalse(menuActionSource.contains("performBibleChooserAction()"))
+        XCTAssertTrue(readerSource.contains("@State private var bibleQuickModuleSelectorRows"))
+        XCTAssertTrue(readerSource.contains("let rows = bibleQuickModuleSelectorRows"))
         XCTAssertTrue(readerSource.contains("moduleActionsEnabled: controller != nil"))
         XCTAssertTrue(readerSource.contains("ReaderBibleToolbarButtonBoundsPreferenceKey"))
         XCTAssertTrue(

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -365,6 +365,7 @@ extension AndBibleTests {
             strongsEnabled: true,
             isBibleActive: true,
             isCommentaryActive: false,
+            moduleActionsEnabled: true,
             onShowSearch: {},
             onShowSpeak: {},
             onApplyStrongsMode: { _ in },
@@ -1050,8 +1051,10 @@ extension AndBibleTests {
 
      The coordinator state is intentionally private, so this source-level test checks the routing
      contract at the function boundary: Android's `menuForDocs` equivalent must route to the quick
-     selector and the toolbar button must publish anchor geometry for an in-reader popup. A failure
-     means the user-visible selector likely drifted back toward the old full-sheet behavior.
+     selector, the toolbar button must publish anchor geometry for an in-reader popup, and module
+     actions must be disabled until the focused pane controller exists. A failure means the
+     user-visible selector likely drifted back toward the old full-sheet behavior or can accept taps
+     before the Android-equivalent document state is available.
      */
     func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
         let readerSource = try bibleUISource(named: "BibleReaderView.swift")
@@ -1063,12 +1066,14 @@ extension AndBibleTests {
 
         XCTAssertTrue(menuActionSource.contains("presentBibleQuickSelector(controller)"))
         XCTAssertFalse(menuActionSource.contains("performBibleChooserAction()"))
+        XCTAssertTrue(readerSource.contains("moduleActionsEnabled: controller != nil"))
         XCTAssertTrue(readerSource.contains("ReaderBibleToolbarButtonBoundsPreferenceKey"))
         XCTAssertTrue(
             toolbarSource.contains(
                 ".anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self"
             )
         )
+        XCTAssertTrue(toolbarSource.contains(".allowsHitTesting(moduleActionsEnabled)"))
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1163,8 +1163,9 @@ extension AndBibleTests {
 
      Android's popup selection calls the same current-document switch path used elsewhere in the
      reader. iOS should likewise route selected quick-menu modules through
-     `BibleReaderController.switchModule(to:)` and persist the chosen Bible document on the pane's
-     `PageManager`, rather than maintaining separate quick-selector state.
+     `BibleReaderController.switchBibleDocument(to:)` and persist the chosen Bible document plus
+     Bible category on the pane's `PageManager`, rather than maintaining separate quick-selector
+     state.
      */
     func testBibleQuickModuleSelectorSelectionUsesControllerSwitchPathAndPersistsPaneDocument() throws {
         let (bridge, _) = makeRecordingBridge()
@@ -1190,12 +1191,60 @@ extension AndBibleTests {
             return
         }
 
-        controller.switchModule(to: selectedModuleName)
-        controller.switchCategory(to: .bible)
+        controller.switchBibleDocument(to: selectedModuleName)
 
         XCTAssertEqual(controller.activeModuleName, "WEB")
         XCTAssertEqual(pageManager.bibleDocument, "WEB")
         XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+    }
+
+    /**
+     Protects Android's atomic current-document switch behavior for Bible quick selections.
+
+     Android `MainBibleActivity.menuForDocs` delegates selected Bible rows to
+     `CurrentPageManager.setCurrentDocument(book)`, which updates the active document and page
+     category as one transition. iOS must not first reload the current non-Bible category and then
+     reload the selected Bible, because that creates unnecessary WebView work and visible flicker.
+     */
+    @MainActor
+    func testBibleDocumentSwitchFromCommentaryReloadsSelectedBibleOnce() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedBibleAliasModule(
+            named: "WEB",
+            description: "World English Bible",
+            in: modulePath
+        )
+        try seedEmptyRawCommentaryModule(in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        controller.switchCategory(to: .commentary)
+        controller.bridgeDidSetClientReady(bridge)
+        let baselineScriptCount = recordedScripts().count
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchBibleDocument(to: "WEB")
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.2))
+
+        let addDocumentScripts = recordedScripts()
+            .dropFirst(baselineScriptCount)
+            .filter { $0.contains("emit('add_documents'") }
+        XCTAssertEqual(addDocumentScripts.count, 1)
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: Array(addDocumentScripts), event: "add_documents") as? [String: Any]
+        )
+        XCTAssertEqual(payload["bookCategory"] as? String, "BIBLE")
+        XCTAssertEqual(payload["bookInitials"] as? String, "WEB")
+        XCTAssertEqual(controller.currentCategory, .bible)
+        XCTAssertEqual(controller.activeModuleName, "WEB")
+        XCTAssertEqual(pageManager.bibleDocument, "WEB")
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+        XCTAssertEqual(persistCount, 1)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1254,15 +1254,20 @@ extension AndBibleTests {
      contract at the function boundary: Android's `menuForDocs` equivalent must route the resolved
      quick-selector rows into the popup, the toolbar button must publish anchor geometry for an
      in-reader popup, and module actions must be disabled until the focused pane controller exists,
-     including accessibility exposure. A failure means the user-visible selector likely drifted back
-     toward the old full-sheet behavior or can accept taps before the Android-equivalent document
-     state is available.
+     including accessibility exposure. Row selection must also dismiss the popup before checking
+     whether the captured controller still exists. A failure means the user-visible selector likely
+     drifted back toward the old full-sheet behavior, can accept taps before the Android-equivalent
+     document state is available, or can leave a stale popup onscreen after pane teardown.
      */
     func testBibleToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
         let readerSource = try bibleUISource(named: "BibleReaderView.swift")
         let toolbarSource = try bibleUISource(named: "BibleReaderToolbarActions.swift")
         let menuActionSource = try extractFunction(
             named: "performBibleMenuAction",
+            from: readerSource
+        )
+        let selectionSource = try extractFunction(
+            named: "selectBibleQuickModule",
             from: readerSource
         )
 
@@ -1284,6 +1289,9 @@ extension AndBibleTests {
                 .count - 1,
             2
         )
+        let dismissIndex = try XCTUnwrap(selectionSource.range(of: "dismissBibleQuickSelector()")?.lowerBound)
+        let guardIndex = try XCTUnwrap(selectionSource.range(of: "guard let controller else { return }")?.lowerBound)
+        XCTAssertLessThan(dismissIndex, guardIndex)
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -10,6 +10,23 @@ extension AndBibleUITests {
         for identifier: String,
         in app: XCUIApplication
     ) -> [XCUIElement] {
+        if identifier == "readerBibleQuickSelector" {
+            return [
+                app.scrollViews[identifier].firstMatch,
+                app.otherElements[identifier].firstMatch,
+            ]
+        }
+
+        if identifier.hasPrefix("readerBibleQuickSelectorRow_") {
+            return [
+                app.buttons[identifier].firstMatch,
+                app.scrollViews.buttons[identifier].firstMatch,
+                app.staticTexts[identifier].firstMatch,
+                app.scrollViews.staticTexts[identifier].firstMatch,
+                app.otherElements[identifier].firstMatch,
+            ]
+        }
+
         if identifier.hasSuffix("Screen") {
             return [
                 app.collectionViews[identifier].firstMatch,

--- a/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -148,13 +148,14 @@ extension AndBibleUITests {
             return true
         }
 
-        let visibleFrame = container.frame.insetBy(dx: 0, dy: 16)
+        let minimumVisibleHeight = min(max(24, element.frame.height * 0.5), element.frame.height)
+        let minimumVisibleWidth = min(max(40, element.frame.width * 0.3), element.frame.width)
+        let verticalInset = min(16, max(0, (container.frame.height - minimumVisibleHeight) / 2))
+        let visibleFrame = container.frame.insetBy(dx: 0, dy: verticalInset)
         let intersection = visibleFrame.intersection(element.frame)
         guard !intersection.isNull else {
             return false
         }
-        let minimumVisibleHeight = min(max(24, element.frame.height * 0.5), element.frame.height)
-        let minimumVisibleWidth = min(max(40, element.frame.width * 0.3), element.frame.width)
         return intersection.height >= minimumVisibleHeight &&
             intersection.width >= minimumVisibleWidth
     }

--- a/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
+++ b/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
@@ -147,7 +147,21 @@ extension AndBibleUITests {
 
         tapElementReliably(requireElement("readerBibleToolbarButton", in: app, timeout: 10), timeout: 10)
         if waitForAnyElement(["readerBibleQuickSelector"], in: app, timeout: 3) != nil {
+            let quickSelector = requireElement("readerBibleQuickSelector", in: app, timeout: 10)
             let kjvQuickRow = requireElement("readerBibleQuickSelectorRow_KJV", in: app, timeout: 10)
+            XCTAssertEqual(
+                kjvQuickRow.value as? String,
+                "available",
+                "KJV quick-selector row must remain selectable when returning from commentary."
+            )
+            for _ in 0..<8 where !isElementVisible(kjvQuickRow, within: quickSelector) {
+                quickSelector.swipeUp()
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            }
+            XCTAssertTrue(
+                isElementVisible(kjvQuickRow, within: quickSelector),
+                "Expected quick selector to scroll until KJV is visible."
+            )
             tapElementReliably(kjvQuickRow, timeout: 10)
         } else if waitForAnyElement(["modulePickerScreen"], in: app, timeout: 3) != nil {
             if let kjvRow = resolvedElement("modulePickerRow::KJV", in: app) {

--- a/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
+++ b/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
@@ -107,7 +107,8 @@ extension AndBibleUITests {
      *   - launches the baseline reader shell, creates two additional windows, and activates the
      *     third one
      *   - switches that third pane into commentary and then back into Bible using the real toolbar
-     *     document controls and, when needed, the real module picker
+     *     document controls and, when needed, the Android-parity quick selector or full module
+     *     picker
      *   - switches back to the first tab to confirm its rendered content never left `Genesis 1`
      * - Failure modes:
      *   - fails if the third window cannot be activated
@@ -145,7 +146,10 @@ extension AndBibleUITests {
         )
 
         tapElementReliably(requireElement("readerBibleToolbarButton", in: app, timeout: 10), timeout: 10)
-        if waitForAnyElement(["modulePickerScreen"], in: app, timeout: 3) != nil {
+        if waitForAnyElement(["readerBibleQuickSelector"], in: app, timeout: 3) != nil {
+            let kjvQuickRow = requireElement("readerBibleQuickSelectorRow_KJV", in: app, timeout: 10)
+            tapElementReliably(kjvQuickRow, timeout: 10)
+        } else if waitForAnyElement(["modulePickerScreen"], in: app, timeout: 3) != nil {
             if let kjvRow = resolvedElement("modulePickerRow::KJV", in: app) {
                 tapElementReliably(kjvRow, timeout: 10)
             } else {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -668,6 +668,46 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         loadCurrentContent()
     }
 
+    /**
+     Switches the visible document to a Bible module in one Android-parity transition.
+
+     Android's `CurrentPageManager.setCurrentDocument(book)` updates the selected Bible and active
+     page together before notifying the reader. This method gives iOS the same contract for toolbar
+     quick selectors and the full module picker: the pane's Bible document and category are updated
+     together, persisted together, and then rendered once when the web client is ready.
+
+     - Parameter moduleName: Installed SWORD Bible module abbreviation to make current.
+     Side effects:
+     - mutates the active Bible module and current document category
+     - refreshes the cached Bible book list for the selected module
+     - writes `bibleDocument` and `currentCategoryName` to the active pane's `PageManager`
+     - invokes `onPersistState` once when pane state is available
+     - reloads the visible reader document once when the JavaScript client is ready
+     Failure modes:
+     - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     */
+    public func switchBibleDocument(to moduleName: String) {
+        guard let mgr = swordManager,
+              let mod = mgr.module(named: moduleName) else {
+            logger.warning("Cannot switch to Bible document \(moduleName) — not found")
+            return
+        }
+        activeModule = mod
+        activeModuleName = moduleName
+        currentCategory = .bible
+        refreshBookList()
+        logger.info("Switched to Bible document: \(moduleName) (\(self.moduleBookList.count) books)")
+
+        if let pm = activeWindow?.pageManager {
+            pm.bibleDocument = moduleName
+            pm.currentCategoryName = DocumentCategory.bible.pageManagerKey
+            onPersistState?()
+        }
+
+        guard clientReady else { return }
+        loadCurrentContent()
+    }
+
     /// Switch to a different installed commentary module.
     public func switchCommentaryModule(to moduleName: String) {
         guard let mgr = swordManager,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -687,7 +687,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
      - if the resolved module is not a Bible, logs a warning and leaves controller/page state
        unchanged
+     - Important: Main-actor isolated because successful switches can mutate SwiftUI-observed reader
+       state and synchronously emit WebView bridge updates through `loadCurrentContent()`.
      */
+    @MainActor
     public func switchBibleDocument(to moduleName: String) {
         guard let mgr = swordManager,
               let mod = mgr.module(named: moduleName) else {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -685,11 +685,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - reloads the visible reader document once when the JavaScript client is ready
      Failure modes:
      - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     - if the resolved module is not a Bible, logs a warning and leaves controller/page state
+       unchanged
      */
     public func switchBibleDocument(to moduleName: String) {
         guard let mgr = swordManager,
               let mod = mgr.module(named: moduleName) else {
             logger.warning("Cannot switch to Bible document \(moduleName) — not found")
+            return
+        }
+        guard mod.info.category == .bible else {
+            logger.warning("Cannot switch to Bible document \(moduleName) — category \(mod.info.category.rawValue)")
             return
         }
         activeModule = mod

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -319,10 +319,7 @@ struct BibleReaderModulePicker: View {
             controller.switchCategory(to: .map)
             dismissAndPresentAuxiliaryBrowser(onOpenMapBrowser)
         default:
-            controller.switchModule(to: module.name)
-            if controller.currentCategory != .bible {
-                controller.switchCategory(to: .bible)
-            }
+            controller.switchBibleDocument(to: module.name)
             onDismiss()
         }
     }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -130,6 +130,12 @@ struct BibleReaderQuickModuleSelectorPresentation {
  Android's disabled `PopupMenu` item instead of disappearing.
  */
 struct BibleReaderQuickModuleSelector: View {
+    /// Fixed compact menu row height used to keep viewport calculations deterministic.
+    private static let rowHeight: CGFloat = 44
+
+    /// Divider contribution between adjacent rows in the compact popup.
+    private static let dividerHeight: CGFloat = 1
+
     /**
      Sorted rows to render in Android quick-selector order.
 
@@ -147,12 +153,43 @@ struct BibleReaderQuickModuleSelector: View {
     let colorScheme: ColorScheme
 
     /**
+     Maximum visible height available to the selector popup.
+
+     The toolbar overlay computes this from the trigger position and safe areas. Long module lists
+     scroll within this height so installed Bibles remain reachable instead of expanding off-screen.
+     */
+    let maximumHeight: CGFloat
+
+    /**
      Selection callback for enabled rows.
 
      - Side effects: The parent is expected to dismiss the popup and switch the pane's Bible module.
      - Failure modes: Disabled rows never call this closure.
      */
     let onSelect: (ModuleInfo) -> Void
+
+    /**
+     Creates a stateless quick-selector popup renderer.
+
+     - Parameters:
+       - rows: Sorted Android-parity rows to render.
+       - colorScheme: Current app color scheme used for the popup surface.
+       - maximumHeight: Visible viewport for the popup; long lists scroll within this height.
+       - onSelect: Callback invoked only for enabled module rows.
+     - Side effects: none at initialization; row taps later invoke `onSelect`.
+     - Failure modes: none; empty rows produce a zero-height popup body.
+     */
+    init(
+        rows: [BibleReaderQuickModuleSelectorPresentation.Row],
+        colorScheme: ColorScheme,
+        maximumHeight: CGFloat = .infinity,
+        onSelect: @escaping (ModuleInfo) -> Void
+    ) {
+        self.rows = rows
+        self.colorScheme = colorScheme
+        self.maximumHeight = maximumHeight
+        self.onSelect = onSelect
+    }
 
     /**
      Renders the compact quick selector rows.
@@ -162,35 +199,48 @@ struct BibleReaderQuickModuleSelector: View {
      - Failure modes: none; empty rows produce an empty popup body.
      */
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                if index > 0 {
-                    Divider()
+        ScrollView(.vertical, showsIndicators: contentHeight > popupHeight) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    if index > 0 {
+                        Divider()
+                    }
+                    Button {
+                        guard row.isEnabled else { return }
+                        onSelect(row.module)
+                    } label: {
+                        Text(row.title)
+                            .font(.system(size: 15))
+                            .lineLimit(1)
+                            .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
+                            .frame(height: Self.rowHeight, alignment: .center)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!row.isEnabled)
+                    .opacity(row.isEnabled ? 1 : 0.48)
+                    .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
+                    .accessibilityValue(row.isEnabled ? "available" : "current")
                 }
-                Button {
-                    guard row.isEnabled else { return }
-                    onSelect(row.module)
-                } label: {
-                    Text(row.title)
-                        .font(.system(size: 15))
-                        .lineLimit(1)
-                        .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(!row.isEnabled)
-                .opacity(row.isEnabled ? 1 : 0.48)
-                .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
-                .accessibilityValue(row.isEnabled ? "available" : "current")
             }
         }
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(height: popupHeight)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("readerBibleQuickSelector")
         .background(menuBackground)
+    }
+
+    /// Intrinsic height of the rendered row stack before viewport clipping.
+    private var contentHeight: CGFloat {
+        guard !rows.isEmpty else { return 0 }
+        return CGFloat(rows.count) * Self.rowHeight + CGFloat(rows.count - 1) * Self.dividerHeight
+    }
+
+    /// Height applied to the scroll container after respecting the available toolbar viewport.
+    private var popupHeight: CGFloat {
+        min(contentHeight, max(0, maximumHeight))
     }
 
     /// Popup surface color matching the existing Android-style reader overflow menu.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -197,29 +197,12 @@ struct BibleReaderQuickModuleSelector: View {
      */
     var body: some View {
         ScrollView(.vertical, showsIndicators: contentHeight > popupHeight) {
-            VStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                     if index > 0 {
                         Divider()
                     }
-                    Button {
-                        guard row.isEnabled else { return }
-                        onSelect(row.module)
-                    } label: {
-                        Text(row.title)
-                            .font(.system(size: 15))
-                            .lineLimit(1)
-                            .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 16)
-                            .frame(height: Self.rowHeight, alignment: .center)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(!row.isEnabled)
-                    .opacity(row.isEnabled ? 1 : 0.48)
-                    .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
-                    .accessibilityValue(row.isEnabled ? "available" : "current")
+                    selectorRow(row)
                 }
             }
         }
@@ -227,6 +210,42 @@ struct BibleReaderQuickModuleSelector: View {
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("readerBibleQuickSelector")
         .background(menuBackground)
+    }
+
+    /**
+     Renders one Android popup-menu row without installing a competing button drag recognizer.
+
+     Android popup rows are tap targets inside a scrollable menu. The SwiftUI row therefore uses a
+     passive text surface with explicit tap and accessibility actions so vertical drags continue to
+     belong to the parent `ScrollView` when dozens of installed Bibles are present.
+
+     - Parameter row: Presentation row to render.
+     - Returns: A tappable row for enabled modules or an inert current-module row.
+     - Side effects: Tapping or activating an enabled row invokes `onSelect`.
+     - Failure modes: Disabled rows ignore tap and accessibility activation.
+     */
+    private func selectorRow(_ row: BibleReaderQuickModuleSelectorPresentation.Row) -> some View {
+        Text(row.title)
+            .font(.system(size: 15))
+            .lineLimit(1)
+            .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .frame(height: Self.rowHeight, alignment: .center)
+            .contentShape(Rectangle())
+            .opacity(row.isEnabled ? 1 : 0.48)
+            .onTapGesture {
+                guard row.isEnabled else { return }
+                onSelect(row.module)
+            }
+            .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
+            .accessibilityValue(row.isEnabled ? "available" : "current")
+            .accessibilityAddTraits(.isButton)
+            .disabled(!row.isEnabled)
+            .accessibilityAction {
+                guard row.isEnabled else { return }
+                onSelect(row.module)
+            }
     }
 
     /// Intrinsic height of the rendered row stack before viewport clipping.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+import SwordKit
+
+/**
+ Presentation contract for Android's Bible-toolbar quick module menu.
+
+ Android implements this path in `MainBibleActivity.menuForDocs`: available books are sorted by
+ language code and abbreviation, the current book is disabled, exactly two books switch directly,
+ and every other non-empty list shows an anchored popup. This type keeps those rules pure and
+ testable so the SwiftUI overlay cannot drift back toward the full document picker sheet.
+ */
+struct BibleReaderQuickModuleSelectorPresentation {
+    /**
+     One rendered row in the quick selector popup.
+
+     The row keeps the full module for selection while exposing a compact Android label and enabled
+     state for rendering. It has no side effects; equality is limited to fields that affect selector
+     behavior and visible output.
+     */
+    struct Row: Identifiable, Equatable {
+        /// Installed SWORD module represented by this row.
+        let module: ModuleInfo
+
+        /// Compact Android-parity title, formatted as abbreviation plus language code.
+        let title: String
+
+        /// Whether the row can be selected. The current document is visible but disabled.
+        let isEnabled: Bool
+
+        /// Stable row identity derived from the module abbreviation.
+        var id: String { module.name }
+
+        /**
+         Compares rows by selector-visible identity and behavior.
+
+         - Parameters:
+           - lhs: First row to compare.
+           - rhs: Second row to compare.
+         - Returns: `true` when the row would render and behave equivalently in the quick selector.
+         - Side effects: none.
+         - Failure modes: none.
+         */
+        static func == (lhs: Row, rhs: Row) -> Bool {
+            lhs.module.name == rhs.module.name &&
+                lhs.module.description == rhs.module.description &&
+                lhs.module.category == rhs.module.category &&
+                lhs.module.language == rhs.module.language &&
+                lhs.title == rhs.title &&
+                lhs.isEnabled == rhs.isEnabled
+        }
+    }
+
+    /**
+     Resolved toolbar behavior for the current Bible module set.
+
+     The enum separates direct switching from popup presentation so reader routing can stay explicit:
+     no installed modules do nothing, exactly two modules switch directly, and every other non-empty
+     list renders rows in the anchored selector. Cases have no side effects by themselves.
+     */
+    enum Action: Equatable {
+        /// No menu action is available because there are no candidate modules.
+        case none
+
+        /// Android's two-document shortcut: switch directly to the other module.
+        case switchDirectly(String)
+
+        /// Android's popup path: show the sorted compact rows in an anchored menu.
+        case showPopup([Row])
+    }
+
+    /**
+     Builds sorted quick-selector rows from installed Bible modules.
+
+     - Parameters:
+       - modules: Candidate Bible modules visible to the toolbar action.
+       - activeModuleName: Current module abbreviation, if the pane has one.
+     - Returns: Rows sorted by language code and module abbreviation, matching Android.
+     - Side effects: none.
+     - Failure modes: none; an empty input returns an empty row list.
+     */
+    static func rows(for modules: [ModuleInfo], activeModuleName: String?) -> [Row] {
+        modules
+            .sorted { lhs, rhs in
+                if lhs.language != rhs.language {
+                    return lhs.language < rhs.language
+                }
+                return lhs.name < rhs.name
+            }
+            .map { module in
+                Row(
+                    module: module,
+                    title: "\(module.name) (\(module.language))",
+                    isEnabled: module.name != activeModuleName
+                )
+            }
+    }
+
+    /**
+     Resolves Android's `menuForDocs` action for the current Bible module set.
+
+     - Parameters:
+       - modules: Candidate Bible modules visible to the toolbar action.
+       - activeModuleName: Current module abbreviation, if the pane has one.
+     - Returns: `.none` for no modules, `.switchDirectly` for exactly two modules, and `.showPopup`
+       for every other non-empty module list.
+     - Side effects: none.
+     - Failure modes: none; invalid or missing active-module names fall back to the first sorted row
+       for the two-document shortcut.
+     */
+    static func action(for modules: [ModuleInfo], activeModuleName: String?) -> Action {
+        let rows = rows(for: modules, activeModuleName: activeModuleName)
+        guard !rows.isEmpty else {
+            return .none
+        }
+        if rows.count == 2 {
+            guard let directRow = rows.first(where: { $0.module.name != activeModuleName }) ?? rows.first else {
+                return .none
+            }
+            return .switchDirectly(directRow.module.name)
+        }
+        return .showPopup(rows)
+    }
+}
+
+/**
+ Compact Android-style popup for selecting an installed Bible module.
+
+ The parent owns pane state and module switching. This view only renders sorted quick-selector rows
+ and forwards enabled row selections. Disabled rows stay visible so the current Bible mirrors
+ Android's disabled `PopupMenu` item instead of disappearing.
+ */
+struct BibleReaderQuickModuleSelector: View {
+    /**
+     Sorted rows to render in Android quick-selector order.
+
+     The parent computes these rows from installed Bible modules so the view remains a stateless
+     renderer. Empty arrays render no buttons.
+     */
+    let rows: [BibleReaderQuickModuleSelectorPresentation.Row]
+
+    /**
+     Current app color scheme used to choose the popup surface color.
+
+     Android uses a compact popup surface rather than the iOS document sheet; this input lets the
+     iOS overlay keep that dedicated popup treatment without reading global state internally.
+     */
+    let colorScheme: ColorScheme
+
+    /**
+     Selection callback for enabled rows.
+
+     - Side effects: The parent is expected to dismiss the popup and switch the pane's Bible module.
+     - Failure modes: Disabled rows never call this closure.
+     */
+    let onSelect: (ModuleInfo) -> Void
+
+    /**
+     Renders the compact quick selector rows.
+
+     - Returns: A vertically sized SwiftUI popup body.
+     - Side effects: Enabled row taps invoke `onSelect`; disabled current rows remain inert.
+     - Failure modes: none; empty rows produce an empty popup body.
+     */
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                if index > 0 {
+                    Divider()
+                }
+                Button {
+                    guard row.isEnabled else { return }
+                    onSelect(row.module)
+                } label: {
+                    Text(row.title)
+                        .font(.system(size: 15))
+                        .lineLimit(1)
+                        .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!row.isEnabled)
+                .opacity(row.isEnabled ? 1 : 0.48)
+                .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
+                .accessibilityValue(row.isEnabled ? "available" : "current")
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("readerBibleQuickSelector")
+        .background(menuBackground)
+    }
+
+    /// Popup surface color matching the existing Android-style reader overflow menu.
+    private var menuBackground: Color {
+        if colorScheme == .dark {
+            return Color(red: 0.22, green: 0.22, blue: 0.22)
+        }
+        #if os(iOS)
+        return Color(uiColor: .systemBackground)
+        #elseif os(macOS)
+        return Color(nsColor: .windowBackgroundColor)
+        #endif
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -42,9 +42,6 @@ struct BibleReaderQuickModuleSelectorPresentation {
          */
         static func == (lhs: Row, rhs: Row) -> Bool {
             lhs.module.name == rhs.module.name &&
-                lhs.module.description == rhs.module.description &&
-                lhs.module.category == rhs.module.category &&
-                lhs.module.language == rhs.module.language &&
                 lhs.title == rhs.title &&
                 lhs.isEnabled == rhs.isEnabled
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -213,11 +213,11 @@ struct BibleReaderQuickModuleSelector: View {
     }
 
     /**
-     Renders one Android popup-menu row without installing a competing button drag recognizer.
+     Renders one Android popup-menu row as a real control inside the scrollable menu.
 
-     Android popup rows are tap targets inside a scrollable menu. The SwiftUI row therefore uses a
-     passive text surface with explicit tap and accessibility actions so vertical drags continue to
-     belong to the parent `ScrollView` when dozens of installed Bibles are present.
+     Android popup rows are tap targets inside a scrollable menu. The SwiftUI row keeps a real
+     `Button` for reliable activation and XCTest hit handling while the parent `LazyVStack` and
+     bounded `ScrollView` preserve reachability for long installed-module lists.
 
      - Parameter row: Presentation row to render.
      - Returns: A tappable row for enabled modules or an inert current-module row.
@@ -225,27 +225,25 @@ struct BibleReaderQuickModuleSelector: View {
      - Failure modes: Disabled rows ignore tap and accessibility activation.
      */
     private func selectorRow(_ row: BibleReaderQuickModuleSelectorPresentation.Row) -> some View {
-        Text(row.title)
-            .font(.system(size: 15))
-            .lineLimit(1)
-            .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 16)
-            .frame(height: Self.rowHeight, alignment: .center)
-            .contentShape(Rectangle())
-            .opacity(row.isEnabled ? 1 : 0.48)
-            .onTapGesture {
-                guard row.isEnabled else { return }
-                onSelect(row.module)
-            }
-            .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
-            .accessibilityValue(row.isEnabled ? "available" : "current")
-            .accessibilityAddTraits(.isButton)
-            .disabled(!row.isEnabled)
-            .accessibilityAction {
-                guard row.isEnabled else { return }
-                onSelect(row.module)
-            }
+        Button {
+            guard row.isEnabled else { return }
+            onSelect(row.module)
+        } label: {
+            Text(row.title)
+                .font(.system(size: 15))
+                .lineLimit(1)
+                .foregroundStyle(row.isEnabled ? Color.primary : Color.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: Self.rowHeight, alignment: .center)
+        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+        .disabled(!row.isEnabled)
+        .opacity(row.isEnabled ? 1 : 0.48)
+        .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
+        .accessibilityValue(row.isEnabled ? "available" : "current")
     }
 
     /// Intrinsic height of the rendered row stack before viewport clipping.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+/**
+ Captures the Bible toolbar trigger bounds so Android-style popups can anchor to the button.
+
+ The reader view consumes this preference when presenting the quick Bible selector. It carries only
+ layout geometry, does not mutate state, and falls back to the previous anchor if SwiftUI reports no
+ newer value during a reduction pass.
+ */
+struct ReaderBibleToolbarButtonBoundsPreferenceKey: PreferenceKey {
+    /// No toolbar button anchor is known until the Bible toolbar icon publishes one.
+    static var defaultValue: Anchor<CGRect>?
+
+    /**
+     Stores the newest non-nil toolbar anchor emitted by SwiftUI preference propagation.
+
+     - Parameters:
+       - value: Previously captured anchor, if any.
+       - nextValue: Deferred provider for the next anchor candidate.
+     - Side effects: Mutates `value` with the latest available anchor.
+     - Failure modes: none; nil candidates leave the previous anchor intact.
+     */
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = nextValue() ?? value
+    }
+}
+
 /// Width-collapsible accessory buttons that compete for toolbar space ahead of workspaces.
 enum BibleReaderToolbarAccessoryButton {
     case search
@@ -170,6 +195,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture(perform: onBibleTap)
                 .onLongPressGesture(perform: onBibleLongPress)
+                .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
             commentaryToolbarIcon
                 .foregroundStyle(toolbarIconColor(isActive: isCommentaryActive))

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -46,6 +46,8 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
     private let strongsEnabled: Bool
     private let isBibleActive: Bool
     private let isCommentaryActive: Bool
+    /// Whether Bible/commentary document actions can accept gestures for the focused pane.
+    private let moduleActionsEnabled: Bool
     private let onShowSearch: () -> Void
     private let onShowSpeak: () -> Void
     private let onApplyStrongsMode: (Int) -> Void
@@ -65,6 +67,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
         strongsEnabled: Bool,
         isBibleActive: Bool,
         isCommentaryActive: Bool,
+        moduleActionsEnabled: Bool,
         onShowSearch: @escaping () -> Void,
         onShowSpeak: @escaping () -> Void,
         onApplyStrongsMode: @escaping (Int) -> Void,
@@ -83,6 +86,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
         self.strongsEnabled = strongsEnabled
         self.isBibleActive = isBibleActive
         self.isCommentaryActive = isCommentaryActive
+        self.moduleActionsEnabled = moduleActionsEnabled
         self.onShowSearch = onShowSearch
         self.onShowSpeak = onShowSpeak
         self.onApplyStrongsMode = onApplyStrongsMode
@@ -189,22 +193,26 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
 
             bibleToolbarIcon
                 .foregroundStyle(toolbarIconColor(isActive: isBibleActive))
+                .opacity(moduleActionsEnabled ? 1 : 0.45)
                 .contentShape(Rectangle())
                 .accessibilityIdentifier("readerBibleToolbarButton")
                 .accessibilityLabel(String(localized: "bible"))
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture(perform: onBibleTap)
                 .onLongPressGesture(perform: onBibleLongPress)
+                .allowsHitTesting(moduleActionsEnabled)
                 .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
             commentaryToolbarIcon
                 .foregroundStyle(toolbarIconColor(isActive: isCommentaryActive))
+                .opacity(moduleActionsEnabled ? 1 : 0.45)
                 .contentShape(Rectangle())
                 .accessibilityIdentifier("readerCommentaryToolbarButton")
                 .accessibilityLabel(String(localized: "commentaries"))
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture(perform: onCommentaryTap)
                 .onLongPressGesture(perform: onCommentaryLongPress)
+                .allowsHitTesting(moduleActionsEnabled)
 
             if showWorkspace {
                 Button(action: onShowWorkspaces) {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -201,6 +201,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
                 .onTapGesture(perform: onBibleTap)
                 .onLongPressGesture(perform: onBibleLongPress)
                 .allowsHitTesting(moduleActionsEnabled)
+                .accessibilityHidden(!moduleActionsEnabled)
                 .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
             commentaryToolbarIcon
@@ -213,6 +214,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
                 .onTapGesture(perform: onCommentaryTap)
                 .onLongPressGesture(perform: onCommentaryLongPress)
                 .allowsHitTesting(moduleActionsEnabled)
+                .accessibilityHidden(!moduleActionsEnabled)
 
             if showWorkspace {
                 Button(action: onShowWorkspaces) {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -191,30 +191,32 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
                 .accessibilityLabel(String(localized: "toggle_strongs_numbers"))
             }
 
-            bibleToolbarIcon
-                .foregroundStyle(toolbarIconColor(isActive: isBibleActive))
-                .opacity(moduleActionsEnabled ? 1 : 0.45)
-                .contentShape(Rectangle())
-                .accessibilityIdentifier("readerBibleToolbarButton")
-                .accessibilityLabel(String(localized: "bible"))
-                .accessibilityAddTraits(.isButton)
-                .onTapGesture(perform: onBibleTap)
-                .onLongPressGesture(perform: onBibleLongPress)
-                .allowsHitTesting(moduleActionsEnabled)
-                .accessibilityHidden(!moduleActionsEnabled)
-                .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
+            Button(action: onBibleTap) {
+                bibleToolbarIcon
+                    .foregroundStyle(toolbarIconColor(isActive: isBibleActive))
+                    .opacity(moduleActionsEnabled ? 1 : 0.45)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!moduleActionsEnabled)
+            .accessibilityIdentifier("readerBibleToolbarButton")
+            .accessibilityLabel(String(localized: "bible"))
+            .accessibilityHidden(!moduleActionsEnabled)
+            .simultaneousGesture(LongPressGesture().onEnded { _ in onBibleLongPress() })
+            .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
-            commentaryToolbarIcon
-                .foregroundStyle(toolbarIconColor(isActive: isCommentaryActive))
-                .opacity(moduleActionsEnabled ? 1 : 0.45)
-                .contentShape(Rectangle())
-                .accessibilityIdentifier("readerCommentaryToolbarButton")
-                .accessibilityLabel(String(localized: "commentaries"))
-                .accessibilityAddTraits(.isButton)
-                .onTapGesture(perform: onCommentaryTap)
-                .onLongPressGesture(perform: onCommentaryLongPress)
-                .allowsHitTesting(moduleActionsEnabled)
-                .accessibilityHidden(!moduleActionsEnabled)
+            Button(action: onCommentaryTap) {
+                commentaryToolbarIcon
+                    .foregroundStyle(toolbarIconColor(isActive: isCommentaryActive))
+                    .opacity(moduleActionsEnabled ? 1 : 0.45)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!moduleActionsEnabled)
+            .accessibilityIdentifier("readerCommentaryToolbarButton")
+            .accessibilityLabel(String(localized: "commentaries"))
+            .accessibilityHidden(!moduleActionsEnabled)
+            .simultaneousGesture(LongPressGesture().onEnded { _ in onCommentaryLongPress() })
 
             if showWorkspace {
                 Button(action: onShowWorkspaces) {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -191,32 +191,26 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
                 .accessibilityLabel(String(localized: "toggle_strongs_numbers"))
             }
 
-            Button(action: onBibleTap) {
+            moduleToolbarAction(
+                isActive: isBibleActive,
+                accessibilityIdentifier: "readerBibleToolbarButton",
+                accessibilityLabel: String(localized: "bible"),
+                onTap: onBibleTap,
+                onLongPress: onBibleLongPress
+            ) {
                 bibleToolbarIcon
-                    .foregroundStyle(toolbarIconColor(isActive: isBibleActive))
-                    .opacity(moduleActionsEnabled ? 1 : 0.45)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .disabled(!moduleActionsEnabled)
-            .accessibilityIdentifier("readerBibleToolbarButton")
-            .accessibilityLabel(String(localized: "bible"))
-            .accessibilityHidden(!moduleActionsEnabled)
-            .simultaneousGesture(LongPressGesture().onEnded { _ in onBibleLongPress() })
             .anchorPreference(key: ReaderBibleToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
-            Button(action: onCommentaryTap) {
+            moduleToolbarAction(
+                isActive: isCommentaryActive,
+                accessibilityIdentifier: "readerCommentaryToolbarButton",
+                accessibilityLabel: String(localized: "commentaries"),
+                onTap: onCommentaryTap,
+                onLongPress: onCommentaryLongPress
+            ) {
                 commentaryToolbarIcon
-                    .foregroundStyle(toolbarIconColor(isActive: isCommentaryActive))
-                    .opacity(moduleActionsEnabled ? 1 : 0.45)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .disabled(!moduleActionsEnabled)
-            .accessibilityIdentifier("readerCommentaryToolbarButton")
-            .accessibilityLabel(String(localized: "commentaries"))
-            .accessibilityHidden(!moduleActionsEnabled)
-            .simultaneousGesture(LongPressGesture().onEnded { _ in onCommentaryLongPress() })
 
             if showWorkspace {
                 Button(action: onShowWorkspaces) {
@@ -245,6 +239,75 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
     private var commentaryToolbarIcon: some View {
         ToolbarAssetIcon(name: "ToolbarCommentary")
             .frame(width: 24, height: 22)
+    }
+
+    /**
+     Renders a Bible/commentary module action with mutually exclusive tap and long-press dispatch.
+
+     Android exposes the quick selector on tap and the full document chooser on long press. SwiftUI
+     `Button` plus `simultaneousGesture` can dispatch both paths for a long press, so this helper
+     owns the gesture contract directly and exposes a default accessibility action for the tap path.
+
+     - Parameters:
+       - isActive: Whether the represented document category is active in the focused pane.
+       - accessibilityIdentifier: Stable UI-test identifier for the toolbar action.
+       - accessibilityLabel: VoiceOver label for the toolbar action.
+       - onTap: Action for Android's quick-selector path.
+       - onLongPress: Action for Android's full-chooser path.
+       - icon: Toolbar icon content supplied by the caller.
+     - Returns: A toolbar icon view that dispatches either tap or long press, never both.
+     - Side effects: Invokes the supplied callback for the recognized gesture.
+     - Failure modes: Disabled module actions ignore gestures and hide from accessibility.
+     */
+    private func moduleToolbarAction<Icon: View>(
+        isActive: Bool,
+        accessibilityIdentifier: String,
+        accessibilityLabel: String,
+        onTap: @escaping () -> Void,
+        onLongPress: @escaping () -> Void,
+        @ViewBuilder icon: () -> Icon
+    ) -> some View {
+        icon()
+            .foregroundStyle(toolbarIconColor(isActive: isActive))
+            .opacity(moduleActionsEnabled ? 1 : 0.45)
+            .contentShape(Rectangle())
+            .gesture(moduleToolbarGesture(onTap: onTap, onLongPress: onLongPress))
+            .disabled(!moduleActionsEnabled)
+            .accessibilityIdentifier(accessibilityIdentifier)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityHidden(!moduleActionsEnabled)
+            .accessibilityAction {
+                guard moduleActionsEnabled else { return }
+                onTap()
+            }
+    }
+
+    /**
+     Builds the mutually exclusive module toolbar gesture used for tap versus long press.
+
+     - Parameters:
+       - onTap: Action for a completed tap gesture.
+       - onLongPress: Action for a completed long-press gesture.
+     - Returns: An exclusive gesture that resolves to exactly one callback.
+     - Side effects: Invokes one callback when the toolbar action is enabled.
+     - Failure modes: Disabled module actions ignore completed gestures.
+     */
+    private func moduleToolbarGesture(
+        onTap: @escaping () -> Void,
+        onLongPress: @escaping () -> Void
+    ) -> some Gesture {
+        LongPressGesture().exclusively(before: TapGesture()).onEnded { value in
+            guard moduleActionsEnabled else { return }
+            switch value {
+            case .first(true):
+                onLongPress()
+            case .second:
+                onTap()
+            case .first(false):
+                break
+            }
+        }
     }
 
     private var workspaceToolbarIcon: some View {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -223,6 +223,9 @@ public struct BibleReaderView: View {
     /// Rows resolved by the Android-parity quick-selector contract for the active popup instance.
     @State private var bibleQuickModuleSelectorRows: [BibleReaderQuickModuleSelectorPresentation.Row] = []
 
+    /// Window that owns the active Bible quick selector, kept separate from modal routing state.
+    @State private var bibleQuickModuleSelectorTargetWindowId: UUID?
+
     /// Presents the Android-style left navigation drawer from the reader header.
     @State private var showReaderNavigationDrawer = false
 
@@ -313,12 +316,6 @@ public struct BibleReaderView: View {
     /// Preference controlling whether the floating fullscreen reference capsule is hidden.
     @State private var hideBibleReferenceOverlayPref =
         AppPreferenceRegistry.boolDefault(for: .hideBibleReferenceOverlay) ?? false
-
-    /// Suppresses the tap handler that SwiftUI fires after a completed Bible-button long press.
-    @State private var suppressBibleTapAfterLongPress = false
-
-    /// Suppresses the tap handler that SwiftUI fires after a completed commentary-button long press.
-    @State private var suppressCommentaryTapAfterLongPress = false
 
     /// Tracks whether fullscreen was last entered by the double-tap gesture instead of scrolling.
     @State private var lastFullScreenByDoubleTap = false
@@ -1509,7 +1506,9 @@ public struct BibleReaderView: View {
         let targetWindowId = windowManager.controllers.first { _, registeredController in
             (registeredController as? BibleReaderController) === controller
         }?.key
-        setPanePresentationTarget(targetWindowId ?? windowManager.activeWindow?.id)
+        let resolvedTargetWindowId = targetWindowId ?? windowManager.activeWindow?.id
+        setPanePresentationTarget(resolvedTargetWindowId)
+        bibleQuickModuleSelectorTargetWindowId = resolvedTargetWindowId
         bibleQuickModuleSelectorRows = rows
         showReaderOverflowMenu = false
         showReaderNavigationDrawer = false
@@ -1520,6 +1519,7 @@ public struct BibleReaderView: View {
     private func dismissBibleQuickSelector() {
         showBibleQuickModuleSelector = false
         bibleQuickModuleSelectorRows = []
+        bibleQuickModuleSelectorTargetWindowId = nil
     }
 
     /**
@@ -1569,7 +1569,8 @@ public struct BibleReaderView: View {
        mode so the selection persists through the controller's normal document-switching path.
      - Failure modes: If the controller is no longer available, the selection is ignored.
      */
-    private func selectBibleQuickModule(_ module: ModuleInfo, controller: BibleReaderController?) {
+    private func selectBibleQuickModule(_ module: ModuleInfo, targetWindowId: UUID?) {
+        let controller = controller(for: targetWindowId)
         dismissBibleQuickSelector()
         guard let controller else { return }
         controller.switchBibleDocument(to: module.name)
@@ -2392,7 +2393,7 @@ public struct BibleReaderView: View {
     private func bibleQuickModuleSelectorOverlay(anchor: Anchor<CGRect>?) -> some View {
         GeometryReader { proxy in
             let buttonRect = anchor.map { proxy[$0] }
-            let controller = panePresentationController
+            let targetWindowId = bibleQuickModuleSelectorTargetWindowId
             let rows = bibleQuickModuleSelectorRows
             let width = min(max(proxy.size.width * 0.42, 156), min(proxy.size.width - 16, 232))
             let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
@@ -2415,7 +2416,7 @@ public struct BibleReaderView: View {
                         colorScheme: colorScheme,
                         maximumHeight: placement.maximumHeight,
                         onSelect: { module in
-                            selectBibleQuickModule(module, controller: controller)
+                            selectBibleQuickModule(module, targetWindowId: targetWindowId)
                         }
                     )
                     .frame(width: width, alignment: .topLeading)
@@ -2714,25 +2715,15 @@ public struct BibleReaderView: View {
             },
             onApplyStrongsMode: { mode in applyStrongsMode(mode) },
             onBibleTap: {
-                if suppressBibleTapAfterLongPress {
-                    suppressBibleTapAfterLongPress = false
-                    return
-                }
                 handleBibleToolbarTap(controller)
             },
             onBibleLongPress: {
-                suppressBibleTapAfterLongPress = true
                 handleBibleToolbarLongPress(controller)
             },
             onCommentaryTap: {
-                if suppressCommentaryTapAfterLongPress {
-                    suppressCommentaryTapAfterLongPress = false
-                    return
-                }
                 handleCommentaryToolbarTap(controller)
             },
             onCommentaryLongPress: {
-                suppressCommentaryTapAfterLongPress = true
                 handleCommentaryToolbarLongPress(controller)
             },
             onShowWorkspaces: { presentReaderSheet(.workspaces, from: windowManager.activeWindow?.id) }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2360,7 +2360,11 @@ public struct BibleReaderView: View {
     private func readerOverflowMenuOverlay(anchor: Anchor<CGRect>?) -> some View {
         GeometryReader { proxy in
             let buttonRect = anchor.map { proxy[$0] }
-            let width = min(proxy.size.width - 16, CGFloat(236))
+            let width = ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: proxy.size.width,
+                preferredWidth: 236,
+                maximumWidth: 236
+            )
             let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
                 containerSize: proxy.size,
                 safeAreaInsets: proxy.safeAreaInsets,
@@ -2395,7 +2399,11 @@ public struct BibleReaderView: View {
             let buttonRect = anchor.map { proxy[$0] }
             let targetWindowId = bibleQuickModuleSelectorTargetWindowId
             let rows = bibleQuickModuleSelectorRows
-            let width = min(max(proxy.size.width * 0.42, 156), min(proxy.size.width - 16, 232))
+            let width = ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: proxy.size.width,
+                preferredWidth: max(proxy.size.width * 0.42, 156),
+                maximumWidth: 232
+            )
             let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
                 containerSize: proxy.size,
                 safeAreaInsets: proxy.safeAreaInsets,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2237,15 +2237,12 @@ public struct BibleReaderView: View {
         GeometryReader { proxy in
             let buttonRect = anchor.map { proxy[$0] }
             let width = min(proxy.size.width - 16, CGFloat(236))
-            let leadingInset: CGFloat = 8
-            let trailingInset: CGFloat = 8
-            let resolvedRightEdge = buttonRect?.maxX ?? (proxy.size.width - trailingInset)
-            let resolvedBottomEdge = buttonRect?.maxY ?? (proxy.safeAreaInsets.top + 38)
-            let x = min(
-                max(leadingInset, resolvedRightEdge - width),
-                proxy.size.width - width - trailingInset
+            let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+                containerSize: proxy.size,
+                safeAreaInsets: proxy.safeAreaInsets,
+                triggerRect: buttonRect,
+                popupWidth: width
             )
-            let y = max(proxy.safeAreaInsets.top + 6, resolvedBottomEdge + 6)
 
             ZStack(alignment: .topLeading) {
                 Color.black.opacity(0.001)
@@ -2262,7 +2259,7 @@ public struct BibleReaderView: View {
                             .strokeBorder(Color.black.opacity(colorScheme == .dark ? 0.45 : 0.12), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.32 : 0.18), radius: 14, y: 6)
-                    .offset(x: x, y: y)
+                    .offset(x: placement.offset.width, y: placement.offset.height)
                     .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topTrailing)))
             }
         }
@@ -2278,15 +2275,12 @@ public struct BibleReaderView: View {
                 activeModuleName: currentBibleQuickSelectorModuleName(for: controller)
             )
             let width = min(max(proxy.size.width * 0.42, 156), min(proxy.size.width - 16, 232))
-            let leadingInset: CGFloat = 8
-            let trailingInset: CGFloat = 8
-            let resolvedRightEdge = buttonRect?.maxX ?? (proxy.size.width - trailingInset)
-            let resolvedBottomEdge = buttonRect?.maxY ?? (proxy.safeAreaInsets.top + 38)
-            let x = min(
-                max(leadingInset, resolvedRightEdge - width),
-                proxy.size.width - width - trailingInset
+            let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+                containerSize: proxy.size,
+                safeAreaInsets: proxy.safeAreaInsets,
+                triggerRect: buttonRect,
+                popupWidth: width
             )
-            let y = max(proxy.safeAreaInsets.top + 6, resolvedBottomEdge + 6)
 
             ZStack(alignment: .topLeading) {
                 Color.black.opacity(0.001)
@@ -2310,7 +2304,7 @@ public struct BibleReaderView: View {
                             .strokeBorder(Color.black.opacity(colorScheme == .dark ? 0.45 : 0.12), lineWidth: 1)
                     )
                     .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.32 : 0.18), radius: 14, y: 6)
-                    .offset(x: x, y: y)
+                    .offset(x: placement.offset.width, y: placement.offset.height)
                     .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topTrailing)))
                 }
             }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1541,8 +1541,7 @@ public struct BibleReaderView: View {
     private func selectBibleQuickModule(_ module: ModuleInfo, controller: BibleReaderController?) {
         guard let controller else { return }
         dismissBibleQuickSelector()
-        controller.switchModule(to: module.name)
-        controller.switchCategory(to: .bible)
+        controller.switchBibleDocument(to: module.name)
     }
 
     // MARK: - Modal Routing
@@ -3144,8 +3143,7 @@ public struct BibleReaderView: View {
         case .none:
             return
         case .switchDirectly(let nextName):
-            controller.switchModule(to: nextName)
-            controller.switchCategory(to: .bible)
+            controller.switchBibleDocument(to: nextName)
         case .showPopup:
             presentBibleQuickSelector(controller)
         }
@@ -3175,8 +3173,7 @@ public struct BibleReaderView: View {
             modules: controller.installedBibleModules,
             activeName: controller.activeModuleName
         ) { nextName in
-            controller.switchModule(to: nextName)
-            controller.switchCategory(to: .bible)
+            controller.switchBibleDocument(to: nextName)
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2583,6 +2583,7 @@ public struct BibleReaderView: View {
             strongsEnabled: strongsEnabled,
             isBibleActive: controller?.currentCategory == .bible,
             isCommentaryActive: controller?.currentCategory == .commentary,
+            moduleActionsEnabled: controller != nil,
             onShowSearch: { presentSearch(from: windowManager.activeWindow?.id) },
             onShowSpeak: {
                 speakLastUsed = Date().timeIntervalSince1970

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1539,6 +1539,27 @@ public struct BibleReaderView: View {
     }
 
     /**
+     Resolves the Bible document Android would switch back to from a non-Bible document mode.
+
+     Android's `DocumentControl.suggestedBible` returns the active window's current Bible document
+     when Bible is not the visible document type. iOS stores that same pane-scoped choice on
+     `PageManager.bibleDocument`; if it is absent or no longer installed, the installed Bible list
+     provides the same default fallback established when the reader is initialized.
+
+     - Parameter controller: Pane controller that owns the toolbar action.
+     - Returns: Installed Bible module abbreviation to show, or `nil` when no Bible module exists.
+     - Side effects: none.
+     - Failure modes: returns `nil` when the pane has no installed Bible modules.
+     */
+    private func suggestedBibleDocumentName(for controller: BibleReaderController) -> String? {
+        if let saved = controller.activeWindow?.pageManager?.bibleDocument,
+           controller.installedBibleModules.contains(where: { $0.name == saved }) {
+            return saved
+        }
+        return controller.installedBibleModules.first?.name
+    }
+
+    /**
      Applies a quick-selector Bible module choice to the captured pane.
 
      - Parameters:
@@ -3173,7 +3194,8 @@ public struct BibleReaderView: View {
     private func performBibleNextDocumentAction(_ controller: BibleReaderController?) {
         guard let controller else { return }
         if controller.currentCategory != .bible {
-            controller.switchCategory(to: .bible)
+            guard let moduleName = suggestedBibleDocumentName(for: controller) else { return }
+            controller.switchBibleDocument(to: moduleName)
             return
         }
         cycleToNextModule(

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2386,6 +2386,7 @@ public struct BibleReaderView: View {
                     BibleReaderQuickModuleSelector(
                         rows: rows,
                         colorScheme: colorScheme,
+                        maximumHeight: placement.maximumHeight,
                         onSelect: { module in
                             selectBibleQuickModule(module, controller: controller)
                         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -214,6 +214,9 @@ public struct BibleReaderView: View {
     /// Presents the reader's overflow action sheet.
     @State private var showReaderOverflowMenu = false
 
+    /// Presents Android's compact Bible-module quick selector anchored to the toolbar button.
+    @State private var showBibleQuickModuleSelector = false
+
     /// Presents the Android-style left navigation drawer from the reader header.
     @State private var showReaderNavigationDrawer = false
 
@@ -568,6 +571,42 @@ public struct BibleReaderView: View {
     }
 
     /**
+     Binding that presents the native share sheet while a share payload exists.
+
+     - Returns: A Boolean binding derived from `shareText`.
+     - Side effects: Setting the binding to `false` clears the pending share payload.
+     - Failure modes: none.
+     */
+    private var shareSheetBinding: Binding<Bool> {
+        Binding(
+            get: { shareText != nil },
+            set: { isPresented in
+                if !isPresented {
+                    shareText = nil
+                }
+            }
+        )
+    }
+
+    /**
+     Binding that presents the cross-reference sheet while cross-reference payload exists.
+
+     - Returns: A Boolean binding derived from `crossReferences`.
+     - Side effects: Setting the binding to `false` clears the pending cross-reference payload.
+     - Failure modes: none.
+     */
+    private var crossReferenceSheetBinding: Binding<Bool> {
+        Binding(
+            get: { crossReferences != nil },
+            set: { isPresented in
+                if !isPresented {
+                    crossReferences = nil
+                }
+            }
+        )
+    }
+
+    /**
      Creates the reader coordinator view.
 
      - Note: This initializer performs no work directly. The view resolves its dependencies from
@@ -604,9 +643,15 @@ public struct BibleReaderView: View {
                 readerOverflowMenuOverlay(anchor: anchor)
             }
         }
+        .overlayPreferenceValue(ReaderBibleToolbarButtonBoundsPreferenceKey.self) { anchor in
+            if showBibleQuickModuleSelector {
+                bibleQuickModuleSelectorOverlay(anchor: anchor)
+            }
+        }
         .animation(.easeInOut(duration: 0.25), value: toastMessage)
         .animation(.easeInOut(duration: 0.2), value: showReaderNavigationDrawer)
         .animation(.easeInOut(duration: 0.16), value: showReaderOverflowMenu)
+        .animation(.easeInOut(duration: 0.16), value: showBibleQuickModuleSelector)
         .background {
             readerSceneMetricsBackground
         }
@@ -620,6 +665,7 @@ public struct BibleReaderView: View {
             handleReaderAppear()
         }
         .onChange(of: windowManager.activeWindow?.id) { _, _ in
+            dismissBibleQuickSelector()
             syncActiveDisplaySettings()
         }
         #if os(iOS)
@@ -702,16 +748,10 @@ public struct BibleReaderView: View {
                 lastFullScreenByDoubleTap = false
             }
         }
-        .sheet(isPresented: Binding(
-            get: { shareText != nil },
-            set: { if !$0 { shareText = nil } }
-        )) {
+        .sheet(isPresented: shareSheetBinding) {
             shareSheetContent
         }
-        .sheet(isPresented: Binding(
-            get: { crossReferences != nil },
-            set: { if !$0 { crossReferences = nil } }
-        )) {
+        .sheet(isPresented: crossReferenceSheetBinding) {
             crossReferenceSheetContent
         }
         .sheet(isPresented: $showRefChooser) {
@@ -1354,6 +1394,63 @@ public struct BibleReaderView: View {
     /// Closes the book chooser without changing the current pane target.
     private func dismissBookChooser() {
         showBookChooser = false
+    }
+
+    /**
+     Presents Android's Bible-toolbar quick selector for the focused pane.
+
+     - Parameter controller: Pane controller whose installed Bible module list should back the popup.
+     - Side effects: Captures the active pane, closes competing reader popups, and shows the anchored
+       quick selector overlay.
+     - Failure modes: If the active pane cannot be identified, the popup still uses the focused
+       controller fallback through `panePresentationController`.
+     */
+    private func presentBibleQuickSelector(_ controller: BibleReaderController) {
+        let targetWindowId = windowManager.controllers.first { _, registeredController in
+            (registeredController as? BibleReaderController) === controller
+        }?.key
+        setPanePresentationTarget(targetWindowId ?? windowManager.activeWindow?.id)
+        showReaderOverflowMenu = false
+        showReaderNavigationDrawer = false
+        showBibleQuickModuleSelector = true
+    }
+
+    /// Dismisses the Bible quick selector without changing the captured pane target.
+    private func dismissBibleQuickSelector() {
+        showBibleQuickModuleSelector = false
+    }
+
+    /**
+     Resolves the current Bible document name for Android quick-menu row disabling.
+
+     - Parameter controller: Pane controller that owns the quick selector, if still available.
+     - Returns: The active Bible module only when the pane is currently displaying a Bible document;
+       otherwise `nil` so Bible rows remain selectable from commentary or other document modes.
+     - Side effects: none.
+     - Failure modes: none; missing controllers are treated as having no current Bible document.
+     */
+    private func currentBibleQuickSelectorModuleName(for controller: BibleReaderController?) -> String? {
+        guard let controller, controller.currentCategory == .bible else {
+            return nil
+        }
+        return controller.activeModuleName
+    }
+
+    /**
+     Applies a quick-selector Bible module choice to the captured pane.
+
+     - Parameters:
+       - module: Installed Bible module selected from the Android-parity quick selector.
+       - controller: Pane controller captured when the popup was rendered.
+     - Side effects: Dismisses the popup, switches the active module, and ensures the pane is in Bible
+       mode so the selection persists through the controller's normal document-switching path.
+     - Failure modes: If the controller is no longer available, the selection is ignored.
+     */
+    private func selectBibleQuickModule(_ module: ModuleInfo, controller: BibleReaderController?) {
+        guard let controller else { return }
+        dismissBibleQuickSelector()
+        controller.switchModule(to: module.name)
+        controller.switchCategory(to: .bible)
     }
 
     // MARK: - Modal Routing
@@ -2171,6 +2268,55 @@ public struct BibleReaderView: View {
         }
     }
 
+    /// Full-screen dismiss area plus anchored Bible quick selector mirroring Android's toolbar popup.
+    private func bibleQuickModuleSelectorOverlay(anchor: Anchor<CGRect>?) -> some View {
+        GeometryReader { proxy in
+            let buttonRect = anchor.map { proxy[$0] }
+            let controller = panePresentationController
+            let rows = BibleReaderQuickModuleSelectorPresentation.rows(
+                for: controller?.installedBibleModules ?? [],
+                activeModuleName: currentBibleQuickSelectorModuleName(for: controller)
+            )
+            let width = min(max(proxy.size.width * 0.42, 156), min(proxy.size.width - 16, 232))
+            let leadingInset: CGFloat = 8
+            let trailingInset: CGFloat = 8
+            let resolvedRightEdge = buttonRect?.maxX ?? (proxy.size.width - trailingInset)
+            let resolvedBottomEdge = buttonRect?.maxY ?? (proxy.safeAreaInsets.top + 38)
+            let x = min(
+                max(leadingInset, resolvedRightEdge - width),
+                proxy.size.width - width - trailingInset
+            )
+            let y = max(proxy.safeAreaInsets.top + 6, resolvedBottomEdge + 6)
+
+            ZStack(alignment: .topLeading) {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { dismissBibleQuickSelector() }
+                    .accessibilityIdentifier("readerBibleQuickSelectorDismissArea")
+
+                if !rows.isEmpty {
+                    BibleReaderQuickModuleSelector(
+                        rows: rows,
+                        colorScheme: colorScheme,
+                        onSelect: { module in
+                            selectBibleQuickModule(module, controller: controller)
+                        }
+                    )
+                    .frame(width: width, alignment: .topLeading)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(Color.black.opacity(colorScheme == .dark ? 0.45 : 0.12), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.32 : 0.18), radius: 14, y: 6)
+                    .offset(x: x, y: y)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topTrailing)))
+                }
+            }
+        }
+    }
+
     /// Full-screen dimmer plus left drawer panel mirroring Android's main navigation drawer.
     private var readerNavigationDrawerOverlay: some View {
         GeometryReader { proxy in
@@ -2892,26 +3038,25 @@ public struct BibleReaderView: View {
      Handles the Android `menuForDocs` Bible action.
 
      When exactly two Bible modules are installed, this mirrors Android's auto-cycle shortcut.
-     Otherwise it opens the Bible picker sheet.
+     Every other non-empty module list shows the compact anchored popup instead of the full document
+     picker sheet.
 
      - Parameter controller: Focused pane controller, if one is currently registered.
      */
     private func performBibleMenuAction(_ controller: BibleReaderController?) {
-        guard let controller else {
-            performBibleChooserAction()
+        guard let controller else { return }
+        switch BibleReaderQuickModuleSelectorPresentation.action(
+            for: controller.installedBibleModules,
+            activeModuleName: currentBibleQuickSelectorModuleName(for: controller)
+        ) {
+        case .none:
             return
+        case .switchDirectly(let nextName):
+            controller.switchModule(to: nextName)
+            controller.switchCategory(to: .bible)
+        case .showPopup:
+            presentBibleQuickSelector(controller)
         }
-        if controller.installedBibleModules.count == 2 {
-            cycleToNextModule(
-                modules: controller.installedBibleModules,
-                activeName: controller.activeModuleName
-            ) { nextName in
-                controller.switchModule(to: nextName)
-                controller.switchCategory(to: .bible)
-            }
-            return
-        }
-        performBibleChooserAction()
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1549,8 +1549,8 @@ public struct BibleReaderView: View {
      - Failure modes: If the controller is no longer available, the selection is ignored.
      */
     private func selectBibleQuickModule(_ module: ModuleInfo, controller: BibleReaderController?) {
-        guard let controller else { return }
         dismissBibleQuickSelector()
+        guard let controller else { return }
         controller.switchBibleDocument(to: module.name)
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -220,6 +220,9 @@ public struct BibleReaderView: View {
     /// Presents Android's compact Bible-module quick selector anchored to the toolbar button.
     @State private var showBibleQuickModuleSelector = false
 
+    /// Rows resolved by the Android-parity quick-selector contract for the active popup instance.
+    @State private var bibleQuickModuleSelectorRows: [BibleReaderQuickModuleSelectorPresentation.Row] = []
+
     /// Presents the Android-style left navigation drawer from the reader header.
     @State private var showReaderNavigationDrawer = false
 
@@ -1491,17 +1494,23 @@ public struct BibleReaderView: View {
     /**
      Presents Android's Bible-toolbar quick selector for the focused pane.
 
-     - Parameter controller: Pane controller whose installed Bible module list should back the popup.
+     - Parameters:
+       - controller: Pane controller whose installed Bible module list should back the popup.
+       - rows: Android-parity rows resolved by the pure quick-selector presentation contract.
      - Side effects: Captures the active pane, closes competing reader popups, and shows the anchored
        quick selector overlay.
      - Failure modes: If the active pane cannot be identified, the popup still uses the focused
        controller fallback through `panePresentationController`.
      */
-    private func presentBibleQuickSelector(_ controller: BibleReaderController) {
+    private func presentBibleQuickSelector(
+        _ controller: BibleReaderController,
+        rows: [BibleReaderQuickModuleSelectorPresentation.Row]
+    ) {
         let targetWindowId = windowManager.controllers.first { _, registeredController in
             (registeredController as? BibleReaderController) === controller
         }?.key
         setPanePresentationTarget(targetWindowId ?? windowManager.activeWindow?.id)
+        bibleQuickModuleSelectorRows = rows
         showReaderOverflowMenu = false
         showReaderNavigationDrawer = false
         showBibleQuickModuleSelector = true
@@ -1510,6 +1519,7 @@ public struct BibleReaderView: View {
     /// Dismisses the Bible quick selector without changing the captured pane target.
     private func dismissBibleQuickSelector() {
         showBibleQuickModuleSelector = false
+        bibleQuickModuleSelectorRows = []
     }
 
     /**
@@ -2362,10 +2372,7 @@ public struct BibleReaderView: View {
         GeometryReader { proxy in
             let buttonRect = anchor.map { proxy[$0] }
             let controller = panePresentationController
-            let rows = BibleReaderQuickModuleSelectorPresentation.rows(
-                for: controller?.installedBibleModules ?? [],
-                activeModuleName: currentBibleQuickSelectorModuleName(for: controller)
-            )
+            let rows = bibleQuickModuleSelectorRows
             let width = min(max(proxy.size.width * 0.42, 156), min(proxy.size.width - 16, 232))
             let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
                 containerSize: proxy.size,
@@ -3144,8 +3151,8 @@ public struct BibleReaderView: View {
             return
         case .switchDirectly(let nextName):
             controller.switchBibleDocument(to: nextName)
-        case .showPopup:
-            presentBibleQuickSelector(controller)
+        case .showPopup(let rows):
+            presentBibleQuickSelector(controller, rows: rows)
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2362,6 +2362,7 @@ public struct BibleReaderView: View {
             let buttonRect = anchor.map { proxy[$0] }
             let width = ReaderToolbarPopupPlacement.boundedWidth(
                 containerWidth: proxy.size.width,
+                safeAreaInsets: proxy.safeAreaInsets,
                 preferredWidth: 236,
                 maximumWidth: 236
             )
@@ -2401,6 +2402,7 @@ public struct BibleReaderView: View {
             let rows = bibleQuickModuleSelectorRows
             let width = ReaderToolbarPopupPlacement.boundedWidth(
                 containerWidth: proxy.size.width,
+                safeAreaInsets: proxy.safeAreaInsets,
                 preferredWidth: max(proxy.size.width * 0.42, 156),
                 maximumWidth: 232
             )

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
@@ -24,21 +24,27 @@ struct ReaderToolbarPopupPlacement: Equatable {
 
      - Parameters:
        - containerWidth: Full overlay coordinate-space width.
+       - safeAreaInsets: Safe-area insets reported by the overlay `GeometryProxy`.
        - preferredWidth: Width the popup would use when enough horizontal space exists.
        - maximumWidth: Maximum Android-style popup width for the concrete menu.
-       - horizontalMargin: Combined leading/trailing margin reserved outside the popup.
+       - leadingInset: Minimum leading screen inset for very narrow containers.
+       - trailingInset: Trailing inset for the shared app-bar popup rail.
      - Returns: A non-negative width no larger than the preferred width, maximum width, or
-       available container width after margins.
+       available container width after safe-area and toolbar popup margins.
      - Side effects: none.
      - Failure modes: none; negative or undersized geometry is clamped to zero.
      */
     static func boundedWidth(
         containerWidth: CGFloat,
+        safeAreaInsets: EdgeInsets = EdgeInsets(),
         preferredWidth: CGFloat,
         maximumWidth: CGFloat,
-        horizontalMargin: CGFloat = 16
+        leadingInset: CGFloat = 8,
+        trailingInset: CGFloat = 8
     ) -> CGFloat {
-        let availableWidth = max(0, containerWidth - horizontalMargin)
+        let resolvedLeadingInset = safeAreaInsets.leading + leadingInset
+        let resolvedTrailingInset = safeAreaInsets.trailing + trailingInset
+        let availableWidth = max(0, containerWidth - resolvedLeadingInset - resolvedTrailingInset)
         return min(max(0, preferredWidth), min(max(0, maximumWidth), availableWidth))
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
@@ -31,7 +31,7 @@ struct ReaderToolbarPopupPlacement: Equatable {
        the trigger bottom, falling back to a toolbar-height estimate when the trigger is unavailable,
        plus the remaining visible height available to scrollable popup content.
      - Side effects: none.
-     - Failure modes: none; oversized widths are clamped to the available horizontal space.
+     - Failure modes: none; oversized widths are clamped to the safe horizontal space.
      */
     static func trailingToolbarPopup(
         containerSize: CGSize,
@@ -43,13 +43,15 @@ struct ReaderToolbarPopupPlacement: Equatable {
         verticalGap: CGFloat = 6,
         bottomInset: CGFloat = 8
     ) -> ReaderToolbarPopupPlacement {
-        let availableWidth = max(0, containerSize.width - leadingInset - trailingInset)
+        let resolvedLeadingInset = safeAreaInsets.leading + leadingInset
+        let resolvedTrailingInset = safeAreaInsets.trailing + trailingInset
+        let availableWidth = max(0, containerSize.width - resolvedLeadingInset - resolvedTrailingInset)
         let width = min(max(0, popupWidth), availableWidth)
-        let trailingRightEdge = containerSize.width - trailingInset
+        let trailingRightEdge = containerSize.width - resolvedTrailingInset
         let fallbackBottomEdge = safeAreaInsets.top + 38
         let resolvedBottomEdge = triggerRect?.maxY ?? fallbackBottomEdge
-        let maximumX = max(leadingInset, containerSize.width - width - trailingInset)
-        let x = min(max(leadingInset, trailingRightEdge - width), maximumX)
+        let maximumX = max(resolvedLeadingInset, containerSize.width - width - resolvedTrailingInset)
+        let x = min(max(resolvedLeadingInset, trailingRightEdge - width), maximumX)
         let y = max(safeAreaInsets.top + verticalGap, resolvedBottomEdge + verticalGap)
         let maximumHeight = max(0, containerSize.height - y - safeAreaInsets.bottom - bottomInset)
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
@@ -12,6 +12,9 @@ struct ReaderToolbarPopupPlacement: Equatable {
     /// Top-leading overlay offset used by SwiftUI's `.offset` modifier.
     let offset: CGSize
 
+    /// Maximum visible popup height below the toolbar trigger and above the bottom safe area.
+    let maximumHeight: CGFloat
+
     /**
      Resolves the top-leading offset for a trailing toolbar popup.
 
@@ -23,8 +26,10 @@ struct ReaderToolbarPopupPlacement: Equatable {
        - leadingInset: Minimum leading screen inset for very narrow containers.
        - trailingInset: Trailing inset for the shared app-bar popup rail.
        - verticalGap: Gap between the trigger bottom and popup top.
+       - bottomInset: Minimum gap above the bottom safe area for scrollable popup content.
      - Returns: A placement whose right edge is pinned to the trailing rail and whose top follows
-       the trigger bottom, falling back to a toolbar-height estimate when the trigger is unavailable.
+       the trigger bottom, falling back to a toolbar-height estimate when the trigger is unavailable,
+       plus the remaining visible height available to scrollable popup content.
      - Side effects: none.
      - Failure modes: none; oversized widths are clamped to the available horizontal space.
      */
@@ -35,7 +40,8 @@ struct ReaderToolbarPopupPlacement: Equatable {
         popupWidth: CGFloat,
         leadingInset: CGFloat = 8,
         trailingInset: CGFloat = 8,
-        verticalGap: CGFloat = 6
+        verticalGap: CGFloat = 6,
+        bottomInset: CGFloat = 8
     ) -> ReaderToolbarPopupPlacement {
         let availableWidth = max(0, containerSize.width - leadingInset - trailingInset)
         let width = min(max(0, popupWidth), availableWidth)
@@ -45,7 +51,11 @@ struct ReaderToolbarPopupPlacement: Equatable {
         let maximumX = max(leadingInset, containerSize.width - width - trailingInset)
         let x = min(max(leadingInset, trailingRightEdge - width), maximumX)
         let y = max(safeAreaInsets.top + verticalGap, resolvedBottomEdge + verticalGap)
+        let maximumHeight = max(0, containerSize.height - y - safeAreaInsets.bottom - bottomInset)
 
-        return ReaderToolbarPopupPlacement(offset: CGSize(width: x, height: y))
+        return ReaderToolbarPopupPlacement(
+            offset: CGSize(width: x, height: y),
+            maximumHeight: maximumHeight
+        )
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
@@ -16,6 +16,33 @@ struct ReaderToolbarPopupPlacement: Equatable {
     let maximumHeight: CGFloat
 
     /**
+     Bounds a toolbar popup width to the currently visible overlay space.
+
+     SwiftUI can report transient zero or near-zero geometry during presentation and rotation
+     transitions. Popup callers use this value for both placement and `.frame(width:)`, so the
+     returned width is clamped before layout receives it.
+
+     - Parameters:
+       - containerWidth: Full overlay coordinate-space width.
+       - preferredWidth: Width the popup would use when enough horizontal space exists.
+       - maximumWidth: Maximum Android-style popup width for the concrete menu.
+       - horizontalMargin: Combined leading/trailing margin reserved outside the popup.
+     - Returns: A non-negative width no larger than the preferred width, maximum width, or
+       available container width after margins.
+     - Side effects: none.
+     - Failure modes: none; negative or undersized geometry is clamped to zero.
+     */
+    static func boundedWidth(
+        containerWidth: CGFloat,
+        preferredWidth: CGFloat,
+        maximumWidth: CGFloat,
+        horizontalMargin: CGFloat = 16
+    ) -> CGFloat {
+        let availableWidth = max(0, containerWidth - horizontalMargin)
+        return min(max(0, preferredWidth), min(max(0, maximumWidth), availableWidth))
+    }
+
+    /**
      Resolves the top-leading offset for a trailing toolbar popup.
 
      - Parameters:

--- a/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/ReaderToolbarPopupPlacement.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/**
+ Computes Android-style toolbar popup placement for reader overlays.
+
+ Android toolbar popups open from the trailing app-bar rail even when the triggering icon is not
+ the final overflow icon. This helper keeps that behavior shared between the reader overflow menu
+ and the Bible quick selector: the trigger supplies vertical placement, while the popup right edge
+ is pinned to the screen trailing inset. The calculation is deterministic and has no side effects.
+ */
+struct ReaderToolbarPopupPlacement: Equatable {
+    /// Top-leading overlay offset used by SwiftUI's `.offset` modifier.
+    let offset: CGSize
+
+    /**
+     Resolves the top-leading offset for a trailing toolbar popup.
+
+     - Parameters:
+       - containerSize: Size of the overlay coordinate space.
+       - safeAreaInsets: Safe-area insets reported by the overlay `GeometryProxy`.
+       - triggerRect: Toolbar trigger bounds, if SwiftUI has reported them.
+       - popupWidth: Final popup width chosen by the caller.
+       - leadingInset: Minimum leading screen inset for very narrow containers.
+       - trailingInset: Trailing inset for the shared app-bar popup rail.
+       - verticalGap: Gap between the trigger bottom and popup top.
+     - Returns: A placement whose right edge is pinned to the trailing rail and whose top follows
+       the trigger bottom, falling back to a toolbar-height estimate when the trigger is unavailable.
+     - Side effects: none.
+     - Failure modes: none; oversized widths are clamped to the available horizontal space.
+     */
+    static func trailingToolbarPopup(
+        containerSize: CGSize,
+        safeAreaInsets: EdgeInsets,
+        triggerRect: CGRect?,
+        popupWidth: CGFloat,
+        leadingInset: CGFloat = 8,
+        trailingInset: CGFloat = 8,
+        verticalGap: CGFloat = 6
+    ) -> ReaderToolbarPopupPlacement {
+        let availableWidth = max(0, containerSize.width - leadingInset - trailingInset)
+        let width = min(max(0, popupWidth), availableWidth)
+        let trailingRightEdge = containerSize.width - trailingInset
+        let fallbackBottomEdge = safeAreaInsets.top + 38
+        let resolvedBottomEdge = triggerRect?.maxY ?? fallbackBottomEdge
+        let maximumX = max(leadingInset, containerSize.width - width - trailingInset)
+        let x = min(max(leadingInset, trailingRightEdge - width), maximumX)
+        let y = max(safeAreaInsets.top + verticalGap, resolvedBottomEdge + verticalGap)
+
+        return ReaderToolbarPopupPlacement(offset: CGSize(width: x, height: y))
+    }
+}


### PR DESCRIPTION
## Summary

Aligns the iOS Bible toolbar quick selector with Android's `MainBibleActivity.menuForDocs` behavior for issue #208.

## Scope

- Adds a compact anchored Bible quick selector for the reader toolbar menu path.
- Keeps `BibleReaderModulePicker` as the full Choose Document flow for long press/document browsing.
- Preserves Android `toolbar_button_actions` routing: default tap quick menu, default long press full chooser, `swap-menu` long press quick menu, and swap tap next document.
- Adds focused parity tests and a SWORD alias fixture for real controller persistence coverage.

## Contract References

- GitHub issue #208: Align Bible translation quick selector with Android.
- Android source: `app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt`.
- Android contract: `menuForDocs` sorts by language code then abbreviation, labels rows as abbreviation plus language code, disables the current document, switches directly only for exactly two documents, and otherwise shows a popup anchored to the toolbar view.
- iOS source contracts: `BibleReaderView.performBibleMenuAction`, `BibleReaderToolbarActions`, and `BibleReaderController.switchModule(to:)`.

## Change Details

- Added `BibleReaderQuickModuleSelectorPresentation` as the pure quick-menu contract for row ordering, labels, disabled state, and action resolution.
- Added `BibleReaderQuickModuleSelector` as the compact SwiftUI popup renderer.
- Captured the Bible toolbar button bounds through a SwiftUI preference so the popup anchors to the toolbar action instead of presenting an iOS sheet.
- Routed the Bible quick-menu action away from `BibleReaderModulePicker`; the full chooser remains available through the full chooser path.
- Ensured disabled-row logic only treats the active Bible as current when the pane is actually displaying Bible content, so commentary-to-Bible switching stays available.
- Added tests for Android ordering/labels, current-row disabled state, exactly-two direct switching, single-module popup behavior, multi-module popup behavior, sheet-route regression, and controller/PageManager persistence.

## Validation Evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -derivedDataPath .derived/issue-208` with the six issue #208 focused tests.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -derivedDataPath .derived/issue-208` with the existing toolbar/module-picker baseline tests.
- `python3 scripts/check_repo_standards.py docblocks --all-files`.
- `python3 scripts/check_repo_standards.py commits`.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project AndBible.xcodeproj -scheme AndBible -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -derivedDataPath .derived/issue-208-build`.
- `git diff --cached --check`.
- GitNexus staged-change detection run against the worktree path; broad risk was from the shared reader/test-helper surfaces, with the implementation scoped to the reader toolbar quick-selector path.

## Risks / Follow-ups

- The compact popup is implemented in SwiftUI rather than Android `PopupMenu`, but the user-facing routing and document-selection semantics match Android.
- Commentary quick-menu parity is intentionally not changed here; issue #208 scopes Bible translation quick selection.
- No iOS-only alternate quick-selector behavior is preserved for the Bible toolbar path.

## Issue Closure Reference

Closes #208

## Screenshots

| Old | New |
| --- | --- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-19 at 15 19 12" src="https://github.com/user-attachments/assets/7b4cb78b-b02c-4f81-9f87-c07778ec1b25" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-20 at 20 54 38" src="https://github.com/user-attachments/assets/c6a09616-b8ab-48a7-af6f-4e2bb588da05" /> |
