### PR TITLE
fix(downloads): align document downloads with Android

### DIFF
--- a/AndBible/af.lproj/Localizable.strings
+++ b/AndBible/af.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Fout met aflaai";
+"install_zip" = "Laai dokumente van uit lêers";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ar.lproj/Localizable.strings
+++ b/AndBible/ar.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "أخطاء التنزيل";
+"install_zip" = "حمّل المستندات من الملفات";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/az.lproj/Localizable.strings
+++ b/AndBible/az.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Download errors";
+"install_zip" = "Sənədi ZIP arxivdən yüklə";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/bg.lproj/Localizable.strings
+++ b/AndBible/bg.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Грешки при изтегляне";
+"install_zip" = "Зареди документ от ZIP архив";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/bn.lproj/Localizable.strings
+++ b/AndBible/bn.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "ডাউনলোড ত্রুটি";
+"install_zip" = "ফাইল থেকে নথি লোড করুন";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/cs.lproj/Localizable.strings
+++ b/AndBible/cs.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Chyby stahování";
+"install_zip" = "Načíst dokumenty ze souborů";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/de.lproj/Localizable.strings
+++ b/AndBible/de.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Downloadfehler";
+"install_zip" = "Lade Dokumente aus Dateien";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/el.lproj/Localizable.strings
+++ b/AndBible/el.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Σφάλματα λήψης";
+"install_zip" = "Φόρτωση Εγγράφων από αρχεία";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "refresh_catalog" = "Refresh Catalog";
 "repositories" = "Repositories";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Download errors";
+"install_zip" = "Load Documents From Files";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";
@@ -316,6 +319,9 @@
    Repository Manager
    ======================================== */
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";

--- a/AndBible/eo.lproj/Localizable.strings
+++ b/AndBible/eo.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Eraroj dum elŝuti";
+"install_zip" = "Enlegi dokumentojn el dosieroj";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/es.lproj/Localizable.strings
+++ b/AndBible/es.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Descargar errores";
+"install_zip" = "Cargar Documentos Desde Archivos";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/et.lproj/Localizable.strings
+++ b/AndBible/et.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Allalaadimise vead";
+"install_zip" = "Lae dokumente failidest";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/fi.lproj/Localizable.strings
+++ b/AndBible/fi.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Virheet latauksessa";
+"install_zip" = "Lataa dokumentteja tiedostoista";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/fr.lproj/Localizable.strings
+++ b/AndBible/fr.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Erreurs de téléchargement";
+"install_zip" = "Charger des documents depuis des fichiers";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/he.lproj/Localizable.strings
+++ b/AndBible/he.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "שגיאות הורדה";
+"install_zip" = "טעינת מסמכים מתוך קבצים";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/hi.lproj/Localizable.strings
+++ b/AndBible/hi.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "डाउनलोड त्रुटियाँ";
+"install_zip" = "फ़ाइलों से दस्तावेज़ लोड करें";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/hr.lproj/Localizable.strings
+++ b/AndBible/hr.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Pogreške preuzimanja";
+"install_zip" = "Učitaj dokumente iz Datoteka";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/hu.lproj/Localizable.strings
+++ b/AndBible/hu.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Hiba a letöltés közben";
+"install_zip" = "Dokumentumok betöltése fájlokból";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/id.lproj/Localizable.strings
+++ b/AndBible/id.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Kesalahan unduhan";
+"install_zip" = "Buka Dokumen dari Zip";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/it.lproj/Localizable.strings
+++ b/AndBible/it.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Errori di scaricamento";
+"install_zip" = "Carica Documenti Dai File";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/kk.lproj/Localizable.strings
+++ b/AndBible/kk.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Жүктеу қателері";
+"install_zip" = "Құжаттарды файлдардан жүктеңіз";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ko.lproj/Localizable.strings
+++ b/AndBible/ko.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "다운로드 에러";
+"install_zip" = "파일에서 문서 불러오기";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/lt.lproj/Localizable.strings
+++ b/AndBible/lt.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Atsiuntimo klaidos";
+"install_zip" = "Įkelti dokumentus iš failų";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ml.lproj/Localizable.strings
+++ b/AndBible/ml.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Download errors";
+"install_zip" = "സിപ്പ് ഫയലില്‍ നിന്നും ഡോക്യമെന്റ് ലോഡ് ചെയ്യുക";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/my.lproj/Localizable.strings
+++ b/AndBible/my.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "ဒေါင်းလုပ် မှားယွင်းချက်များ";
+"install_zip" = "Load Documents From Files";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/nb.lproj/Localizable.strings
+++ b/AndBible/nb.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Nedlastingsfeil";
+"install_zip" = "Last inn dokumenter fra filer";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/nl.lproj/Localizable.strings
+++ b/AndBible/nl.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Downloadfouten";
+"install_zip" = "Document laden uit bestanden.";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/pl.lproj/Localizable.strings
+++ b/AndBible/pl.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Błędy pobierania";
+"install_zip" = "Wczytaj dokument z pliku";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/pt-BR.lproj/Localizable.strings
+++ b/AndBible/pt-BR.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Erros ao baixar";
+"install_zip" = "Carregar documento dos arquivos";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/pt.lproj/Localizable.strings
+++ b/AndBible/pt.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Erros no download";
+"install_zip" = "Carregar Documentos a partir de Arquivos";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ro.lproj/Localizable.strings
+++ b/AndBible/ro.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Eroare la descărcare";
+"install_zip" = "Folosește documente din fișiere";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ru.lproj/Localizable.strings
+++ b/AndBible/ru.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Ошибки при загрузке";
+"install_zip" = "Загрузка ресурсов из файлов";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/sk.lproj/Localizable.strings
+++ b/AndBible/sk.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Chyby sťahovania";
+"install_zip" = "Načítať dokumenty zo súborov";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/sl.lproj/Localizable.strings
+++ b/AndBible/sl.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Napake pri prenosu";
+"install_zip" = "Naloži dokumente iz datotek";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/sr-Latn.lproj/Localizable.strings
+++ b/AndBible/sr-Latn.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Greške preuzimanja";
+"install_zip" = "Učitaj dokumenta iz Menadžera fajlova";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/sr.lproj/Localizable.strings
+++ b/AndBible/sr.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Грешке преузимања";
+"install_zip" = "Учитај документа из Менаџера фајлова";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/sv.lproj/Localizable.strings
+++ b/AndBible/sv.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Nerladdningsfel";
+"install_zip" = "Läs in dokument från filer";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/ta.lproj/Localizable.strings
+++ b/AndBible/ta.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "பதிவிறக்க பிழைகள்";
+"install_zip" = "கோப்புகளிலிருந்து ஆவணங்களை ஏற்றவும்";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/te.lproj/Localizable.strings
+++ b/AndBible/te.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "లోపాలను డౌన్‌లోడ్ చేయి";
+"install_zip" = "ఫైల్‌ల నుండి పత్రాలను లోడ్ చేయండి";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/tr.lproj/Localizable.strings
+++ b/AndBible/tr.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "İndirme hataları";
+"install_zip" = "Dosyalardan Belge Yükle";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/uk.lproj/Localizable.strings
+++ b/AndBible/uk.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Помилки завантаження";
+"install_zip" = "Завантажувати ресурси з файлів";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/uz.lproj/Localizable.strings
+++ b/AndBible/uz.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "Download errors";
+"install_zip" = "ZIP o\'qish";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/yue.lproj/Localizable.strings
+++ b/AndBible/yue.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "下載錯誤";
+"install_zip" = "從檔案載入文件";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/zh-Hans.lproj/Localizable.strings
+++ b/AndBible/zh-Hans.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "下载错误";
+"install_zip" = "从文件载入文档";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBible/zh-Hant.lproj/Localizable.strings
+++ b/AndBible/zh-Hant.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 "installed_font_%@" = "Installed font: %@";
 "install_do_you_want" = "Do you want to install %@?";
 "no_sources_configured" = "No repository sources configured.";
+"module_unavailable_for_installation %@" = "%@ is not available for installation.";
+"module_source_not_found %@" = "Source not found for %@";
+"uninstall_failed %@" = "Uninstall failed: %@";
 "remote_sources" = "Remote Sources";
 "sources_count_%lld_%lld" = "%lld sources configured, %lld enabled";
 "reset_sources_title" = "Reset Sources?";
@@ -410,6 +413,9 @@
 /* Phase H: Module Browser */
 "category_books" = "Books";
 "all_languages_count %lld" = "All Languages (%lld)";
+"documents_count %lld" = "%lld documents";
+"download_errors" = "下載錯誤";
+"install_zip" = "從檔案載入文件";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -545,17 +545,16 @@ extension AndBibleTests {
         XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderOverflowMenu"))
     }
 
-    func testBibleReaderActiveSheetContentBuildsDownloadsSheet() {
-        let view = BibleReaderActiveSheetContent(
-            sheet: .downloads,
-            controller: nil,
-            readingProgressInitialTab: .reading,
-            chapterReadHistoryTarget: nil,
-            downloadsInitialSearchText: "",
-            onDismiss: {}
-        )
+    /**
+     Verifies Downloads is modeled as a reader destination rather than a top-level sheet.
 
-        XCTAssertTrue(String(describing: type(of: view)).contains("BibleReaderActiveSheetContent"))
+     Android opens `Download Documents` as an activity-style route with its own back app bar. The iOS
+     reader should therefore expose Downloads through destination routing, leaving `ReaderSheet` for
+     genuinely modal reader surfaces.
+     */
+    func testBibleReaderDownloadsUsesReaderDestinationRoute() {
+        XCTAssertEqual(BibleReaderView.ReaderDestination.downloads.rawValue, "downloads")
+        XCTAssertEqual(BibleReaderView.ReaderDestination.downloads.id, "downloads")
     }
 
     func testBibleReaderKeyboardShortcutsBuildCommandSurface() {
@@ -895,7 +894,14 @@ extension AndBibleTests {
         }
     }
 
-    func testCatalogModuleConvertsSwordInstallSizeKilobytes() {
+    /**
+     Verifies iOS preserves Android's `InstallSize` units when rendering Downloads sizes.
+
+     Android reads SWORD `KEY_INSTALL_SIZE` directly as bytes and formats that value as megabytes.
+     iOS must not multiply it by 1024, because that inflates catalog sizes by three orders of
+     magnitude and makes the Downloads browser disagree with Android for the same repository row.
+     */
+    func testCatalogModulePreservesAndroidInstallSizeBytes() {
         let module = CatalogModule(
             name: "KJV",
             description: "King James Version",
@@ -906,10 +912,10 @@ extension AndBibleTests {
             confContent: "",
             sourceName: "CrossWire",
             version: "1.0",
-            size: "1260"
+            size: "1260000"
         )
 
-        XCTAssertEqual(module.remoteModuleInfo.installSizeBytes, 1_290_240)
+        XCTAssertEqual(module.remoteModuleInfo.installSizeBytes, 1_260_000)
         XCTAssertEqual(ModuleBrowserView.installSizeText(for: module.remoteModuleInfo.installSizeBytes), "1.3 MB")
     }
 

--- a/AndBibleTests/AndBibleTests+Downloads.swift
+++ b/AndBibleTests/AndBibleTests+Downloads.swift
@@ -187,6 +187,273 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Verifies normal Downloads opens with Android's default document-type filter.
+
+     Android persists the selected document filter and uses index 0 (`All types`) for a fresh
+     Downloads browser. iOS previously defaulted to Bibles, hiding commentaries, dictionaries, books,
+     and maps until the user changed filters.
+     */
+    func testModuleBrowserInitialCategoryDefaultsToAndroidAllTypes() {
+        XCTAssertNil(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "",
+                defaultDownloadMode: .disabled
+            )
+        )
+        XCTAssertNil(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "KJV",
+                defaultDownloadMode: .disabled
+            )
+        )
+        XCTAssertNil(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "",
+                defaultDownloadMode: .englishStartup
+            )
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "",
+                defaultDownloadMode: .disabled,
+                storedFilterIndex: 2
+            ),
+            .commentary
+        )
+        XCTAssertNil(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "KJV",
+                defaultDownloadMode: .disabled,
+                storedFilterIndex: 2
+            )
+        )
+        XCTAssertNil(
+            ModuleBrowserView.initialSelectedCategory(
+                initialSearchText: "",
+                defaultDownloadMode: .englishStartup,
+                storedFilterIndex: 2
+            )
+        )
+        XCTAssertEqual(ModuleBrowserView.androidFilterIndex(for: .commentary), 2)
+        XCTAssertEqual(ModuleBrowserView.category(forAndroidFilterIndex: 6), .addon)
+        XCTAssertNil(ModuleBrowserView.category(forAndroidFilterIndex: 99))
+    }
+
+    /**
+     Verifies Downloads default language selection follows Android's priority order.
+
+     Android `DocumentSelectionBase.defaultLanguage` first reuses a valid sticky language, then the
+     device language when that language has Bible rows, then an installed Bible language, then English
+     or the first available language. iOS should not preserve its own all-language default when Android
+     would select a concrete language.
+     */
+    func testModuleBrowserDefaultLanguageMatchesAndroidPriority() {
+        let englishBible = RemoteModuleInfo(
+            name: "KJV",
+            description: "King James Version",
+            category: .bible,
+            language: "en",
+            sourceName: "CrossWire"
+        )
+        let frenchBible = RemoteModuleInfo(
+            name: "LSG",
+            description: "Louis Segond",
+            category: .bible,
+            language: "fr",
+            sourceName: "CrossWire"
+        )
+        let germanCommentary = RemoteModuleInfo(
+            name: "GERCOM",
+            description: "German Commentary",
+            category: .commentary,
+            language: "de",
+            sourceName: "CrossWire"
+        )
+
+        XCTAssertEqual(
+            ModuleBrowserView.defaultLanguageCode(
+                availableModules: [englishBible, frenchBible],
+                installedModules: [],
+                availableLanguages: ["en", "fr"],
+                localeLanguageCode: "en",
+                stickyLanguageCode: "fr"
+            ),
+            "fr"
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.defaultLanguageCode(
+                availableModules: [englishBible, frenchBible],
+                installedModules: [],
+                availableLanguages: ["en", "fr"],
+                localeLanguageCode: "fr",
+                stickyLanguageCode: nil
+            ),
+            "fr"
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.defaultLanguageCode(
+                availableModules: [germanCommentary],
+                installedModules: [
+                    ModuleInfo(
+                        name: "GER",
+                        description: "German Bible",
+                        category: .bible,
+                        language: "de"
+                    )
+                ],
+                availableLanguages: ["de", "fr"],
+                localeLanguageCode: "fr",
+                stickyLanguageCode: nil
+            ),
+            "de"
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.defaultLanguageCode(
+                availableModules: [germanCommentary],
+                installedModules: [],
+                availableLanguages: ["de", "en"],
+                localeLanguageCode: "fr",
+                stickyLanguageCode: nil
+            ),
+            "en"
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.defaultLanguageCode(
+                availableModules: [germanCommentary],
+                installedModules: [],
+                availableLanguages: ["de"],
+                localeLanguageCode: "fr",
+                stickyLanguageCode: nil
+            ),
+            "de"
+        )
+    }
+
+    /**
+     Verifies Android sticky-language state only records explicit user language choices.
+
+     Android stores `DocumentSelectionBase.lastSelectedLanguage` from the language item-click handler.
+     Its default-language routine updates the spinner text but does not make the computed default
+     sticky. iOS must preserve that distinction so a device/default language does not override future
+     default-language resolution as if the user had selected it.
+     */
+    func testModuleBrowserStickyLanguageRecordsOnlyExplicitSelection() {
+        ModuleBrowserView.resetExplicitSelectedLanguageForTesting()
+        defer { ModuleBrowserView.resetExplicitSelectedLanguageForTesting() }
+
+        _ = ModuleBrowserView.defaultLanguageCode(
+            availableModules: [
+                RemoteModuleInfo(
+                    name: "GER",
+                    description: "German Bible",
+                    category: .bible,
+                    language: "de",
+                    sourceName: "CrossWire"
+                )
+            ],
+            installedModules: [],
+            availableLanguages: ["de"],
+            localeLanguageCode: "de",
+            stickyLanguageCode: ModuleBrowserView.explicitSelectedLanguageForTesting()
+        )
+
+        XCTAssertNil(ModuleBrowserView.explicitSelectedLanguageForTesting())
+
+        ModuleBrowserView.rememberExplicitSelectedLanguage("")
+        XCTAssertNil(ModuleBrowserView.explicitSelectedLanguageForTesting())
+
+        ModuleBrowserView.rememberExplicitSelectedLanguage("fr")
+        XCTAssertEqual(ModuleBrowserView.explicitSelectedLanguageForTesting(), "fr")
+    }
+
+    /**
+     Verifies iOS picker cancellation is ignored like Android's Install ZIP cancel path.
+
+     Android returns from the Install ZIP activity without showing a download error when the user
+     backs out. SwiftUI reports the same user action as a file-importer failure, so iOS must classify
+     the Cocoa cancellation code separately from real importer failures.
+     */
+    func testModuleBrowserInstallZipCancellationMatchesAndroidNoErrorBehavior() {
+        XCTAssertTrue(
+            ModuleBrowserView.isFileImporterCancellation(
+                NSError(domain: NSCocoaErrorDomain, code: CocoaError.userCancelled.rawValue)
+            )
+        )
+        XCTAssertFalse(
+            ModuleBrowserView.isFileImporterCancellation(
+                NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileNoSuchFile.rawValue)
+            )
+        )
+        XCTAssertFalse(
+            ModuleBrowserView.isFileImporterCancellation(
+                NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+            )
+        )
+    }
+
+    /**
+     Verifies refresh errors do not erase prior install/import errors.
+
+     Android tracks document install errors and metadata/repository errors independently. The
+     Downloads overflow should keep earlier install failures visible after a later catalog refresh
+     while still de-duplicating repeated repository errors.
+     */
+    func testModuleBrowserDownloadErrorsMergeRefreshFailures() {
+        XCTAssertEqual(
+            ModuleBrowserView.mergedDownloadErrors(
+                existing: [" Install failed ", "Metadata failed"],
+                refreshErrors: ["Repo failed", "", "Install failed", " Repo failed "]
+            ),
+            ["Install failed", "Metadata failed", "Repo failed"]
+        )
+    }
+
+    /**
+     Verifies install failures reuse the localized download-failure prefix.
+
+     Android surfaces install failures through the same Download errors affordance as repository
+     failures. iOS should keep that shared error contract and avoid introducing hard-coded English
+     prefixes inside the overflow dialog.
+     */
+    func testModuleBrowserDownloadFailureMessageUsesLocalizedPrefix() {
+        let prefix = String(localized: "error_download_failed", defaultValue: "Download failed")
+
+        XCTAssertEqual(
+            ModuleBrowserView.downloadFailureMessage("Network unavailable"),
+            "\(prefix): Network unavailable"
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.downloadFailureMessage(moduleName: "KJV", message: "Network unavailable"),
+            "\(prefix): KJV: Network unavailable"
+        )
+    }
+
+    /**
+     Verifies Downloads failure fallbacks use stable localization keys.
+
+     Android routes repository, install, and uninstall failures through user-visible Downloads
+     surfaces. iOS should keep the same behavior without hard-coded English fallback messages.
+     */
+    func testModuleBrowserFailureFallbackMessagesUseLocalization() {
+        XCTAssertEqual(
+            ModuleBrowserView.noRepositorySourcesConfiguredMessage(),
+            String(localized: "no_sources_configured", defaultValue: "No repository sources configured.")
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.moduleUnavailableForInstallationMessage(moduleName: "KJV"),
+            String(localized: "module_unavailable_for_installation \("KJV")")
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.moduleSourceNotFoundMessage(moduleName: "KJV"),
+            String(localized: "module_source_not_found \("KJV")")
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.uninstallFailureMessage("Disk locked"),
+            String(localized: "uninstall_failed \("Disk locked")")
+        )
+    }
+
     func testModuleRepositoryRefreshesMyBibleCatalogFromManifest() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -1344,6 +1611,180 @@ extension AndBibleTests {
             try Data(contentsOf: localDir.appendingPathComponent("custom.idx")),
             Data("index-data".utf8)
         )
