### PR TITLE
fix(reader): align commentary quick selector with Android

### DIFF
--- a/AndBibleTests/AndBibleTestSupport.swift
+++ b/AndBibleTests/AndBibleTestSupport.swift
@@ -406,6 +406,109 @@ extension AndBibleTests {
     }
 
     /**
+     Seeds a deterministic empty SWORD dictionary module into a temporary module directory.
+
+     Commentary quick-selector parity tests need a real dictionary category because Android's
+     commentary popup includes dictionaries beside commentaries. The module uses empty `RawLD`
+     payload files, which is enough for SWORD category discovery and controller switching without
+     redistributing dictionary content.
+
+     - Parameters:
+       - moduleName: SWORD module initials to publish in `mods.d`.
+       - modulePath: Temporary SWORD root returned by `makeTemporaryBundledSwordPath()`.
+     - Side effects: Writes a `.conf` file and empty `RawLD` data files under `modulePath`.
+     - Failure modes: Propagates filesystem write errors.
+     */
+    func seedEmptyRawDictionaryModule(named moduleName: String = "UITestDict", in modulePath: String) throws {
+        let fm = FileManager.default
+        let moduleKey = moduleName.lowercased()
+        let moduleRoot = URL(fileURLWithPath: modulePath, isDirectory: true)
+        let modsDURL = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let dataURL = moduleRoot
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("lexdict", isDirectory: true)
+            .appendingPathComponent("rawld", isDirectory: true)
+            .appendingPathComponent(moduleKey, isDirectory: true)
+
+        try fm.createDirectory(at: modsDURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: dataURL, withIntermediateDirectories: true)
+        for fileName in ["\(moduleKey).dat", "\(moduleKey).idx"] {
+            let fileURL = dataURL.appendingPathComponent(fileName, isDirectory: false)
+            if !fm.fileExists(atPath: fileURL.path) {
+                try Data().write(to: fileURL)
+            }
+        }
+
+        let conf = """
+        [\(moduleName)]
+        Description=UI Test Dictionary
+        Category=Lexicons / Dictionaries
+        DataPath=./modules/lexdict/rawld/\(moduleKey)/\(moduleKey)
+        ModDrv=RawLD
+        SourceType=OSIS
+        Encoding=UTF-8
+        Lang=en
+        About=Deterministic empty dictionary module for iOS parity tests.
+        """
+        try conf.write(
+            to: modsDURL.appendingPathComponent("\(moduleKey).conf", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /**
+     Seeds a deterministic empty SWORD general-book module into a temporary module directory.
+
+     Android's commentary quick selector includes general books. This fixture gives controller
+     parity tests a real general-book module through SWORD's installed-module discovery without
+     adding redistributable book content to the repository.
+
+     - Parameters:
+       - moduleName: SWORD module initials to publish in `mods.d`.
+       - modulePath: Temporary SWORD root returned by `makeTemporaryBundledSwordPath()`.
+     - Side effects: Writes a `.conf` file and empty `RawGenBook` data files under `modulePath`.
+     - Failure modes: Propagates filesystem write errors.
+     */
+    func seedEmptyRawGeneralBookModule(named moduleName: String = "UITestGB", in modulePath: String) throws {
+        let fm = FileManager.default
+        let moduleKey = moduleName.lowercased()
+        let moduleRoot = URL(fileURLWithPath: modulePath, isDirectory: true)
+        let modsDURL = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let dataURL = moduleRoot
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("genbook", isDirectory: true)
+            .appendingPathComponent("rawgenbook", isDirectory: true)
+            .appendingPathComponent(moduleKey, isDirectory: true)
+
+        try fm.createDirectory(at: modsDURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: dataURL, withIntermediateDirectories: true)
+        for fileName in ["\(moduleKey).dat", "\(moduleKey).idx"] {
+            let fileURL = dataURL.appendingPathComponent(fileName, isDirectory: false)
+            if !fm.fileExists(atPath: fileURL.path) {
+                try Data().write(to: fileURL)
+            }
+        }
+
+        let conf = """
+        [\(moduleName)]
+        Description=UI Test General Book
+        Category=Generic Books
+        DataPath=./modules/genbook/rawgenbook/\(moduleKey)/\(moduleKey)
+        ModDrv=RawGenBook
+        SourceType=OSIS
+        Encoding=UTF-8
+        Lang=en
+        About=Deterministic empty general book module for iOS parity tests.
+        """
+        try conf.write(
+            to: modsDURL.appendingPathComponent("\(moduleKey).conf", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /**
      Seeds an additional Bible module identity that reuses the bundled KJV fixture payload.
 
      Quick-selector parity tests need multiple installed Bible module initials so they can exercise

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1140,7 +1140,12 @@ extension AndBibleTests {
             activeModuleName: "KJV"
         )
 
-        XCTAssertEqual(action, .switchDirectly("WEB"))
+        guard case .switchDirectly(let row) = action else {
+            XCTFail("Expected Android's exactly-two-module shortcut to select the alternate Bible.")
+            return
+        }
+        XCTAssertEqual(row.module.name, "WEB")
+        XCTAssertEqual(row.module.category, .bible)
     }
 
     /**
@@ -1242,16 +1247,159 @@ extension AndBibleTests {
             for: controller.installedBibleModules,
             activeModuleName: controller.activeModuleName
         )
-        guard case .switchDirectly(let selectedModuleName) = action else {
+        guard case .switchDirectly(let row) = action else {
             XCTFail("Expected Android's exactly-two-module shortcut to select the alternate Bible.")
             return
         }
 
-        controller.switchBibleDocument(to: selectedModuleName)
+        controller.switchBibleDocument(to: row.module.name)
 
         XCTAssertEqual(controller.activeModuleName, "WEB")
         XCTAssertEqual(pageManager.bibleDocument, "WEB")
         XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+    }
+
+    /**
+     Protects Android `MainBibleActivity.commentaryClick` candidate and row semantics.
+
+     The Android default commentary toolbar tap calls `menuForDocs` with unlocked commentaries plus
+     general books plus dictionaries, then `menuForDocs` sorts by language code and abbreviation and
+     renders compact `initials (language)` rows. This test keeps that category mix in the shared
+     quick-selector presentation contract so iOS cannot regress to the full commentary-only chooser
+     sheet or sort by localized descriptions.
+     */
+    func testCommentaryQuickModuleSelectorRowsIncludeAndroidDocumentCategories() {
+        let commentary = ModuleInfo(
+            name: "MHC",
+            description: "Matthew Henry",
+            category: .commentary,
+            language: "en"
+        )
+        let dictionary = ModuleInfo(
+            name: "BDBT",
+            description: "Brown Driver Briggs",
+            category: .dictionary,
+            language: "en"
+        )
+        let generalBook = ModuleInfo(
+            name: "Pilgrim",
+            description: "Pilgrim's Progress",
+            category: .generalBook,
+            language: "en"
+        )
+        let finnishCommentary = ModuleInfo(
+            name: "FinComm",
+            description: "Finnish Commentary",
+            category: .commentary,
+            language: "fi"
+        )
+
+        let rows = BibleReaderQuickModuleSelectorPresentation.rows(
+            for: [generalBook, finnishCommentary, commentary, dictionary],
+            activeModuleName: "BDBT"
+        )
+
+        XCTAssertEqual(rows.map(\.module.category), [.dictionary, .commentary, .generalBook, .commentary])
+        XCTAssertEqual(rows.map(\.title), ["BDBT (en)", "MHC (en)", "Pilgrim (en)", "FinComm (fi)"])
+        XCTAssertEqual(rows.map(\.isEnabled), [false, true, true, true])
+    }
+
+    /**
+     Protects Android's atomic current-document switch behavior for commentary quick selections.
+
+     Android `menuForDocs` delegates the selected commentary `Book` to `setCurrentDocument(book)`,
+     which updates the active document and visible category together. iOS must provide the same
+     controller-level contract for the quick selector instead of switching module and category in
+     separate calls that can reload stale content or persist partial pane state.
+     */
+    @MainActor
+    func testCommentaryDocumentSwitchPersistsModuleAndCategoryTogether() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawCommentaryModule(named: "UITestComm", in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchCommentaryDocument(to: "UITestComm")
+
+        XCTAssertEqual(controller.currentCategory, .commentary)
+        XCTAssertEqual(controller.activeCommentaryModuleName, "UITestComm")
+        XCTAssertEqual(pageManager.commentaryDocument, "UITestComm")
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.commentary.pageManagerKey)
+        XCTAssertEqual(persistCount, 1)
+    }
+
+    /**
+     Protects Android's atomic current-document switch behavior for dictionary quick selections.
+
+     Android routes dictionaries from the commentary quick popup through `setCurrentDocument(book)`.
+     iOS must therefore persist the selected dictionary, clear stale dictionary entry state, and
+     switch the visible category in one controller call rather than splitting module and category
+     updates across separate mutations.
+     */
+    @MainActor
+    func testDictionaryDocumentSwitchPersistsModuleCategoryAndClearsKeyTogether() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawDictionaryModule(named: "UITestDict", in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        pageManager.dictionaryKey = "stale-key"
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchDictionaryDocument(to: "UITestDict")
+
+        XCTAssertEqual(controller.currentCategory, .dictionary)
+        XCTAssertEqual(controller.activeDictionaryModuleName, "UITestDict")
+        XCTAssertNil(controller.currentDictionaryKey)
+        XCTAssertEqual(pageManager.dictionaryDocument, "UITestDict")
+        XCTAssertNil(pageManager.dictionaryKey)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.dictionary.pageManagerKey)
+        XCTAssertEqual(persistCount, 1)
+    }
+
+    /**
+     Protects Android's atomic current-document switch behavior for general-book quick selections.
+
+     Android includes general books in the commentary quick popup and applies selections through the
+     same current-document transition. The iOS controller must persist module/category and clear the
+     stale general-book key together so quick selection cannot leave mixed pane state behind.
+     */
+    @MainActor
+    func testGeneralBookDocumentSwitchPersistsModuleCategoryAndClearsKeyTogether() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawGeneralBookModule(named: "UITestGB", in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        pageManager.generalBookKey = "stale-key"
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchGeneralBookDocument(to: "UITestGB")
+
+        XCTAssertEqual(controller.currentCategory, .generalBook)
+        XCTAssertEqual(controller.activeGeneralBookModuleName, "UITestGB")
+        XCTAssertNil(controller.currentGeneralBookKey)
+        XCTAssertEqual(pageManager.generalBookDocument, "UITestGB")
+        XCTAssertNil(pageManager.generalBookKey)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.generalBook.pageManagerKey)
+        XCTAssertEqual(persistCount, 1)
     }
 
     /**
@@ -1396,6 +1544,57 @@ extension AndBibleTests {
         let resolveIndex = try XCTUnwrap(selectionSource.range(of: "let controller = controller(for: targetWindowId)")?.lowerBound)
         let dismissIndex = try XCTUnwrap(selectionSource.range(of: "dismissBibleQuickSelector()")?.lowerBound)
         XCTAssertLessThan(resolveIndex, dismissIndex)
+    }
+
+    /**
+     Guards the commentary toolbar quick-menu route against preserving the old iOS sheet.
+
+     Android default commentary taps show an anchored `PopupMenu` with commentaries, general books,
+     and dictionaries while the reader remains visible. Long press remains the full
+     `ChooseDocument` activity path except for Android's `swap-menu` setting. The SwiftUI
+     coordinator state is private, so this source-level contract checks the same boundary as the
+     Bible quick-menu test: commentary tap must resolve rows, show the anchored popup, anchor from
+     the commentary toolbar button, and route selections through category-specific current-document
+     switch methods.
+     */
+    func testCommentaryToolbarMenuRoutesThroughAnchoredQuickSelectorInsteadOfSheet() throws {
+        let readerSource = try bibleUISource(named: "BibleReaderView.swift")
+        let toolbarSource = try bibleUISource(named: "BibleReaderToolbarActions.swift")
+        let menuActionSource = try extractFunction(
+            named: "performCommentaryMenuAction",
+            from: readerSource
+        )
+        let selectionSource = try extractFunction(
+            named: "selectCommentaryQuickModule",
+            from: readerSource
+        )
+
+        XCTAssertTrue(menuActionSource.contains("BibleReaderQuickModuleSelectorPresentation.action("))
+        XCTAssertTrue(menuActionSource.contains("commentaryQuickSelectorModules("))
+        XCTAssertTrue(menuActionSource.contains("presentCommentaryQuickSelector(controller, rows: rows)"))
+        XCTAssertFalse(menuActionSource.contains("performCommentaryChooserAction()"))
+        XCTAssertTrue(readerSource.contains("performCommentaryMenuAction(controller, includeAuxiliaryDocuments: false)"))
+        XCTAssertTrue(readerSource.contains("modules += controller.installedGeneralBookModules"))
+        XCTAssertTrue(readerSource.contains("modules += controller.installedDictionaryModules"))
+        XCTAssertTrue(readerSource.contains("controller.installedCommentaryModules.filter(\\.isUnlocked)"))
+        XCTAssertTrue(readerSource.contains("@State private var commentaryQuickModuleSelectorRows"))
+        XCTAssertTrue(readerSource.contains("@State private var commentaryQuickModuleSelectorTargetWindowId"))
+        XCTAssertTrue(readerSource.contains("commentaryQuickModuleSelectorTargetWindowId = resolvedTargetWindowId"))
+        XCTAssertTrue(readerSource.contains("commentaryQuickModuleSelectorTargetWindowId = nil"))
+        XCTAssertTrue(readerSource.contains("commentaryQuickModuleSelectorOverlay(anchor: anchor)"))
+        XCTAssertTrue(readerSource.contains("ReaderCommentaryToolbarButtonBoundsPreferenceKey"))
+        XCTAssertTrue(
+            toolbarSource.contains(
+                ".anchorPreference(key: ReaderCommentaryToolbarButtonBoundsPreferenceKey.self"
+            )
+        )
+        XCTAssertTrue(selectionSource.contains("case .commentary:"))
+        XCTAssertTrue(selectionSource.contains("controller.switchCommentaryDocument(to: module.name)"))
+        XCTAssertTrue(selectionSource.contains("case .dictionary:"))
+        XCTAssertTrue(selectionSource.contains("controller.switchDictionaryDocument(to: module.name)"))
+        XCTAssertTrue(selectionSource.contains("case .generalBook:"))
+        XCTAssertTrue(selectionSource.contains("controller.switchGeneralBookDocument(to: module.name)"))
+        XCTAssertTrue(selectionSource.contains("dismissCommentaryQuickSelector()"))
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -6,18 +6,44 @@ import UIKit
 #endif
 
 extension AndBibleUITests {
+    /**
+     Returns whether an identifier belongs to the Android-style reader quick-selector popup family.
+
+     Both Bible and commentary toolbar popups render through `BibleReaderQuickModuleSelector`, which
+     exposes a scroll-view container and button rows. Keeping the resolver family-based prevents
+     tests from accidentally preserving old iOS picker behavior for one document category while the
+     other uses Android's compact popup.
+     */
+    func isReaderQuickSelectorIdentifier(_ identifier: String) -> Bool {
+        identifier == "readerBibleQuickSelector" ||
+            identifier == "readerCommentaryQuickSelector"
+    }
+
+    /**
+     Returns whether an identifier belongs to a row inside an Android-style reader quick selector.
+
+     - Parameter identifier: Accessibility identifier requested by a UI test.
+     - Returns: `true` for Bible or commentary quick-selector row identifiers.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    func isReaderQuickSelectorRowIdentifier(_ identifier: String) -> Bool {
+        identifier.hasPrefix("readerBibleQuickSelectorRow_") ||
+            identifier.hasPrefix("readerCommentaryQuickSelectorRow_")
+    }
+
     func heuristicElementCandidates(
         for identifier: String,
         in app: XCUIApplication
     ) -> [XCUIElement] {
-        if identifier == "readerBibleQuickSelector" {
+        if isReaderQuickSelectorIdentifier(identifier) {
             return [
                 app.scrollViews[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
             ]
         }
 
-        if identifier.hasPrefix("readerBibleQuickSelectorRow_") {
+        if isReaderQuickSelectorRowIdentifier(identifier) {
             return [
                 app.buttons[identifier].firstMatch,
                 app.scrollViews.buttons[identifier].firstMatch,

--- a/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
+++ b/AndBibleUITests/AndBibleUITests+BookmarksHistory.swift
@@ -136,7 +136,24 @@ extension AndBibleUITests {
         )
 
         tapElementReliably(requireElement("readerCommentaryToolbarButton", in: app, timeout: 10), timeout: 10)
-        if waitForAnyElement(["modulePickerScreen"], in: app, timeout: 3) != nil {
+        if waitForAnyElement(["readerCommentaryQuickSelector"], in: app, timeout: 3) != nil {
+            let quickSelector = requireElement("readerCommentaryQuickSelector", in: app, timeout: 10)
+            let commentaryQuickRow = requireElement("readerCommentaryQuickSelectorRow_UITestComm", in: app, timeout: 10)
+            XCTAssertEqual(
+                commentaryQuickRow.value as? String,
+                "available",
+                "UITestComm quick-selector row must be selectable when switching from Bible."
+            )
+            for _ in 0..<8 where !isElementVisible(commentaryQuickRow, within: quickSelector) {
+                quickSelector.swipeUp()
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            }
+            XCTAssertTrue(
+                isElementVisible(commentaryQuickRow, within: quickSelector),
+                "Expected quick selector to scroll until UITestComm is visible."
+            )
+            tapElementReliably(commentaryQuickRow, timeout: 10)
+        } else if waitForAnyElement(["modulePickerScreen"], in: app, timeout: 3) != nil {
             tapFirstModulePickerRow(in: app, timeout: 10)
         }
         waitForReaderRenderedContentState(

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -739,6 +739,50 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         loadCurrentContent()
     }
 
+    /**
+     Switches the visible document to a commentary module in one Android-parity transition.
+
+     Android's toolbar quick selector delegates selected commentary documents to
+     `setCurrentDocument(book)`, so the selected module and visible document category change
+     together. This method keeps iOS on that contract for both quick selectors and full chooser
+     selections that should show commentary content immediately.
+
+     - Parameter moduleName: Installed SWORD commentary module abbreviation to make current.
+     Side effects:
+     - mutates the active commentary module and current document category
+     - writes `commentaryDocument` and `currentCategoryName` to the active pane's `PageManager`
+     - invokes `onPersistState` once when pane state is available
+     - reloads the visible reader document once when the JavaScript client is ready
+     Failure modes:
+     - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     - if the resolved module is not a commentary, logs a warning and leaves state unchanged
+     */
+    @MainActor
+    public func switchCommentaryDocument(to moduleName: String) {
+        guard let mgr = swordManager,
+              let mod = mgr.module(named: moduleName) else {
+            logger.warning("Cannot switch to commentary document \(moduleName) — not found")
+            return
+        }
+        guard mod.info.category == .commentary else {
+            logger.warning("Cannot switch to commentary document \(moduleName) — category \(mod.info.category.rawValue)")
+            return
+        }
+        activeCommentaryModule = mod
+        activeCommentaryModuleName = moduleName
+        currentCategory = .commentary
+        logger.info("Switched to commentary document: \(moduleName)")
+
+        if let pm = activeWindow?.pageManager {
+            pm.commentaryDocument = moduleName
+            pm.currentCategoryName = DocumentCategory.commentary.pageManagerKey
+            onPersistState?()
+        }
+
+        guard clientReady else { return }
+        loadCurrentContent()
+    }
+
     /// Switch the active dictionary module.
     public func switchDictionaryModule(to moduleName: String) {
         guard let mgr = swordManager,
@@ -758,6 +802,52 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     }
 
+    /**
+     Switches the visible document to a dictionary module in one Android-parity transition.
+
+     Android's commentary quick popup can include dictionaries and selects them through the same
+     current-document path as commentaries. The selected dictionary, cleared entry key, and visible
+     document category must therefore be persisted together before rendering dictionary content.
+
+     - Parameter moduleName: Installed SWORD dictionary module abbreviation to make current.
+     Side effects:
+     - mutates the active dictionary module, clears the selected dictionary key, and sets the
+       current category to dictionary
+     - writes `dictionaryDocument`, `dictionaryKey`, and `currentCategoryName` to `PageManager`
+     - invokes `onPersistState` once when pane state is available
+     - reloads the visible reader document once when the JavaScript client is ready
+     Failure modes:
+     - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     - if the resolved module is not a dictionary, logs a warning and leaves state unchanged
+     */
+    @MainActor
+    public func switchDictionaryDocument(to moduleName: String) {
+        guard let mgr = swordManager,
+              let mod = mgr.module(named: moduleName) else {
+            logger.warning("Cannot switch to dictionary document \(moduleName) — not found")
+            return
+        }
+        guard mod.info.category == .dictionary else {
+            logger.warning("Cannot switch to dictionary document \(moduleName) — category \(mod.info.category.rawValue)")
+            return
+        }
+        activeDictionaryModule = mod
+        activeDictionaryModuleName = moduleName
+        currentDictionaryKey = nil
+        currentCategory = .dictionary
+        logger.info("Switched to dictionary document: \(moduleName)")
+
+        if let pm = activeWindow?.pageManager {
+            pm.dictionaryDocument = moduleName
+            pm.dictionaryKey = nil
+            pm.currentCategoryName = DocumentCategory.dictionary.pageManagerKey
+            onPersistState?()
+        }
+
+        guard clientReady else { return }
+        loadCurrentContent()
+    }
+
     /// Switch the active general book module.
     public func switchGeneralBookModule(to moduleName: String) {
         guard let mgr = swordManager,
@@ -775,6 +865,52 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             pm.generalBookKey = nil
             onPersistState?()
         }
+    }
+
+    /**
+     Switches the visible document to a general-book module in one Android-parity transition.
+
+     Android's commentary quick popup includes general books and routes selected rows through the
+     same current-document switch as other documents. iOS should not split this into separate module
+     and category updates because that can persist partial pane state or reload stale content.
+
+     - Parameter moduleName: Installed SWORD general-book module abbreviation to make current.
+     Side effects:
+     - mutates the active general-book module, clears the selected general-book key, and sets the
+       current category to general book
+     - writes `generalBookDocument`, `generalBookKey`, and `currentCategoryName` to `PageManager`
+     - invokes `onPersistState` once when pane state is available
+     - reloads the visible reader document once when the JavaScript client is ready
+     Failure modes:
+     - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     - if the resolved module is not a general book, logs a warning and leaves state unchanged
+     */
+    @MainActor
+    public func switchGeneralBookDocument(to moduleName: String) {
+        guard let mgr = swordManager,
+              let mod = mgr.module(named: moduleName) else {
+            logger.warning("Cannot switch to general book document \(moduleName) — not found")
+            return
+        }
+        guard mod.info.category == .generalBook else {
+            logger.warning("Cannot switch to general book document \(moduleName) — category \(mod.info.category.rawValue)")
+            return
+        }
+        activeGeneralBookModule = mod
+        activeGeneralBookModuleName = moduleName
+        currentGeneralBookKey = nil
+        currentCategory = .generalBook
+        logger.info("Switched to general book document: \(moduleName)")
+
+        if let pm = activeWindow?.pageManager {
+            pm.generalBookDocument = moduleName
+            pm.generalBookKey = nil
+            pm.currentCategoryName = DocumentCategory.generalBook.pageManagerKey
+            onPersistState?()
+        }
+
+        guard clientReady else { return }
+        loadCurrentContent()
     }
 
     /// Switch the active map module.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -301,18 +301,13 @@ struct BibleReaderModulePicker: View {
 
         switch selectedDocumentCategory {
         case .commentary:
-            controller.switchCommentaryModule(to: module.name)
-            if controller.currentCategory != .commentary {
-                controller.switchCategory(to: .commentary)
-            }
+            controller.switchCommentaryDocument(to: module.name)
             onDismiss()
         case .dictionary:
-            controller.switchDictionaryModule(to: module.name)
-            controller.switchCategory(to: .dictionary)
+            controller.switchDictionaryDocument(to: module.name)
             dismissAndPresentAuxiliaryBrowser(onOpenDictionaryBrowser)
         case .generalBook:
-            controller.switchGeneralBookModule(to: module.name)
-            controller.switchCategory(to: .generalBook)
+            controller.switchGeneralBookDocument(to: module.name)
             dismissAndPresentAuxiliaryBrowser(onOpenGeneralBookBrowser)
         case .map:
             controller.switchMapModule(to: module.name)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderQuickModuleSelector.swift
@@ -58,8 +58,8 @@ struct BibleReaderQuickModuleSelectorPresentation {
         /// No menu action is available because there are no candidate modules.
         case none
 
-        /// Android's two-document shortcut: switch directly to the other module.
-        case switchDirectly(String)
+        /// Android's two-document shortcut: switch directly to the other module row.
+        case switchDirectly(Row)
 
         /// Android's popup path: show the sorted compact rows in an anchored menu.
         case showPopup([Row])
@@ -113,7 +113,7 @@ struct BibleReaderQuickModuleSelectorPresentation {
             guard let directRow = rows.first(where: { $0.module.name != activeModuleName }) ?? rows.first else {
                 return .none
             }
-            return .switchDirectly(directRow.module.name)
+            return .switchDirectly(directRow)
         }
         return .showPopup(rows)
     }
@@ -157,6 +157,12 @@ struct BibleReaderQuickModuleSelector: View {
      */
     let maximumHeight: CGFloat
 
+    /// Accessibility identifier applied to the popup container.
+    let accessibilityIdentifier: String
+
+    /// Accessibility identifier prefix applied to each popup row before the module abbreviation.
+    let rowAccessibilityIdentifierPrefix: String
+
     /**
      Selection callback for enabled rows.
 
@@ -172,6 +178,8 @@ struct BibleReaderQuickModuleSelector: View {
        - rows: Sorted Android-parity rows to render.
        - colorScheme: Current app color scheme used for the popup surface.
        - maximumHeight: Visible viewport for the popup; long lists scroll within this height.
+       - accessibilityIdentifier: Stable identifier for the popup container.
+       - rowAccessibilityIdentifierPrefix: Stable identifier prefix for row controls.
        - onSelect: Callback invoked only for enabled module rows.
      - Side effects: none at initialization; row taps later invoke `onSelect`.
      - Failure modes: none; empty rows produce a zero-height popup body.
@@ -180,11 +188,15 @@ struct BibleReaderQuickModuleSelector: View {
         rows: [BibleReaderQuickModuleSelectorPresentation.Row],
         colorScheme: ColorScheme,
         maximumHeight: CGFloat = .infinity,
+        accessibilityIdentifier: String = "readerBibleQuickSelector",
+        rowAccessibilityIdentifierPrefix: String = "readerBibleQuickSelectorRow",
         onSelect: @escaping (ModuleInfo) -> Void
     ) {
         self.rows = rows
         self.colorScheme = colorScheme
         self.maximumHeight = maximumHeight
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.rowAccessibilityIdentifierPrefix = rowAccessibilityIdentifierPrefix
         self.onSelect = onSelect
     }
 
@@ -208,7 +220,7 @@ struct BibleReaderQuickModuleSelector: View {
         }
         .frame(height: popupHeight)
         .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("readerBibleQuickSelector")
+        .accessibilityIdentifier(accessibilityIdentifier)
         .background(menuBackground)
     }
 
@@ -242,7 +254,7 @@ struct BibleReaderQuickModuleSelector: View {
         .buttonStyle(.plain)
         .disabled(!row.isEnabled)
         .opacity(row.isEnabled ? 1 : 0.48)
-        .accessibilityIdentifier("readerBibleQuickSelectorRow_\(row.module.name)")
+        .accessibilityIdentifier("\(rowAccessibilityIdentifierPrefix)_\(row.module.name)")
         .accessibilityValue(row.isEnabled ? "available" : "current")
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderToolbarActions.swift
@@ -25,6 +25,31 @@ struct ReaderBibleToolbarButtonBoundsPreferenceKey: PreferenceKey {
     }
 }
 
+/**
+ Captures the commentary toolbar trigger bounds so Android-style popups can anchor to the button.
+
+ The reader view consumes this preference when presenting the commentary/document quick selector.
+ It mirrors `ReaderBibleToolbarButtonBoundsPreferenceKey` so Bible and commentary quick menus share
+ the same toolbar anchoring contract without routing commentary through the overflow/menu sheet.
+ */
+struct ReaderCommentaryToolbarButtonBoundsPreferenceKey: PreferenceKey {
+    /// No toolbar button anchor is known until the commentary toolbar icon publishes one.
+    static var defaultValue: Anchor<CGRect>?
+
+    /**
+     Stores the newest non-nil toolbar anchor emitted by SwiftUI preference propagation.
+
+     - Parameters:
+       - value: Previously captured anchor, if any.
+       - nextValue: Deferred provider for the next anchor candidate.
+     - Side effects: Mutates `value` with the latest available anchor.
+     - Failure modes: none; nil candidates leave the previous anchor intact.
+     */
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = nextValue() ?? value
+    }
+}
+
 /// Width-collapsible accessory buttons that compete for toolbar space ahead of workspaces.
 enum BibleReaderToolbarAccessoryButton {
     case search
@@ -211,6 +236,7 @@ struct BibleReaderToolbarActions<OverflowButton: View>: View {
             ) {
                 commentaryToolbarIcon
             }
+            .anchorPreference(key: ReaderCommentaryToolbarButtonBoundsPreferenceKey.self, value: .bounds) { $0 }
 
             if showWorkspace {
                 Button(action: onShowWorkspaces) {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -226,6 +226,15 @@ public struct BibleReaderView: View {
     /// Window that owns the active Bible quick selector, kept separate from modal routing state.
     @State private var bibleQuickModuleSelectorTargetWindowId: UUID?
 
+    /// Presents Android's compact commentary/document quick selector anchored to the toolbar button.
+    @State private var showCommentaryQuickModuleSelector = false
+
+    /// Rows resolved by Android's commentary quick-selector contract for the active popup instance.
+    @State private var commentaryQuickModuleSelectorRows: [BibleReaderQuickModuleSelectorPresentation.Row] = []
+
+    /// Window that owns the active commentary quick selector, kept separate from modal routing state.
+    @State private var commentaryQuickModuleSelectorTargetWindowId: UUID?
+
     /// Presents the Android-style left navigation drawer from the reader header.
     @State private var showReaderNavigationDrawer = false
 
@@ -618,6 +627,49 @@ public struct BibleReaderView: View {
     public init() {}
 
     /**
+     Builds the reader content plus always-on reader overlays.
+
+     Keeping this chain out of `body` gives Swift smaller expressions to type-check while
+     preserving the same runtime view hierarchy.
+     */
+    private var readerScreenWithReaderOverlays: some View {
+        readerScreenContent
+            .animation(.easeInOut(duration: 0.2), value: isFullScreen)
+            .overlay(alignment: .bottom) {
+                bibleReferenceOverlay
+            }
+            .overlay(alignment: .bottom) {
+                toastOverlay
+            }
+            .overlay(alignment: .topLeading) {
+                readerRenderedContentStateExport
+            }
+            .overlay {
+                if showReaderNavigationDrawer {
+                    readerNavigationDrawerOverlay
+                }
+                if showBookChooser {
+                    bookChooserDrawerOverlay
+                }
+            }
+            .overlayPreferenceValue(ReaderOverflowButtonBoundsPreferenceKey.self) { anchor in
+                if showReaderOverflowMenu {
+                    readerOverflowMenuOverlay(anchor: anchor)
+                }
+            }
+            .overlayPreferenceValue(ReaderBibleToolbarButtonBoundsPreferenceKey.self) { anchor in
+                if showBibleQuickModuleSelector {
+                    bibleQuickModuleSelectorOverlay(anchor: anchor)
+                }
+            }
+            .overlayPreferenceValue(ReaderCommentaryToolbarButtonBoundsPreferenceKey.self) { anchor in
+                if showCommentaryQuickModuleSelector {
+                    commentaryQuickModuleSelectorOverlay(anchor: anchor)
+                }
+            }
+    }
+
+    /**
      Builds the full reading-screen hierarchy.
 
      The body composes the document header, split pane layout, sheet presenters, keyboard
@@ -625,40 +677,13 @@ public struct BibleReaderView: View {
      `WindowManager` state.
      */
     public var body: some View {
-        readerScreenContent
-        .animation(.easeInOut(duration: 0.2), value: isFullScreen)
-        .overlay(alignment: .bottom) {
-            bibleReferenceOverlay
-        }
-        .overlay(alignment: .bottom) {
-            toastOverlay
-        }
-        .overlay(alignment: .topLeading) {
-            readerRenderedContentStateExport
-        }
-        .overlay {
-            if showReaderNavigationDrawer {
-                readerNavigationDrawerOverlay
-            }
-            if showBookChooser {
-                bookChooserDrawerOverlay
-            }
-        }
-        .overlayPreferenceValue(ReaderOverflowButtonBoundsPreferenceKey.self) { anchor in
-            if showReaderOverflowMenu {
-                readerOverflowMenuOverlay(anchor: anchor)
-            }
-        }
-        .overlayPreferenceValue(ReaderBibleToolbarButtonBoundsPreferenceKey.self) { anchor in
-            if showBibleQuickModuleSelector {
-                bibleQuickModuleSelectorOverlay(anchor: anchor)
-            }
-        }
+        readerScreenWithReaderOverlays
         .animation(.easeInOut(duration: 0.25), value: toastMessage)
         .animation(.easeInOut(duration: 0.2), value: showReaderNavigationDrawer)
         .animation(.easeInOut(duration: 0.2), value: showBookChooser)
         .animation(.easeInOut(duration: 0.16), value: showReaderOverflowMenu)
         .animation(.easeInOut(duration: 0.16), value: showBibleQuickModuleSelector)
+        .animation(.easeInOut(duration: 0.16), value: showCommentaryQuickModuleSelector)
         .background {
             readerSceneMetricsBackground
         }
@@ -673,6 +698,7 @@ public struct BibleReaderView: View {
         }
         .onChange(of: windowManager.activeWindow?.id) { _, _ in
             dismissBibleQuickSelector()
+            dismissCommentaryQuickSelector()
             syncActiveDisplaySettings()
         }
         #if os(iOS)
@@ -1512,6 +1538,7 @@ public struct BibleReaderView: View {
         bibleQuickModuleSelectorRows = rows
         showReaderOverflowMenu = false
         showReaderNavigationDrawer = false
+        dismissCommentaryQuickSelector()
         showBibleQuickModuleSelector = true
     }
 
@@ -1574,6 +1601,123 @@ public struct BibleReaderView: View {
         dismissBibleQuickSelector()
         guard let controller else { return }
         controller.switchBibleDocument(to: module.name)
+    }
+
+    /**
+     Presents Android's commentary/document quick selector for the focused pane.
+
+     - Parameters:
+       - controller: Pane controller whose installed commentary-adjacent module list backs the popup.
+       - rows: Android-parity rows resolved by the pure quick-selector presentation contract.
+     - Side effects: Captures the active pane, closes competing reader popups, and shows the anchored
+       quick selector overlay.
+     - Failure modes: If the active pane cannot be identified, the popup still uses the focused
+       controller fallback through `panePresentationController`.
+     */
+    private func presentCommentaryQuickSelector(
+        _ controller: BibleReaderController,
+        rows: [BibleReaderQuickModuleSelectorPresentation.Row]
+    ) {
+        let targetWindowId = windowManager.controllers.first { _, registeredController in
+            (registeredController as? BibleReaderController) === controller
+        }?.key
+        let resolvedTargetWindowId = targetWindowId ?? windowManager.activeWindow?.id
+        setPanePresentationTarget(resolvedTargetWindowId)
+        commentaryQuickModuleSelectorTargetWindowId = resolvedTargetWindowId
+        commentaryQuickModuleSelectorRows = rows
+        showReaderOverflowMenu = false
+        showReaderNavigationDrawer = false
+        dismissBibleQuickSelector()
+        showCommentaryQuickModuleSelector = true
+    }
+
+    /// Dismisses the commentary quick selector without changing the captured pane target.
+    private func dismissCommentaryQuickSelector() {
+        showCommentaryQuickModuleSelector = false
+        commentaryQuickModuleSelectorRows = []
+        commentaryQuickModuleSelectorTargetWindowId = nil
+    }
+
+    /**
+     Resolves the current commentary-adjacent document name for quick-menu row disabling.
+
+     Android disables whichever document is currently visible in the popup candidate list. The
+     commentary toolbar popup can include commentaries, dictionaries, and general books, so the
+     disabled row follows the pane's active document category instead of always using commentary.
+
+     - Parameter controller: Pane controller that owns the quick selector, if still available.
+     - Returns: Active module abbreviation for commentary, dictionary, or general-book categories;
+       otherwise `nil` so rows remain selectable from Bible and other modes.
+     - Side effects: none.
+     - Failure modes: none; missing controllers are treated as having no current document.
+     */
+    private func currentCommentaryQuickSelectorModuleName(for controller: BibleReaderController?) -> String? {
+        guard let controller else { return nil }
+        switch controller.currentCategory {
+        case .commentary:
+            return controller.activeCommentaryModuleName
+        case .dictionary:
+            return controller.activeDictionaryModuleName
+        case .generalBook:
+            return controller.activeGeneralBookModuleName
+        default:
+            return nil
+        }
+    }
+
+    /**
+     Builds Android's commentary toolbar quick-selector candidate set.
+
+     Android default commentary taps call `menuForDocs` with unlocked commentaries plus general books
+     plus dictionaries. In `swap-menu`, commentary long press calls `menuForDocs` with commentaries
+     only. This helper preserves that distinction and leaves sorting/labeling to the shared
+     presentation contract.
+
+     - Parameters:
+       - controller: Pane controller that owns installed module lists.
+       - includeAuxiliaryDocuments: Whether to include general books and dictionaries.
+     - Returns: Candidate modules in the same category mix Android hands to `menuForDocs`.
+     - Side effects: none.
+     - Failure modes: none; empty installed lists return an empty candidate list.
+     */
+    private func commentaryQuickSelectorModules(
+        _ controller: BibleReaderController,
+        includeAuxiliaryDocuments: Bool
+    ) -> [ModuleInfo] {
+        var modules = controller.installedCommentaryModules.filter(\.isUnlocked)
+        guard includeAuxiliaryDocuments else {
+            return modules
+        }
+        modules += controller.installedGeneralBookModules
+        modules += controller.installedDictionaryModules
+        return modules
+    }
+
+    /**
+     Applies a commentary/document quick-selector choice to the captured pane.
+
+     - Parameters:
+       - module: Installed module selected from the Android-parity quick selector.
+       - targetWindowId: Captured window whose controller owns the popup selection.
+     - Side effects: Dismisses the popup and switches the pane through the category-specific
+       current-document path.
+     - Failure modes: If the controller is no longer available, or the selected module category is
+       not part of Android's commentary quick popup, the selection is ignored after dismissal.
+     */
+    private func selectCommentaryQuickModule(_ module: ModuleInfo, targetWindowId: UUID?) {
+        let controller = controller(for: targetWindowId)
+        dismissCommentaryQuickSelector()
+        guard let controller else { return }
+        switch module.category {
+        case .commentary:
+            controller.switchCommentaryDocument(to: module.name)
+        case .dictionary:
+            controller.switchDictionaryDocument(to: module.name)
+        case .generalBook:
+            controller.switchGeneralBookDocument(to: module.name)
+        default:
+            return
+        }
     }
 
     // MARK: - Modal Routing
@@ -2443,6 +2587,57 @@ public struct BibleReaderView: View {
         }
     }
 
+    /// Full-screen dismiss area plus anchored commentary quick selector mirroring Android's popup.
+    private func commentaryQuickModuleSelectorOverlay(anchor: Anchor<CGRect>?) -> some View {
+        GeometryReader { proxy in
+            let buttonRect = anchor.map { proxy[$0] }
+            let targetWindowId = commentaryQuickModuleSelectorTargetWindowId
+            let rows = commentaryQuickModuleSelectorRows
+            let width = ReaderToolbarPopupPlacement.boundedWidth(
+                containerWidth: proxy.size.width,
+                safeAreaInsets: proxy.safeAreaInsets,
+                preferredWidth: max(proxy.size.width * 0.42, 156),
+                maximumWidth: 232
+            )
+            let placement = ReaderToolbarPopupPlacement.trailingToolbarPopup(
+                containerSize: proxy.size,
+                safeAreaInsets: proxy.safeAreaInsets,
+                triggerRect: buttonRect,
+                popupWidth: width
+            )
+
+            ZStack(alignment: .topLeading) {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { dismissCommentaryQuickSelector() }
+                    .accessibilityIdentifier("readerCommentaryQuickSelectorDismissArea")
+
+                if !rows.isEmpty {
+                    BibleReaderQuickModuleSelector(
+                        rows: rows,
+                        colorScheme: colorScheme,
+                        maximumHeight: placement.maximumHeight,
+                        accessibilityIdentifier: "readerCommentaryQuickSelector",
+                        rowAccessibilityIdentifierPrefix: "readerCommentaryQuickSelectorRow",
+                        onSelect: { module in
+                            selectCommentaryQuickModule(module, targetWindowId: targetWindowId)
+                        }
+                    )
+                    .frame(width: width, alignment: .topLeading)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(Color.black.opacity(colorScheme == .dark ? 0.45 : 0.12), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.32 : 0.18), radius: 14, y: 6)
+                    .offset(x: placement.offset.width, y: placement.offset.height)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topTrailing)))
+                }
+            }
+        }
+    }
+
     /// Full-screen dimmer plus left drawer panel mirroring Android's main navigation drawer.
     private var readerNavigationDrawerOverlay: some View {
         ReaderSideDrawerOverlay(
@@ -3148,7 +3343,7 @@ public struct BibleReaderView: View {
     private func handleCommentaryToolbarLongPress(_ controller: BibleReaderController?) {
         switch toolbarActionsMode {
         case .swapMenu:
-            performCommentaryMenuAction(controller)
+            performCommentaryMenuAction(controller, includeAuxiliaryDocuments: false)
         case .defaultMode, .swapActivity:
             performCommentaryChooserAction()
         }
@@ -3171,8 +3366,8 @@ public struct BibleReaderView: View {
         ) {
         case .none:
             return
-        case .switchDirectly(let nextName):
-            controller.switchBibleDocument(to: nextName)
+        case .switchDirectly(let row):
+            controller.switchBibleDocument(to: row.module.name)
         case .showPopup(let rows):
             presentBibleQuickSelector(controller, rows: rows)
         }
@@ -3210,27 +3405,38 @@ public struct BibleReaderView: View {
     /**
      Handles the Android `menuForDocs` commentary action.
 
-     When exactly two commentary modules are installed, this mirrors Android's auto-cycle
-     shortcut. Otherwise it opens the commentary picker sheet.
+     When exactly two documents are available, this mirrors Android's auto-cycle shortcut. Every
+     other non-empty module list shows the compact anchored popup instead of the full document
+     picker sheet.
 
-     - Parameter controller: Focused pane controller, if one is currently registered.
+     - Parameters:
+       - controller: Focused pane controller, if one is currently registered.
+       - includeAuxiliaryDocuments: Whether to include Android's default general-book and dictionary
+         candidates in addition to commentaries.
      */
-    private func performCommentaryMenuAction(_ controller: BibleReaderController?) {
-        guard let controller else {
-            performCommentaryChooserAction()
+    private func performCommentaryMenuAction(
+        _ controller: BibleReaderController?,
+        includeAuxiliaryDocuments: Bool = true
+    ) {
+        guard let controller else { return }
+        let modules = commentaryQuickSelectorModules(
+            controller,
+            includeAuxiliaryDocuments: includeAuxiliaryDocuments
+        )
+        switch BibleReaderQuickModuleSelectorPresentation.action(
+            for: modules,
+            activeModuleName: currentCommentaryQuickSelectorModuleName(for: controller)
+        ) {
+        case .none:
             return
+        case .switchDirectly(let row):
+            let targetWindowId = windowManager.controllers.first { _, registeredController in
+                (registeredController as? BibleReaderController) === controller
+            }?.key ?? windowManager.activeWindow?.id
+            selectCommentaryQuickModule(row.module, targetWindowId: targetWindowId)
+        case .showPopup(let rows):
+            presentCommentaryQuickSelector(controller, rows: rows)
         }
-        if controller.installedCommentaryModules.count == 2 {
-            cycleToNextModule(
-                modules: controller.installedCommentaryModules,
-                activeName: controller.activeCommentaryModuleName
-            ) { nextName in
-                controller.switchCommentaryModule(to: nextName)
-                controller.switchCategory(to: .commentary)
-            }
-            return
-        }
-        performCommentaryChooserAction()
     }
 
     /**
@@ -3250,10 +3456,10 @@ public struct BibleReaderView: View {
     private func performCommentaryNextDocumentAction(_ controller: BibleReaderController?) {
         guard let controller else { return }
         if controller.currentCategory != .commentary {
-            if controller.activeCommentaryModuleName == nil {
-                performCommentaryChooserAction()
+            if let moduleName = controller.activeCommentaryModuleName {
+                controller.switchCommentaryDocument(to: moduleName)
             } else {
-                controller.switchCategory(to: .commentary)
+                performCommentaryChooserAction()
             }
             return
         }
@@ -3261,8 +3467,7 @@ public struct BibleReaderView: View {
             modules: controller.installedCommentaryModules,
             activeName: controller.activeCommentaryModuleName
         ) { nextName in
-            controller.switchCommentaryModule(to: nextName)
-            controller.switchCategory(to: .commentary)
+            controller.switchCommentaryDocument(to: nextName)
         }
     }
 


### PR DESCRIPTION
## Summary

Aligns the iOS commentary toolbar quick selector with Android by replacing the full Choose Document sheet path with a compact anchored popup.

## Scope

- Reuses the shared Android-style quick selector for commentary/document toolbar actions.
- Anchors the commentary popup to the commentary toolbar button.
- Builds Android-parity quick candidates from unlocked commentaries plus general books and dictionaries for the default tap path.
- Keeps swap-menu long press commentary-only and keeps full chooser flows where Android uses ChooseDocument.
- Adds atomic commentary, dictionary, and general-book document switching so module/category persistence is not split.
- Adds focused tests for candidate categories, selector routing, persistence, and sheet avoidance.

## Contract References

- Android: MainBibleActivity.commentaryClick/commentaryLongPress/menuForDocs.
- Android: DocumentControl.commentariesForVerse actual quick-list source.
- iOS: BibleReaderView toolbar routing and BibleReaderQuickModuleSelectorPresentation.

## Change Details

- Commentary quick selection now uses the same row sorting, labeling, disabled-current-row, exact-two shortcut, and scrollable popup primitive as the Bible quick selector.
- Dictionary and general-book quick selections update the active module, document category, pane state, and visible reader content through a single controller method.
- Bible quick-selector direct actions now carry the selected row so shared selection can preserve document category metadata.

## Validation Evidence

- git diff --check
- python3 scripts/check_repo_standards.py docblocks
- python3 scripts/check_repo_standards.py docblocks --all-files
- python3 scripts/check_repo_standards.py commits
- Focused #209 xcodebuild tests passed on iPhone 17 simulator.
- Adjacent quick-selector xcodebuild tests passed on iPhone 17 simulator.
- Full AndBibleTests target passed: 504 tests, 0 failures.
- GitNexus detect_changes run on staged diff; reader controller/view impact is critical as expected for this flow.

## Risks / Follow-ups

- Risk is concentrated in reader toolbar/module switching and pane persistence. The PR includes focused tests and full unit coverage for those flows.
- No known follow-up is required for #209.

Closes #209

## Screenshots

| Old | New | 
| --- | --- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-19 at 15 19 19" src="https://github.com/user-attachments/assets/a9b7bc19-7818-4d40-bad4-898cfbc1c70a" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-21 at 08 31 34" src="https://github.com/user-attachments/assets/0d4a7db9-4b8c-40af-a51b-d0b286836ee8" /> |