### PR TITLE
fix(passage-selector): align deuterocanonical toggle with Android

### DIFF
--- a/AndBible/af.lproj/Localizable.strings
+++ b/AndBible/af.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bybel";
+"deuterocanonical" = "Deuterokanonieke";
 "bookmarks" = "Boekmerke";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ar.lproj/Localizable.strings
+++ b/AndBible/ar.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "إنجيل";
+"deuterocanonical" = "الاسفار القانونية الثانية";
 "bookmarks" = "إشارات مرجعية";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/az.lproj/Localizable.strings
+++ b/AndBible/az.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Müqəddəs Kitab";
+"deuterocanonical" = "Deutero Kanonik (İkinci Dərəcədə Esin Kitablar)";
 "bookmarks" = "Nişanlı yerlər (Əlfəcinlər)";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/bg.lproj/Localizable.strings
+++ b/AndBible/bg.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библия";
+"deuterocanonical" = "Неканонични";
 "bookmarks" = "Отметките";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/bn.lproj/Localizable.strings
+++ b/AndBible/bn.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "বাইবেল";
+"deuterocanonical" = "ডিটোরোক্যানোনিক্যাল";
 "bookmarks" = "বুকমার্ক";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/cs.lproj/Localizable.strings
+++ b/AndBible/cs.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bible";
+"deuterocanonical" = "Deuterokanonické";
 "bookmarks" = "Záložky";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/de.lproj/Localizable.strings
+++ b/AndBible/de.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Apokryphen";
 "bookmarks" = "Lesezeichen";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/el.lproj/Localizable.strings
+++ b/AndBible/el.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Αγία Γραφή";
+"deuterocanonical" = "Δευτεροκανονικά";
 "bookmarks" = "Σελιδοδείκτες";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -51,6 +51,7 @@
    Navigation / Bible Reader
    ======================================== */
 "bible" = "Bible";
+"deuterocanonical" = "Deuterocanonical";
 "bookmarks" = "Bookmarks";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/eo.lproj/Localizable.strings
+++ b/AndBible/eo.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblio";
+"deuterocanonical" = "Dua-kanonaj libroj";
 "bookmarks" = "Legosignoj";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/es.lproj/Localizable.strings
+++ b/AndBible/es.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterocanónico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/et.lproj/Localizable.strings
+++ b/AndBible/et.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Piibel";
+"deuterocanonical" = "Apokriiva";
 "bookmarks" = "Järjehoidjad";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/fi.lproj/Localizable.strings
+++ b/AndBible/fi.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Raamattu";
+"deuterocanonical" = "Deuterokanoninen";
 "bookmarks" = "Kirjanmerkit";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/fr.lproj/Localizable.strings
+++ b/AndBible/fr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bible";
+"deuterocanonical" = "Deutérocanonique";
 "bookmarks" = "Signets";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/he.lproj/Localizable.strings
+++ b/AndBible/he.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "תנ\"ך";
+"deuterocanonical" = "ספרים חיצוניים";
 "bookmarks" = "סימניות";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/hi.lproj/Localizable.strings
+++ b/AndBible/hi.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "बाइबिल";
+"deuterocanonical" = " विशेषण";
 "bookmarks" = "बुकमार्क";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/hi.lproj/Localizable.strings
+++ b/AndBible/hi.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "बाइबिल";
-"deuterocanonical" = " विशेषण";
+"deuterocanonical" = "विशेषण";
 "bookmarks" = "बुकमार्क";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/hr.lproj/Localizable.strings
+++ b/AndBible/hr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Deuterokanonske";
 "bookmarks" = "Straničnik";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/hu.lproj/Localizable.strings
+++ b/AndBible/hu.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanonikus";
 "bookmarks" = "Könyvjelzők";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/id.lproj/Localizable.strings
+++ b/AndBible/id.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Alkitab";
+"deuterocanonical" = "Deuterokanonika";
 "bookmarks" = "Penanda Buku";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/it.lproj/Localizable.strings
+++ b/AndBible/it.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibbia";
+"deuterocanonical" = "Deuterocanonici";
 "bookmarks" = "Segnalibri";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/kk.lproj/Localizable.strings
+++ b/AndBible/kk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Киелі Кітап";
+"deuterocanonical" = "Екінші Жинақ Ережелері";
 "bookmarks" = "Кітап белгілері";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ko.lproj/Localizable.strings
