### PR TITLE
fix(sync): recover from CloudKit startup failure

### DIFF
--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -177,6 +177,20 @@ struct AndBibleApp: App {
      */
     static let iCloudSyncEnabledKey = "icloud_sync_enabled"
 
+    /**
+     User-visible recovery message shown when CloudKit-backed SwiftData startup fails.
+     *
+     * The app has already recovered by opening the same store locally and clearing the iCloud
+     * bootstrap toggle before this message is presented. Keep this copy generic because failures
+     * can come from iCloud availability, entitlement, or model-compatibility validation.
+     */
+    private static var iCloudStartupRecoveryMessage: String {
+        String(
+            localized: "icloud_startup_recovery_message",
+            defaultValue: "iCloud sync could not be started, so sync was turned off and AndBible opened your local data."
+        )
+    }
+
     init() {
         let networkMonitor = RemoteSyncNetworkMonitor()
         self.remoteSyncNetworkMonitor = networkMonitor
@@ -185,7 +199,7 @@ struct AndBibleApp: App {
         DataMigration.migrateIfNeeded()
 
         // Read iCloud sync preference from UserDefaults (before container creation)
-        let iCloudEnabled = UserDefaults.standard.bool(forKey: Self.iCloudSyncEnabledKey)
+        let requestedICloudEnabled = UserDefaults.standard.bool(forKey: Self.iCloudSyncEnabledKey)
 
         // -- User data models: keep config name "AndBible" so existing store file is reused.
         // When iCloud sync is enabled, these models sync via CloudKit. --
@@ -222,13 +236,6 @@ struct AndBibleApp: App {
 
         // Keep the original config name "AndBible" so SwiftData reuses the existing
         // "AndBible.store" file. Changing the name would break PersistentIdentifiers.
-        let cloudConfig = ModelConfiguration(
-            "AndBible",
-            schema: Schema(cloudModels),
-            isStoredInMemoryOnly: false,
-            cloudKitDatabase: iCloudEnabled ? .private("iCloud.org.andbible.ios") : .none
-        )
-
         let localConfig = ModelConfiguration(
             "LocalStore",
             schema: Schema(localModels),
@@ -239,13 +246,38 @@ struct AndBibleApp: App {
         // Set up SWORD module directory before creating any SwordManager
         SwordSetup.ensureModulesReady()
 
-        // Initialize SyncService with current toggle state
+        // Initialize SyncService after container startup resolves the effective CloudKit mode.
         let sync = SyncService()
-        sync.setInitialState(enabled: iCloudEnabled)
-        self._syncService = State(initialValue: sync)
 
         do {
-            let container = try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+            let startupResult = try ICloudModelContainerStartupRecovery.loadContainer(
+                iCloudEnabled: requestedICloudEnabled,
+                syncEnabledKey: Self.iCloudSyncEnabledKey,
+                loadCloudKitContainer: {
+                    let cloudConfig = ModelConfiguration(
+                        "AndBible",
+                        schema: Schema(cloudModels),
+                        isStoredInMemoryOnly: false,
+                        cloudKitDatabase: .private("iCloud.org.andbible.ios")
+                    )
+                    return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+                },
+                loadLocalContainer: {
+                    let cloudConfig = ModelConfiguration(
+                        "AndBible",
+                        schema: Schema(cloudModels),
+                        isStoredInMemoryOnly: false,
+                        cloudKitDatabase: .none
+                    )
+                    return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+                }
+            )
+            let container = startupResult.container
+            sync.setInitialState(enabled: startupResult.effectiveICloudEnabled)
+            self._syncService = State(initialValue: sync)
+            if startupResult.didRecoverFromCloudKitFailure {
+                self._remoteSyncErrorMessage = State(initialValue: Self.iCloudStartupRecoveryMessage)
+            }
             self.modelContainer = container
 
             // Initialize services that need ModelContext

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 /* iCloud Sync */
 "icloud_sync" = "iCloud Sync";
 "icloud_sync_enabled" = "Enable iCloud Sync";
+"icloud_startup_recovery_message" = "iCloud sync could not be started, so sync was turned off and AndBible opened your local data.";
 "icloud_sync_description" = "Sync bookmarks, labels, workspaces, reading plans, and notes across your devices via iCloud. Requires an iCloud account.";
 "sync_status" = "Status";
 "status" = "Status";

--- a/AndBibleTests/AndBibleTests+RemoteSyncState.swift
+++ b/AndBibleTests/AndBibleTests+RemoteSyncState.swift
@@ -17,8 +17,12 @@ import WebKit
 import struct SwiftUI.Color
 #endif
 
-private enum TestStartupContainerError: Error {
+private enum TestStartupContainerError: LocalizedError {
     case cloudKitModelRejected
+
+    var errorDescription: String? {
+        "CloudKit model validation failed"
+    }
 }
 
 extension AndBibleTests {
@@ -60,6 +64,7 @@ extension AndBibleTests {
         XCTAssertEqual(loadAttempts, ["cloud", "local"])
         XCTAssertFalse(result.effectiveICloudEnabled)
         XCTAssertTrue(result.didRecoverFromCloudKitFailure)
+        XCTAssertEqual(result.cloudKitLoadErrorDescription, "CloudKit model validation failed")
         XCTAssertFalse(defaults.bool(forKey: syncEnabledKey))
     }
 

--- a/AndBibleTests/AndBibleTests+RemoteSyncState.swift
+++ b/AndBibleTests/AndBibleTests+RemoteSyncState.swift
@@ -17,7 +17,130 @@ import WebKit
 import struct SwiftUI.Color
 #endif
 
+private enum TestStartupContainerError: Error {
+    case cloudKitModelRejected
+}
+
 extension AndBibleTests {
+    /**
+     Protects startup recovery when the persisted iCloud toggle points app launch at a
+     CloudKit-backed SwiftData container that cannot load.
+
+     The issue-196 crash happened before any view rendered because `AndBibleApp` treated the
+     CloudKit container failure as fatal. The recovery contract is that startup retries the same
+     store locally, clears the persisted iCloud toggle so the next launch does not repeat the
+     crash loop, and reports that the effective runtime mode is local-only.
+     */
+    func testICloudStartupRecoveryFallsBackToLocalContainerAndDisablesCrashLoopPreference() throws {
+        let defaultsName = "org.andbible.tests.icloud-startup-recovery.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        defaults.set(true, forKey: syncEnabledKey)
+        var loadAttempts: [String] = []
+
+        let result: ICloudModelContainerStartupRecovery.Result<String> = try ICloudModelContainerStartupRecovery.loadContainer(
+            iCloudEnabled: true,
+            defaults: defaults,
+            syncEnabledKey: syncEnabledKey,
+            loadCloudKitContainer: {
+                loadAttempts.append("cloud")
+                throw TestStartupContainerError.cloudKitModelRejected
+            },
+            loadLocalContainer: {
+                loadAttempts.append("local")
+                return "local-container"
+            }
+        )
+
+        XCTAssertEqual(result.container, "local-container")
+        XCTAssertEqual(loadAttempts, ["cloud", "local"])
+        XCTAssertFalse(result.effectiveICloudEnabled)
+        XCTAssertTrue(result.didRecoverFromCloudKitFailure)
+        XCTAssertFalse(defaults.bool(forKey: syncEnabledKey))
+    }
+
+    /**
+     Verifies the normal CloudKit startup path preserves the persisted iCloud toggle.
+
+     The issue-196 recovery must stay limited to failed CloudKit startup. A successful
+     CloudKit-backed container load remains the effective runtime mode and must not rewrite the
+     bootstrap preference.
+     */
+    func testICloudStartupRecoveryKeepsICloudEnabledWhenCloudKitContainerLoads() throws {
+        let defaultsName = "org.andbible.tests.icloud-startup-success.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        defaults.set(true, forKey: syncEnabledKey)
+        var loadAttempts: [String] = []
+
+        let result: ICloudModelContainerStartupRecovery.Result<String> = try ICloudModelContainerStartupRecovery.loadContainer(
+            iCloudEnabled: true,
+            defaults: defaults,
+            syncEnabledKey: syncEnabledKey,
+            loadCloudKitContainer: {
+                loadAttempts.append("cloud")
+                return "cloud-container"
+            },
+            loadLocalContainer: {
+                loadAttempts.append("local")
+                return "local-container"
+            }
+        )
+
+        XCTAssertEqual(result.container, "cloud-container")
+        XCTAssertEqual(loadAttempts, ["cloud"])
+        XCTAssertTrue(result.effectiveICloudEnabled)
+        XCTAssertFalse(result.didRecoverFromCloudKitFailure)
+        XCTAssertTrue(defaults.bool(forKey: syncEnabledKey))
+    }
+
+    /**
+     Verifies local-only startup never probes CloudKit or mutates the iCloud bootstrap toggle.
+
+     This guards Android-parity sync behavior from being coupled to the iOS-only recovery path:
+     local startup should remain a plain local container open with the existing preference left
+     untouched unless an actual CloudKit failure was recovered.
+     */
+    func testICloudStartupRecoveryUsesLocalContainerWhenICloudDisabled() throws {
+        let defaultsName = "org.andbible.tests.icloud-startup-local.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        defaults.set(false, forKey: syncEnabledKey)
+        var loadAttempts: [String] = []
+
+        let result: ICloudModelContainerStartupRecovery.Result<String> = try ICloudModelContainerStartupRecovery.loadContainer(
+            iCloudEnabled: false,
+            defaults: defaults,
+            syncEnabledKey: syncEnabledKey,
+            loadCloudKitContainer: {
+                loadAttempts.append("cloud")
+                return "cloud-container"
+            },
+            loadLocalContainer: {
+                loadAttempts.append("local")
+                return "local-container"
+            }
+        )
+
+        XCTAssertEqual(result.container, "local-container")
+        XCTAssertEqual(loadAttempts, ["local"])
+        XCTAssertFalse(result.effectiveICloudEnabled)
+        XCTAssertFalse(result.didRecoverFromCloudKitFailure)
+        XCTAssertFalse(defaults.bool(forKey: syncEnabledKey))
+    }
+
     func testRemoteSyncSettingsStoreDefaultsToICloudWhenBackendMissing() throws {
         let settingsStore = try makeInMemorySettingsStore()
         let secretStore = InMemorySecretStore()

--- a/AndBibleTests/AndBibleTests+RemoteSyncState.swift
+++ b/AndBibleTests/AndBibleTests+RemoteSyncState.swift
@@ -27,6 +27,60 @@ private enum TestStartupContainerError: LocalizedError {
 
 extension AndBibleTests {
     /**
+     Verifies the synced SwiftData schema itself satisfies CloudKit startup validation.
+
+     The crash fallback prevents a bad CloudKit schema from taking the whole app down, but the
+     feature contract is stronger: when the user enables iCloud sync, the CloudKit-backed
+     `AndBible` store should load instead of immediately falling back to local storage. This test
+     constructs the same split cloud/local model set as app startup with isolated store names.
+     Failure means the model still contains CloudKit-forbidden constraints, missing relationship
+     inverses, or required attributes without declaration-level defaults.
+     */
+    func testICloudSwiftDataSchemaLoadsWithCloudKitConfiguration() throws {
+        let cloudModels: [any PersistentModel.Type] = [
+            Workspace.self,
+            Window.self,
+            PageManager.self,
+            HistoryItem.self,
+            BibleBookmark.self,
+            BibleBookmarkNotes.self,
+            BibleBookmarkToLabel.self,
+            GenericBookmark.self,
+            GenericBookmarkNotes.self,
+            GenericBookmarkToLabel.self,
+            Label.self,
+            StudyPadTextEntry.self,
+            StudyPadTextEntryText.self,
+            MyDocument.self,
+            MyDocumentPage.self,
+            MyDocumentPageContent.self,
+            AiPageCacheEntry.self,
+            ReadingPlan.self,
+            ReadingPlanDay.self,
+        ]
+        let localModels: [any PersistentModel.Type] = [
+            Repository.self,
+            Setting.self,
+        ]
+        let schema = Schema(cloudModels + localModels)
+        let storeSuffix = UUID().uuidString
+        let cloudConfig = ModelConfiguration(
+            "AndBibleCloudCompatibility-\(storeSuffix)",
+            schema: Schema(cloudModels),
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: .private("iCloud.org.andbible.ios")
+        )
+        let localConfig = ModelConfiguration(
+            "LocalCompatibility-\(storeSuffix)",
+            schema: Schema(localModels),
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: .none
+        )
+
+        _ = try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+    }
+
+    /**
      Protects startup recovery when the persisted iCloud toggle points app launch at a
      CloudKit-backed SwiftData container that cannot load.
 

--- a/AndBibleTests/AndBibleTests+RemoteSyncState.swift
+++ b/AndBibleTests/AndBibleTests+RemoteSyncState.swift
@@ -87,6 +87,7 @@ extension AndBibleTests {
         )
 
         _ = try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+        XCTAssertEqual(ReadingPlanDay().dayNumber, 1)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+RemoteSyncState.swift
+++ b/AndBibleTests/AndBibleTests+RemoteSyncState.swift
@@ -64,16 +64,25 @@ extension AndBibleTests {
         ]
         let schema = Schema(cloudModels + localModels)
         let storeSuffix = UUID().uuidString
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AndBibleCloudCompatibility-\(storeSuffix)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
         let cloudConfig = ModelConfiguration(
             "AndBibleCloudCompatibility-\(storeSuffix)",
             schema: Schema(cloudModels),
-            isStoredInMemoryOnly: false,
+            url: temporaryDirectory.appendingPathComponent("AndBibleCloud.store"),
             cloudKitDatabase: .private("iCloud.org.andbible.ios")
         )
         let localConfig = ModelConfiguration(
             "LocalCompatibility-\(storeSuffix)",
             schema: Schema(localModels),
-            isStoredInMemoryOnly: false,
+            url: temporaryDirectory.appendingPathComponent("AndBibleLocal.store"),
             cloudKitDatabase: .none
         )
 

--- a/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/AndBibleTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -9,6 +9,28 @@ import SwiftData
 private let myDocumentRestoreSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
+    /**
+     Verifies local My Documents insertion keeps Android bridge initials unique after
+     removing SwiftData's CloudKit-incompatible unique constraint.
+
+     The bridge resolves documents by initials, so allowing two local documents with the same
+     initials would make reader actions nondeterministic and later Android-compatible exports
+     fail against their unique initials index. The store should reject the duplicate before it
+     reaches SwiftData persistence.
+     */
+    func testMyDocumentStoreRejectsDuplicateInitials() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let store = MyDocumentStore(modelContext: modelContext)
+
+        XCTAssertTrue(store.insert(MyDocument(name: "First", initials: "MYDOC")))
+        XCTAssertFalse(store.insert(MyDocument(name: "Duplicate", initials: "MYDOC")))
+
+        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
+        XCTAssertEqual(documents.map(\.name), ["First"])
+        XCTAssertEqual(store.document(initials: "MYDOC")?.name, "First")
+    }
+
     func testRemoteSyncMyDocumentRestoreReplacesLocalGraphAndPreservesAIContext() throws {
         let container = try makeModelContainer()
         let modelContext = ModelContext(container)
@@ -144,6 +166,46 @@ final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
                     "MyDocumentPage.id=\(orphanPageID.uuidString) missing MyDocument"
                 ])
             )
+        }
+
+        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
+        XCTAssertEqual(documents.map(\.initials), ["EXISTING"])
+    }
+
+    /**
+     Verifies staged Android My Documents rows cannot introduce duplicate bridge initials.
+
+     CloudKit does not allow SwiftData to keep `MyDocument.initials` as a store-level unique
+     constraint, but Android bridge lookup and remote backup uploads still require one document
+     per initials value. Invalid remote data must be rejected before the restore deletes current
+     local rows so the app remains on a deterministic, exportable graph.
+     */
+    func testRemoteSyncMyDocumentRestoreRejectsDuplicateInitialsWithoutMutation() throws {
+        let container = try makeModelContainer()
+        let modelContext = ModelContext(container)
+        let existingDocument = MyDocument(name: "Existing", initials: "EXISTING")
+        modelContext.insert(existingDocument)
+        try modelContext.save()
+
+        let firstDocumentID = UUID(uuidString: "e1000000-0000-0000-0000-000000000001")!
+        let secondDocumentID = UUID(uuidString: "e1000000-0000-0000-0000-000000000002")!
+        let databaseURL = try makeAndroidMyDocumentsDatabase(
+            documents: [
+                .init(id: firstDocumentID, name: "First", initials: "DUP"),
+                .init(id: secondDocumentID, name: "Second", initials: "DUP"),
+            ],
+            pages: [],
+            pageContents: [],
+            aiPageCacheEntries: []
+        )
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let service = RemoteSyncMyDocumentRestoreService()
+        let snapshot = try service.readSnapshot(from: databaseURL)
+        XCTAssertThrowsError(
+            try service.replaceLocalMyDocuments(from: snapshot, modelContext: modelContext)
+        ) { error in
+            XCTAssertEqual(error as? RemoteSyncMyDocumentRestoreError, .duplicateInitials(["DUP"]))
         }
 
         let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())

--- a/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentStore.swift
@@ -93,7 +93,12 @@ public final class MyDocumentStore {
      */
     public func document(initials: String) -> MyDocument? {
         var descriptor = FetchDescriptor<MyDocument>(
-            predicate: #Predicate { $0.initials == initials }
+            predicate: #Predicate { $0.initials == initials },
+            sortBy: [
+                SortDescriptor(\.createdAt),
+                SortDescriptor(\.updatedAt),
+                SortDescriptor(\.name),
+            ]
         )
         descriptor.fetchLimit = 1
         return try? modelContext.fetch(descriptor).first
@@ -290,9 +295,19 @@ public final class MyDocumentStore {
     /**
      Inserts a My Documents graph and saves immediately.
      */
-    public func insert(_ document: MyDocument) {
+    @discardableResult
+    public func insert(_ document: MyDocument) -> Bool {
+        guard !hasDocument(initials: document.initials, excluding: document.id) else {
+            return false
+        }
         modelContext.insert(document)
-        save()
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            modelContext.rollback()
+            return false
+        }
     }
 
     /**
@@ -300,5 +315,23 @@ public final class MyDocumentStore {
      */
     public func save() {
         try? modelContext.save()
+    }
+
+    /**
+     Checks whether another persisted My Documents row already owns the supplied bridge initials.
+
+     `MyDocument.initials` must stay unique for Android-compatible bridge resolution and remote
+     backup export, but CloudKit-backed SwiftData stores cannot use a store-level unique
+     constraint. This helper preserves the uniqueness contract at the app layer before new local
+     rows are inserted.
+     */
+    private func hasDocument(initials: String, excluding documentID: UUID) -> Bool {
+        var descriptor = FetchDescriptor<MyDocument>(
+            predicate: #Predicate {
+                $0.initials == initials && $0.id != documentID
+            }
+        )
+        descriptor.fetchLimit = 1
+        return ((try? modelContext.fetch(descriptor)) ?? []).isEmpty == false
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Models/Bookmark.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Bookmark.swift
@@ -95,23 +95,23 @@ public enum BookmarkSortOrder: String, Codable, Sendable {
  */
 @Model
 public final class BibleBookmark {
-    /// Unique identifier used for persistence, label linking, and sync reconciliation.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for persistence, label linking, and sync reconciliation.
+    public var id: UUID = UUID()
 
     /// Start ordinal normalized into KJVA versification for cross-module queries.
-    public var kjvOrdinalStart: Int
+    public var kjvOrdinalStart: Int = 0
 
     /// End ordinal normalized into KJVA versification for cross-module queries.
-    public var kjvOrdinalEnd: Int
+    public var kjvOrdinalEnd: Int = 0
 
     /// Start ordinal in the originating module's own versification.
-    public var ordinalStart: Int
+    public var ordinalStart: Int = 0
 
     /// End ordinal in the originating module's own versification.
-    public var ordinalEnd: Int
+    public var ordinalEnd: Int = 0
 
     /// Raw versification identifier for the originating module.
-    public var v11n: String
+    public var v11n: String = "KJVA"
 
     /// Optional book name captured at creation time for display and legacy lookup paths.
     public var book: String?
@@ -120,7 +120,7 @@ public final class BibleBookmark {
     public var playbackSettings: PlaybackSettings?
 
     /// Creation timestamp used by sorting and export flows.
-    public var createdAt: Date
+    public var createdAt: Date = Date()
 
     /// Character offset recorded for the start of a sub-verse selection, if any.
     public var startOffset: Int?
@@ -132,10 +132,10 @@ public final class BibleBookmark {
     public var primaryLabelId: UUID?
 
     /// Timestamp of the last bookmark mutation.
-    public var lastUpdatedOn: Date
+    public var lastUpdatedOn: Date = Date()
 
     /// Indicates whether the bookmark covers a whole verse instead of a text span.
-    public var wholeVerse: Bool
+    public var wholeVerse: Bool = true
 
     /// Optional raw bookmark type string used by specialized features.
     public var type: String?
@@ -204,13 +204,13 @@ public final class BibleBookmark {
 @Model
 public final class BibleBookmarkNotes {
     /// Identifier mirroring the owning bookmark for the intended 1:1 relationship.
-    @Attribute(.unique) public var bookmarkId: UUID
+    public var bookmarkId: UUID = UUID()
 
     /// Back-reference to the owning Bible bookmark.
     public var bookmark: BibleBookmark?
 
     /// User-authored note text associated with the bookmark.
-    public var notes: String
+    public var notes: String = ""
 
     /// Optional Android `TextContentType` raw value (`HTML` or `MARKDOWN`) for the note body.
     public var contentType: String?
@@ -247,13 +247,13 @@ public final class BibleBookmarkToLabel {
     public var label: Label?
 
     /// Display order within label-focused lists and StudyPad views.
-    public var orderNumber: Int
+    public var orderNumber: Int = -1
 
     /// Nesting level used by label/StudyPad outline rendering.
-    public var indentLevel: Int
+    public var indentLevel: Int = 0
 
     /// Whether child content for this row is expanded in StudyPad-like views.
-    public var expandContent: Bool
+    public var expandContent: Bool = true
 
     /**
      Creates a Bible bookmark-to-label junction row.
@@ -283,23 +283,23 @@ public final class BibleBookmarkToLabel {
  */
 @Model
 public final class GenericBookmark {
-    /// Unique identifier used for persistence, label linking, and sync reconciliation.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for persistence, label linking, and sync reconciliation.
+    public var id: UUID = UUID()
 
     /// Canonical document key or OSIS-style reference for the bookmarked entry.
-    public var key: String
+    public var key: String = ""
 
     /// Module initials for the bookmarked document.
-    public var bookInitials: String
+    public var bookInitials: String = ""
 
     /// Creation timestamp used by sorting and export flows.
-    public var createdAt: Date
+    public var createdAt: Date = Date()
 
     /// Start ordinal within the target document, or `0` when unavailable.
-    public var ordinalStart: Int
+    public var ordinalStart: Int = 0
 
     /// End ordinal within the target document, or `0` when unavailable.
-    public var ordinalEnd: Int
+    public var ordinalEnd: Int = 0
 
     /// Inclusive character offset at the start of a partial selection, if any.
     public var startOffset: Int?
@@ -311,10 +311,10 @@ public final class GenericBookmark {
     public var primaryLabelId: UUID?
 
     /// Timestamp of the last bookmark mutation.
-    public var lastUpdatedOn: Date
+    public var lastUpdatedOn: Date = Date()
 
     /// Indicates whether the bookmark covers the entire keyed entry instead of a text span.
-    public var wholeVerse: Bool
+    public var wholeVerse: Bool = true
 
     /// Optional text-to-speech playback metadata for this bookmark.
     public var playbackSettings: PlaybackSettings?
@@ -379,13 +379,13 @@ public final class GenericBookmark {
 @Model
 public final class GenericBookmarkNotes {
     /// Identifier mirroring the owning bookmark for the intended 1:1 relationship.
-    @Attribute(.unique) public var bookmarkId: UUID
+    public var bookmarkId: UUID = UUID()
 
     /// Back-reference to the owning generic bookmark.
     public var bookmark: GenericBookmark?
 
     /// User-authored note text associated with the bookmark.
-    public var notes: String
+    public var notes: String = ""
 
     /// Optional Android `TextContentType` raw value (`HTML` or `MARKDOWN`) for the note body.
     public var contentType: String?
@@ -422,13 +422,13 @@ public final class GenericBookmarkToLabel {
     public var label: Label?
 
     /// Display order within label-focused lists and StudyPad views.
-    public var orderNumber: Int
+    public var orderNumber: Int = -1
 
     /// Nesting level used by label/StudyPad outline rendering.
-    public var indentLevel: Int
+    public var indentLevel: Int = 0
 
     /// Whether child content for this row is expanded in StudyPad-like views.
-    public var expandContent: Bool
+    public var expandContent: Bool = true
 
     /**
      Creates a generic bookmark-to-label junction row.

--- a/Sources/BibleCore/Sources/BibleCore/Models/Label.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Label.swift
@@ -18,40 +18,41 @@ public enum LabelType: String, Codable, Sendable {
  Stores a bookmark label and its visual styling metadata.
 
  Labels are used for user-visible tagging, highlighting rules, quick actions, and as the
- container entity for StudyPad notes. Deleting a label cascades to its StudyPad entries,
- while bookmark junction rows are managed by their owning bookmark relationships.
+ container entity for StudyPad notes. Deleting a label cascades to its StudyPad entries
+ and bookmark junction rows, matching the existing behavior where label deletion detaches
+ bookmark relationships instead of deleting the bookmarked content.
  */
 @Model
 public final class Label {
-    /// Unique identifier used for persistence, bookmark linking, and CloudKit deduplication.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for persistence, bookmark linking, and sync reconciliation.
+    public var id: UUID = UUID()
 
     /// User-visible label name or one of the reserved system label identifiers.
-    public var name: String
+    public var name: String = ""
 
     /// Signed ARGB color integer consumed by native and web rendering layers.
-    public var color: Int
+    public var color: Int = 0xFF91A7FF
 
     /// Enables marker-style rendering instead of the default highlight treatment.
-    public var markerStyle: Bool
+    public var markerStyle: Bool = false
 
     /// Applies the marker style to the whole verse instead of only the selected text span.
-    public var markerStyleWholeVerse: Bool
+    public var markerStyleWholeVerse: Bool = false
 
     /// Enables underline-style rendering for bookmarks using this label.
-    public var underlineStyle: Bool
+    public var underlineStyle: Bool = false
 
     /// Applies underline styling to the whole verse instead of only the selected text span.
-    public var underlineStyleWholeVerse: Bool
+    public var underlineStyleWholeVerse: Bool = true
 
     /// Hides the visible highlight while keeping the label and bookmark metadata intact.
-    public var hideStyle: Bool
+    public var hideStyle: Bool = false
 
     /// Applies the hidden style to the whole verse instead of only the selected text span.
-    public var hideStyleWholeVerse: Bool
+    public var hideStyleWholeVerse: Bool = false
 
     /// Flags the label for quick-access surfaces such as bookmark and label pickers.
-    public var favourite: Bool
+    public var favourite: Bool = false
 
     /// Optional raw label type string mirrored from Android parity state.
     public var type: String?
@@ -62,6 +63,14 @@ public final class Label {
     /// StudyPad text rows owned by this label and cascade-deleted with it.
     @Relationship(deleteRule: .cascade, inverse: \StudyPadTextEntry.label)
     public var studyPadEntries: [StudyPadTextEntry]?
+
+    /// Bible bookmark junction rows that reference this label.
+    @Relationship(deleteRule: .cascade, inverse: \BibleBookmarkToLabel.label)
+    public var bibleBookmarkToLabels: [BibleBookmarkToLabel]?
+
+    /// Generic bookmark junction rows that reference this label.
+    @Relationship(deleteRule: .cascade, inverse: \GenericBookmarkToLabel.label)
+    public var genericBookmarkToLabels: [GenericBookmarkToLabel]?
 
     /**
      Creates a label with styling metadata.

--- a/Sources/BibleCore/Sources/BibleCore/Models/MyDocument.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/MyDocument.swift
@@ -25,25 +25,25 @@ public enum MyDocumentContentType: String, Codable, Sendable {
 @Model
 public final class MyDocument {
     /// Stable primary key used by SwiftData and future sync mapping.
-    @Attribute(.unique) public var id: UUID
+    public var id: UUID = UUID()
 
     /// User-visible document name.
-    public var name: String
+    public var name: String = ""
 
     /// Optional document description.
     public var documentDescription: String?
 
     /// Stable Android-style document initials used by bridge lookups.
-    @Attribute(.unique) public var initials: String
+    public var initials: String = ""
 
     /// Zero-based display order.
-    public var orderNumber: Int
+    public var orderNumber: Int = 0
 
     /// Creation timestamp.
-    public var createdAt: Date
+    public var createdAt: Date = Date()
 
     /// Last metadata/content update timestamp.
-    public var updatedAt: Date
+    public var updatedAt: Date = Date()
 
     /// Prompt identifier when this document was created from AI output.
     public var sourcePromptId: UUID?
@@ -83,28 +83,28 @@ public final class MyDocument {
 @Model
 public final class MyDocumentPage {
     /// Stable primary key for the page.
-    @Attribute(.unique) public var id: UUID
+    public var id: UUID = UUID()
 
     /// Parent document.
     public var document: MyDocument?
 
     /// User-visible page title.
-    public var title: String
+    public var title: String = ""
 
     /// Stable key scoped to the parent document and used by bridge calls.
-    public var pageKey: String
+    public var pageKey: String = ""
 
     /// Persisted raw content type value.
-    public var contentTypeRawValue: String
+    public var contentTypeRawValue: String = MyDocumentContentType.markdown.rawValue
 
     /// Zero-based display order within the document.
-    public var orderNumber: Int
+    public var orderNumber: Int = 0
 
     /// Creation timestamp.
-    public var createdAt: Date
+    public var createdAt: Date = Date()
 
     /// Last metadata/content update timestamp.
-    public var updatedAt: Date
+    public var updatedAt: Date = Date()
 
     /// Prompt identifier when this page was generated from AI output.
     public var sourcePromptId: UUID?
@@ -154,13 +154,13 @@ public final class MyDocumentPage {
 @Model
 public final class MyDocumentPageContent {
     /// Mirrors the owning page identifier for 1:1 lookup and future sync mapping.
-    @Attribute(.unique) public var pageId: UUID
+    public var pageId: UUID = UUID()
 
     /// Back-reference to the owning page.
     public var page: MyDocumentPage?
 
     /// Stored raw page content.
-    public var content: String
+    public var content: String = ""
 
     public init(pageId: UUID, content: String = "") {
         self.pageId = pageId
@@ -174,16 +174,16 @@ public final class MyDocumentPageContent {
 @Model
 public final class AiPageCacheEntry {
     /// Stable primary key for the cache row.
-    @Attribute(.unique) public var id: UUID
+    public var id: UUID = UUID()
 
     /// Owning page identifier.
-    public var pageId: UUID
+    public var pageId: UUID = UUID()
 
     /// Back-reference to the owning page.
     public var page: MyDocumentPage?
 
     /// Prompt that generated or updated the page.
-    public var sourcePromptId: UUID
+    public var sourcePromptId: UUID = UUID()
 
     /// Optional serialized source context.
     public var sourceContext: String?
@@ -198,7 +198,7 @@ public final class AiPageCacheEntry {
     public var contextHash: String?
 
     /// Whether the AI write tools were used for this cache entry.
-    public var usedWriteTools: Bool
+    public var usedWriteTools: Bool = false
 
     /// Optional AI model name.
     public var sourceModelName: String?

--- a/Sources/BibleCore/Sources/BibleCore/Models/ReadingPlan.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/ReadingPlan.swift
@@ -12,26 +12,26 @@ import SwiftData
  */
 @Model
 public final class ReadingPlan {
-    /// Unique identifier used for SwiftData identity and sync-safe plan references.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for SwiftData identity and sync-safe plan references.
+    public var id: UUID = UUID()
 
     /// Stable plan code used to map this record back to a bundled or imported definition.
-    public var planCode: String
+    public var planCode: String = ""
 
     /// User-visible plan name captured at start time for display in history and progress UI.
-    public var planName: String
+    public var planName: String = ""
 
     /// Date the user started the plan; used to compute expected day progression.
-    public var startDate: Date
+    public var startDate: Date = Date()
 
     /// Persisted current-day field retained for parity/backup flows; new plans initialize it to `0`.
-    public var currentDay: Int
+    public var currentDay: Int = 0
 
     /// Total number of day rows the plan definition expects.
-    public var totalDays: Int
+    public var totalDays: Int = 365
 
     /// Marks whether the plan should be treated as the actively followed plan.
-    public var isActive: Bool
+    public var isActive: Bool = true
 
     /// Child day rows that store readings and completion state for each plan day.
     @Relationship(deleteRule: .cascade, inverse: \ReadingPlanDay.plan)
@@ -76,23 +76,23 @@ public final class ReadingPlan {
  */
 @Model
 public final class ReadingPlanDay {
-    /// Unique identifier used for SwiftData identity and day-level updates.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for SwiftData identity and day-level updates.
+    public var id: UUID = UUID()
 
     /// Parent plan that owns this day row.
     public var plan: ReadingPlan?
 
     /// One-based day number within the parent plan definition.
-    public var dayNumber: Int
+    public var dayNumber: Int = 0
 
     /// Marks whether the user has completed this day's readings.
-    public var isCompleted: Bool
+    public var isCompleted: Bool = false
 
     /// Timestamp recorded when the day was marked complete; nil means incomplete.
     public var completedDate: Date?
 
     /// Canonical reading assignment string, typically semicolon-separated Bible references.
-    public var readings: String
+    public var readings: String = ""
 
     /**
      Creates a reading plan day record.

--- a/Sources/BibleCore/Sources/BibleCore/Models/ReadingPlan.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/ReadingPlan.swift
@@ -83,7 +83,7 @@ public final class ReadingPlanDay {
     public var plan: ReadingPlan?
 
     /// One-based day number within the parent plan definition.
-    public var dayNumber: Int = 0
+    public var dayNumber: Int = 1
 
     /// Marks whether the user has completed this day's readings.
     public var isCompleted: Bool = false
@@ -105,7 +105,7 @@ public final class ReadingPlanDay {
      */
     public init(
         id: UUID = UUID(),
-        dayNumber: Int = 0,
+        dayNumber: Int = 1,
         isCompleted: Bool = false,
         readings: String = ""
     ) {

--- a/Sources/BibleCore/Sources/BibleCore/Models/StudyPad.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/StudyPad.swift
@@ -14,17 +14,17 @@ import SwiftData
  */
 @Model
 public final class StudyPadTextEntry {
-    /// Unique identifier used for SwiftData identity and 1:1 text payload linkage.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for SwiftData identity and 1:1 text payload linkage.
+    public var id: UUID = UUID()
 
     /// Parent label that owns this StudyPad entry; deleting the label removes the entry.
     public var label: Label?
 
     /// Zero-based display order within the label's StudyPad outline.
-    public var orderNumber: Int
+    public var orderNumber: Int = 0
 
     /// Hierarchy depth used by the StudyPad outline renderer.
-    public var indentLevel: Int
+    public var indentLevel: Int = 0
 
     /// Optional Android `TextContentType` raw value (`HTML` or `MARKDOWN`) for the text payload.
     public var contentType: String?
@@ -69,13 +69,13 @@ public final class StudyPadTextEntry {
 @Model
 public final class StudyPadTextEntryText {
     /// Mirrors the parent entry identifier to enforce the intended 1:1 relationship.
-    @Attribute(.unique) public var studyPadTextEntryId: UUID
+    public var studyPadTextEntryId: UUID = UUID()
 
     /// Back-reference to the owning StudyPad entry.
     public var entry: StudyPadTextEntry?
 
     /// Serialized note body shown in the StudyPad editor and renderer.
-    public var text: String
+    public var text: String = ""
 
     /**
      Creates the text payload entity for a StudyPad entry.

--- a/Sources/BibleCore/Sources/BibleCore/Models/Window.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Window.swift
@@ -11,35 +11,35 @@ import SwiftData
  */
 @Model
 public final class Window {
-    /// Unique identifier used for persistence and cross-entity references.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier used for persistence and cross-entity references.
+    public var id: UUID = UUID()
 
     /// Parent workspace that owns this window.
     public var workspace: Workspace?
 
     /// Enables synchronized navigation and scroll behavior with peer windows in the same group.
-    public var isSynchronized: Bool
+    public var isSynchronized: Bool = true
 
     /// Keeps the window fixed in the layout when the user switches other panes or documents.
-    public var isPinMode: Bool
+    public var isPinMode: Bool = false
 
     /// Marks this window as the dedicated links/cross-reference destination.
-    public var isLinksWindow: Bool
+    public var isLinksWindow: Bool = false
 
     /// Zero-based display order within the parent workspace.
-    public var orderNumber: Int
+    public var orderNumber: Int = 0
 
     /// Optional explicit target window for link routing inside the workspace.
     public var targetLinksWindowId: UUID?
 
     /// Integer sync group identifier used by synchronized scrolling/navigation features.
-    public var syncGroup: Int
+    public var syncGroup: Int = 0
 
     /// Relative split-view weight used to size the pane compared with sibling windows.
-    public var layoutWeight: Float
+    public var layoutWeight: Float = 1.0
 
     /// Serialized layout mode string consumed by the workspace layout engine.
-    public var layoutState: String
+    public var layoutState: String = "split"
 
     /// 1:1 page-state record for the current document/category selections in this window.
     @Relationship(deleteRule: .cascade, inverse: \PageManager.window)
@@ -92,8 +92,8 @@ public final class Window {
  */
 @Model
 public final class PageManager {
-    /// Unique identifier that mirrors the owning window's identifier for the intended 1:1 link.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier that mirrors the owning window's identifier for the intended 1:1 link.
+    public var id: UUID = UUID()
 
     /// Back-reference to the owning window.
     public var window: Window?
@@ -144,7 +144,7 @@ public final class PageManager {
     public var epubHref: String?
 
     /// Raw category name that identifies which of the persisted category states is active.
-    public var currentCategoryName: String
+    public var currentCategoryName: String = "bible"
 
     /// Window-scoped text display overrides applied before workspace/app defaults.
     public var textDisplaySettings: TextDisplaySettings?
@@ -178,19 +178,19 @@ public final class PageManager {
 @Model
 public final class HistoryItem {
     /// Unique identifier for the navigation snapshot.
-    public var id: UUID
+    public var id: UUID = UUID()
 
     /// Owning window that uses this row for back/forward navigation.
     public var window: Window?
 
     /// Timestamp captured when the history row was recorded.
-    public var createdAt: Date
+    public var createdAt: Date = Date()
 
     /// Module initials that were active at this history checkpoint.
-    public var document: String
+    public var document: String = ""
 
     /// Persisted document key or reference for the checkpoint.
-    public var key: String
+    public var key: String = ""
 
     /// Optional anchor ordinal used to restore scroll position more precisely.
     public var anchorOrdinal: Int?

--- a/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Workspace.swift
@@ -12,17 +12,17 @@ import SwiftData
  */
 @Model
 public final class Workspace {
-    /// Unique identifier mirrored from Android's workspace IdType contract.
-    @Attribute(.unique) public var id: UUID
+    /// Stable identifier mirrored from Android's workspace IdType contract.
+    public var id: UUID = UUID()
 
     /// User-visible workspace name shown in workspace pickers and headers.
-    public var name: String
+    public var name: String = ""
 
     /// Optional summary text describing the workspace contents for list UI.
     public var contentsText: String?
 
     /// Zero-based display order among all persisted workspaces.
-    public var orderNumber: Int
+    public var orderNumber: Int = 0
 
     /// Workspace-scoped text display overrides inherited by windows that do not override them.
     public var textDisplaySettings: TextDisplaySettings?

--- a/Sources/BibleCore/Sources/BibleCore/Services/ICloudModelContainerStartupRecovery.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ICloudModelContainerStartupRecovery.swift
@@ -79,7 +79,7 @@ public enum ICloudModelContainerStartupRecovery {
                 container: container,
                 effectiveICloudEnabled: false,
                 didRecoverFromCloudKitFailure: true,
-                cloudKitLoadErrorDescription: String(describing: cloudKitError)
+                cloudKitLoadErrorDescription: cloudKitError.localizedDescription
             )
         }
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/ICloudModelContainerStartupRecovery.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ICloudModelContainerStartupRecovery.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/**
+ Loads the startup model container while treating iCloud/CloudKit activation as recoverable.
+
+ SwiftData's CloudKit integration validates the full model before the app can render any UI. When
+ a persisted iCloud toggle points startup at a CloudKit-backed container that cannot load, the app
+ must not trap before users can recover. This helper preserves the requested CloudKit path first,
+ then retries the same store locally and clears the bootstrap toggle only after local startup has
+ succeeded.
+ */
+public enum ICloudModelContainerStartupRecovery {
+    /**
+     Result of startup container loading.
+
+     - Parameter Container: Concrete container type supplied by the app shell.
+     - Note: The type is generic so the retry and preference contract can be unit-tested without
+       constructing real SwiftData or CloudKit containers.
+     */
+    public struct Result<Container> {
+        /// Container returned by the successful startup path.
+        public let container: Container
+
+        /// Effective iCloud mode for the current runtime after any fallback.
+        public let effectiveICloudEnabled: Bool
+
+        /// Whether startup recovered from a failed CloudKit-backed load by opening locally.
+        public let didRecoverFromCloudKitFailure: Bool
+
+        /// Original CloudKit load error preserved for diagnostics when fallback succeeds.
+        public let cloudKitLoadErrorDescription: String?
+    }
+
+    /**
+     Loads the requested startup container and falls back to local storage after CloudKit failure.
+
+     - Parameters:
+       - iCloudEnabled: Persisted bootstrap preference read before the app has a SwiftData context.
+       - defaults: Defaults store that owns `syncEnabledKey`.
+       - syncEnabledKey: Defaults key used by the app's iCloud toggle.
+       - loadCloudKitContainer: Closure that attempts the CloudKit-backed container.
+       - loadLocalContainer: Closure that attempts the local-only container.
+     - Returns: Container load result and the effective runtime iCloud mode.
+     - Side effects:
+       - calls `loadCloudKitContainer` before `loadLocalContainer` when `iCloudEnabled` is true
+       - writes `false` to `syncEnabledKey` only when CloudKit failed and local fallback succeeded
+     - Failure modes:
+       - rethrows local container failures when iCloud is disabled
+       - rethrows local fallback failures when both CloudKit and local startup fail
+     */
+    public static func loadContainer<Container>(
+        iCloudEnabled: Bool,
+        defaults: UserDefaults = .standard,
+        syncEnabledKey: String,
+        loadCloudKitContainer: () throws -> Container,
+        loadLocalContainer: () throws -> Container
+    ) throws -> Result<Container> {
+        guard iCloudEnabled else {
+            return Result(
+                container: try loadLocalContainer(),
+                effectiveICloudEnabled: false,
+                didRecoverFromCloudKitFailure: false,
+                cloudKitLoadErrorDescription: nil
+            )
+        }
+
+        do {
+            return Result(
+                container: try loadCloudKitContainer(),
+                effectiveICloudEnabled: true,
+                didRecoverFromCloudKitFailure: false,
+                cloudKitLoadErrorDescription: nil
+            )
+        } catch {
+            let cloudKitError = error
+            let container = try loadLocalContainer()
+            defaults.set(false, forKey: syncEnabledKey)
+            return Result(
+                container: container,
+                effectiveICloudEnabled: false,
+                didRecoverFromCloudKitFailure: true,
+                cloudKitLoadErrorDescription: String(describing: cloudKitError)
+            )
+        }
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift
@@ -22,6 +22,9 @@ public enum RemoteSyncMyDocumentRestoreError: Error, Equatable {
     /// One Android UUID-like blob could not be converted into an iOS `UUID`.
     case invalidIdentifierBlob(table: String, column: String)
 
+    /// One staged Android backup would create duplicate bridge initials.
+    case duplicateInitials([String])
+
     /// One required staged column was missing or contained an unusable value.
     case invalidColumnValue(table: String, column: String)
 
@@ -261,6 +264,10 @@ public final class RemoteSyncMyDocumentRestoreService {
         if !snapshot.orphanReferences.isEmpty {
             throw RemoteSyncMyDocumentRestoreError.orphanReferences(snapshot.orphanReferences)
         }
+        let duplicateInitials = Self.duplicateInitials(in: snapshot.documents)
+        if !duplicateInitials.isEmpty {
+            throw RemoteSyncMyDocumentRestoreError.duplicateInitials(duplicateInitials)
+        }
 
         let existingCacheEntries = try modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())
         let existingContents = try modelContext.fetch(FetchDescriptor<MyDocumentPageContent>())
@@ -365,6 +372,31 @@ public final class RemoteSyncMyDocumentRestoreService {
             restoredContentCount: snapshot.pageContents.count,
             restoredAIPageCacheEntryCount: snapshot.aiPageCacheEntries.count
         )
+    }
+
+    /**
+     Returns staged My Documents initials that would violate Android bridge uniqueness.
+
+     Android exposes each My Document as a generated general-book module and keeps `initials`
+     unique. iOS must preserve that contract at import time because CloudKit-backed SwiftData
+     stores cannot use a native unique constraint on the synced model attribute.
+
+     - Parameter documents: Android-shaped My Documents rows decoded from restore or patch data.
+     - Returns: Sorted duplicate initials values; empty when the staged rows are unique.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func duplicateInitials(in documents: [RemoteSyncAndroidMyDocument]) -> [String] {
+        var seen: Set<String> = []
+        var duplicates: Set<String> = []
+        for document in documents {
+            if seen.contains(document.initials) {
+                duplicates.insert(document.initials)
+            } else {
+                seen.insert(document.initials)
+            }
+        }
+        return duplicates.sorted()
     }
 
     private static func orphanReferences(


### PR DESCRIPTION
## Summary
- Recover app startup when the persisted iCloud toggle makes SwiftData try a CloudKit-backed container that cannot load.
- Retry the same user-data store locally, clear the iCloud bootstrap toggle after successful fallback, and surface the existing device synchronization alert.
- Add focused regression coverage for fallback, successful CloudKit startup, and local-only startup.

## Scope
- iOS-only CloudKit/SwiftData startup behavior in `AndBibleApp`.
- New generic startup recovery helper in `BibleCore` so the retry contract is unit-testable without constructing CloudKit containers.
- No changes to Android-compatible WebDAV/category sync settings or backup format behavior.

## Contract References
- Android parity: remote/category sync settings remain independent of the iOS-only iCloud bootstrap key.
- Recovery preserves the requested CloudKit path first; it only disables the iCloud bootstrap preference after CloudKit fails and local startup succeeds.

## Change Details
- Move startup container creation behind `ICloudModelContainerStartupRecovery.loadContainer`.
- Set `SyncService` to the effective runtime mode after startup resolves.
- Show a cloud-sync recovery alert when fallback occurs.

## Validation Evidence
- `xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 16,OS=18.6 -derivedDataPath .derivedData-issue-196 -only-testing:AndBibleTests/AndBibleTests/testICloudStartupRecoveryFallsBackToLocalContainerAndDisablesCrashLoopPreference -only-testing:AndBibleTests/AndBibleTests/testICloudStartupRecoveryKeepsICloudEnabledWhenCloudKitContainerLoads -only-testing:AndBibleTests/AndBibleTests/testICloudStartupRecoveryUsesLocalContainerWhenICloudDisabled test -quiet`
- `xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -derivedDataPath .derivedData-issue-196 build -quiet`
- Manual iPhone 16 iOS 18.6 simulator launch with `icloud_sync_enabled=true`: app stayed alive, showed the recovery alert, and cleared `icloud_sync_enabled` back to `false`.
- `git diff --check`
- GitNexus staged `detect_changes`: low risk, no affected execution flows.

## Risks / Follow-ups
- This intentionally does not claim the current SwiftData model is CloudKit-compatible; it prevents the fatal startup loop and leaves full model compatibility as separate work.

Closes #196