### PR TITLE
refactor(reader): extract module switch coordinator

### DIFF
--- a/AndBibleTests/AndBibleTestSupport.swift
+++ b/AndBibleTests/AndBibleTestSupport.swift
@@ -509,6 +509,57 @@ extension AndBibleTests {
     }
 
     /**
+     Seeds a deterministic empty SWORD map module into a temporary module directory.
+
+     Android treats map modules as documents in `CurrentPageManager.setCurrentDocument(book)`.
+     Controller parity tests need a real map category from SWORD discovery so iOS can verify the
+     same current-document transition without carrying redistributable map payloads.
+
+     - Parameters:
+       - moduleName: SWORD module initials to publish in `mods.d`.
+       - modulePath: Temporary SWORD root returned by `makeTemporaryBundledSwordPath()`.
+     - Side effects: Writes a `.conf` file and empty `RawGenBook` data files under `modulePath`.
+     - Failure modes: Propagates filesystem write errors.
+     */
+    func seedEmptyRawMapModule(named moduleName: String = "UITestMap", in modulePath: String) throws {
+        let fm = FileManager.default
+        let moduleKey = moduleName.lowercased()
+        let moduleRoot = URL(fileURLWithPath: modulePath, isDirectory: true)
+        let modsDURL = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let dataURL = moduleRoot
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent("genbook", isDirectory: true)
+            .appendingPathComponent("rawgenbook", isDirectory: true)
+            .appendingPathComponent(moduleKey, isDirectory: true)
+
+        try fm.createDirectory(at: modsDURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: dataURL, withIntermediateDirectories: true)
+        for fileName in ["\(moduleKey).dat", "\(moduleKey).idx"] {
+            let fileURL = dataURL.appendingPathComponent(fileName, isDirectory: false)
+            if !fm.fileExists(atPath: fileURL.path) {
+                try Data().write(to: fileURL)
+            }
+        }
+
+        let conf = """
+        [\(moduleName)]
+        Description=UI Test Map
+        Category=Maps
+        DataPath=./modules/genbook/rawgenbook/\(moduleKey)/\(moduleKey)
+        ModDrv=RawGenBook
+        SourceType=OSIS
+        Encoding=UTF-8
+        Lang=en
+        About=Deterministic empty map module for iOS parity tests.
+        """
+        try conf.write(
+            to: modsDURL.appendingPathComponent("\(moduleKey).conf", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /**
      Seeds an additional Bible module identity that reuses the bundled KJV fixture payload.
 
      Quick-selector parity tests need multiple installed Bible module initials so they can exercise

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1498,6 +1498,101 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the extracted document-switch category guard used by Android-style current-document
+     changes.
+
+     A Bible document switch must not accept a commentary module because that would persist a Bible
+     page identity with non-Bible initials. The controller's public API logs the failure; this
+     collaborator-level contract keeps the rule isolated from logging and WebView reload concerns.
+     */
+    func testReaderModuleSwitchCoordinatorRejectsMismatchedDocumentCategory() {
+        let coordinator = BibleReaderModuleSwitchCoordinator()
+
+        let result = coordinator.documentSwitchPlan(
+            moduleName: "MHC",
+            moduleCategory: .commentary,
+            targetCategory: .bible
+        )
+
+        XCTAssertEqual(
+            result,
+            .failure(.categoryMismatch(moduleName: "MHC", expected: .bible, actual: .commentary))
+        )
+    }
+
+    /**
+     Protects Android's atomic dictionary document switch persistence contract.
+
+     Selecting a dictionary from the commentary/document chooser updates the visible category and
+     selected dictionary together while clearing a stale dictionary key. A failure here means the
+     controller could again split module selection from category persistence.
+     */
+    func testReaderModuleSwitchCoordinatorPersistsDictionaryDocumentAndClearsStaleKey() throws {
+        let coordinator = BibleReaderModuleSwitchCoordinator()
+        let pageManager = PageManager(currentCategoryName: DocumentCategory.bible.pageManagerKey)
+        pageManager.dictionaryDocument = "OldDict"
+        pageManager.dictionaryKey = "stale-key"
+
+        let plan = try coordinator.documentSwitchPlan(
+            moduleName: "BDBT",
+            moduleCategory: .dictionary,
+            targetCategory: .dictionary
+        ).get()
+
+        plan.apply(to: pageManager)
+
+        XCTAssertEqual(plan.category, .dictionary)
+        XCTAssertTrue(plan.updatesVisibleCategory)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.dictionary.pageManagerKey)
+        XCTAssertEqual(pageManager.dictionaryDocument, "BDBT")
+        XCTAssertNil(pageManager.dictionaryKey)
+    }
+
+    /**
+     Protects module-only switching as separate from visible category switching.
+
+     The full module picker currently selects a map by first switching the map module and then
+     switching category. This legacy two-call path is still present in the UI, so a module-only plan
+     must update the selected map and clear the stale key without changing the visible page category.
+     */
+    func testReaderModuleSwitchCoordinatorModuleOnlyPlanDoesNotChangeVisibleCategory() {
+        let coordinator = BibleReaderModuleSwitchCoordinator()
+        let pageManager = PageManager(currentCategoryName: DocumentCategory.bible.pageManagerKey)
+        pageManager.mapDocument = "OldMap"
+        pageManager.mapKey = "stale-map-key"
+
+        let plan = coordinator.moduleOnlySwitchPlan(
+            moduleName: "BibleMap",
+            targetCategory: .map
+        )
+
+        plan.apply(to: pageManager)
+
+        XCTAssertEqual(plan.category, .map)
+        XCTAssertFalse(plan.updatesVisibleCategory)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+        XCTAssertEqual(pageManager.mapDocument, "BibleMap")
+        XCTAssertNil(pageManager.mapKey)
+    }
+
+    /**
+     Protects category-only reload decisions from being hidden inside controller code.
+
+     Switching to the same category should persist the category but not request a WebView reload;
+     switching to a different category should request one. The controller remains responsible for
+     checking client readiness before actually reloading.
+     */
+    func testReaderModuleSwitchCoordinatorCategoryPlanRequestsReloadOnlyWhenCategoryChanges() {
+        let coordinator = BibleReaderModuleSwitchCoordinator()
+
+        let unchanged = coordinator.categorySwitchPlan(from: .bible, to: .bible)
+        let changed = coordinator.categorySwitchPlan(from: .bible, to: .commentary)
+
+        XCTAssertFalse(unchanged.shouldReloadContent)
+        XCTAssertTrue(changed.shouldReloadContent)
+    }
+
+    /**
      Guards the reader coordinator against regressing to the iOS sheet for the quick-menu path.
 
      The coordinator state is intentionally private, so this source-level test checks the routing

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1038,6 +1038,23 @@ extension AndBibleTests {
     }
 
     /**
+     Guards Android current-document parity for full module-picker map selections.
+
+     Android routes map rows through `setCurrentDocument(book)` just like other document rows. The
+     full iOS picker must therefore call the controller's map document switch instead of splitting
+     map module and category updates across separate mutations.
+     */
+    func testBibleReaderModulePickerRoutesMapsThroughDocumentSwitch() throws {
+        let source = try bibleUISource(named: "BibleReaderModulePicker.swift")
+        let selectionSource = try extractFunction(named: "select", from: source)
+
+        XCTAssertTrue(selectionSource.contains("case .map:"))
+        XCTAssertTrue(selectionSource.contains("controller.switchMapDocument(to: module.name)"))
+        XCTAssertFalse(selectionSource.contains("controller.switchMapModule(to: module.name)"))
+        XCTAssertFalse(selectionSource.contains("controller.switchCategory(to: .map)"))
+    }
+
+    /**
      Protects Android `MainBibleActivity.menuForDocs` parity for the Bible toolbar quick menu.
 
      Android sorts quick-menu entries by language code and then book abbreviation, renders labels as
@@ -1411,6 +1428,39 @@ extension AndBibleTests {
     }
 
     /**
+     Protects Android's atomic current-document switch behavior for map selections.
+
+     Android routes maps through the same current-document transition as other chooser rows. The
+     iOS controller must therefore persist the selected map/category and clear stale map keys
+     together so map selection cannot leave mixed pane state behind.
+     */
+    @MainActor
+    func testMapDocumentSwitchPersistsModuleCategoryAndClearsKeyTogether() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedEmptyRawMapModule(named: "UITestMap", in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        pageManager.mapKey = "stale-key"
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchMapDocument(to: "UITestMap")
+
+        XCTAssertEqual(controller.currentCategory, .map)
+        XCTAssertEqual(controller.activeMapModuleName, "UITestMap")
+        XCTAssertNil(controller.currentMapKey)
+        XCTAssertEqual(pageManager.mapDocument, "UITestMap")
+        XCTAssertNil(pageManager.mapKey)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.map.pageManagerKey)
+        XCTAssertEqual(persistCount, 1)
+    }
+
+    /**
      Protects Android's atomic current-document switch behavior for Bible quick selections.
 
      Android `MainBibleActivity.menuForDocs` delegates selected Bible rows to
@@ -1549,11 +1599,39 @@ extension AndBibleTests {
     }
 
     /**
+     Protects Android's atomic map document switch persistence contract.
+
+     Selecting a map from the document chooser updates the visible category and selected map
+     together while clearing stale map entry state. A failure here means map selection can again
+     split module selection from category persistence.
+     */
+    func testReaderModuleSwitchCoordinatorPersistsMapDocumentAndClearsStaleKey() throws {
+        let coordinator = BibleReaderModuleSwitchCoordinator()
+        let pageManager = PageManager(currentCategoryName: DocumentCategory.bible.pageManagerKey)
+        pageManager.mapDocument = "OldMap"
+        pageManager.mapKey = "stale-key"
+
+        let plan = try coordinator.documentSwitchPlan(
+            moduleName: "BibleMap",
+            moduleCategory: .map,
+            targetCategory: .map
+        ).get()
+
+        plan.apply(to: pageManager)
+
+        XCTAssertEqual(plan.category, .map)
+        XCTAssertTrue(plan.updatesVisibleCategory)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.map.pageManagerKey)
+        XCTAssertEqual(pageManager.mapDocument, "BibleMap")
+        XCTAssertNil(pageManager.mapKey)
+    }
+
+    /**
      Protects module-only switching as separate from visible category switching.
 
-     The full module picker currently selects a map by first switching the map module and then
-     switching category. This legacy two-call path is still present in the UI, so a module-only plan
-     must update the selected map and clear the stale key without changing the visible page category.
+     Direct module-switch paths can update the selected module for an inactive category. That must
+     remain separate from full current-document chooser paths, which update the selected module and
+     visible category together.
      */
     func testReaderModuleSwitchCoordinatorModuleOnlyPlanDoesNotChangeVisibleCategory() {
         let coordinator = BibleReaderModuleSwitchCoordinator()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1013,6 +1013,30 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         moduleSwitchCoordinator.switchMapModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
+    /**
+     Switches the visible document to a map module in one Android-parity transition.
+
+     Android routes map rows through the same `setCurrentDocument(book)` path as Bible,
+     commentary, dictionary, and general-book rows. iOS must therefore persist the selected map,
+     clear stale map entry state, and switch the visible category together instead of splitting map
+     selection and category selection across separate controller mutations.
+
+     - Parameter moduleName: Installed SWORD map module abbreviation to make current.
+     Side effects:
+     - mutates the active map module, clears the selected map key, and sets the current category to
+       map
+     - writes `mapDocument`, `mapKey`, and `currentCategoryName` to `PageManager`
+     - invokes `onPersistState` once when pane state is available
+     - reloads the visible reader document once when the JavaScript client is ready
+     Failure modes:
+     - if the module cannot be resolved, logs a warning and leaves controller/page state unchanged
+     - if the resolved module is not a map, logs a warning and leaves state unchanged
+     */
+    @MainActor
+    public func switchMapDocument(to moduleName: String) {
+        moduleSwitchCoordinator.switchMapDocument(to: moduleName, context: makeModuleSwitchContext())
+    }
+
     /// Switch between document categories (Bible, Commentary, Dictionary, General Book, Map).
     public func switchCategory(to category: DocumentCategory) {
         moduleSwitchCoordinator.switchCategory(to: category, context: makeModuleSwitchContext())

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -148,6 +148,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var activeCommentaryModule: SwordModule?
     private(set) var activeCommentaryModuleName: String?
     private(set) var currentCategory: DocumentCategory = .bible
+    /// Pure planner for Android-style module/category PageManager transitions.
+    private let moduleSwitchCoordinator = BibleReaderModuleSwitchCoordinator()
 
     /// Dictionary/Lexicon module support
     private(set) var installedDictionaryModules: [ModuleInfo] = []
@@ -707,6 +709,60 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
     }
 
+    /**
+     Builds the controller-owned mutation context used by the module switch coordinator.
+
+     The coordinator owns module/category switching rules while this controller remains the owner of
+     observed active-module state, current keys, persistence callbacks, and WebView reloads. Closures
+     capture the controller weakly so a pending switch action cannot extend pane lifetime.
+     */
+    private func makeModuleSwitchContext() -> BibleReaderModuleSwitchContext {
+        BibleReaderModuleSwitchContext(
+            swordManager: swordManager,
+            activeWindow: activeWindow,
+            clientReady: clientReady,
+            currentCategory: currentCategory,
+            setBibleModule: { [weak self] module, moduleName in
+                self?.activeModule = module
+                self?.activeModuleName = moduleName
+            },
+            setCommentaryModule: { [weak self] module, moduleName in
+                self?.activeCommentaryModule = module
+                self?.activeCommentaryModuleName = moduleName
+            },
+            setDictionaryModule: { [weak self] module, moduleName in
+                self?.activeDictionaryModule = module
+                self?.activeDictionaryModuleName = moduleName
+                self?.currentDictionaryKey = nil
+            },
+            setGeneralBookModule: { [weak self] module, moduleName in
+                self?.activeGeneralBookModule = module
+                self?.activeGeneralBookModuleName = moduleName
+                self?.currentGeneralBookKey = nil
+            },
+            setMapModule: { [weak self] module, moduleName in
+                self?.activeMapModule = module
+                self?.activeMapModuleName = moduleName
+                self?.currentMapKey = nil
+            },
+            setCurrentCategory: { [weak self] category in
+                self?.currentCategory = category
+            },
+            refreshBookList: { [weak self] in
+                self?.refreshBookList()
+            },
+            moduleBookListCount: { [weak self] in
+                self?.moduleBookList.count ?? 0
+            },
+            persistState: { [weak self] in
+                self?.onPersistState?()
+            },
+            loadCurrentContent: { [weak self] in
+                self?.loadCurrentContent()
+            }
+        )
+    }
+
     /// Update display settings and re-emit config to Vue.js.
     public func updateDisplaySettings(_ settings: TextDisplaySettings, nightMode: Bool) {
         self.displaySettings = settings
@@ -838,25 +894,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Switch to a different installed Bible module.
     public func switchModule(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to module \(moduleName) — not found")
-            return
-        }
-        activeModule = mod
-        activeModuleName = moduleName
-        refreshBookList()
-        logger.info("Switched to module: \(moduleName) (\(self.moduleBookList.count) books)")
-
-        // Persist module selection to PageManager
-        if let pm = activeWindow?.pageManager {
-            pm.bibleDocument = moduleName
-            onPersistState?()
-        }
-
-        // Reload the current chapter with the new module
-        guard clientReady else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /**
@@ -883,51 +921,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @MainActor
     public func switchBibleDocument(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to Bible document \(moduleName) — not found")
-            return
-        }
-        guard mod.info.category == .bible else {
-            logger.warning("Cannot switch to Bible document \(moduleName) — category \(mod.info.category.rawValue)")
-            return
-        }
-        activeModule = mod
-        activeModuleName = moduleName
-        currentCategory = .bible
-        refreshBookList()
-        logger.info("Switched to Bible document: \(moduleName) (\(self.moduleBookList.count) books)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.bibleDocument = moduleName
-            pm.currentCategoryName = DocumentCategory.bible.pageManagerKey
-            onPersistState?()
-        }
-
-        guard clientReady else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchBibleDocument(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /// Switch to a different installed commentary module.
     public func switchCommentaryModule(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to commentary module \(moduleName) — not found")
-            return
-        }
-        activeCommentaryModule = mod
-        activeCommentaryModuleName = moduleName
-        logger.info("Switched to commentary module: \(moduleName)")
-
-        // Persist to PageManager
-        if let pm = activeWindow?.pageManager {
-            pm.commentaryDocument = moduleName
-            onPersistState?()
-        }
-
-        // Reload if currently viewing commentary
-        guard clientReady, currentCategory == .commentary else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchCommentaryModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /**
@@ -950,47 +949,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @MainActor
     public func switchCommentaryDocument(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to commentary document \(moduleName) — not found")
-            return
-        }
-        guard mod.info.category == .commentary else {
-            logger.warning("Cannot switch to commentary document \(moduleName) — category \(mod.info.category.rawValue)")
-            return
-        }
-        activeCommentaryModule = mod
-        activeCommentaryModuleName = moduleName
-        currentCategory = .commentary
-        logger.info("Switched to commentary document: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.commentaryDocument = moduleName
-            pm.currentCategoryName = DocumentCategory.commentary.pageManagerKey
-            onPersistState?()
-        }
-
-        guard clientReady else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchCommentaryDocument(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /// Switch the active dictionary module.
     public func switchDictionaryModule(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to dictionary module \(moduleName) — not found")
-            return
-        }
-        activeDictionaryModule = mod
-        activeDictionaryModuleName = moduleName
-        currentDictionaryKey = nil
-        logger.info("Switched to dictionary module: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.dictionaryDocument = moduleName
-            pm.dictionaryKey = nil
-            onPersistState?()
-        }
+        moduleSwitchCoordinator.switchDictionaryModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /**
@@ -1013,49 +977,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @MainActor
     public func switchDictionaryDocument(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to dictionary document \(moduleName) — not found")
-            return
-        }
-        guard mod.info.category == .dictionary else {
-            logger.warning("Cannot switch to dictionary document \(moduleName) — category \(mod.info.category.rawValue)")
-            return
-        }
-        activeDictionaryModule = mod
-        activeDictionaryModuleName = moduleName
-        currentDictionaryKey = nil
-        currentCategory = .dictionary
-        logger.info("Switched to dictionary document: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.dictionaryDocument = moduleName
-            pm.dictionaryKey = nil
-            pm.currentCategoryName = DocumentCategory.dictionary.pageManagerKey
-            onPersistState?()
-        }
-
-        guard clientReady else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchDictionaryDocument(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /// Switch the active general book module.
     public func switchGeneralBookModule(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to general book module \(moduleName) — not found")
-            return
-        }
-        activeGeneralBookModule = mod
-        activeGeneralBookModuleName = moduleName
-        currentGeneralBookKey = nil
-        logger.info("Switched to general book module: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.generalBookDocument = moduleName
-            pm.generalBookKey = nil
-            onPersistState?()
-        }
+        moduleSwitchCoordinator.switchGeneralBookModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /**
@@ -1078,65 +1005,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @MainActor
     public func switchGeneralBookDocument(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to general book document \(moduleName) — not found")
-            return
-        }
-        guard mod.info.category == .generalBook else {
-            logger.warning("Cannot switch to general book document \(moduleName) — category \(mod.info.category.rawValue)")
-            return
-        }
-        activeGeneralBookModule = mod
-        activeGeneralBookModuleName = moduleName
-        currentGeneralBookKey = nil
-        currentCategory = .generalBook
-        logger.info("Switched to general book document: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.generalBookDocument = moduleName
-            pm.generalBookKey = nil
-            pm.currentCategoryName = DocumentCategory.generalBook.pageManagerKey
-            onPersistState?()
-        }
-
-        guard clientReady else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchGeneralBookDocument(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /// Switch the active map module.
     public func switchMapModule(to moduleName: String) {
-        guard let mgr = swordManager,
-              let mod = mgr.module(named: moduleName) else {
-            logger.warning("Cannot switch to map module \(moduleName) — not found")
-            return
-        }
-        activeMapModule = mod
-        activeMapModuleName = moduleName
-        currentMapKey = nil
-        logger.info("Switched to map module: \(moduleName)")
-
-        if let pm = activeWindow?.pageManager {
-            pm.mapDocument = moduleName
-            pm.mapKey = nil
-            onPersistState?()
-        }
+        moduleSwitchCoordinator.switchMapModule(to: moduleName, context: makeModuleSwitchContext())
     }
 
     /// Switch between document categories (Bible, Commentary, Dictionary, General Book, Map).
     public func switchCategory(to category: DocumentCategory) {
-        let oldCategory = currentCategory
-        currentCategory = category
-
-        // Persist to PageManager
-        if let pm = activeWindow?.pageManager {
-            pm.currentCategoryName = category.pageManagerKey
-            onPersistState?()
-        }
-
-        // Reload content if the category actually changed
-        guard clientReady, category != oldCategory else { return }
-        loadCurrentContent()
+        moduleSwitchCoordinator.switchCategory(to: category, context: makeModuleSwitchContext())
     }
 
     /// Load the appropriate content for the current category.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -310,8 +310,7 @@ struct BibleReaderModulePicker: View {
             controller.switchGeneralBookDocument(to: module.name)
             dismissAndPresentAuxiliaryBrowser(onOpenGeneralBookBrowser)
         case .map:
-            controller.switchMapModule(to: module.name)
-            controller.switchCategory(to: .map)
+            controller.switchMapDocument(to: module.name)
             dismissAndPresentAuxiliaryBrowser(onOpenMapBrowser)
         default:
             controller.switchBibleDocument(to: module.name)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
@@ -1,0 +1,638 @@
+// BibleReaderModuleSwitchCoordinator.swift -- Module/category switch planning for reader panes
+
+import BibleCore
+import SwordKit
+import os.log
+
+private let moduleSwitchLogger = Logger(subsystem: "org.andbible", category: "BibleReaderController")
+
+/**
+ Describes why a requested module/category switch cannot be planned.
+
+ These failures are intentionally pure value types so controller-facing code can keep logging,
+ installed-module lookup, active SWORD module mutation, persistence callbacks, and WebView reloads
+ outside the rule collaborator.
+ */
+enum BibleReaderModuleSwitchFailure: Error, Equatable {
+    /// The resolved SWORD module category does not match the document category being selected.
+    case categoryMismatch(moduleName: String, expected: DocumentCategory, actual: ModuleCategory)
+}
+
+/**
+ Supplies controller-owned state mutations to the module switch coordinator.
+
+ The coordinator owns the switching rules, but the controller still owns observed reader state,
+ SWORD module references, and WebView rendering. Keeping those mutations as explicit closures
+ avoids making the coordinator retain a reader controller while still moving the switching workflow
+ out of the large controller file.
+
+ Inputs:
+ - current SWORD manager, active window, client-ready state, and visible category snapshot
+ - category-specific setters for active modules and selected keys
+ - callbacks for book-list refresh, persistence, and content reload
+
+ Outputs:
+ - no return value; switch operations invoke closures to mutate controller/page state
+
+ Side effects:
+ - switch operations may mutate controller state, active `PageManager` fields, persist SwiftData, and
+   reload rendered content through the supplied callbacks
+
+ Failure modes:
+ - if a closure target has gone away, weak controller closures can become no-ops; switch methods will
+   still avoid creating fallback state not backed by the controller
+ */
+struct BibleReaderModuleSwitchContext {
+    let swordManager: SwordManager?
+    let activeWindow: Window?
+    let clientReady: Bool
+    let currentCategory: DocumentCategory
+    let setBibleModule: (SwordModule, String) -> Void
+    let setCommentaryModule: (SwordModule, String) -> Void
+    let setDictionaryModule: (SwordModule, String) -> Void
+    let setGeneralBookModule: (SwordModule, String) -> Void
+    let setMapModule: (SwordModule, String) -> Void
+    let setCurrentCategory: (DocumentCategory) -> Void
+    let refreshBookList: () -> Void
+    let moduleBookListCount: () -> Int
+    let persistState: () -> Void
+    let loadCurrentContent: () -> Void
+}
+
+/**
+ Applies a category-specific module selection to a pane's `PageManager`.
+
+ The plan mirrors Android's durable `PageManager` fields: every document category owns its selected
+ module independently, and document-switch paths may also update `currentCategoryName` atomically.
+
+ Inputs:
+ - `moduleName`: installed SWORD module initials to persist for the target category
+ - `category`: durable document category that owns the module field
+ - `updatesVisibleCategory`: whether applying the plan also changes the active PageManager category
+
+ Outputs:
+ - `apply(to:)` mutates the supplied PageManager in place and returns no value.
+
+ Side effects:
+ - writes the category-owned module field
+ - clears stale entry keys for dictionary, general-book, and map selections
+ - optionally writes `currentCategoryName`
+
+ Failure modes:
+ - unsupported categories currently have no module-owned PageManager field, so applying them only
+   updates `currentCategoryName` when requested
+ */
+struct BibleReaderModuleSwitchPlan: Equatable {
+    let moduleName: String
+    let category: DocumentCategory
+    let updatesVisibleCategory: Bool
+
+    /**
+     Writes this switch plan to the pane page manager.
+
+     - Parameter pageManager: Page state to update for the selected category.
+     - Side effects: Mutates category-specific module/key fields and, for document switches,
+       `currentCategoryName`.
+     - Failure modes: Categories without module fields are intentionally ignored except for the
+       visible category write, preserving the caller's explicit category ownership.
+     */
+    func apply(to pageManager: PageManager) {
+        switch category {
+        case .bible:
+            pageManager.bibleDocument = moduleName
+        case .commentary:
+            pageManager.commentaryDocument = moduleName
+        case .dictionary:
+            pageManager.dictionaryDocument = moduleName
+            pageManager.dictionaryKey = nil
+        case .generalBook:
+            pageManager.generalBookDocument = moduleName
+            pageManager.generalBookKey = nil
+        case .map:
+            pageManager.mapDocument = moduleName
+            pageManager.mapKey = nil
+        case .epub, .dailyDevotion:
+            break
+        }
+
+        guard updatesVisibleCategory else { return }
+        pageManager.currentCategoryName = category.pageManagerKey
+    }
+}
+
+/**
+ Applies a category-only switch to a pane's `PageManager`.
+
+ The controller remains responsible for updating its observed `currentCategory`, deciding whether
+ the JavaScript client is ready, and performing the actual reload. This value only records the
+ durable category write and whether content should be reloaded after the category change.
+ */
+struct BibleReaderCategorySwitchPlan: Equatable {
+    let category: DocumentCategory
+    let shouldReloadContent: Bool
+
+    /**
+     Writes this category switch to the pane page manager.
+
+     - Parameter pageManager: Page state to update with the selected category.
+     - Side effects: Mutates `currentCategoryName`.
+     - Failure modes: None; every `DocumentCategory` has a durable PageManager key.
+     */
+    func apply(to pageManager: PageManager) {
+        pageManager.currentCategoryName = category.pageManagerKey
+    }
+}
+
+/**
+ Plans reader module/category switches without owning active SWORD modules or WebView reloads.
+
+ Android routes current-document selection through one durable page-manager transition: the selected
+ document and visible category are updated together before the reader reloads. This coordinator
+ isolates those rules from `BibleReaderController` so the controller can remain the orchestration
+ boundary for module lookup, active-module assignment, persistence callbacks, and rendering.
+ */
+struct BibleReaderModuleSwitchCoordinator {
+    /**
+     Switches the selected Bible module without changing the visible document category.
+
+     - Parameters:
+       - moduleName: Installed Bible module initials to activate.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active Bible module state, refreshes the book list, persists
+       `PageManager.bibleDocument`, and reloads current content when the client is ready.
+     - Failure modes: Logs and leaves state unchanged when the module cannot be resolved.
+     */
+    func switchModule(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "module") else {
+            return
+        }
+
+        context.setBibleModule(mod, moduleName)
+        context.refreshBookList()
+        moduleSwitchLogger.info("Switched to module: \(moduleName) (\(context.moduleBookListCount()) books)")
+
+        persist(
+            moduleOnlySwitchPlan(moduleName: moduleName, targetCategory: .bible),
+            context: context
+        )
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the visible document to a Bible module in one Android-parity transition.
+
+     Android's `CurrentPageManager.setCurrentDocument(book)` updates the selected Bible and active
+     page together before notifying the reader. This keeps iOS on the same contract for toolbar
+     quick selectors and full module-picker selections.
+
+     - Parameters:
+       - moduleName: Installed SWORD Bible module initials to make current.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active Bible module/category state, persists `bibleDocument` and
+       `currentCategoryName` together, and reloads once when the client is ready.
+     - Failure modes: Logs and leaves state unchanged when the module is missing or is not a Bible.
+     */
+    func switchBibleDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "Bible document") else {
+            return
+        }
+        guard let plan = validatedDocumentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: mod.info.category,
+            targetCategory: .bible,
+            logSubject: "Bible document"
+        ) else {
+            return
+        }
+
+        context.setBibleModule(mod, moduleName)
+        context.setCurrentCategory(plan.category)
+        context.refreshBookList()
+        moduleSwitchLogger.info("Switched to Bible document: \(moduleName) (\(context.moduleBookListCount()) books)")
+
+        persist(plan, context: context)
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the selected commentary module without changing the visible document category.
+
+     - Parameters:
+       - moduleName: Installed commentary module initials to activate.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active commentary module state, persists
+       `PageManager.commentaryDocument`, and reloads only when commentary is already visible.
+     - Failure modes: Logs and leaves state unchanged when the module cannot be resolved.
+     */
+    func switchCommentaryModule(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "commentary module") else {
+            return
+        }
+
+        context.setCommentaryModule(mod, moduleName)
+        moduleSwitchLogger.info("Switched to commentary module: \(moduleName)")
+
+        persist(
+            moduleOnlySwitchPlan(moduleName: moduleName, targetCategory: .commentary),
+            context: context
+        )
+
+        guard context.clientReady, context.currentCategory == .commentary else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the visible document to a commentary module in one Android-parity transition.
+
+     - Parameters:
+       - moduleName: Installed commentary module initials to make current.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active commentary module/category state, persists
+       `commentaryDocument` and `currentCategoryName` together, and reloads once when ready.
+     - Failure modes: Logs and leaves state unchanged when the module is missing or not commentary.
+     */
+    func switchCommentaryDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "commentary document") else {
+            return
+        }
+        guard let plan = validatedDocumentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: mod.info.category,
+            targetCategory: .commentary,
+            logSubject: "commentary document"
+        ) else {
+            return
+        }
+
+        context.setCommentaryModule(mod, moduleName)
+        context.setCurrentCategory(plan.category)
+        moduleSwitchLogger.info("Switched to commentary document: \(moduleName)")
+
+        persist(plan, context: context)
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the selected dictionary module without changing the visible document category.
+
+     - Parameters:
+       - moduleName: Installed dictionary module initials to activate.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active dictionary state, clears stale dictionary keys, and persists the
+       dictionary module/key fields.
+     - Failure modes: Logs and leaves state unchanged when the module cannot be resolved.
+     */
+    func switchDictionaryModule(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "dictionary module") else {
+            return
+        }
+
+        context.setDictionaryModule(mod, moduleName)
+        moduleSwitchLogger.info("Switched to dictionary module: \(moduleName)")
+
+        persist(
+            moduleOnlySwitchPlan(moduleName: moduleName, targetCategory: .dictionary),
+            context: context
+        )
+    }
+
+    /**
+     Switches the visible document to a dictionary module in one Android-parity transition.
+
+     - Parameters:
+       - moduleName: Installed dictionary module initials to make current.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active dictionary/category state, clears stale dictionary keys, persists
+       dictionary document/category fields together, and reloads once when ready.
+     - Failure modes: Logs and leaves state unchanged when the module is missing or not a dictionary.
+     */
+    func switchDictionaryDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "dictionary document") else {
+            return
+        }
+        guard let plan = validatedDocumentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: mod.info.category,
+            targetCategory: .dictionary,
+            logSubject: "dictionary document"
+        ) else {
+            return
+        }
+
+        context.setDictionaryModule(mod, moduleName)
+        context.setCurrentCategory(plan.category)
+        moduleSwitchLogger.info("Switched to dictionary document: \(moduleName)")
+
+        persist(plan, context: context)
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the selected general-book module without changing the visible document category.
+
+     - Parameters:
+       - moduleName: Installed general-book module initials to activate.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active general-book state, clears stale keys, and persists the selected
+       general-book module/key fields.
+     - Failure modes: Logs and leaves state unchanged when the module cannot be resolved.
+     */
+    func switchGeneralBookModule(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "general book module") else {
+            return
+        }
+
+        context.setGeneralBookModule(mod, moduleName)
+        moduleSwitchLogger.info("Switched to general book module: \(moduleName)")
+
+        persist(
+            moduleOnlySwitchPlan(moduleName: moduleName, targetCategory: .generalBook),
+            context: context
+        )
+    }
+
+    /**
+     Switches the visible document to a general-book module in one Android-parity transition.
+
+     - Parameters:
+       - moduleName: Installed general-book module initials to make current.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active general-book/category state, clears stale keys, persists
+       general-book document/category fields together, and reloads once when ready.
+     - Failure modes: Logs and leaves state unchanged when the module is missing or not a general
+       book.
+     */
+    func switchGeneralBookDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "general book document") else {
+            return
+        }
+        guard let plan = validatedDocumentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: mod.info.category,
+            targetCategory: .generalBook,
+            logSubject: "general book document"
+        ) else {
+            return
+        }
+
+        context.setGeneralBookModule(mod, moduleName)
+        context.setCurrentCategory(plan.category)
+        moduleSwitchLogger.info("Switched to general book document: \(moduleName)")
+
+        persist(plan, context: context)
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Switches the selected map module without changing the visible document category.
+
+     - Parameters:
+       - moduleName: Installed map module initials to activate.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active map state, clears stale map keys, and persists map module/key
+       fields.
+     - Failure modes: Logs and leaves state unchanged when the module cannot be resolved.
+     */
+    func switchMapModule(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "map module") else {
+            return
+        }
+
+        context.setMapModule(mod, moduleName)
+        moduleSwitchLogger.info("Switched to map module: \(moduleName)")
+
+        persist(
+            moduleOnlySwitchPlan(moduleName: moduleName, targetCategory: .map),
+            context: context
+        )
+    }
+
+    /**
+     Switches the visible document category without changing selected modules.
+
+     - Parameters:
+       - category: Category that should become visible.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active category state, persists `currentCategoryName`, and reloads only
+       when the category actually changed and the client is ready.
+     - Failure modes: None.
+     */
+    func switchCategory(to category: DocumentCategory, context: BibleReaderModuleSwitchContext) {
+        let plan = categorySwitchPlan(from: context.currentCategory, to: category)
+        context.setCurrentCategory(plan.category)
+        persist(plan, context: context)
+
+        guard context.clientReady, plan.shouldReloadContent else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Builds an Android-style current-document switch plan.
+
+     - Parameters:
+       - moduleName: Installed module initials to persist.
+       - moduleCategory: Resolved SWORD category for the installed module.
+       - targetCategory: Visible document category the caller is trying to select.
+     - Returns: A switch plan that updates the selected module and current category together, or a
+       category mismatch failure when the installed module cannot satisfy the requested category.
+     - Side effects: None.
+     - Failure modes: Returns `.categoryMismatch` without mutating page state when the module
+       category does not map to `targetCategory`.
+     */
+    func documentSwitchPlan(
+        moduleName: String,
+        moduleCategory: ModuleCategory,
+        targetCategory: DocumentCategory
+    ) -> Result<BibleReaderModuleSwitchPlan, BibleReaderModuleSwitchFailure> {
+        guard Self.documentCategory(for: moduleCategory) == targetCategory else {
+            return .failure(.categoryMismatch(
+                moduleName: moduleName,
+                expected: targetCategory,
+                actual: moduleCategory
+            ))
+        }
+
+        return .success(BibleReaderModuleSwitchPlan(
+            moduleName: moduleName,
+            category: targetCategory,
+            updatesVisibleCategory: true
+        ))
+    }
+
+    /**
+     Builds a module-only switch plan.
+
+     This preserves existing iOS call paths that update the selected module for a category without
+     changing which category is visible. The full map picker currently uses this before an explicit
+     category switch, and direct module switches use it to keep category and module ownership
+     separate.
+
+     - Parameters:
+       - moduleName: Installed module initials to persist.
+       - targetCategory: Category-owned module field to update.
+     - Returns: A switch plan that updates only the category-owned module/key fields.
+     - Side effects: None.
+     - Failure modes: None; callers that need installed-module validation do it before planning.
+     */
+    func moduleOnlySwitchPlan(
+        moduleName: String,
+        targetCategory: DocumentCategory
+    ) -> BibleReaderModuleSwitchPlan {
+        BibleReaderModuleSwitchPlan(
+            moduleName: moduleName,
+            category: targetCategory,
+            updatesVisibleCategory: false
+        )
+    }
+
+    /**
+     Builds a category-only switch plan.
+
+     - Parameters:
+       - oldCategory: Currently visible category before the switch.
+       - newCategory: Category that should become visible.
+     - Returns: A plan that always writes the selected category and requests a reload only when the
+       visible category actually changes.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func categorySwitchPlan(
+        from oldCategory: DocumentCategory,
+        to newCategory: DocumentCategory
+    ) -> BibleReaderCategorySwitchPlan {
+        BibleReaderCategorySwitchPlan(
+            category: newCategory,
+            shouldReloadContent: oldCategory != newCategory
+        )
+    }
+
+    /**
+     Maps installed SWORD module categories onto the durable document categories iOS can display.
+
+     - Parameter moduleCategory: SWORD module category reported by the installed module.
+     - Returns: Matching document category, or `nil` when the module category is unsupported by the
+       reader switch surface.
+     - Side effects: None.
+     - Failure modes: Unsupported categories return nil so document switch planning rejects them
+       without creating iOS-only fallback behavior.
+     */
+    private static func documentCategory(for moduleCategory: ModuleCategory) -> DocumentCategory? {
+        switch moduleCategory {
+        case .bible:
+            return .bible
+        case .commentary:
+            return .commentary
+        case .dictionary:
+            return .dictionary
+        case .generalBook:
+            return .generalBook
+        case .map:
+            return .map
+        case .dailyDevotion, .glossary, .addon, .unknown:
+            return nil
+        }
+    }
+
+    /**
+     Resolves an installed module for a switch workflow.
+
+     - Parameters:
+       - moduleName: Installed module initials to resolve.
+       - context: Controller state containing the current SWORD manager.
+       - logSubject: Human-readable switch target used in warning logs.
+     - Returns: The resolved module, or nil when the manager/module is unavailable.
+     - Side effects: Emits a warning when resolution fails.
+     - Failure modes: Missing manager or module returns nil without mutating state.
+     */
+    private func module(
+        named moduleName: String,
+        context: BibleReaderModuleSwitchContext,
+        logSubject: String
+    ) -> SwordModule? {
+        guard let mgr = context.swordManager,
+              let mod = mgr.module(named: moduleName) else {
+            moduleSwitchLogger.warning("Cannot switch to \(logSubject) \(moduleName) — not found")
+            return nil
+        }
+        return mod
+    }
+
+    /**
+     Validates an installed module category and logs the controller-compatible warning on mismatch.
+
+     - Parameters:
+       - moduleName: Installed module initials being selected.
+       - moduleCategory: Category reported by SWORD for the resolved module.
+       - targetCategory: Visible category the caller is trying to select.
+       - logSubject: Human-readable switch target used in warning logs.
+     - Returns: A valid document switch plan, or nil when the module category does not match.
+     - Side effects: Emits a warning on mismatch.
+     - Failure modes: Category mismatch returns nil and leaves caller state unchanged.
+     */
+    private func validatedDocumentSwitchPlan(
+        moduleName: String,
+        moduleCategory: ModuleCategory,
+        targetCategory: DocumentCategory,
+        logSubject: String
+    ) -> BibleReaderModuleSwitchPlan? {
+        switch documentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: moduleCategory,
+            targetCategory: targetCategory
+        ) {
+        case .success(let plan):
+            return plan
+        case .failure:
+            moduleSwitchLogger.warning("Cannot switch to \(logSubject) \(moduleName) — category \(moduleCategory.rawValue)")
+            return nil
+        }
+    }
+
+    /**
+     Persists a module switch plan through the active pane page manager.
+
+     - Parameters:
+       - plan: Category-specific module switch to persist.
+       - context: Controller state containing the active window and persistence callback.
+     - Side effects: Mutates `PageManager` fields and invokes `persistState` once when a page manager
+       is available.
+     - Failure modes: Missing active page manager is a no-op, matching prior controller behavior.
+     */
+    private func persist(
+        _ plan: BibleReaderModuleSwitchPlan,
+        context: BibleReaderModuleSwitchContext
+    ) {
+        guard let pageManager = context.activeWindow?.pageManager else { return }
+        plan.apply(to: pageManager)
+        context.persistState()
+    }
+
+    /**
+     Persists a category switch plan through the active pane page manager.
+
+     - Parameters:
+       - plan: Category switch to persist.
+       - context: Controller state containing the active window and persistence callback.
+     - Side effects: Mutates `PageManager.currentCategoryName` and invokes `persistState` once when
+       a page manager is available.
+     - Failure modes: Missing active page manager is a no-op, matching prior controller behavior.
+     */
+    private func persist(
+        _ plan: BibleReaderCategorySwitchPlan,
+        context: BibleReaderModuleSwitchContext
+    ) {
+        guard let pageManager = context.activeWindow?.pageManager else { return }
+        plan.apply(to: pageManager)
+        context.persistState()
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
@@ -418,6 +418,43 @@ struct BibleReaderModuleSwitchCoordinator {
     }
 
     /**
+     Switches the visible document to a map module in one Android-parity transition.
+
+     Android's document chooser routes maps through `setCurrentDocument(book)`, so map selections
+     update the selected map, clear stale map entry state, and switch the visible category as one
+     durable page-manager write before content reload.
+
+     - Parameters:
+       - moduleName: Installed map module initials to make current.
+       - context: Controller-owned state and callbacks for the active pane.
+     - Side effects: Mutates active map/category state, clears stale map keys, persists map
+       document/category fields together, and reloads once when ready.
+     - Failure modes: Logs and leaves state unchanged when the module is missing or not a map.
+     */
+    func switchMapDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
+        guard let mod = module(named: moduleName, context: context, logSubject: "map document") else {
+            return
+        }
+        guard let plan = validatedDocumentSwitchPlan(
+            moduleName: moduleName,
+            moduleCategory: mod.info.category,
+            targetCategory: .map,
+            logSubject: "map document"
+        ) else {
+            return
+        }
+
+        context.setMapModule(mod, moduleName)
+        context.setCurrentCategory(plan.category)
+        moduleSwitchLogger.info("Switched to map document: \(moduleName)")
+
+        persist(plan, context: context)
+
+        guard context.clientReady else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
      Switches the visible document category without changing selected modules.
 
      - Parameters:
@@ -472,10 +509,9 @@ struct BibleReaderModuleSwitchCoordinator {
     /**
      Builds a module-only switch plan.
 
-     This preserves existing iOS call paths that update the selected module for a category without
-     changing which category is visible. The full map picker currently uses this before an explicit
-     category switch, and direct module switches use it to keep category and module ownership
-     separate.
+     Direct module-switch actions update the selected module for a category without changing which
+     category is visible. Full current-document chooser paths should use `documentSwitchPlan` so the
+     selected module and visible category are persisted together like Android.
 
      - Parameters:
        - moduleName: Installed module initials to persist.


### PR DESCRIPTION
## Summary

Extracts reader module/category switching into a focused coordinator for issue #146. The controller keeps the public API and observed state ownership, while the coordinator owns module lookup, category validation, Android-style PageManager persistence, and reload gating through an explicit context.

## Scope

- Adds BibleReaderModuleSwitchCoordinator for module-only, current-document, and category-only switch flows.
- Reduces BibleReaderController switching methods to wrappers plus controller-owned context construction.
- Adds focused regression coverage for mismatch rejection, dictionary key clearing, module-only switching, and category reload planning.

## Contract References

- Android parity: preserves the current-document behavior where selected document and visible category are persisted together before reload.
- Issue: Refs #146.
- Closure: this PR intentionally does not close #146 because remaining checklist slices are still open.

## Change Details

- BibleReaderController line count moves from the 9,064-line baseline to 8,943 lines for this slice.
- Existing public switch method names and call sites are preserved.
- Category mismatch logs, module-not-found logs, key clearing, persistence callback count, and reload gates are kept aligned with existing behavior.

## Validation Evidence

- Red test verified before implementation: focused coordinator tests failed because BibleReaderModuleSwitchCoordinator did not exist.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 focused coordinator tests.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 existing module/category regression tests.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 -only-testing:AndBibleTests.
- python3 scripts/check_repo_standards.py docblocks --all-files.
- python3 scripts/check_settings_localization_guardrails.py.
- python3 scripts/check_bridge_parity_inventory.py.
- git diff --check.
- npx gitnexus analyze, then staged detect_changes: low risk, no affected execution flows.

## Risks / Follow-ups

- This touches a CRITICAL controller class by dependency count, but the public API stays unchanged and the affected switch flows have targeted regression coverage.
- #146 still needs the remaining reader navigation, bridge routing, Sword setup, and ownership-audit slices.

## Issue Closure Reference

Refs #146; does not close.