+++ b/AndBible/ko.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "성경";
+"deuterocanonical" = "외경";
 "bookmarks" = "즐겨찾기";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/lt.lproj/Localizable.strings
+++ b/AndBible/lt.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Apokrifai";
 "bookmarks" = "Žymės";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ml.lproj/Localizable.strings
+++ b/AndBible/ml.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "വേദപുസ്തകം";
+"deuterocanonical" = "അപ്രമാണിക";
 "bookmarks" = "പുസ്തകസൂചിക";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/my.lproj/Localizable.strings
+++ b/AndBible/my.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "သမ္မာကျမ်းစာ";
+"deuterocanonical" = "တရားဟောရာကျမ်းဆိုင်ရာ စည်းမျဉ်း";
 "bookmarks" = "စာညှပ်များ";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/nb.lproj/Localizable.strings
+++ b/AndBible/nb.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Apokryfiske bøker";
 "bookmarks" = "Bokmerker";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/nl.lproj/Localizable.strings
+++ b/AndBible/nl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bijbel";
+"deuterocanonical" = "Deuterocanoniek";
 "bookmarks" = "Bladwijzers";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/pl.lproj/Localizable.strings
+++ b/AndBible/pl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanoniczny";
 "bookmarks" = "Zakładki";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/pt-BR.lproj/Localizable.strings
+++ b/AndBible/pt-BR.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bíblia";
+"deuterocanonical" = "Deuterocanônico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/pt.lproj/Localizable.strings
+++ b/AndBible/pt.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bíblia";
+"deuterocanonical" = "Deuterocanónico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ro.lproj/Localizable.strings
+++ b/AndBible/ro.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Apocrife";
 "bookmarks" = "Semne de carte";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ru.lproj/Localizable.strings
+++ b/AndBible/ru.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библия";
+"deuterocanonical" = "Второканонические";
 "bookmarks" = "Закладки";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/sk.lproj/Localizable.strings
+++ b/AndBible/sk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanonické";
 "bookmarks" = "Záložky";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/sl.lproj/Localizable.strings
+++ b/AndBible/sl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Devterokanonične ali apokrifne knjige";
 "bookmarks" = "Zaznamki";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/sr-Latn.lproj/Localizable.strings
+++ b/AndBible/sr-Latn.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Devterokanonske";
 "bookmarks" = "Obeleživači";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/sr.lproj/Localizable.strings
+++ b/AndBible/sr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библија";
+"deuterocanonical" = "Девтероканонске";
 "bookmarks" = "Обележивачи";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/sv.lproj/Localizable.strings
+++ b/AndBible/sv.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Deuterokanonisk";
 "bookmarks" = "Bokmärken";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/ta.lproj/Localizable.strings
+++ b/AndBible/ta.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "திருவிவிலியம்";
+"deuterocanonical" = "இணைத்திருமுறை";
 "bookmarks" = "புக்மார்க்குகள்";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/te.lproj/Localizable.strings
+++ b/AndBible/te.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "బైబిలు";
+"deuterocanonical" = "డ్యూటెరోకోనికల్";
 "bookmarks" = "బుక్ మార్క్‌స్";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/tr.lproj/Localizable.strings
+++ b/AndBible/tr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Kutsal Kitap";
+"deuterocanonical" = "Deuterokanonik";
 "bookmarks" = "Yer İmleri";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/uk.lproj/Localizable.strings
+++ b/AndBible/uk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Біблія";
+"deuterocanonical" = "Второхінонічний";
 "bookmarks" = "Закладки";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/uz.lproj/Localizable.strings
+++ b/AndBible/uz.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Muqaddas Kitob";
+"deuterocanonical" = "Ikkinchi darajali kanonga tegishli";
 "bookmarks" = "Xatcho'plar";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/yue.lproj/Localizable.strings
+++ b/AndBible/yue.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "聖經";
+"deuterocanonical" = "次經";
 "bookmarks" = "書籤";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/zh-Hans.lproj/Localizable.strings
+++ b/AndBible/zh-Hans.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "圣经";
+"deuterocanonical" = "次经";
 "bookmarks" = "书签";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBible/zh-Hant.lproj/Localizable.strings
+++ b/AndBible/zh-Hant.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "聖經";
+"deuterocanonical" = "次經";
 "bookmarks" = "書籤";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/AndBibleTests/AndBibleTests+PassageGrid.swift