+    }
+
+    /**
+     Verifies explicit package-directory metadata is normalized before building package ZIP URLs.
+
+     Android gives JSword a repository package directory, not an arbitrary URL fragment. iOS should
+     preserve that one authoritative directory while making relative legacy/manifest values safe for
+     the `https://host/path/module.zip` request shape.
+     */
+    func testModuleRepositoryNormalizesRelativeCustomPackageDirectoryForPackageFallback() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let source = SourceConfig(
+            name: "Custom Repo",
+            type: "HTTP",
+            host: "custom.example",
+            catalogPath: "/catalog",
+            packageDirectory: "android/packages"
+        )
+        let catalogData = try makeModuleRepositoryCatalogArchive(moduleName: "CUSTOM")
+        let zipData = makeModuleRepositoryZip([
+            ("mods.d/custom.conf", Data("placeholder".utf8)),
+            ("modules/lexdict/rawld/custom/custom.dat", Data("dictionary-data".utf8)),
+            ("modules/lexdict/rawld/custom/custom.idx", Data("index-data".utf8))
+        ])
+        var requestedURLs: [String] = []
+
+        ModuleRepositoryDownloadMockURLProtocol.requestHandler = { request in
+            requestedURLs.append(request.url?.absoluteString ?? "")
+            let response: HTTPURLResponse
+            let data: Data
+            switch request.url?.path {
+            case "/catalog/mods.d.tar.gz":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = catalogData
+            case "/catalog/modules/lexdict/rawld/custom/custom.dat":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            case "/android/packages/CUSTOM.zip":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = zipData
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            }
+            return (response, data)
+        }
+        defer { ModuleRepositoryDownloadMockURLProtocol.requestHandler = nil }
+
+        let repository = ModuleRepository(
+            basePath: tempDir.path,
+            swordPath: swordDir.path,
+            session: makeModuleRepositoryDownloadMockSession()
+        )
+
+        _ = try await repository.refreshCatalog(for: source)
+        try await repository.installModule(named: "CUSTOM", from: source)
+
+        XCTAssertTrue(requestedURLs.contains("https://custom.example/android/packages/CUSTOM.zip"))
+        XCTAssertFalse(
+            requestedURLs.contains("https://custom.exampleandroid/packages/CUSTOM.zip"),
+            "Relative package metadata must not be appended directly to the host."
+        )
+    }
+
+    /**
+     Verifies explicit Android package directories are authoritative for package fallback.
+
+     Android gives the installer one package directory per repository. When that explicit directory
+     does not contain a ZIP, iOS should surface the install failure instead of probing catalog-relative
+     guesses that Android would never use.
+     */
+    func testModuleRepositoryDoesNotGuessPackageDirectoriesWhenAndroidPackageDirectoryIsExplicit() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let source = SourceConfig(
+            name: "Custom Repo",
+            type: "HTTP",
+            host: "custom.example",
+            catalogPath: "/catalog",
+            packageDirectory: "/android/packages"
+        )
+        let catalogData = try makeModuleRepositoryCatalogArchive(moduleName: "CUSTOM")
+        var requestedPaths: [String] = []
+
+        ModuleRepositoryDownloadMockURLProtocol.requestHandler = { request in
+            requestedPaths.append(request.url?.path ?? "")
+            let response: HTTPURLResponse
+            let data: Data
+            switch request.url?.path {
+            case "/catalog/mods.d.tar.gz":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = catalogData
+            case "/catalog/modules/lexdict/rawld/custom/custom.dat":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            case "/android/packages/CUSTOM.zip":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            default:
+                XCTFail("Unexpected package-directory guess: \(request.url?.absoluteString ?? "<nil>")")
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            }
+            return (response, data)
+        }
+        defer { ModuleRepositoryDownloadMockURLProtocol.requestHandler = nil }
+
+        let repository = ModuleRepository(
+            basePath: tempDir.path,
+            swordPath: swordDir.path,
+            session: makeModuleRepositoryDownloadMockSession()
+        )
+
+        _ = try await repository.refreshCatalog(for: source)
+        do {
+            try await repository.installModule(named: "CUSTOM", from: source)
+            XCTFail("Expected the install to fail after Android's explicit package directory returned 404.")
+        } catch {
+            XCTAssertTrue(requestedPaths.contains("/android/packages/CUSTOM.zip"))
+        }
+
+        XCTAssertFalse(requestedPaths.contains("/catalog/packages/CUSTOM.zip"))
+        XCTAssertFalse(requestedPaths.contains("/catalog/zip/CUSTOM.zip"))
+        XCTAssertFalse(requestedPaths.contains("/catalog/packages/rawzip/CUSTOM.zip"))
     }
 
     func testModuleRepositoryCancellationStopsBeforeInstalledMarker() async throws {

--- a/AndBibleTests/AndBibleTests+WorkspaceAndRepository.swift
+++ b/AndBibleTests/AndBibleTests+WorkspaceAndRepository.swift
@@ -698,6 +698,118 @@ extension AndBibleTests {
         XCTAssertTrue(manager.loadSources().contains { $0.name == "Example Repo" })
     }
 
+    /**
+     Verifies SWORD package directories are normalized before persistence and reload.
+
+     Android package directories are repository paths. iOS accepts Android-style manifests and direct
+     sidecar reloads, so relative manifest values must become root-relative paths before Downloads
+     later builds package ZIP URLs from the host/path tuple.
+     */
+    func testRepositorySourceManagerNormalizesRelativeSwordManifestPackageDirectory() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manifestData = """
+        {
+          "name": "Relative Repo",
+          "description": "Relative package catalog",
+          "type": "sword-https",
+          "host": "example.org",
+          "catalogDirectory": "/sword",
+          "packageDirectory": "sword/packages",
+          "manifestUrl": "https://example.org/sword/manifest.json"
+        }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://example.org/sword/manifest.json")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, manifestData)
+        }
+
+        let manager = RepositorySourceManager(
+            basePath: tempDir.path,
+            session: makeMockedURLSession()
+        )
+
+        let registration = try await manager.addCustomSource(from: "https://example.org/sword/manifest.json")
+
+        XCTAssertEqual(registration.packageDirectory, "/sword/packages")
+        let source = try XCTUnwrap(manager.loadSources().first { $0.name == "Relative Repo" })
+        XCTAssertEqual(source.packageDirectory, "/sword/packages")
+
+        let sidecarData = try Data(contentsOf: tempDir.appendingPathComponent("CustomRepositories.json"))
+        let sidecarJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: sidecarData) as? [String: Any]
+        )
+        let repositories = try XCTUnwrap(sidecarJSON["repositories"] as? [[String: Any]])
+        let record = try XCTUnwrap(repositories.first { ($0["name"] as? String) == "Relative Repo" })
+        XCTAssertEqual(record["packageDirectory"] as? String, "/sword/packages")
+    }
+
+    /**
+     Verifies empty SWORD package directories fall back to the Android default package path.
+
+     A manifest can include a blank package directory. Android/JSword behavior treats missing package
+     metadata as a catalog-relative packages path, so iOS must normalize blank values to that fallback
+     instead of persisting an empty package URL component.
+     */
+    func testRepositorySourceManagerFallsBackForBlankSwordManifestPackageDirectory() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manifestData = """
+        {
+          "name": "Blank Package Repo",
+          "description": "Blank package catalog",
+          "type": "sword-https",
+          "host": "example.org",
+          "catalogDirectory": "/sword",
+          "packageDirectory": "   ",
+          "manifestUrl": "https://example.org/sword/manifest.json"
+        }
+        """.data(using: .utf8)!
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://example.org/sword/manifest.json")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, manifestData)
+        }
+
+        let manager = RepositorySourceManager(
+            basePath: tempDir.path,
+            session: makeMockedURLSession()
+        )
+
+        let registration = try await manager.addCustomSource(from: "https://example.org/sword/manifest.json")
+
+        XCTAssertEqual(registration.packageDirectory, "/sword/packages")
+        let source = try XCTUnwrap(manager.loadSources().first { $0.name == "Blank Package Repo" })
+        XCTAssertEqual(source.packageDirectory, "/sword/packages")
+
+        let sidecarData = try Data(contentsOf: tempDir.appendingPathComponent("CustomRepositories.json"))
+        let sidecarJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: sidecarData) as? [String: Any]
+        )
+        let repositories = try XCTUnwrap(sidecarJSON["repositories"] as? [[String: Any]])
+        let record = try XCTUnwrap(repositories.first { ($0["name"] as? String) == "Blank Package Repo" })
+        XCTAssertEqual(record["packageDirectory"] as? String, "/sword/packages")
+    }
+
     func testRepositorySourceManagerIgnoresNonHTTPSSwordManifestURLMetadata() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -810,6 +922,93 @@ extension AndBibleTests {
         XCTAssertEqual(source.manifestURL?.absoluteString, "https://legacy.example/catalog")
         XCTAssertEqual(source.packageDirectory, "/catalog/packages")
         XCTAssertEqual(try Data(contentsOf: sidecarURL), unreadableSidecar)
+    }
+
+    /**
+     Verifies sidecar package directories are normalized when merged onto SWORD config rows.
+
+     Older sidecars can contain Android package-directory values before iOS normalized them at write
+     time. Loading must normalize the merged `SourceConfig` so Downloads package fallback receives
+     the same root-relative repository path Android passes to JSword.
+     */
+    func testRepositorySourceManagerNormalizesSidecarPackageDirectoryWhenMergingConfigSource() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        InstallManager.ensureDefaultConfigPublic(at: tempDir.path)
+        let configURL = tempDir.appendingPathComponent("InstallMgr.conf")
+        var config = try String(contentsOf: configURL, encoding: .utf8)
+        config += "\nHTTPSource=Sidecar Repo|sidecar.example|/catalog\n"
+        try config.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let sidecar = """
+        {
+          "version": 1,
+          "repositories": [
+            {
+              "name": "Sidecar Repo",
+              "description": "Sidecar catalog",
+              "type": "sword-https",
+              "host": "sidecar.example",
+              "catalogDirectory": "/catalog",
+              "packageDirectory": " packages ",
+              "manifestURL": "https://sidecar.example/catalog",
+              "sourceURL": "https://sidecar.example/catalog"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        try sidecar.write(to: tempDir.appendingPathComponent("CustomRepositories.json"))
+
+        let manager = RepositorySourceManager(basePath: tempDir.path)
+        let source = try XCTUnwrap(manager.loadSources().first { $0.name == "Sidecar Repo" })
+
+        XCTAssertEqual(source.packageDirectory, "/packages")
+    }
+
+    /**
+     Verifies whitespace-only package metadata is treated as absent when loading old sidecars.
+
+     A whitespace string is not an Android package directory. Keeping it as non-nil empty metadata
+     can hide the direct-catalog fallback path, so the source model should expose `nil` instead.
+     */
+    func testRepositorySourceManagerTreatsWhitespaceSidecarPackageDirectoryAsMissing() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        InstallManager.ensureDefaultConfigPublic(at: tempDir.path)
+        let configURL = tempDir.appendingPathComponent("InstallMgr.conf")
+        var config = try String(contentsOf: configURL, encoding: .utf8)
+        config += "\nHTTPSource=Whitespace Repo|whitespace.example|/catalog\n"
+        try config.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let sidecar = """
+        {
+          "version": 1,
+          "repositories": [
+            {
+              "name": "Whitespace Repo",
+              "description": "Whitespace catalog",
+              "type": "sword-https",
+              "host": "whitespace.example",
+              "catalogDirectory": "/catalog",
+              "packageDirectory": "   ",
+              "manifestURL": "https://whitespace.example/catalog",
+              "sourceURL": "https://whitespace.example/catalog"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        try sidecar.write(to: tempDir.appendingPathComponent("CustomRepositories.json"))
+
+        let manager = RepositorySourceManager(basePath: tempDir.path)
+        let source = try XCTUnwrap(manager.loadSources().first { $0.name == "Whitespace Repo" })
+
+        XCTAssertNil(source.packageDirectory)
     }
 
     func testRepositorySourceManagerAddsMyBibleManifestSource() async throws {
@@ -1562,6 +1761,33 @@ extension AndBibleTests {
         let remaining = manager.loadSources()
         XCTAssertTrue(remaining.contains { $0.name == "AndBible" })
         XCTAssertFalse(remaining.contains { $0.name == "Example Repo" })
+    }
+
+    /**
+     Verifies built-in Downloads sources retain Android's package and catalog directories separately.
+
+     Android's `repositories.txt` defines both directories for every SWORD repository. iOS uses a
+     SWORD-compatible config file as local plumbing, but the source model consumed by Downloads and
+     installs must still expose the Android package directory instead of reconstructing it later.
+     */
+    func testRepositorySourceManagerLoadsAndroidDefaultPackageDirectories() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let manager = RepositorySourceManager(basePath: tempDir.path)
+        let sources = manager.loadSources()
+
+        let crossWire = try XCTUnwrap(sources.first { $0.name == "CrossWire" })
+        XCTAssertEqual(crossWire.host, "crosswire.org")
+        XCTAssertEqual(crossWire.catalogPath, "/ftpmirror/pub/sword/raw")
+        XCTAssertEqual(crossWire.packageDirectory, "/ftpmirror/pub/sword/packages/rawzip")
+
+        let step = try XCTUnwrap(sources.first { $0.name == "STEP Bible (Tyndale)" })
+        XCTAssertEqual(step.host, "public.modules.stepbible.org")
+        XCTAssertEqual(step.catalogPath, "/catalog")
+        XCTAssertEqual(step.packageDirectory, "/packages")
     }
 
     func testRepositorySourceManagerResetToDefaultsRemovesCustomSourcesAndRestoresDefaults() throws {

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -778,7 +778,7 @@ extension AndBibleUITests {
         openReaderActionDestination(
             actionIdentifier: "readerOpenDownloadsAction",
             destinationIdentifier: "moduleBrowserScreen",
-            readinessIdentifiers: ["moduleBrowserRepositoriesButton"],
+            readinessIdentifiers: ["moduleBrowserOverflowButton", "moduleBrowserSearchField"],
             in: app
         )
     }

--- a/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
+++ b/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
@@ -92,7 +92,7 @@ extension AndBibleUITests {
      *
      * - Side effects:
      *   - launches directly into Downloads
-     *   - opens the repository manager from the real downloads toolbar button
+     *   - opens the repository manager from Android's Downloads overflow menu
      *   - opens the add-source sheet and cancels it
      * - Failure modes:
      *   - fails if the downloads browser or repository manager never appears
@@ -104,6 +104,10 @@ extension AndBibleUITests {
         app.launch()
 
         XCTAssertTrue(openDownloads(in: app).exists)
+        tapElementReliably(
+            requireElement("moduleBrowserOverflowButton", in: app, timeout: 10),
+            timeout: 15
+        )
         tapElementReliably(
             requireElement("moduleBrowserRepositoriesButton", in: app, timeout: 10),
             timeout: 15

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
@@ -13,15 +13,6 @@ struct BibleReaderActiveSheetContent: View {
     let readingProgressInitialTab: ReadingProgressTab
     let chapterReadHistoryTarget: ChapterReadHistoryTarget?
 
-    /// Initial Downloads search text supplied by Android-compatible `download://` links.
-    let downloadsInitialSearchText: String
-
-    /// Startup/default-document mode supplied when the reader opens Downloads for Easy Start.
-    let downloadsDefaultDownloadMode: ModuleBrowserDefaultDownloadMode
-
-    /// Callback reporting startup default refresh/install activity from Downloads.
-    let onDefaultDownloadActivityChanged: (Bool) -> Void
-
     let onDismiss: () -> Void
 
     /**
@@ -32,10 +23,6 @@ struct BibleReaderActiveSheetContent: View {
        - controller: Focused reader controller backing sheet navigation actions.
        - readingProgressInitialTab: Initial reading-progress tab for progress routes.
        - chapterReadHistoryTarget: Optional chapter read-history target.
-       - downloadsInitialSearchText: Initial Downloads filter from Android-compatible links.
-       - downloadsDefaultDownloadMode: Optional startup/default-document mode for Easy Start.
-       - onDefaultDownloadActivityChanged: Callback invoked when Easy Start Downloads starts or
-         finishes refresh/install activity.
        - onDismiss: Callback used to close the active sheet.
 
      Side effects:
@@ -49,18 +36,12 @@ struct BibleReaderActiveSheetContent: View {
         controller: BibleReaderController?,
         readingProgressInitialTab: ReadingProgressTab,
         chapterReadHistoryTarget: ChapterReadHistoryTarget?,
-        downloadsInitialSearchText: String,
-        downloadsDefaultDownloadMode: ModuleBrowserDefaultDownloadMode = .disabled,
-        onDefaultDownloadActivityChanged: @escaping (Bool) -> Void = { _ in },
         onDismiss: @escaping () -> Void
     ) {
         self.sheet = sheet
         self.controller = controller
         self.readingProgressInitialTab = readingProgressInitialTab
         self.chapterReadHistoryTarget = chapterReadHistoryTarget
-        self.downloadsInitialSearchText = downloadsInitialSearchText
-        self.downloadsDefaultDownloadMode = downloadsDefaultDownloadMode
-        self.onDefaultDownloadActivityChanged = onDefaultDownloadActivityChanged
         self.onDismiss = onDismiss
     }
 
@@ -80,19 +61,6 @@ struct BibleReaderActiveSheetContent: View {
                         controller?.bookmarkListVerseReference(book: book, ordinal: ordinal)
                     }
                 )
-            }
-        case .downloads:
-            NavigationStack {
-                ModuleBrowserView(
-                    initialSearchText: downloadsInitialSearchText,
-                    defaultDownloadMode: downloadsDefaultDownloadMode,
-                    onDefaultDownloadActivityChanged: onDefaultDownloadActivityChanged
-                )
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button(String(localized: "done"), action: onDismiss)
-                        }
-                    }
             }
         case .history:
             NavigationStack {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -92,7 +92,6 @@ public struct BibleReaderView: View {
     /// Top-level sheets launched from the reader shell or its global shortcuts.
     enum ReaderSheet: String, Identifiable {
         case bookmarks
-        case downloads
         case history
         case readingPlans
         case readingProgress
@@ -107,6 +106,7 @@ public struct BibleReaderView: View {
     /// Reader-stack destinations opened from global reader actions.
     enum ReaderDestination: String, Identifiable, Hashable {
         case settings
+        case downloads
         case globalTextOptions
         case workspaceTextOptions = "textOptions"
         case windowTextOptions
@@ -980,11 +980,6 @@ public struct BibleReaderView: View {
             controller: panePresentationController,
             readingProgressInitialTab: readingProgressInitialTab,
             chapterReadHistoryTarget: chapterReadHistoryTarget,
-            downloadsInitialSearchText: downloadsInitialSearchText,
-            downloadsDefaultDownloadMode: downloadsDefaultDownloadMode,
-            onDefaultDownloadActivityChanged: { isInFlight in
-                handleStartupDefaultDownloadActivityChanged(isInFlight: isInFlight)
-            },
             onDismiss: dismissReaderSheet
         )
     }
@@ -1007,6 +1002,17 @@ public struct BibleReaderView: View {
             // pushed, so re-emit the compact reader-state export here. This keeps reader routing
             // tokens (for example `readerSheet=none;readerDestination=settings`) observable by UI
             // tests on the pushed destination without exposing reader internals to SettingsView.
+            .overlay(alignment: .topLeading) {
+                readerRenderedContentStateExport
+            }
+        case .downloads:
+            ModuleBrowserView(
+                initialSearchText: downloadsInitialSearchText,
+                defaultDownloadMode: downloadsDefaultDownloadMode,
+                onDefaultDownloadActivityChanged: { isInFlight in
+                    handleStartupDefaultDownloadActivityChanged(isInFlight: isInFlight)
+                }
+            )
             .overlay(alignment: .topLeading) {
                 readerRenderedContentStateExport
             }
@@ -1237,7 +1243,7 @@ public struct BibleReaderView: View {
         showSearch = false
     }
 
-    // MARK: - Sheet Routing
+    // MARK: - Sheet and Destination Routing
 
     /// Presents a top-level reader sheet and captures the pane target that should back it.
     private func presentReaderSheet(_ sheet: ReaderSheet, from windowId: UUID? = nil) {
@@ -1310,11 +1316,11 @@ public struct BibleReaderView: View {
     }
 
     /**
-     Presents Downloads and seeds its free-text search from an Android `download://` target.
+     Opens Downloads and seeds its free-text search from an Android `download://` target.
 
      - Parameters:
-       - windowId: Pane whose controller should own the sheet context. When `nil`, the focused pane
-         is used.
+       - windowId: Pane whose controller should own the destination context. When `nil`, the focused
+         pane is used.
        - initialSearchText: Optional module initials from the link query. Empty and whitespace-only
          values are normalized away so normal Downloads entry points remain unfiltered.
        - defaultDownloadMode: Optional startup/default-document mode for Android Easy Start.
@@ -1323,7 +1329,7 @@ public struct BibleReaderView: View {
      - captures the pane presentation target
      - updates `downloadsInitialSearchText`
      - updates `downloadsDefaultDownloadMode`
-     - presents the `.downloads` reader sheet
+     - pushes the `.downloads` reader destination
 
      Failure modes:
      - invalid search text is normalized to an empty string and opens the standard Downloads view
@@ -1335,7 +1341,7 @@ public struct BibleReaderView: View {
     ) {
         downloadsInitialSearchText = normalizedDownloadsSearchText(initialSearchText)
         downloadsDefaultDownloadMode = defaultDownloadMode
-        presentReaderSheet(.downloads, from: windowId)
+        presentReaderDestination(.downloads, from: windowId)
     }
 
     /**
@@ -1359,10 +1365,6 @@ public struct BibleReaderView: View {
 
     /// Closes the currently active top-level reader sheet.
     private func dismissReaderSheet() {
-        if activeReaderSheet == .downloads {
-            downloadsInitialSearchText = ""
-            downloadsDefaultDownloadMode = .disabled
-        }
         activeReaderSheet = nil
         chapterReadHistoryTarget = nil
     }
@@ -1375,10 +1377,8 @@ public struct BibleReaderView: View {
        - currentSheet: Sheet now visible after SwiftUI reported the change.
 
      Side effects:
-     - clears Downloads launch state after Downloads closes
-     - refreshes installed-module caches for each reader controller
-     - reopens the startup prompt when Downloads closes without an installed Bible unless Easy Start
-       downloads are still refreshing or installing
+     - currently no non-download sheet has extra close side effects; Downloads is handled as a
+       reader destination for Android parity
 
      Failure modes:
      - non-closing sheet transitions are ignored
@@ -1391,44 +1391,66 @@ public struct BibleReaderView: View {
             return
         }
 
-        switch previousSheet {
-        case .downloads:
-            downloadsInitialSearchText = ""
-            downloadsDefaultDownloadMode = .disabled
-            let shouldWaitForStartupDefaultDownloads = startupDefaultDownloadsInFlight
-            for (_, ctrl) in windowManager.controllers {
-                (ctrl as? BibleReaderController)?.refreshInstalledModules()
-            }
-            guard !shouldWaitForStartupDefaultDownloads else {
-                return
-            }
-            reevaluateStartupDownloadPromptAfterDownloads()
-        default:
-            break
-        }
+        _ = previousSheet
     }
 
     /**
      Handles side effects that belong to a reader-stack destination closing.
 
-     Settings is now a navigation destination instead of a sheet. Reloading behavior preferences on
-     pop keeps the same refresh boundary as the former modal route without coupling the behavior to
-     sheet state.
+     Settings and Downloads are navigation destinations instead of sheets. Reloading behavior
+     preferences on Settings pop preserves the former modal refresh boundary; Downloads pop refreshes
+     module caches and reopens Android's first-download prompt only if the user still has no Bibles.
 
      - Parameters:
        - previousDestination: Destination that was visible before SwiftUI reported the change.
        - currentDestination: Destination now visible after SwiftUI reported the change.
-     - Side Effects: Reloads reader behavior preferences after Settings closes.
+     - Side Effects: Reloads reader behavior preferences after Settings closes and refreshes module
+       state after Downloads closes.
      - Failure: Non-closing destination transitions are ignored.
      */
     private func handleActiveReaderDestinationChange(
         from previousDestination: ReaderDestination?,
         to currentDestination: ReaderDestination?
     ) {
-        guard currentDestination == nil, previousDestination == .settings else {
+        guard currentDestination == nil, let previousDestination else {
             return
         }
-        reloadBehaviorPreferences()
+        switch previousDestination {
+        case .settings:
+            reloadBehaviorPreferences()
+        case .downloads:
+            handleDownloadsDestinationClosed()
+        case .globalTextOptions, .workspaceTextOptions, .windowTextOptions:
+            break
+        }
+    }
+
+    /**
+     Applies Android's after-download behavior after the Downloads destination closes.
+
+     Android `afterDownload()` refreshes document state and returns to the first-download prompt when
+     the user exits Downloads without installing a Bible. iOS mirrors that on destination pop instead
+     of sheet dismissal because Downloads is a reader-stack route.
+
+     Side effects:
+     - clears one-shot Downloads launch state
+     - refreshes installed-module snapshots in every open reader controller
+     - may re-show the startup no-Bible prompt when no Bible was installed
+
+     Failure modes:
+     - module-refresh failures remain isolated inside each controller's refresh path
+     */
+    private func handleDownloadsDestinationClosed() {
+        downloadsInitialSearchText = ""
+        downloadsDefaultDownloadMode = .disabled
+        let shouldWaitForStartupDefaultDownloads = startupDefaultDownloadsInFlight
+        for (_, ctrl) in windowManager.controllers {
+            (ctrl as? BibleReaderController)?.refreshInstalledModules()
+        }
+        guard !shouldWaitForStartupDefaultDownloads else {
+            return
+        }
+        reevaluateStartupDownloadPromptAfterDownloads()
     }
 
     /**
@@ -1459,8 +1481,13 @@ public struct BibleReaderView: View {
         activeReaderSheet = sheet
     }
 
+    /// Presents a follow-up reader destination after another flow already captured the pane target.
+    private func presentReaderDestinationPreservingPane(_ destination: ReaderDestination) {
+        activeReaderDestination = destination
+    }
+
     /**
-     Presents Downloads after a pane-scoped flow has already captured the owning pane.
+     Opens Downloads after a pane-scoped flow has already captured the owning pane.
 
      - Parameters:
        - initialSearchText: Optional module initials from an Android-compatible link.
@@ -1477,7 +1504,7 @@ public struct BibleReaderView: View {
     ) {
         downloadsInitialSearchText = normalizedDownloadsSearchText(initialSearchText)
         downloadsDefaultDownloadMode = defaultDownloadMode
-        presentReaderSheetPreservingPane(.downloads)
+        presentReaderDestinationPreservingPane(.downloads)
     }
 
     /**
@@ -1945,6 +1972,7 @@ public struct BibleReaderView: View {
     private func evaluateStartupDownloadPromptIfNeeded() {
         guard !didEvaluateStartupDownloadPrompt,
               activeReaderSheet == nil,
+              activeReaderDestination == nil,
               activeReaderModal == nil else {
             return
         }
@@ -1991,7 +2019,7 @@ public struct BibleReaderView: View {
      */
     private func handleStartupDefaultDownloadActivityChanged(isInFlight: Bool) {
         startupDefaultDownloadsInFlight = isInFlight
-        guard !isInFlight, activeReaderSheet == nil else {
+        guard !isInFlight, activeReaderSheet == nil, activeReaderDestination == nil else {
             return
         }
 

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import SwiftUI
+import UniformTypeIdentifiers
 import BibleCore
 import SwordKit
 
@@ -172,6 +173,48 @@ public enum ModuleBrowserDefaultDownloadMode: Sendable, Equatable {
 }
 
 /**
+ Fixed Android Downloads surface colors.
+
+ Android renders the document download browser with a dark app-bar/list surface independent of the
+ reader's day/night theme. iOS keeps those colors local to Downloads so app theming still controls
+ the reader while this route matches Android's document-management UI.
+
+ Side effects:
+ - none; values are static color constants
+
+ Failure modes:
+ - none
+ */
+private enum ModuleBrowserPalette {
+    /// Full-screen Downloads background.
+    static let background = Color(red: 0.18, green: 0.18, blue: 0.18)
+
+    /// Android top app bar background.
+    static let appBar = Color.black
+
+    /// Android overflow menu popup surface.
+    static let menuSurface = Color(red: 0.20, green: 0.20, blue: 0.20)
+
+    /// Row divider and filter underline color.
+    static let divider = Color.white.opacity(0.16)
+
+    /// Primary row/app-bar text color.
+    static let primaryText = Color.white
+
+    /// Secondary row/filter text color.
+    static let secondaryText = Color.white.opacity(0.72)
+
+    /// Muted metadata text color.
+    static let tertiaryText = Color.white.opacity(0.52)
+
+    /// Android install/update affordance color.
+    static let install = Color.orange
+
+    /// Android installed affordance color.
+    static let installed = Color(red: 0.15, green: 0.85, blue: 0.28)
+}
+
+/**
  Browses installed and remote SWORD modules, then coordinates install and uninstall actions.
 
  The view combines locally installed module metadata from `SwordManager` with cached or refreshed
@@ -199,6 +242,15 @@ public struct ModuleBrowserView: View {
     /// Android's repository list staleness window before Downloads refreshes catalogs on open.
     static let downloadCatalogStaleInterval: TimeInterval = 24 * 60 * 60
 
+    /// Persisted Android-style document type filter index.
+    private static let selectedDocumentFilterIndexKey = "downloads.selectedDocumentFilterIndex"
+
+    /// Android-style sticky Downloads language for the current app process.
+    private static var lastSelectedLanguageCode: String?
+
+    /// Dismisses the Android-style Downloads destination back to the reader stack.
+    @Environment(\.dismiss) private var dismiss
+
     /// Shared full-text search index service used for Android's Delete Index row action.
     @Environment(SearchIndexService.self) private var searchIndexService
 
@@ -209,7 +261,7 @@ public struct ModuleBrowserView: View {
     private let onDefaultDownloadActivityChanged: (Bool) -> Void
 
     /// Selected remote/local module category segment, or `nil` for Android's "All types" filter.
-    @State private var selectedCategory: ModuleCategory? = .bible
+    @State private var selectedCategory: ModuleCategory?
 
     /// Selected language filter, or an empty string when all languages should be shown.
     @State private var selectedLanguage: String = ""
@@ -262,8 +314,35 @@ public struct ModuleBrowserView: View {
     /// User-visible error text for refresh, install, or uninstall failures.
     @State private var errorMessage: String?
 
+    /// Android overflow-menu download errors accumulated from repositories, metadata, and installs.
+    @State private var downloadErrors: [String] = []
+
+    /// Whether the Android-equivalent Download errors alert is visible.
+    @State private var showDownloadErrors = false
+
+    /// Whether Android's top-right Downloads overflow popup is visible.
+    @State private var showOverflowMenu = false
+
     /// Module details currently presented from Android's row About action.
     @State private var selectedModuleDetails: ModuleBrowserModuleDetails?
+
+    /// Whether the custom repository manager is pushed from the Downloads overflow menu.
+    @State private var showRepositoryManager = false
+
+    /// Whether Android's Install ZIP file picker is visible.
+    @State private var showInstallZipImporter = false
+
+    /// Whether a selected ZIP/EPUB/font import is currently installing.
+    @State private var isImportingExternalDocument = false
+
+    /// Feedback from Android's Install ZIP equivalent.
+    @State private var externalDocumentImportMessage: String?
+
+    /// Current Dynamic Type size used to keep Android's compact filter row readable.
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    /// Ensures Android's startup/default language is applied once after catalog state exists.
+    @State private var didApplyAndroidDefaultLanguage = false
 
     /// Destructive row action waiting for Android-style confirmation.
     @State private var pendingRowActionConfirmation: ModuleBrowserRowActionConfirmation?
@@ -308,10 +387,13 @@ public struct ModuleBrowserView: View {
         self.defaultDownloadMode = defaultDownloadMode
         self.onDefaultDownloadActivityChanged = onDefaultDownloadActivityChanged
         let normalizedSearchText = initialSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedFilterIndex = Self.persistedDocumentFilterIndex()
         _selectedCategory = State(
-            initialValue: normalizedSearchText.isEmpty && !defaultDownloadMode.shouldInstallDefaultDocuments
-                ? .bible
-                : nil
+            initialValue: Self.initialSelectedCategory(
+                initialSearchText: normalizedSearchText,
+                defaultDownloadMode: defaultDownloadMode,
+                storedFilterIndex: storedFilterIndex
+            )
         )
         _searchText = State(initialValue: normalizedSearchText)
     }
@@ -380,129 +462,96 @@ public struct ModuleBrowserView: View {
      Builds the filtered Android-style download list and repository-management toolbar actions.
      */
     public var body: some View {
+        androidDownloadsScreen
+    }
+
+    /**
+     Builds Android's full-screen Downloads route.
+
+     iOS previously reused a modal `List` sheet. Android opens a full-screen activity with a dark
+     app bar, inline filters, and document rows. Keeping this as the root screen body avoids carrying
+     iOS sheet chrome into a route whose UX is platform-shared in AndBible.
+
+     - Returns: Full-screen Downloads content with app bar, filters, and rows.
+     - Side effects: Toolbar buttons can dismiss, show Android overflow actions, or push repository
+       management.
+     - Failure modes: Repository errors are rendered in the list and do not prevent the route from
+       opening.
+     */
+    private var androidDownloadsScreen: some View {
         let visibleModules = filteredAvailableModules
         let installedModulesByName = Self.installedModuleLookup(from: installedModules)
 
-        List {
-            // Category picker
-            Section {
-                Picker("Category", selection: $selectedCategory) {
-                    Text(String(localized: "doc_type_all", defaultValue: "All types"))
-                        .tag(Optional<ModuleCategory>.none)
-                    Text(String(localized: "bibles")).tag(Optional(ModuleCategory.bible))
-                    Text(String(localized: "commentaries")).tag(Optional(ModuleCategory.commentary))
-                    Text(String(localized: "dictionaries")).tag(Optional(ModuleCategory.dictionary))
-                    Text(String(localized: "category_books")).tag(Optional(ModuleCategory.generalBook))
-                    Text(String(localized: "maps", defaultValue: "Maps")).tag(Optional(ModuleCategory.map))
-                    if shouldShowAddonsFilter {
-                        Text(String(localized: "doc_type_addons", defaultValue: "Add-ons"))
-                            .tag(Optional(ModuleCategory.addon))
-                    }
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: selectedCategory) {
-                    // Reset language filter when category changes
-                    selectedLanguage = ""
-                }
+        return ZStack(alignment: .topTrailing) {
+            moduleBrowserScreenMarker
+            VStack(spacing: 0) {
+                androidTopAppBar
+                androidFilterBar(visibleModuleCount: visibleModules.count)
+                androidDownloadsContent(
+                    visibleModules: visibleModules,
+                    installedModulesByName: installedModulesByName
+                )
             }
-
-            // Language filter
-            if !availableLanguages.isEmpty {
-                Section {
-                    Picker("Language", selection: $selectedLanguage) {
-                        Text(String(localized: "all_languages_count \(availableLanguages.count)"))
-                            .tag("")
-                        ForEach(availableLanguages, id: \.self) { lang in
-                            Text(displayName(for: lang))
-                                .tag(lang)
-                        }
+            if showOverflowMenu {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .accessibilityHidden(true)
+                    .onTapGesture {
+                        showOverflowMenu = false
                     }
-                }
-            }
-
-            if let errorMessage {
-                Section {
-                    Text(errorMessage)
-                        .foregroundStyle(.red)
-                        .font(.caption)
-                }
-            }
-
-            if isLoadingInitialState || isRefreshing {
-                Section {
-                    VStack(spacing: 8) {
-                        ProgressView()
-                        if let refreshProgress {
-                            Text(refreshProgress)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else if isLoadingInitialState {
-                            Text(String(localized: "loading", defaultValue: "Loading..."))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else {
-                            Text(String(localized: "refreshing_catalog"))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                }
-            } else if visibleModules.isEmpty && !availableModules.isEmpty {
-                Section {
-                    Text(String(localized: "no_modules_match_filters"))
-                        .foregroundStyle(.secondary)
-                }
-            } else if !visibleModules.isEmpty {
-                Section(String(localized: "document_filter_results \(visibleModules.count)")) {
-                    ForEach(visibleModules) { module in
-                        remoteModuleRow(
-                            module,
-                            installedModulesByName: installedModulesByName
-                        )
-                    }
-                }
-            } else if availableModules.isEmpty && !isRefreshing && !isLoadingInitialState {
-                Section {
-                    VStack(spacing: 8) {
-                        Text(String(localized: "tap_refresh_to_load"))
-                            .foregroundStyle(.secondary)
-                        Button(String(localized: "refresh_catalog")) {
-                            refreshCatalog()
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical)
-                }
+                androidOverflowMenu
+                    .padding(.top, 56)
+                    .padding(.trailing, 8)
+                    .zIndex(1)
             }
         }
-        .accessibilityIdentifier("moduleBrowserScreen")
-        .searchable(text: $searchText, prompt: String(localized: "search_modules"))
+        .background(ModuleBrowserPalette.background.ignoresSafeArea())
         .onChange(of: searchText) {
             alignFiltersWithAndroidSearchState(searchText)
         }
-        .navigationTitle(String(localized: "downloads"))
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                HStack(spacing: 12) {
-                    NavigationLink {
-                        RepositoryManagerView()
-                    } label: {
-                        Image(systemName: "server.rack")
-                    }
-                    .accessibilityIdentifier("moduleBrowserRepositoriesButton")
-                    Button("Refresh", systemImage: "arrow.clockwise") {
-                        refreshCatalog()
-                    }
-                    .disabled(isRefreshing || isLoadingInitialState)
-                }
-            }
+        .navigationBarBackButtonHidden(true)
+        #if os(iOS)
+        .toolbar(.hidden, for: .navigationBar)
+        #endif
+        .navigationDestination(isPresented: $showRepositoryManager) {
+            RepositoryManagerView()
+            #if os(iOS)
+            .toolbar(.visible, for: .navigationBar)
+            #endif
         }
+        .fileImporter(
+            isPresented: $showInstallZipImporter,
+            allowedContentTypes: ExternalDocumentImportService.supportedContentTypes,
+            allowsMultipleSelection: false,
+            onCompletion: handleInstallZipSelection
+        )
         .sheet(item: $selectedModuleDetails) { details in
             NavigationStack {
                 ModuleBrowserModuleDetailsView(details: details)
             }
+        }
+        .alert(
+            String(localized: "download_errors", defaultValue: "Download errors"),
+            isPresented: $showDownloadErrors
+        ) {
+            Button(String(localized: "okay", defaultValue: "OK"), role: .cancel) {}
+        } message: {
+            Text(downloadErrors.joined(separator: "\n"))
+        }
+        .alert(
+            String(localized: "install_zip", defaultValue: "Load Documents From Files"),
+            isPresented: Binding(
+                get: { externalDocumentImportMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        externalDocumentImportMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button(String(localized: "okay", defaultValue: "OK"), role: .cancel) {}
+        } message: {
+            Text(externalDocumentImportMessage ?? "")
         }
         .alert(
             pendingRowActionConfirmation?.title ?? "",
@@ -549,6 +598,820 @@ public struct ModuleBrowserView: View {
         }
     }
 
+    /**
+     Builds a stable screen-level accessibility marker without overriding child identifiers.
+
+     SwiftUI propagates container accessibility identifiers to descendants in this layout. Keeping
+     the screen identifier on a tiny explicit marker lets UI tests detect the route while preserving
+     concrete identifiers on the app bar, filters, and rows.
+
+     - Returns: A one-pixel accessibility marker for the Downloads route.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private var moduleBrowserScreenMarker: some View {
+        Rectangle()
+            .fill(ModuleBrowserPalette.background.opacity(0.001))
+            .frame(width: 1, height: 1)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "download_documents", defaultValue: "Download Documents"))
+            .accessibilityIdentifier("moduleBrowserScreen")
+            .allowsHitTesting(false)
+    }
+
+    /**
+     Builds the Android Downloads top app bar with back navigation and overflow actions.
+
+     - Returns: Dark app bar matching Android's `Download Documents` activity title row.
+     - Side effects: Back dismisses the pushed route; the overflow button shows Android's Downloads
+       action menu.
+     - Failure modes: none.
+     */
+    private var androidTopAppBar: some View {
+        HStack(spacing: 16) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 24, weight: .semibold))
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(ModuleBrowserPalette.primaryText)
+            .accessibilityLabel(String(localized: "back_to_previous", defaultValue: "Back"))
+            .accessibilityIdentifier("moduleBrowserBackButton")
+
+            Text(String(localized: "download_documents", defaultValue: "Download Documents"))
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(ModuleBrowserPalette.primaryText)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Button {
+                showOverflowMenu.toggle()
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 24, weight: .bold))
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(ModuleBrowserPalette.primaryText)
+            .accessibilityLabel(String(localized: "more", defaultValue: "More"))
+            .accessibilityIdentifier("moduleBrowserOverflowButton")
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 56)
+        .background(ModuleBrowserPalette.appBar)
+    }
+
+    /**
+     Builds the Downloads overflow popup using Android's menu item set.
+
+     Android defines Download errors, Load Documents From Files, and Custom repositories for this activity. iOS
+     presents the same actions from an explicit top-right popup instead of SwiftUI's native `Menu`
+     because the route needs Android-style placement and stable accessibility behavior.
+
+     - Returns: A dark, right-aligned overflow popup anchored below the app bar.
+     - Side effects: Menu rows can show download errors, start the ZIP importer, or push repository
+       management.
+     - Failure modes: Install ZIP remains visible but disabled while a selected external document is
+       being imported.
+     */
+    private var androidOverflowMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if !downloadErrors.isEmpty {
+                androidOverflowMenuButton(
+                    title: String(localized: "download_errors", defaultValue: "Download errors"),
+                    accessibilityIdentifier: "moduleBrowserDownloadErrorsButton"
+                ) {
+                    showOverflowMenu = false
+                    showDownloadErrors = true
+                }
+                Divider()
+                    .background(ModuleBrowserPalette.divider)
+            }
+
+            androidOverflowMenuButton(
+                title: String(localized: "install_zip", defaultValue: "Load Documents From Files"),
+                accessibilityIdentifier: "moduleBrowserInstallZipButton",
+                disabled: isImportingExternalDocument
+            ) {
+                showOverflowMenu = false
+                showInstallZipImporter = true
+            }
+
+            androidOverflowMenuButton(
+                title: String(localized: "custom_repositories", defaultValue: "Custom repositories"),
+                accessibilityIdentifier: "moduleBrowserRepositoriesButton"
+            ) {
+                showOverflowMenu = false
+                showRepositoryManager = true
+            }
+        }
+        .frame(width: 260, alignment: .leading)
+        .background(ModuleBrowserPalette.menuSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+        .shadow(color: Color.black.opacity(0.35), radius: 8, x: 0, y: 4)
+    }
+
+    /**
+     Builds one Android overflow-menu row.
+
+     - Parameters:
+       - title: Localized row title.
+       - accessibilityIdentifier: Stable identifier used by UI tests for the concrete action.
+       - disabled: Whether the row should reject taps while remaining visible.
+       - action: Action to execute when the row is enabled and tapped.
+     - Returns: A full-width text row matching Android's compact overflow menu.
+     - Side effects: Executes `action` when tapped.
+     - Failure modes: Disabled rows do not execute their action.
+     */
+    private func androidOverflowMenuButton(
+        title: String,
+        accessibilityIdentifier: String,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            guard !disabled else { return }
+            action()
+        } label: {
+            Text(title)
+                .font(.system(size: 18, weight: .regular))
+                .foregroundStyle(disabled ? ModuleBrowserPalette.tertiaryText : ModuleBrowserPalette.primaryText)
+                .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+                .padding(.horizontal, 16)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    /**
+     Builds Android's inline Downloads filters.
+
+     - Parameter visibleModuleCount: Number of rows visible after current filters.
+     - Returns: Language, search, document-type, and count controls in Android's compact row.
+     - Side effects: Filter menus mutate `selectedLanguage` and `selectedCategory`; search text
+       mutates `searchText`.
+     - Failure modes: Empty language catalogs show the all-language label and keep the menu usable.
+     */
+    private func androidFilterBar(visibleModuleCount: Int) -> some View {
+        VStack(spacing: 4) {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(alignment: .bottom, spacing: 14) {
+                            androidLanguageFilterMenu()
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            androidDocumentTypeFilterMenu(visibleModuleCount: visibleModuleCount)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        androidSearchFilterField()
+                    }
+                } else {
+                    HStack(alignment: .bottom, spacing: 14) {
+                        androidLanguageFilterMenu()
+                            .frame(minWidth: 96, maxWidth: .infinity, alignment: .leading)
+                            .layoutPriority(1)
+                        androidSearchFilterField()
+                            .frame(minWidth: 96)
+                            .layoutPriority(2)
+                        androidDocumentTypeFilterMenu(visibleModuleCount: visibleModuleCount)
+                            .frame(minWidth: 112, maxWidth: .infinity, alignment: .trailing)
+                            .layoutPriority(1)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 18)
+            .padding(.bottom, 10)
+
+            Rectangle()
+                .fill(ModuleBrowserPalette.divider)
+                .frame(height: 1)
+        }
+        .background(ModuleBrowserPalette.background)
+    }
+
+    /**
+     Builds Android's language filter menu for the Downloads filter row.
+
+     - Returns: Menu containing all available languages plus Android's all-language option.
+     - Side effects: Mutates `selectedLanguage` when a menu item is selected.
+     - Failure modes: Empty catalogs show only the all-language option.
+     */
+    private func androidLanguageFilterMenu() -> some View {
+        Menu {
+            Button(languageFilterTitle(for: "")) {
+                selectedLanguage = ""
+            }
+            if !availableLanguages.isEmpty {
+                Divider()
+            }
+            ForEach(availableLanguages, id: \.self) { language in
+                Button(displayName(for: language)) {
+                    selectedLanguage = language
+                    Self.rememberExplicitSelectedLanguage(language)
+                }
+            }
+        } label: {
+            androidFilterLabel(languageFilterTitle(for: selectedLanguage))
+        }
+    }
+
+    /**
+     Builds Android's inline search filter for the Downloads filter row.
+
+     - Returns: Plain underlined search field matching Android's compact Downloads toolbar.
+     - Side effects: Mutates `searchText` as the user types.
+     - Failure modes: none.
+     */
+    private func androidSearchFilterField() -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            TextField(String(localized: "search", defaultValue: "Search"), text: $searchText)
+                .textFieldStyle(.plain)
+                .foregroundStyle(ModuleBrowserPalette.primaryText)
+                .tint(ModuleBrowserPalette.primaryText)
+                .submitLabel(.search)
+            Rectangle()
+                .fill(ModuleBrowserPalette.secondaryText)
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("moduleBrowserSearchField")
+    }
+
+    /**
+     Builds Android's document-type filter and visible document count.
+
+     - Parameter visibleModuleCount: Number of rows visible after current filters.
+     - Returns: Count text stacked above the Android document-type filter menu.
+     - Side effects: Mutates and persists `selectedCategory`; resets language selection using Android's
+       category-switch behavior.
+     - Failure modes: Empty category catalogs still expose Android's all-type option.
+     */
+    private func androidDocumentTypeFilterMenu(visibleModuleCount: Int) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(documentsCountTitle(visibleModuleCount))
+                .font(.system(size: 14, weight: .regular))
+                .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                .multilineTextAlignment(.trailing)
+            Menu {
+                Button(categoryFilterTitle(for: nil)) {
+                    selectedCategory = nil
+                    selectedLanguage = ""
+                    persistSelectedCategory(nil)
+                    applyAndroidDefaultLanguageIfNeeded(force: true)
+                }
+                Divider()
+                ForEach(visibleCategoryFilters, id: \.self) { category in
+                    Button(categoryFilterTitle(for: category)) {
+                        selectedCategory = category
+                        selectedLanguage = ""
+                        persistSelectedCategory(category)
+                        applyAndroidDefaultLanguageIfNeeded(force: true)
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(categoryFilterTitle(for: selectedCategory))
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                        .multilineTextAlignment(.trailing)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .foregroundStyle(ModuleBrowserPalette.primaryText)
+            }
+        }
+    }
+
+    /**
+     Builds one underlined Android filter menu label.
+
+     - Parameter title: User-visible filter title.
+     - Returns: Compact label with underline.
+     - Side effects: none.
+     - Failure modes: Long titles use two lines at accessibility Dynamic Type sizes and otherwise
+       compress like Android's toolbar filters.
+     */
+    private func androidFilterLabel(_ title: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(ModuleBrowserPalette.primaryText)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+            Rectangle()
+                .fill(ModuleBrowserPalette.secondaryText)
+                .frame(height: 1)
+        }
+    }
+
+    /**
+     Builds the scrollable Android Downloads row list.
+
+     - Parameters:
+       - visibleModules: Rows visible after filter/search processing.
+       - installedModulesByName: Installed modules keyed by initials for row status resolution.
+     - Returns: Loading, empty, error, or row content matching Android's document list.
+     - Side effects: Row buttons can start/cancel installs or open row details.
+     - Failure modes: Empty or failed catalogs show retry affordances instead of a blank list.
+     */
+    @ViewBuilder
+    private func androidDownloadsContent(
+        visibleModules: [RemoteModuleInfo],
+        installedModulesByName: [String: ModuleInfo]
+    ) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                }
+
+                if isLoadingInitialState || isRefreshing {
+                    androidLoadingRow
+                } else if visibleModules.isEmpty && !availableModules.isEmpty {
+                    androidMessageRow(String(localized: "no_modules_match_filters"))
+                } else if !visibleModules.isEmpty {
+                    ForEach(visibleModules) { module in
+                        remoteModuleRow(
+                            module,
+                            installedModulesByName: installedModulesByName
+                        )
+                    }
+                } else if availableModules.isEmpty && !isRefreshing && !isLoadingInitialState {
+                    VStack(spacing: 10) {
+                        Text(String(localized: "tap_refresh_to_load"))
+                            .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                        Button {
+                            refreshCatalog()
+                        } label: {
+                            Label(String(localized: "refresh_catalog"), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(ModuleBrowserPalette.primaryText)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 28)
+                }
+
+                if isImportingExternalDocument {
+                    androidLoadingRow
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(ModuleBrowserPalette.background)
+    }
+
+    /**
+     Loading row used while local state or repositories are refreshing.
+
+     - Returns: Android-dark progress row with current source text when available.
+     - Side effects: none.
+     - Failure modes: Missing progress text falls back to Loading/Refreshing text.
+     */
+    private var androidLoadingRow: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .tint(ModuleBrowserPalette.primaryText)
+            Text(refreshProgress ?? (isLoadingInitialState
+                ? String(localized: "loading", defaultValue: "Loading...")
+                : String(localized: "refreshing_catalog")))
+                .font(.caption)
+                .foregroundStyle(ModuleBrowserPalette.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 22)
+    }
+
+    /**
+     Message row for empty Android Downloads states.
+
+     - Parameter message: User-visible empty-state message.
+     - Returns: Full-width dark-list message row.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func androidMessageRow(_ message: String) -> some View {
+        Text(message)
+            .font(.body)
+            .foregroundStyle(ModuleBrowserPalette.secondaryText)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 24)
+    }
+
+    /**
+     Document categories shown in Android's type filter.
+
+     - Returns: Category rows in Android filter order, omitting Add-ons until catalog data proves
+       that Android add-on rows are present.
+     - Side effects: none.
+     - Failure modes: none
+     */
+    private var visibleCategoryFilters: [ModuleCategory] {
+        var categories: [ModuleCategory] = [
+            .bible,
+            .commentary,
+            .dictionary,
+            .generalBook,
+            .map,
+        ]
+        if shouldShowAddonsFilter {
+            categories.append(.addon)
+        }
+        return categories
+    }
+
+    /**
+     Resolves the Downloads language filter label.
+
+     - Parameter language: Selected language code, or an empty string for Android's all-languages
+       option.
+     - Returns: User-visible filter title.
+     - Side effects: none.
+     - Failure modes: Unknown language codes fall back through `displayName(for:)`.
+     */
+    private func languageFilterTitle(for language: String) -> String {
+        guard !language.isEmpty else {
+            return String(localized: "all_languages_count \(availableLanguages.count)")
+        }
+        return displayName(for: language)
+    }
+
+    /**
+     Formats the Android Downloads visible-document count.
+
+     - Parameter count: Number of rows visible after filters.
+     - Returns: User-visible count text.
+     - Side effects: none.
+    - Failure modes: none
+     */
+    private func documentsCountTitle(_ count: Int) -> String {
+        String(localized: "documents_count \(count)")
+    }
+
+    /**
+     Resolves the Downloads document-type filter label.
+
+     - Parameter category: Selected document category, or `nil` for Android's All types option.
+     - Returns: User-visible category label.
+     - Side effects: none.
+     - Failure modes: Unsupported categories fall back to their raw SWORD value.
+     */
+    private func categoryFilterTitle(for category: ModuleCategory?) -> String {
+        guard let category else {
+            return String(localized: "doc_type_all", defaultValue: "All types")
+        }
+        switch category {
+        case .bible:
+            return String(localized: "bibles")
+        case .commentary:
+            return String(localized: "commentaries")
+        case .dictionary:
+            return String(localized: "dictionaries")
+        case .generalBook:
+            return String(localized: "category_books")
+        case .map:
+            return String(localized: "maps", defaultValue: "Maps")
+        case .addon:
+            return String(localized: "doc_type_addons", defaultValue: "Add-ons")
+        default:
+            return category.rawValue
+        }
+    }
+
+    /**
+     Reads Android's persisted document type filter index.
+
+     - Returns: Stored index, or `0` when Downloads has never persisted a type filter.
+     - Side effects: Reads `UserDefaults`.
+     - Failure modes: Nonexistent values fall back to Android's All types index.
+     */
+    private static func persistedDocumentFilterIndex() -> Int {
+        UserDefaults.standard.object(forKey: selectedDocumentFilterIndexKey) as? Int ?? 0
+    }
+
+    /**
+     Persists the selected document type using Android's spinner index contract.
+
+     - Parameter category: Selected document category, or `nil` for All types.
+     - Side effects: Writes `UserDefaults`.
+     - Failure modes: Unsupported categories persist as All types.
+     */
+    private func persistSelectedCategory(_ category: ModuleCategory?) {
+        UserDefaults.standard.set(Self.androidFilterIndex(for: category), forKey: Self.selectedDocumentFilterIndexKey)
+    }
+
+    /**
+     Remembers Android's sticky Downloads language after explicit user selection.
+
+     - Parameter language: Selected language code, or empty when the user clears the filter.
+     - Side effects: Updates process memory only for concrete language selections.
+     - Failure modes: Empty language values are ignored so Android's default-language logic can run.
+     */
+    static func rememberExplicitSelectedLanguage(_ language: String) {
+        guard !language.isEmpty else { return }
+        lastSelectedLanguageCode = language
+    }
+
+    /**
+     Clears Android's process-local sticky Downloads language for deterministic tests.
+
+     - Returns: none.
+     - Side effects: Clears `lastSelectedLanguageCode`.
+     - Failure modes: none.
+     */
+    static func resetExplicitSelectedLanguageForTesting() {
+        lastSelectedLanguageCode = nil
+    }
+
+    /**
+     Returns Android's process-local sticky Downloads language for deterministic tests.
+
+     - Returns: Last explicit language-menu selection, or `nil` when none has been selected.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func explicitSelectedLanguageForTesting() -> String? {
+        lastSelectedLanguageCode
+    }
+
+    /**
+     Applies Android's default language rule once catalog rows are available.
+
+     Android chooses a sticky language when present, otherwise the device language if there are Bibles
+     in that language, otherwise an installed Bible language, otherwise English. iOS applies the same
+     rule after cached or refreshed catalog data is loaded because the language list depends on the
+     current document rows.
+
+     - Parameter force: Whether to re-run the rule after a document-type change.
+     - Side effects: Mutates `selectedLanguage` when a matching default exists.
+     - Failure modes: Empty catalogs leave the language unselected until rows are available.
+     */
+    private func applyAndroidDefaultLanguageIfNeeded(force: Bool = false) {
+        if force {
+            didApplyAndroidDefaultLanguage = false
+        }
+        guard !didApplyAndroidDefaultLanguage,
+              selectedLanguage.isEmpty,
+              searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        guard let defaultLanguage = Self.defaultLanguageCode(
+            availableModules: availableModules,
+            installedModules: installedModules,
+            availableLanguages: availableLanguages,
+            localeLanguageCode: Locale.current.language.languageCode?.identifier,
+            stickyLanguageCode: Self.lastSelectedLanguageCode
+        ) else {
+            return
+        }
+        selectedLanguage = defaultLanguage
+        didApplyAndroidDefaultLanguage = true
+    }
+
+    /**
+     Resolves Android's default Downloads language from catalog and installed module state.
+
+     - Parameters:
+       - availableModules: Remote rows used to test whether the device language has Bible rows.
+       - installedModules: Local modules used as Android's installed-language fallback.
+       - availableLanguages: Current language menu values for the selected document filter.
+       - localeLanguageCode: Device language code, such as `en`.
+       - stickyLanguageCode: Previous user-selected Downloads language.
+     - Returns: Language code to select, or `nil` when no language rows are available.
+     - Side effects: none.
+     - Failure modes: Invalid/empty language codes are ignored.
+     */
+    static func defaultLanguageCode(
+        availableModules: [RemoteModuleInfo],
+        installedModules: [ModuleInfo],
+        availableLanguages: [String],
+        localeLanguageCode: String?,
+        stickyLanguageCode: String?
+    ) -> String? {
+        guard !availableLanguages.isEmpty else { return nil }
+        if let stickyLanguageCode,
+           availableLanguages.contains(stickyLanguageCode) {
+            return stickyLanguageCode
+        }
+
+        let normalizedLocaleLanguage = localeLanguageCode?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if let normalizedLocaleLanguage,
+           !normalizedLocaleLanguage.isEmpty,
+           availableModules.contains(where: {
+               $0.category == .bible && $0.language.lowercased() == normalizedLocaleLanguage
+           }),
+           let matchingLanguage = availableLanguages.first(where: { $0.lowercased() == normalizedLocaleLanguage }) {
+            return matchingLanguage
+        }
+
+        if let installedBibleLanguage = installedModules.first(where: {
+            $0.category == .bible && availableLanguages.contains($0.language)
+        })?.language {
+            return installedBibleLanguage
+        }
+
+        if let english = availableLanguages.first(where: { $0.lowercased() == "en" }) {
+            return english
+        }
+        return availableLanguages.first
+    }
+
+    /**
+     Handles Android's Install ZIP overflow picker result.
+
+     - Parameter result: File importer result from iOS document picker.
+     - Side effects: Imports the selected document through `ExternalDocumentImportService`, refreshes
+       installed module state, and surfaces feedback through the Downloads alert/errors menu.
+     - Failure modes: Picker cancellation is ignored; importer failures become user-visible feedback.
+     */
+    private func handleInstallZipSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            isImportingExternalDocument = true
+            Task { @MainActor in
+                let request = ExternalDocumentImportRequest(
+                    url: url,
+                    contentTypeIdentifier: try? url.resourceValues(forKeys: [.contentTypeKey]).contentType?.identifier,
+                    suggestedFileName: url.lastPathComponent
+                )
+                let importResult = await Task.detached(priority: .userInitiated) {
+                    ExternalDocumentImportService().importDocument(request)
+                }.value
+                isImportingExternalDocument = false
+                externalDocumentImportMessage = importResult.feedbackMessage
+                if case .failed(let message) = importResult {
+                    recordDownloadError(message)
+                }
+                refreshInstalledList()
+            }
+        case .failure(let error):
+            if Self.isFileImporterCancellation(error) {
+                return
+            }
+            let message = error.localizedDescription
+            externalDocumentImportMessage = message
+            recordDownloadError(message)
+        }
+    }
+
+    /**
+     Returns whether a file-importer error represents a user-cancelled picker.
+
+     iOS reports picker cancellation through the `.failure` branch even though Android simply
+     returns to the previous screen when Install ZIP is cancelled. Treating cancellation as a no-op
+     keeps iOS plumbing aligned with Android's user-visible behavior.
+
+     - Parameter error: Error delivered by SwiftUI's `fileImporter`.
+     - Returns: `true` when the error is the standard Cocoa user-cancelled code.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func isFileImporterCancellation(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == NSCocoaErrorDomain && nsError.code == CocoaError.userCancelled.rawValue
+    }
+
+    /**
+     Adds one message to Android's Download errors overflow list.
+
+     - Parameter message: Error text from a repository, metadata, or install failure.
+     - Side effects: Mutates `downloadErrors` without duplicating identical messages.
+     - Failure modes: Empty messages are ignored.
+     */
+    private func recordDownloadError(_ message: String) {
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty,
+              !downloadErrors.contains(trimmedMessage) else {
+            return
+        }
+        downloadErrors.append(trimmedMessage)
+    }
+
+    /**
+     Merges Android's catalog refresh errors into the Download errors overflow list.
+
+     - Parameter errors: Repository or metadata errors produced by the refresh.
+     - Side effects: Mutates `downloadErrors` without dropping install/import errors from earlier
+       user actions.
+     - Failure modes: Empty errors leave prior non-refresh errors intact.
+    */
+    private func replaceDownloadErrors(with errors: [String]) {
+        downloadErrors = Self.mergedDownloadErrors(existing: downloadErrors, refreshErrors: errors)
+    }
+
+    /**
+     Merges refresh failures with existing Download errors while preserving first-seen order.
+
+     Android tracks repository/metadata failures separately from row install failures. Refreshing
+     metadata must therefore not erase install/import errors that are still visible through the
+     Downloads overflow menu.
+
+     - Parameters:
+       - existing: Current Download errors list.
+       - refreshErrors: Repository or metadata errors produced by the refresh.
+     - Returns: Trimmed, non-empty, de-duplicated errors in first-seen order.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func mergedDownloadErrors(existing: [String], refreshErrors: [String]) -> [String] {
+        var merged: [String] = []
+        for message in existing + refreshErrors {
+            let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedMessage.isEmpty,
+                  !merged.contains(trimmedMessage) else {
+                continue
+            }
+            merged.append(trimmedMessage)
+        }
+        return merged
+    }
+
+    /**
+     Formats a localized module download failure for Android's Download errors surface.
+
+     - Parameters:
+       - moduleName: Module initials associated with the failure.
+       - message: Platform error detail reported by the repository or installer.
+     - Returns: Download failure text with a localized prefix and stable module context.
+     - Side effects: none.
+     - Failure modes: Empty module names or messages are preserved so the caller can still surface the
+       underlying failure.
+     */
+    static func downloadFailureMessage(moduleName: String, message: String) -> String {
+        "\(String(localized: "error_download_failed", defaultValue: "Download failed")): \(moduleName): \(message)"
+    }
+
+    /**
+     Formats a localized module download failure for inline alert presentation.
+
+     - Parameter message: Platform error detail reported by the repository or installer.
+     - Returns: Download failure text with a localized prefix.
+     - Side effects: none.
+     - Failure modes: Empty messages are preserved so the caller can still surface a failure state.
+     */
+    static func downloadFailureMessage(_ message: String) -> String {
+        "\(String(localized: "error_download_failed", defaultValue: "Download failed")): \(message)"
+    }
+
+    /**
+     Resolves the localized empty-repository error used by refresh and Download errors.
+
+     - Returns: User-visible message for an empty repository source list.
+     - Side effects: none.
+     - Failure modes: none
+     */
+    static func noRepositorySourcesConfiguredMessage() -> String {
+        String(localized: "no_sources_configured", defaultValue: "No repository sources configured.")
+    }
+
+    /**
+     Formats the localized fallback for an unavailable remote module.
+
+     - Parameter moduleName: Module initials shown in the unavailable message.
+     - Returns: User-visible unavailable-module message.
+     - Side effects: none.
+     - Failure modes: Empty module names are preserved so the caller can still show the failure.
+     */
+    static func moduleUnavailableForInstallationMessage(moduleName: String) -> String {
+        String(localized: "module_unavailable_for_installation \(moduleName)")
+    }
+
+    /**
+     Formats the localized fallback for a missing repository source.
+
+     - Parameter moduleName: Module initials whose source could not be resolved.
+     - Returns: User-visible missing-source message.
+     - Side effects: none.
+     - Failure modes: Empty module names are preserved so the caller can still show the failure.
+     */
+    static func moduleSourceNotFoundMessage(moduleName: String) -> String {
+        String(localized: "module_source_not_found \(moduleName)")
+    }
+
+    /**
+     Formats the localized uninstall failure text.
+
+     - Parameter message: Platform error detail reported by the repository.
+     - Returns: User-visible uninstall failure message.
+     - Side effects: none.
+     - Failure modes: Empty messages are preserved so the caller can still show the failure.
+     */
+    static func uninstallFailureMessage(_ message: String) -> String {
+        String(localized: "uninstall_failed \(message)")
+    }
+
     // MARK: - Row Views
 
     /**
@@ -574,6 +1437,90 @@ public struct ModuleBrowserView: View {
         }
         selectedCategory = nil
         selectedLanguage = ""
+        persistSelectedCategory(nil)
+    }
+
+    /**
+     Resolves the initial Downloads document-type filter from Android's startup rules.
+
+     Android starts a fresh Downloads browser on filter index 0, `All types`; search and Easy Start
+     entry points also use an all-type query so a module initials lookup can match any document
+     family.
+
+     - Parameters:
+       - initialSearchText: Optional query supplied by the caller.
+       - defaultDownloadMode: Startup default-download mode supplied by the caller.
+       - storedFilterIndex: Persisted Android document filter index.
+     - Returns: Selected category, or `nil` for Android's `All types` filter.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func initialSelectedCategory(
+        initialSearchText: String,
+        defaultDownloadMode: ModuleBrowserDefaultDownloadMode,
+        storedFilterIndex: Int = 0
+    ) -> ModuleCategory? {
+        guard initialSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !defaultDownloadMode.shouldInstallDefaultDocuments else {
+            return nil
+        }
+        return category(forAndroidFilterIndex: storedFilterIndex)
+    }
+
+    /**
+     Maps Android's document type spinner index to the iOS module category.
+
+     - Parameter index: Android `selected_document_filter_no` value.
+     - Returns: Matching category, or `nil` for All/unknown values.
+     - Side effects: none.
+     - Failure modes: Unknown persisted indexes reset to All types.
+     */
+    static func category(forAndroidFilterIndex index: Int) -> ModuleCategory? {
+        switch index {
+        case 1:
+            return .bible
+        case 2:
+            return .commentary
+        case 3:
+            return .dictionary
+        case 4:
+            return .generalBook
+        case 5:
+            return .map
+        case 6:
+            return .addon
+        default:
+            return nil
+        }
+    }
+
+    /**
+     Maps one iOS module category back to Android's document type spinner index.
+
+     - Parameter category: Selected category, or `nil` for All types.
+     - Returns: Android `selected_document_filter_no` value.
+     - Side effects: none.
+     - Failure modes: Unsupported categories map to All types.
+     */
+    static func androidFilterIndex(for category: ModuleCategory?) -> Int {
+        switch category {
+        case .bible:
+            return 1
+        case .commentary:
+            return 2
+        case .dictionary:
+            return 3
+        case .generalBook:
+            return 4
+        case .map:
+            return 5
+        case .addon:
+            return 6
+        case nil:
+            return 0
+        default:
+            return 0
+        }
     }
 
     /**
@@ -601,55 +1548,85 @@ public struct ModuleBrowserView: View {
         let isRecommended = recommendedDocuments?.contains(module) == true
         let badAction = badDocuments?.badDocumentAction(for: module) ?? .none
 
-        return HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(module.name)
-                    .font(.headline)
-                Text(module.description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(module.isInstallable ? 2 : 3)
-                HStack(spacing: 4) {
-                    Text(displayName(for: module.language))
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                    Text(module.sourceName)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                    if let installSize = Self.installSizeText(for: module.installSizeBytes) {
-                        Text(installSize)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                HStack(spacing: 6) {
+        return VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(spacing: 5) {
+                    categoryIcon(for: module.category)
+                        .foregroundStyle(ModuleBrowserPalette.secondaryText)
                     if isRecommended {
-                        Label(String(localized: "recommended_document"), systemImage: "star.fill")
-                            .font(.caption2)
-                            .foregroundStyle(.orange)
+                        Image(systemName: "star.fill")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(.yellow)
                     }
                     if badAction == .warn {
-                        Label(String(localized: "bad_document_warning"), systemImage: "exclamationmark.triangle.fill")
-                            .font(.caption2)
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 15, weight: .bold))
                             .foregroundStyle(.red)
                     }
+                    Text(displayName(for: module.language))
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                        .lineLimit(1)
+                    if let installSize = Self.installSizeText(for: module.installSizeBytes) {
+                        Text(installSize)
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                            .lineLimit(1)
+                    }
                 }
-                if case let .errorDownloading(message) = status {
-                    Text(message.isEmpty ? String(localized: "error_download_failed") : message)
-                        .font(.caption2)
-                        .foregroundStyle(.red)
+                .frame(width: 70)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(module.name)
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(ModuleBrowserPalette.primaryText)
+                        .lineLimit(1)
+                    Text(module.description)
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                        .lineLimit(module.isInstallable ? 2 : 3)
+                    if isRecommended {
+                        Text(String(localized: "recommended_document", defaultValue: "Recommended!"))
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundStyle(ModuleBrowserPalette.secondaryText)
+                    }
+                    if case let .errorDownloading(message) = status {
+                        Text(message.isEmpty ? String(localized: "error_download_failed") : message)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                VStack(alignment: .trailing, spacing: 10) {
+                    Text(module.sourceName)
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(ModuleBrowserPalette.secondaryText)
                         .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
+
+                    rowTrailingControls(
+                        for: module,
+                        installedModule: installedModule,
+                        status: status,
+                        rowActions: rowActions
+                    )
                 }
+                .frame(width: 112, alignment: .trailing)
             }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
 
-            Spacer()
-
-            rowTrailingControls(
-                for: module,
-                installedModule: installedModule,
-                status: status,
-                rowActions: rowActions
-            )
+            Rectangle()
+                .fill(ModuleBrowserPalette.divider)
+                .frame(height: 1)
+                .padding(.leading, 96)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            performPrimaryRowAction(for: module, status: status)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if rowActions.contains(.uninstall) {
@@ -701,6 +1678,36 @@ public struct ModuleBrowserView: View {
     }
 
     /**
+     Renders the Android-sourced category icon for a Downloads row.
+
+     - Parameter category: Remote module category.
+     - Returns: Template icon matching the closest Android document category glyph available in the
+       packaged icon catalog.
+     - Side effects: Loads local asset images when rendered.
+     - Failure modes: Unsupported categories use the generic documents icon.
+     */
+    @ViewBuilder
+    private func categoryIcon(for category: ModuleCategory) -> some View {
+        switch category {
+        case .bible:
+            AndBibleIconView(name: "ToolbarBible", size: 28)
+        case .commentary:
+            AndBibleIconView(name: "ToolbarCommentary", size: 28)
+        case .dictionary:
+            AndBibleIconView(name: "SettingsIconDictionary", size: 28)
+        case .generalBook:
+            AndBibleIconView(name: "DrawerDocuments", size: 28)
+        case .map:
+            Image(systemName: "map")
+                .font(.system(size: 26, weight: .regular))
+        case .addon:
+            AndBibleIconView(name: "DrawerDownloads", size: 28)
+        default:
+            AndBibleIconView(name: "DrawerDocuments", size: 28)
+        }
+    }
+
+    /**
      Builds the trailing controls for a Downloads row from Android-compatible row actions.
 
      - Parameters:
@@ -728,10 +1735,11 @@ public struct ModuleBrowserView: View {
                         installedModule: installedModule
                     )
                 } label: {
-                    Label(String(localized: "about"), systemImage: "info.circle")
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 22, weight: .regular))
                 }
-                .labelStyle(.iconOnly)
-                .buttonStyle(.borderless)
+                .buttonStyle(.plain)
+                .foregroundStyle(.blue)
                 .accessibilityLabel(String(localized: "about"))
             }
 
@@ -758,50 +1766,92 @@ public struct ModuleBrowserView: View {
         switch status {
         case .installed:
             Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(ModuleBrowserPalette.installed)
         case .beingInstalled(let progressPercent):
             VStack(alignment: .trailing, spacing: 6) {
                 Text("\(progressPercent)%")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ModuleBrowserPalette.secondaryText)
                 ProgressView(value: Double(progressPercent), total: 100)
                     .frame(width: 76)
+                    .tint(ModuleBrowserPalette.primaryText)
                 Button {
                     cancelInstall(module.name)
                 } label: {
-                    Label(String(localized: "cancel"), systemImage: "arrow.uturn.backward.circle")
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: 22, weight: .regular))
                 }
-                .labelStyle(.iconOnly)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .buttonStyle(.plain)
+                .foregroundStyle(ModuleBrowserPalette.secondaryText)
                 .accessibilityLabel(String(localized: "cancel"))
             }
         case .errorDownloading:
             VStack(alignment: .trailing, spacing: 6) {
                 Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(.red)
-                Button(String(localized: "retry", defaultValue: "Retry")) {
+                Button {
                     installModule(module)
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 22, weight: .semibold))
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .buttonStyle(.plain)
+                .foregroundStyle(ModuleBrowserPalette.install)
+                .accessibilityLabel(String(localized: "retry", defaultValue: "Retry"))
             }
         case .updateAvailable:
-            Button(String(localized: "update")) {
+            Button {
                 installModule(module)
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 24, weight: .bold))
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.plain)
+            .foregroundStyle(ModuleBrowserPalette.install)
+            .accessibilityLabel(String(localized: "update"))
         case .unavailable:
             Label(String(localized: "unavailable"), systemImage: "lock.slash")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ModuleBrowserPalette.tertiaryText)
         case .installable:
-            Button(String(localized: "install_module", defaultValue: "Install")) {
+            Button {
                 installModule(module)
+            } label: {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 24, weight: .bold))
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
+            .buttonStyle(.plain)
+            .foregroundStyle(ModuleBrowserPalette.install)
+            .accessibilityLabel(String(localized: "install_module", defaultValue: "Install"))
+        }
+    }
+
+    /**
+     Runs Android's primary row action for a visible Downloads document.
+
+     Android rows dispatch to `DownloadControl.manageDownload`: installable, update, and failed rows
+     start or retry downloads; active rows cancel; installed/unavailable rows do not install again.
+     iOS keeps the same behavior for row taps while preserving the explicit trailing icons.
+
+     - Parameters:
+       - module: Remote catalog row represented by the tapped row.
+       - status: Current Android-equivalent install status.
+     - Side effects: May start, retry, or cancel one install task.
+     - Failure modes: `installModule(_:)` and `cancelInstall(_:)` own their failure behavior.
+     */
+    private func performPrimaryRowAction(
+        for module: RemoteModuleInfo,
+        status: ModuleBrowserDownloadStatus
+    ) {
+        switch status {
+        case .installable, .updateAvailable, .errorDownloading:
+            installModule(module)
+        case .beingInstalled:
+            cancelInstall(module.name)
+        case .installed, .unavailable:
+            break
         }
     }
 
@@ -1389,6 +2439,7 @@ public struct ModuleBrowserView: View {
         if availableModules.isEmpty && !initialState.cachedModules.isEmpty {
             availableModules = deduplicatedModules(from: initialState.cachedModules)
         }
+        applyAndroidDefaultLanguageIfNeeded()
         isLoadingInitialState = false
         if defaultDownloadMode.shouldInstallDefaultDocuments {
             startDefaultDownloadFlowIfNeeded()
@@ -1549,7 +2600,9 @@ public struct ModuleBrowserView: View {
             let shouldRequireDefaultDocuments = defaultDownloadMode.shouldInstallDefaultDocuments
             if sourcesToRefresh.isEmpty {
                 await MainActor.run {
-                    errorMessage = "No remote sources configured."
+                    let message = Self.noRepositorySourcesConfiguredMessage()
+                    errorMessage = message
+                    recordDownloadError(message)
                     isRefreshing = false
                     finishDefaultDownloadActivityIfNeeded()
                 }
@@ -1655,6 +2708,8 @@ public struct ModuleBrowserView: View {
 
             await MainActor.run {
                 availableModules = uniqueModules
+                replaceDownloadErrors(with: errors)
+                applyAndroidDefaultLanguageIfNeeded()
                 isRefreshing = false
                 refreshProgress = nil
                 installDefaultDocumentsIfNeeded(
@@ -1690,10 +2745,13 @@ public struct ModuleBrowserView: View {
      - task cancellation clears active row state without reporting a failure, matching Android
        `INSTALL_CANCELLED`
      - repository installation errors are caught and reported without crashing the view
-     */
+    */
     private func installModule(_ module: RemoteModuleInfo) {
         guard module.isInstallable else {
-            errorMessage = module.unavailableReason ?? "\(module.name) is not available for installation."
+            let message = module.unavailableReason
+                ?? Self.moduleUnavailableForInstallationMessage(moduleName: module.name)
+            errorMessage = message
+            recordDownloadError(message)
             markDefaultDownloadModuleFinishedIfNeeded(module.name)
             return
         }
@@ -1703,7 +2761,9 @@ public struct ModuleBrowserView: View {
         }
 
         guard let source = sources.first(where: { $0.name == module.sourceName }) ?? repository.source(for: module.name) else {
-            errorMessage = "Source not found for \(module.name)"
+            let message = Self.moduleSourceNotFoundMessage(moduleName: module.name)
+            errorMessage = message
+            recordDownloadError(message)
             markDefaultDownloadModuleFinishedIfNeeded(module.name)
             return
         }
@@ -1742,7 +2802,8 @@ public struct ModuleBrowserView: View {
                     } else {
                         let message = error.localizedDescription
                         downloadActivities[module.name] = .failed(message)
-                        errorMessage = "Install failed: \(message)"
+                        errorMessage = Self.downloadFailureMessage(message)
+                        recordDownloadError(Self.downloadFailureMessage(moduleName: module.name, message: message))
                     }
                     markDefaultDownloadModuleFinishedIfNeeded(module.name)
                 }
@@ -1855,7 +2916,9 @@ public struct ModuleBrowserView: View {
                 }
             } catch {
                 await MainActor.run {
-                    errorMessage = "Uninstall failed: \(error.localizedDescription)"
+                    let message = Self.uninstallFailureMessage(error.localizedDescription)
+                    errorMessage = message
+                    recordDownloadError(message)
                 }
             }
         }

--- a/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
@@ -81,6 +81,33 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
 }
 
 /**
+ Android default SWORD repository definition.
+
+ Android stores built-in repositories in `app/src/main/res/raw/repositories.txt` as independent
+ package and catalog directories. iOS still writes `InstallMgr.conf` in the legacy SWORD-compatible
+ row shape, but this definition is the shared source of truth for Downloads and package fallback so
+ iOS does not reconstruct package URLs from catalog paths later.
+ */
+private struct AndroidDefaultRepositorySource: Sendable {
+    /// Visible repository name from Android.
+    let name: String
+
+    /// HTTPS host from Android.
+    let host: String
+
+    /// Android package directory used by package ZIP installs.
+    let packageDirectory: String
+
+    /// SWORD catalog directory used for `mods.d.tar.gz`.
+    let catalogDirectory: String
+
+    /// SWORD-compatible `InstallMgr.conf` row used by local iOS plumbing.
+    var installManagerLine: String {
+        "HTTPSource=\(name)|\(host)|\(catalogDirectory)"
+    }
+}
+
+/**
  Swift wrapper around SWORD's InstallMgr for downloading and installing modules.
 
  All native operations are serialized through `SwordRuntime` since libsword and the flat bridge
@@ -98,17 +125,70 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
 public final class InstallManager: @unchecked Sendable {
     private static let defaultConfigVersionMarker = "# AndBibleDefaultSourcesVersion=2"
 
-    private static let defaultSourceLines = [
-        "HTTPSource=CrossWire|crosswire.org|/ftpmirror/pub/sword/raw",
-        "HTTPSource=Crosswire Beta|crosswire.org|/ftpmirror/pub/sword/betaraw",
-        "HTTPSource=AndBible Extra|andbible.github.io|/andbible-extra",
-        "HTTPSource=AndBible|andbible.github.io|/data/andbible",
-        "HTTPSource=AndBible Beta|andbible.github.io|/data/andbible/beta",
-        "HTTPSource=IBT|ibtrussia.org|/ftpmirror/pub/modsword/raw",
-        "HTTPSource=Wycliffe (CrossWire)|crosswire.org|/ftpmirror/pub/sword/wyclifferaw",
-        "HTTPSource=eBible|ebible.org|/sword",
-        "HTTPSource=Lockman (CrossWire)|crosswire.org|/ftpmirror/pub/sword/lockmanraw",
-        "HTTPSource=STEP Bible (Tyndale)|public.modules.stepbible.org|/catalog",
+    private static let androidDefaultSources = [
+        AndroidDefaultRepositorySource(
+            name: "CrossWire",
+            host: "crosswire.org",
+            packageDirectory: "/ftpmirror/pub/sword/packages/rawzip",
+            catalogDirectory: "/ftpmirror/pub/sword/raw"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "Crosswire Beta",
+            host: "crosswire.org",
+            packageDirectory: "/ftpmirror/pub/sword/betapackages/rawzip",
+            catalogDirectory: "/ftpmirror/pub/sword/betaraw"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "AndBible Extra",
+            host: "andbible.github.io",
+            packageDirectory: "/andbible-extra/zip",
+            catalogDirectory: "/andbible-extra"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "AndBible",
+            host: "andbible.github.io",
+            packageDirectory: "/data/andbible/zip",
+            catalogDirectory: "/data/andbible"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "AndBible Beta",
+            host: "andbible.github.io",
+            packageDirectory: "/data/andbible/beta/zip",
+            catalogDirectory: "/data/andbible/beta"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "IBT",
+            host: "ibtrussia.org",
+            packageDirectory: "/ftpmirror/pub/modsword/rawzip",
+            catalogDirectory: "/ftpmirror/pub/modsword/raw"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "Wycliffe (CrossWire)",
+            host: "crosswire.org",
+            packageDirectory: "/ftpmirror/pub/sword/wycliffepackages/rawzip",
+            catalogDirectory: "/ftpmirror/pub/sword/wyclifferaw"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "eBible",
+            host: "ebible.org",
+            packageDirectory: "/sword/zip",
+            catalogDirectory: "/sword"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "Lockman (CrossWire)",
+            host: "crosswire.org",
+            packageDirectory: "/ftpmirror/pub/sword/lockmanpackages",
+            catalogDirectory: "/ftpmirror/pub/sword/lockmanraw"
+        ),
+        AndroidDefaultRepositorySource(
+            name: "STEP Bible (Tyndale)",
+            host: "public.modules.stepbible.org",
+            packageDirectory: "/packages",
+            catalogDirectory: "/catalog"
+        )
+    ]
+
+    private static let defaultSourceLines = androidDefaultSources.map(\.installManagerLine) + [
         "FTPSource=CrossWire|ftp.crosswire.org|/pub/sword/raw",
     ]
 
@@ -179,6 +259,23 @@ public final class InstallManager: @unchecked Sendable {
     }
 
     /**
+     Returns Android's package directory for a built-in SWORD repository.
+
+     - Parameter source: Parsed iOS source row.
+     - Returns: The package directory from Android's `repositories.txt` when the source matches a
+       built-in normal or beta repository; otherwise `nil`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public static func defaultPackageDirectory(for source: SourceConfig) -> String? {
+        androidDefaultSources.first {
+            $0.name == source.name &&
+                $0.host == source.host &&
+                $0.catalogDirectory == source.catalogPath
+        }?.packageDirectory
+    }
+
+    /**
      Write default InstallMgr.conf with sources matching Android AndBible.
      Sources are from and-bible/app/src/main/res/raw/repositories.txt
      */
@@ -192,7 +289,7 @@ public final class InstallManager: @unchecked Sendable {
         }
 
         // Sources matching AndBible Android's repositories.txt, in priority order.
-        // Format: HTTPSource=Label|host|catalogDirectory
+        // Format: HTTPSource=Label|host|catalogDirectory for SWORD compatibility.
         let config = """
         [General]
         PassiveFTP=true

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -512,20 +512,16 @@ public struct CatalogModule: Sendable, Identifiable {
      Parses the SWORD `InstallSize` property into bytes for download-list display.
 
      - Parameter value: Raw catalog value from a module `.conf` file.
-     - Returns: Byte count when the value is an integer number of kibibytes; otherwise `nil`.
+     - Returns: Byte count when the value is an integer byte count; otherwise `nil`.
 
      Side effects:
      - none
 
      Failure modes:
-     - non-numeric values or values that overflow bytes return `nil`
+     - non-numeric or overflowing values return `nil`
      */
     private static func installSizeBytes(from value: String) -> Int64? {
-        guard let kibibytes = Int64(value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            return nil
-        }
-        let bytes = kibibytes.multipliedReportingOverflow(by: 1024)
-        return bytes.overflow ? nil : bytes.partialValue
+        Int64(value.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 }
 
@@ -2069,107 +2065,58 @@ public final class ModuleRepository: @unchecked Sendable {
     }
 
     /**
-     Builds repository package ZIP candidates that match Android/SWORD repository layouts.
+     Builds the repository package ZIP URL that matches Android's installer source model.
 
      - Parameters:
-       - moduleName: Catalog module abbreviation used as the package filename.
-       - source: Repository source whose host and catalog path anchor package locations.
-     - Returns: De-duplicated HTTPS URLs, ordered from source-local packages to CrossWire-style
-       parent `packages/rawzip` locations.
+     - moduleName: Catalog module abbreviation used as the package filename.
+     - source: Repository source whose host and catalog path anchor package locations.
+     - Returns: The single authoritative package URL for the source, or an empty array when no
+       package directory can be resolved.
      - Side effects: none.
      - Failure modes: malformed host/path combinations are skipped rather than thrown because raw
        file installation remains the primary path.
      */
     private func packageZipCandidateURLs(for moduleName: String, source: SourceConfig) -> [URL] {
         let packageFileName = "\(moduleName).zip"
-        var paths: [String] = []
-        if let androidPackageDirectory = androidPackageDirectory(for: source) {
-            paths.append(appendingPathComponent(packageFileName, toPath: androidPackageDirectory))
-        }
-        paths += [
-            appendingPathComponent("zip/\(packageFileName)", toPath: source.catalogPath),
-            appendingPathComponent("packages/\(packageFileName)", toPath: source.catalogPath),
-            appendingPathComponent("packages/rawzip/\(packageFileName)", toPath: source.catalogPath)
-        ]
-
-        if let rawParentPath = parentPathForRawPackageDirectory(source.catalogPath) {
-            paths.append(appendingPathComponent("packages/rawzip/\(packageFileName)", toPath: rawParentPath))
-        }
-
-        var seen = Set<String>()
-        return paths.compactMap { path in
-            guard let url = URL(string: "https://\(source.host)\(path)") else { return nil }
-            guard seen.insert(url.absoluteString).inserted else { return nil }
-            return url
-        }
+        guard let packageDirectory = packageDirectory(for: source) else { return [] }
+        let path = appendingPathComponent(packageFileName, toPath: packageDirectory)
+        guard let url = URL(string: "https://\(source.host)\(path)") else { return [] }
+        return [url]
     }
 
     /**
-     Returns the Android-parity package directory for known default SWORD repositories.
+     Returns the package directory that Android would give to the SWORD installer.
 
      Android keeps package and catalog directories as distinct repository fields. iOS persists only
-     the catalog-style `HTTPSource` row today, so default sources need an explicit package-directory
-     map to avoid guessing wrong locations for repositories such as STEP, IBT, Wycliffe, and
-     Lockman.
+     the catalog-style `HTTPSource` row for local SWORD compatibility, so default-source metadata is
+     restored through `InstallManager` before falling back to Android's direct custom-repository
+     `catalogDirectory/packages` rule.
 
      - Parameter source: Repository source loaded from `InstallMgr.conf`.
      - Returns: Package directory path from Android's `repositories.txt` when the source matches a
-       built-in repository, otherwise the direct-catalog custom fallback `catalogPath/packages`.
+       built-in repository, an explicit custom package directory, or the direct-catalog custom
+       fallback `catalogPath/packages`.
      - Side effects: none.
      - Failure modes: none.
      */
-    private func androidPackageDirectory(for source: SourceConfig) -> String? {
+    private func packageDirectory(for source: SourceConfig) -> String? {
         if let packageDirectory = source.packageDirectory,
            !packageDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return packageDirectory
+            return normalizedRepositoryPath(packageDirectory)
         }
 
-        switch (source.name, source.host, source.catalogPath) {
-        case ("CrossWire", "crosswire.org", "/ftpmirror/pub/sword/raw"):
-            return "/ftpmirror/pub/sword/packages/rawzip"
-        case ("Crosswire Beta", "crosswire.org", "/ftpmirror/pub/sword/betaraw"):
-            return "/ftpmirror/pub/sword/betapackages/rawzip"
-        case ("AndBible Extra", "andbible.github.io", "/andbible-extra"):
-            return "/andbible-extra/zip"
-        case ("AndBible", "andbible.github.io", "/data/andbible"):
-            return "/data/andbible/zip"
-        case ("AndBible Beta", "andbible.github.io", "/data/andbible/beta"):
-            return "/data/andbible/beta/zip"
-        case ("IBT", "ibtrussia.org", "/ftpmirror/pub/modsword/raw"):
-            return "/ftpmirror/pub/modsword/rawzip"
-        case ("Wycliffe (CrossWire)", "crosswire.org", "/ftpmirror/pub/sword/wyclifferaw"):
-            return "/ftpmirror/pub/sword/wycliffepackages/rawzip"
-        case ("eBible", "ebible.org", "/sword"):
-            return "/sword/zip"
-        case ("Lockman (CrossWire)", "crosswire.org", "/ftpmirror/pub/sword/lockmanraw"):
-            return "/ftpmirror/pub/sword/lockmanpackages"
-        case ("STEP Bible (Tyndale)", "public.modules.stepbible.org", "/catalog"):
-            return "/packages"
-        default:
-            return appendingPathComponent("packages", toPath: source.catalogPath)
+        if let packageDirectory = InstallManager.defaultPackageDirectory(for: source) {
+            return normalizedRepositoryPath(packageDirectory)
         }
+
+        guard !source.isMyBibleRepository else { return nil }
+        return appendingPathComponent("packages", toPath: source.catalogPath)
     }
 
-    /**
-     Resolves the parent repository path whose `packages/rawzip/` directory pairs with a raw data
-     catalog.
-
-     - Parameter catalogPath: Source catalog path from `InstallMgr.conf`.
-     - Returns: The parent path when the final path component is a raw catalog directory, otherwise
-       `nil`.
-     - Side effects: none.
-     - Failure modes: none.
-     */
-    private func parentPathForRawPackageDirectory(_ catalogPath: String) -> String? {
-        let trimmedPath = catalogPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let components = trimmedPath.split(separator: "/").map(String.init)
-        guard let lastComponent = components.last,
-              lastComponent.lowercased().contains("raw") else {
-            return nil
-        }
-
-        let parentComponents = components.dropLast()
-        return "/" + parentComponents.joined(separator: "/")
+    private func normalizedRepositoryPath(_ rawPath: String) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        return trimmed.hasPrefix("/") ? trimmed : "/\(trimmed)"
     }
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/RepositorySourceManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/RepositorySourceManager.swift
@@ -233,8 +233,9 @@ public final class RepositorySourceManager: @unchecked Sendable {
         let recordsByName = Dictionary(customRecords.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
 
         var namesInConfig: Set<String> = []
-        let configSources = persistedSources.map { source in
-            namesInConfig.insert(source.name)
+        let configSources = persistedSources.map { persistedSource in
+            namesInConfig.insert(persistedSource.name)
+            let source = Self.sourceByApplyingAndroidDefaultMetadata(to: persistedSource)
             guard let record = recordsByName[source.name],
                   record.type == SourceConfig.swordHTTPSRepositoryType else {
                 return source
@@ -246,7 +247,7 @@ public final class RepositorySourceManager: @unchecked Sendable {
                 catalogPath: source.catalogPath,
                 repositoryType: record.type,
                 description: record.description,
-                packageDirectory: record.packageDirectory.isEmpty ? nil : record.packageDirectory,
+                packageDirectory: Self.normalizedOptionalPackageDirectory(record.packageDirectory),
                 manifestURL: URL(string: record.manifestURL),
                 sourceURL: URL(string: record.sourceURL)
             )
@@ -257,6 +258,36 @@ public final class RepositorySourceManager: @unchecked Sendable {
             .map(\.source)
 
         return configSources + myBibleSources
+    }
+
+    /**
+     Enriches a SWORD config row with Android default package-directory metadata.
+
+     `InstallMgr.conf` is intentionally kept in SWORD's legacy three-field row shape, but built-in
+     repositories still need Android's package directory before Downloads or package fallback uses
+     them. Custom sidecar records already carry their own package directory and are applied later.
+
+     - Parameter source: Source parsed from local SWORD config.
+     - Returns: A source with Android package metadata when it matches a built-in repository.
+     - Side effects: none.
+     - Failure modes: non-default and already-enriched sources are returned unchanged.
+     */
+    private static func sourceByApplyingAndroidDefaultMetadata(to source: SourceConfig) -> SourceConfig {
+        guard source.packageDirectory == nil,
+              let packageDirectory = InstallManager.defaultPackageDirectory(for: source) else {
+            return source
+        }
+        return SourceConfig(
+            name: source.name,
+            type: source.type,
+            host: source.host,
+            catalogPath: source.catalogPath,
+            repositoryType: source.repositoryType,
+            description: source.description,
+            packageDirectory: packageDirectory,
+            manifestURL: source.manifestURL,
+            sourceURL: source.sourceURL
+        )
     }
 
     /**
@@ -603,7 +634,7 @@ public final class RepositorySourceManager: @unchecked Sendable {
                 catalogPath: catalogDirectory,
                 repositoryType: type,
                 description: description,
-                packageDirectory: packageDirectory.isEmpty ? nil : packageDirectory,
+                packageDirectory: RepositorySourceManager.normalizedOptionalPackageDirectory(packageDirectory),
                 manifestURL: URL(string: manifestURL),
                 sourceURL: URL(string: sourceURL)
             )
@@ -616,7 +647,7 @@ public final class RepositorySourceManager: @unchecked Sendable {
             self.type = registration.type
             self.host = registration.source.host
             self.catalogDirectory = registration.source.catalogPath
-            self.packageDirectory = registration.packageDirectory
+            self.packageDirectory = RepositorySourceManager.normalizedPackageDirectory(registration.packageDirectory)
             self.manifestURL = registration.manifestURL.absoluteString
             self.sourceURL = registration.sourceURL.absoluteString
         }
@@ -938,10 +969,11 @@ public final class RepositorySourceManager: @unchecked Sendable {
             host: manifest.host,
             catalogDirectory: manifest.catalogDirectory
         )
-        let packageDirectory = manifest.packageDirectory ?? Self.appendingPathComponent(
-            "packages",
-            toPath: source.catalogPath
-        )
+        let packageDirectory = Self.normalizedOptionalPackageDirectory(manifest.packageDirectory ?? "")
+            ?? Self.normalizedPackageDirectory(Self.appendingPathComponent(
+                "packages",
+                toPath: source.catalogPath
+            ))
         let sourceURL = try Self.httpsURL(host: source.host, path: source.catalogPath)
         let reportedManifestURL = Self.preferredHTTPSManifestURL(
             from: manifest.manifestUrl,
@@ -1051,6 +1083,15 @@ public final class RepositorySourceManager: @unchecked Sendable {
         let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "" }
         return trimmed.hasPrefix("/") ? trimmed : "/\(trimmed)"
+    }
+
+    private static func normalizedPackageDirectory(_ rawPath: String) -> String {
+        normalizedCatalogDirectory(rawPath)
+    }
+
+    private static func normalizedOptionalPackageDirectory(_ rawPath: String) -> String? {
+        let normalized = normalizedPackageDirectory(rawPath)
+        return normalized.isEmpty ? nil : normalized
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #223.

Aligns the iOS Downloads flow with Android instead of preserving the native sheet/list variant. The browser now opens as a full-screen route with Android-style top app bar, inline filters, dense document rows, overflow actions, install ZIP import, custom repositories, and download error reporting.

## Android Parity

- Uses Android default document type behavior: persisted filter first, otherwise All types.
- Applies Android sticky/default language priority.
- Mirrors Android menu actions for Download errors, Install ZIP, and Custom repositories.
- Keeps package directory and catalog directory separate for built-in repositories from Android `repositories.txt`.
- Stops guessing package ZIP URL variants when Android/JSword has a single repository package directory.
- Fixes InstallSize display to use Android/JSword byte semantics instead of multiplying by 1024.

## Validation

- GitNexus `detect_changes`: 11 changed files, 124 changed symbols, 9 affected processes, high risk as expected for Downloads/catalog/install flows.
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 -m unittest discover -s scripts -p "test_*.py"`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_settings_localization_guardrails.py`
- `git diff --check`
- Focused unit tests: 8 selected Downloads/repository route and package fallback tests passed.
- Focused UI tests: `testDownloadsScreenOpensFromReaderMenu`, `testDownloadsRepositoryManagerAddSourceCancelFlow` passed on iPhone 17 / iOS 26.5.