+++ b/AndBibleTests/AndBibleTests+PassageGrid.swift
@@ -100,6 +100,99 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies iOS mirrors Android's scripture/deuterocanonical book split.
+
+     Android `NavigationControl.getBibleBooks(isScriptureRequired)` filters the active document's
+     own book list through `Scripture.isScripture`, which is KJV-versification membership rather
+     than KJVA membership. Failure means iOS may expose expanded-canon books in the default Bible
+     grid or hide them entirely instead of showing Android's session-level toggle.
+     */
+    func testPassageBookScriptureScopeMirrorsAndroidKJVScriptureSplit() {
+        let expandedBooks = BibleReaderController.defaultBooks + [
+            BookInfo(name: "Tobit", osisId: "Tob", abbreviation: "Tob", chapterCount: 14, testament: 1),
+            BookInfo(name: "Judith", osisId: "Jdt", abbreviation: "Jdt", chapterCount: 16, testament: 1),
+        ]
+
+        let scriptureBooks = PassageBookScriptureScope.books(from: expandedBooks, scope: .scripture)
+        let deuterocanonicalBooks = PassageBookScriptureScope.books(from: expandedBooks, scope: .deuterocanonical)
+
+        XCTAssertEqual(scriptureBooks.count, 66)
+        XCTAssertEqual(scriptureBooks.first?.osisId, "Gen")
+        XCTAssertFalse(scriptureBooks.contains { $0.osisId == "Tob" })
+        XCTAssertEqual(deuterocanonicalBooks.map(\.osisId), ["Tob", "Jdt"])
+        XCTAssertTrue(PassageBookScriptureScope.hasDeuterocanonicalBooks(expandedBooks))
+        XCTAssertFalse(PassageBookScriptureScope.hasDeuterocanonicalBooks(BibleReaderController.defaultBooks))
+    }
+
+    /**
+     Verifies non-scripture book grids do not apply Android category grouping.
+
+     Android passes the non-scripture book list to the same `ButtonGrid`, but `ButtonGrid` only uses
+     grouped rows when `isCurrentlyShowingScripture` is true. Failure means iOS invents grouped
+     deuterocanonical behavior that Android deliberately does not render.
+     */
+    func testPassageBookOrderingDoesNotGroupDeuterocanonicalScope() {
+        let deuterocanonicalBooks = [
+            BookInfo(name: "Tobit", osisId: "Tob", abbreviation: "Tob", chapterCount: 14, testament: 1),
+            BookInfo(name: "Judith", osisId: "Jdt", abbreviation: "Jdt", chapterCount: 16, testament: 1),
+            BookInfo(name: "Wisdom", osisId: "Wis", abbreviation: "Wis", chapterCount: 19, testament: 1),
+            BookInfo(name: "Sirach", osisId: "Sir", abbreviation: "Sir", chapterCount: 51, testament: 1),
+        ]
+        var groupedOptions = PassageChooserOptions.androidDefault
+        groupedOptions.apply(.groupByCategory)
+
+        let slots = PassageBookOrdering.displaySlots(
+            for: deuterocanonicalBooks,
+            options: groupedOptions,
+            orientation: .portrait,
+            allowsCategoryGrouping: false
+        )
+
+        XCTAssertEqual(slots.compactMap { $0?.osisId }, ["Tob", "Jdt", "Wis", "Sir"])
+        XCTAssertEqual(slots[0]?.osisId, "Tob")
+        XCTAssertEqual(slots[1]?.osisId, "Jdt")
+        XCTAssertEqual(
+            PassageBookOrdering.columnCount(
+                itemCount: deuterocanonicalBooks.count,
+                options: groupedOptions,
+                orientation: .portrait,
+                allowsCategoryGrouping: false
+            ),
+            PassageGridLayout.androidDefault(
+                itemCount: deuterocanonicalBooks.count,
+                kind: .book,
+                orientation: .portrait,
+                rowOrder: groupedOptions.rowOrder
+            ).columns
+        )
+    }
+
+    /**
+     Verifies the deuterocanonical toggle is a separate Android action-bar control.
+
+     Android declares `deut_toggle` before the overflow-only checkable options and shows it as an
+     action item when the active document has non-scripture books. Failure means iOS hid the scope
+     switch inside the options popup or modeled it as a persisted preference.
+     */
+    func testPassageChooserExposesDeuterocanonicalActionOutsideOverflow() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        )
+
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("@State private var bookScope = PassageBookScriptureScope.scripture"))
+        XCTAssertTrue(source.contains("PassageBookScriptureScope.books(from: books, scope: bookScope)"))
+        XCTAssertTrue(source.contains("bookScope.toggle()"))
+        XCTAssertTrue(source.contains("passageChooserDeuterocanonicalToggleButton"))
+        XCTAssertFalse(source.contains("bookGridDeuterocanonical"))
+    }
+
+    /**
      Verifies iOS uses Android/JSword short book labels instead of SWORD abbreviations.
 
      The Android chooser calls `versification.getShortName(book)`, producing labels like `2 Ki`,

--- a/Localizations/af.lproj/Localizable.strings
+++ b/Localizations/af.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bybel";
+"deuterocanonical" = "Deuterokanonieke";
 "bookmarks" = "Boekmerke";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ar.lproj/Localizable.strings
+++ b/Localizations/ar.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "إنجيل";
+"deuterocanonical" = "الاسفار القانونية الثانية";
 "bookmarks" = "إشارات مرجعية";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/az.lproj/Localizable.strings
+++ b/Localizations/az.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Müqəddəs Kitab";
+"deuterocanonical" = "Deutero Kanonik (İkinci Dərəcədə Esin Kitablar)";
 "bookmarks" = "Nişanlı yerlər (Əlfəcinlər)";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/bg.lproj/Localizable.strings
+++ b/Localizations/bg.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библия";
+"deuterocanonical" = "Неканонични";
 "bookmarks" = "Отметките";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/bn.lproj/Localizable.strings
+++ b/Localizations/bn.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "বাইবেল";
+"deuterocanonical" = "ডিটোরোক্যানোনিক্যাল";
 "bookmarks" = "বুকমার্ক";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bible";
+"deuterocanonical" = "Deuterokanonické";
 "bookmarks" = "Záložky";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Apokryphen";
 "bookmarks" = "Lesezeichen";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Αγία Γραφή";
+"deuterocanonical" = "Δευτεροκανονικά";
 "bookmarks" = "Σελιδοδείκτες";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
    Navigation / Bible Reader
    ======================================== */
 "bible" = "Bible";
+"deuterocanonical" = "Deuterocanonical";
 "bookmarks" = "Bookmarks";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/eo.lproj/Localizable.strings
+++ b/Localizations/eo.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblio";
+"deuterocanonical" = "Dua-kanonaj libroj";
 "bookmarks" = "Legosignoj";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterocanónico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/et.lproj/Localizable.strings
+++ b/Localizations/et.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Piibel";
+"deuterocanonical" = "Apokriiva";
 "bookmarks" = "Järjehoidjad";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/fi.lproj/Localizable.strings
+++ b/Localizations/fi.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Raamattu";
+"deuterocanonical" = "Deuterokanoninen";
 "bookmarks" = "Kirjanmerkit";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bible";
+"deuterocanonical" = "Deutérocanonique";
 "bookmarks" = "Signets";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "תנ\"ך";
+"deuterocanonical" = "ספרים חיצוניים";
 "bookmarks" = "סימניות";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/hi.lproj/Localizable.strings
+++ b/Localizations/hi.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "बाइबिल";
+"deuterocanonical" = " विशेषण";
 "bookmarks" = "बुकमार्क";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/hi.lproj/Localizable.strings
+++ b/Localizations/hi.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "बाइबिल";
-"deuterocanonical" = " विशेषण";
+"deuterocanonical" = "विशेषण";
 "bookmarks" = "बुकमार्क";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/hr.lproj/Localizable.strings
+++ b/Localizations/hr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Deuterokanonske";
 "bookmarks" = "Straničnik";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/hu.lproj/Localizable.strings
+++ b/Localizations/hu.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanonikus";
 "bookmarks" = "Könyvjelzők";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/id.lproj/Localizable.strings
+++ b/Localizations/id.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Alkitab";
+"deuterocanonical" = "Deuterokanonika";
 "bookmarks" = "Penanda Buku";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/it.lproj/Localizable.strings
+++ b/Localizations/it.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibbia";
+"deuterocanonical" = "Deuterocanonici";
 "bookmarks" = "Segnalibri";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/kk.lproj/Localizable.strings
+++ b/Localizations/kk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Киелі Кітап";
+"deuterocanonical" = "Екінші Жинақ Ережелері";
 "bookmarks" = "Кітап белгілері";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "성경";
+"deuterocanonical" = "외경";
 "bookmarks" = "즐겨찾기";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/lt.lproj/Localizable.strings
+++ b/Localizations/lt.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Apokrifai";
 "bookmarks" = "Žymės";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ml.lproj/Localizable.strings
+++ b/Localizations/ml.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "വേദപുസ്തകം";
+"deuterocanonical" = "അപ്രമാണിക";
 "bookmarks" = "പുസ്തകസൂചിക";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/my.lproj/Localizable.strings
+++ b/Localizations/my.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "သမ္မာကျမ်းစာ";
+"deuterocanonical" = "တရားဟောရာကျမ်းဆိုင်ရာ စည်းမျဉ်း";
 "bookmarks" = "စာညှပ်များ";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/nb.lproj/Localizable.strings
+++ b/Localizations/nb.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Apokryfiske bøker";
 "bookmarks" = "Bokmerker";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/nl.lproj/Localizable.strings
+++ b/Localizations/nl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bijbel";
+"deuterocanonical" = "Deuterocanoniek";
 "bookmarks" = "Bladwijzers";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanoniczny";
 "bookmarks" = "Zakładki";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bíblia";
+"deuterocanonical" = "Deuterocanônico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/pt.lproj/Localizable.strings
+++ b/Localizations/pt.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bíblia";
+"deuterocanonical" = "Deuterocanónico";
 "bookmarks" = "Marcadores";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ro.lproj/Localizable.strings
+++ b/Localizations/ro.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Apocrife";
 "bookmarks" = "Semne de carte";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библия";
+"deuterocanonical" = "Второканонические";
 "bookmarks" = "Закладки";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/sk.lproj/Localizable.strings
+++ b/Localizations/sk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblia";
+"deuterocanonical" = "Deuterokanonické";
 "bookmarks" = "Záložky";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/sl.lproj/Localizable.strings
+++ b/Localizations/sl.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Devterokanonične ali apokrifne knjige";
 "bookmarks" = "Zaznamki";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/sr-Latn.lproj/Localizable.strings
+++ b/Localizations/sr-Latn.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Biblija";
+"deuterocanonical" = "Devterokanonske";
 "bookmarks" = "Obeleživači";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/sr.lproj/Localizable.strings
+++ b/Localizations/sr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Библија";
+"deuterocanonical" = "Девтероканонске";
 "bookmarks" = "Обележивачи";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Bibel";
+"deuterocanonical" = "Deuterokanonisk";
 "bookmarks" = "Bokmärken";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/ta.lproj/Localizable.strings
+++ b/Localizations/ta.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "திருவிவிலியம்";
+"deuterocanonical" = "இணைத்திருமுறை";
 "bookmarks" = "புக்மார்க்குகள்";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/te.lproj/Localizable.strings
+++ b/Localizations/te.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "బైబిలు";
+"deuterocanonical" = "డ్యూటెరోకోనికల్";
 "bookmarks" = "బుక్ మార్క్‌స్";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/tr.lproj/Localizable.strings
+++ b/Localizations/tr.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Kutsal Kitap";
+"deuterocanonical" = "Deuterokanonik";
 "bookmarks" = "Yer İmleri";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/uk.lproj/Localizable.strings
+++ b/Localizations/uk.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Біблія";
+"deuterocanonical" = "Второхінонічний";
 "bookmarks" = "Закладки";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/uz.lproj/Localizable.strings
+++ b/Localizations/uz.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "Muqaddas Kitob";
+"deuterocanonical" = "Ikkinchi darajali kanonga tegishli";
 "bookmarks" = "Xatcho'plar";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/yue.lproj/Localizable.strings
+++ b/Localizations/yue.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "聖經";
+"deuterocanonical" = "次經";
 "bookmarks" = "書籤";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "圣经";
+"deuterocanonical" = "次经";
 "bookmarks" = "书签";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "no_results" = "No Results";
 "searching" = "Searching...";
 "bible" = "聖經";
+"deuterocanonical" = "次經";
 "bookmarks" = "書籤";
 "reading_plans" = "Reading Plans";
 "downloads" = "Downloads";

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift
@@ -34,6 +34,7 @@ import SwordKit
  - tapping a chapter may either complete the flow or advance to the verse step
  - tapping toolbar back actions resets the local step state without dismissing the chooser
  - tapping overflow-menu rows persists Android-compatible chooser options in `SettingsStore`
+ - tapping the deuterocanonical toolbar action toggles a view-local book scope, matching Android
  */
 public struct BookChooserView: View {
     /// Dynamic book list derived from the active module's versification.
@@ -80,6 +81,9 @@ public struct BookChooserView: View {
 
     /// Android chooser overflow-menu state loaded from `SettingsStore`.
     @State private var chooserOptions = PassageChooserOptions.androidDefault
+
+    /// Android scripture/non-scripture book scope for the current chooser presentation.
+    @State private var bookScope = PassageBookScriptureScope.scripture
 
     /// Tracks first appearance so option state is not reloaded after in-view menu changes.
     @State private var hasLoadedChooserOptions = false
@@ -150,7 +154,9 @@ public struct BookChooserView: View {
             PassageChooserAppBar(
                 title: navigationTitle,
                 showsOverflowButton: selectedBook == nil,
+                deuterocanonicalToggleTitle: selectedBook == nil ? deuterocanonicalToggleTitle : nil,
                 onBack: navigateBackOrCancel,
+                onToggleDeuterocanonical: toggleDeuterocanonicalScope,
                 onOverflow: {
                     isChooserMenuPresented.toggle()
                 }
@@ -297,6 +303,21 @@ public struct BookChooserView: View {
     }
 
     /**
+     Toggles Android's session-local scripture/deuterocanonical book scope.
+
+     Android invalidates the book chooser menu and rebuilds the grid without persisting this state.
+     iOS mirrors that by mutating only view-local state and leaving the durable chooser options
+     untouched.
+
+     - Side effects: Hides the overflow popup and changes the visible book grid scope.
+     - Failure modes: none.
+     */
+    private func toggleDeuterocanonicalScope() {
+        isChooserMenuPresented = false
+        bookScope.toggle()
+    }
+
+    /**
      Loads persisted chooser options on first appearance.
 
      - Side effects: Reads SwiftData through `SettingsStore` once per view lifetime.
@@ -325,20 +346,46 @@ public struct BookChooserView: View {
         )
     }
 
+    /// Active module books filtered through Android's current scripture/deuterocanonical scope.
+    private var visibleBooks: [BookInfo] {
+        PassageBookScriptureScope.books(from: books, scope: bookScope)
+    }
+
+    /// Whether Android would show the book chooser deuterocanonical action for this module.
+    private var hasDeuterocanonicalBooks: Bool {
+        PassageBookScriptureScope.hasDeuterocanonicalBooks(books)
+    }
+
+    /// Localized title for Android's `deut_toggle` action item, or `nil` when hidden.
+    private var deuterocanonicalToggleTitle: String? {
+        guard hasDeuterocanonicalBooks else {
+            return nil
+        }
+        return NSLocalizedString(
+            bookScope.androidToolbarLocalizationKey,
+            value: bookScope.androidToolbarDefaultTitle,
+            comment: ""
+        )
+    }
+
     /// Scrollable container for the Android-aligned book grid.
     private var bookGrid: some View {
         GeometryReader { proxy in
             let orientation = PassageGridOrientation(size: proxy.size)
+            let scopedBooks = visibleBooks
+            let allowsCategoryGrouping = bookScope == .scripture
             let slots = PassageBookOrdering.displaySlots(
-                for: books,
+                for: scopedBooks,
                 options: chooserOptions,
-                orientation: orientation
+                orientation: orientation,
+                allowsCategoryGrouping: allowsCategoryGrouping
             )
             let columnCount = max(
                 PassageBookOrdering.columnCount(
-                    itemCount: books.count,
+                    itemCount: scopedBooks.count,
                     options: chooserOptions,
-                    orientation: orientation
+                    orientation: orientation,
+                    allowsCategoryGrouping: allowsCategoryGrouping
                 ),
                 1
             )
@@ -451,8 +498,14 @@ private struct PassageChooserAppBar: View {
     /// Whether the Android overflow menu should be available for the current chooser step.
     let showsOverflowButton: Bool
 
+    /// Title for Android's separate scripture/deuterocanonical action item.
+    let deuterocanonicalToggleTitle: String?
+
     /// Back action for stepping back within the chooser or closing it from the book grid.
     let onBack: () -> Void
+
+    /// Action that toggles Android's scripture/deuterocanonical book scope.
+    let onToggleDeuterocanonical: () -> Void
 
     /// Action that toggles Android's chooser option popup.
     let onOverflow: () -> Void
@@ -477,6 +530,19 @@ private struct PassageChooserAppBar: View {
                 .foregroundStyle(Color.white)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .accessibilityIdentifier("passageChooserTitle")
+
+            if showsOverflowButton,
+               let deuterocanonicalToggleTitle {
+                Button(action: onToggleDeuterocanonical) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 24, weight: .semibold))
+                        .frame(width: 52, height: Self.height)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(deuterocanonicalToggleTitle)
+                .accessibilityIdentifier("passageChooserDeuterocanonicalToggleButton")
+            }
 
             if showsOverflowButton {
                 Button(action: onOverflow) {

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -560,6 +560,7 @@ enum PassageBookOrdering {
        - books: Module-provided book list in Bible-book order.
        - options: Current persisted/session chooser options.
        - orientation: Current visual orientation used by Android layout rules.
+       - allowsCategoryGrouping: Whether Android category grouping is allowed for this book scope.
      - Returns: Row-major visual slots, with `nil` placeholders for empty cells/spacers.
      - Side effects: none.
      - Failure modes: Empty input returns an empty array.
@@ -599,6 +600,7 @@ enum PassageBookOrdering {
        - itemCount: Number of source books.
        - options: Current chooser options.
        - orientation: Current visual orientation.
+       - allowsCategoryGrouping: Whether Android category grouping is allowed for this book scope.
      - Returns: Android grouped-grid column count or the layout-derived count.
      - Side effects: none.
      - Failure modes: Counts below one are clamped by callers.

--- a/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift
@@ -152,6 +152,111 @@ enum PassageChooserSurfacePalette {
 }
 
 /**
+ Android scripture/non-scripture book scope for the passage book chooser.
+
+ Android passes the active document's own `BibleBook` list through `Scripture.isScripture`, where
+ scripture means membership in JSword's KJV versification and excludes introduction pseudo-books.
+ iOS receives `BookInfo` from the active SWORD module instead of JSword, so this helper applies the
+ same KJV 66-book predicate over that module-provided list without replacing it as the data source.
+ */
+enum PassageBookScriptureScope: Equatable, Sendable {
+    /// Android `isScriptureRequired = true`.
+    case scripture
+
+    /// Android `isScriptureRequired = false`, surfaced as the deuterocanonical toggle.
+    case deuterocanonical
+
+    /// JSword KJV scripture books used by Android `Scripture.isScripture`.
+    private static let androidScriptureOsisIds: Set<String> = [
+        "Gen", "Exod", "Lev", "Num", "Deut", "Josh", "Judg", "Ruth",
+        "1Sam", "2Sam", "1Kgs", "2Kgs", "1Chr", "2Chr", "Ezra", "Neh",
+        "Esth", "Job", "Ps", "Prov", "Eccl", "Song", "Isa", "Jer",
+        "Lam", "Ezek", "Dan", "Hos", "Joel", "Amos", "Obad", "Jonah",
+        "Mic", "Nah", "Hab", "Zeph", "Hag", "Zech", "Mal", "Matt",
+        "Mark", "Luke", "John", "Acts", "Rom", "1Cor", "2Cor", "Gal",
+        "Eph", "Phil", "Col", "1Thess", "2Thess", "1Tim", "2Tim",
+        "Titus", "Phlm", "Heb", "Jas", "1Pet", "2Pet", "1John",
+        "2John", "3John", "Jude", "Rev",
+    ]
+
+    /**
+     Filters an active-module book list with Android's scripture/non-scripture predicate.
+
+     - Parameters:
+       - books: Active module-provided books in document order.
+       - scope: Android chooser scope to render.
+     - Returns: Books matching the requested Android scope, preserving the module-provided order.
+     - Side effects: none.
+     - Failure modes: Unknown OSIS ids are treated as non-scripture, matching Android's KJV
+       membership check for books outside `SystemKJV`.
+     */
+    static func books(from books: [BookInfo], scope: PassageBookScriptureScope) -> [BookInfo] {
+        books.filter { book in
+            switch scope {
+            case .scripture:
+                return isScripture(book)
+            case .deuterocanonical:
+                return !isScripture(book)
+            }
+        }
+    }
+
+    /**
+     Returns whether Android would show the passage chooser deuterocanonical action item.
+
+     - Parameter books: Active module-provided books in document order.
+     - Returns: `true` when the module exposes at least one non-scripture book.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    static func hasDeuterocanonicalBooks(_ books: [BookInfo]) -> Bool {
+        books.contains { !isScripture($0) }
+    }
+
+    /**
+     Toggles the visible Android passage book scope.
+
+     - Side effects: Mutates this scope only; Android does not persist this toggle.
+     - Failure modes: none.
+     */
+    mutating func toggle() {
+        self = self == .scripture ? .deuterocanonical : .scripture
+    }
+
+    /// Android `deut_toggle` title localization key for the current scope.
+    var androidToolbarLocalizationKey: String {
+        switch self {
+        case .scripture:
+            return "bible"
+        case .deuterocanonical:
+            return "deuterocanonical"
+        }
+    }
+
+    /// English fallback for Android `deut_toggle` title when no iOS localization exists.
+    var androidToolbarDefaultTitle: String {
+        switch self {
+        case .scripture:
+            return "Bible"
+        case .deuterocanonical:
+            return "Deuterocanonical"
+        }
+    }
+
+    /**
+     Checks Android scripture membership for one book.
+
+     - Parameter book: Active module book metadata.
+     - Returns: `true` when the OSIS id belongs to JSword's KJV scripture versification.
+     - Side effects: none.
+     - Failure modes: Unknown ids return `false`.
+     */
+    private static func isScripture(_ book: BookInfo) -> Bool {
+        androidScriptureOsisIds.contains(book.osisId)
+    }
+}
+
+/**
  Android overflow-menu actions supported by the book chooser.
 
  Each case corresponds to a checkable item in Android `choose_passage_book_menu.xml`. The enum is
@@ -462,13 +567,14 @@ enum PassageBookOrdering {
     static func displaySlots(
         for books: [BookInfo],
         options: PassageChooserOptions,
-        orientation: PassageGridOrientation
+        orientation: PassageGridOrientation,
+        allowsCategoryGrouping: Bool = true
     ) -> [BookInfo?] {
         guard !books.isEmpty else {
             return []
         }
 
-        if options.groupByCategory {
+        if options.groupByCategory, allowsCategoryGrouping {
             return groupedSlots(for: books)
         }
 
@@ -500,9 +606,10 @@ enum PassageBookOrdering {
     static func columnCount(
         itemCount: Int,
         options: PassageChooserOptions,
-        orientation: PassageGridOrientation
+        orientation: PassageGridOrientation,
+        allowsCategoryGrouping: Bool = true
     ) -> Int {
-        if options.groupByCategory {
+        if options.groupByCategory, allowsCategoryGrouping {
             return groupedColumnCount
         }
         return PassageGridLayout.androidDefault(


### PR DESCRIPTION
## Summary

Completes the remaining #215 passage selector parity gap by adding Android-style scripture/deuterocanonical scope toggling to the iOS book chooser.

## Scope

- Filters active-module BookInfo data into Android scripture and deuterocanonical chooser scopes.
- Adds the session-local book chooser toolbar action for switching scopes.
- Keeps non-scripture scope out of category grouping, matching Android ButtonGrid behavior.
- Adds focused passage selector parity tests for scope filtering, grouping behavior, and toolbar placement.

## Contract References

- GitHub issue #215.
- Android GridChoosePassageBook.kt deuterocanonical toggle behavior.
- Android NavigationControl.getBibleBooks scripture filtering semantics.
- Android ButtonGrid category grouping guard for scripture-only grouping.

## Change Details

- Uses the active module-provided BookInfo list as the selector source, then applies Android JSword/KJV scripture membership as a predicate.
- Keeps the deuterocanonical toggle as view-local state, not a persisted iOS preference.
- Preserves existing #206 default grid, color, and selection behavior for normal 66-book modules.

## Validation Evidence

- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme AndBible -destination platform=iOS Simulator,id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F with six selected passage selector tests: 6 tests, 0 failures.
- git diff --check for the changed implementation and test files.
- GitNexus impact checks were run before edits. GitNexus detect-changes could not resolve this worktree through its stale backend registry after indexing, so the staged diff scope was verified directly before commit.

## Risks / Follow-ups

- Risk is limited to passage selector book-grid rendering and chooser option behavior.
- No known follow-up is required for #215 after this final deuterocanonical parity piece.

## Issue Closure Reference

Closes #215