### PR TITLE
refactor(reader): extract bridge event router

### DIFF
--- a/AndBibleTests/AndBibleTests+BridgeIOS.swift
+++ b/AndBibleTests/AndBibleTests+BridgeIOS.swift
@@ -127,6 +127,72 @@ extension AndBibleTests {
         XCTAssertEqual(controller.currentBook, "Genesis")
         XCTAssertEqual(controller.currentChapter, 2)
     }
+
+    /**
+     Verifies bridge event routing keeps modal state and host callback dispatch outside the reader controller.
+
+     - Setup: Uses the focused router with closure recorders instead of a full reader controller so
+       the test protects routing ownership rather than document payload generation.
+     - Expected result: Modal-open key events do not navigate, Escape asks Vue to close modals, host
+       callbacks are forwarded through injected closures, and fullscreen honors the injected
+       preference gate.
+     - Failure meaning: A failure means the #146 extraction has either left routing behavior in the
+       controller or changed the existing bridge event semantics while moving it.
+     */
+    @MainActor
+    func testBridgeEventRouterOwnsModalKeyboardAndHostCallbackRouting() {
+        var emittedEvents: [String] = []
+        var previousCount = 0
+        var nextCount = 0
+        var toasts: [String] = []
+        var sharedHTML: [String] = []
+        var downloadSeeds: [String?] = []
+        var fullscreenAllowed = false
+        var fullscreenToggleCount = 0
+
+        let router = BibleReaderBridgeEventRouter(
+            emitBridgeEvent: { event in
+                emittedEvents.append(event)
+                return true
+            },
+            navigatePrevious: { previousCount += 1 },
+            navigateNext: { nextCount += 1 },
+            showToast: { toasts.append($0) },
+            shareHtml: { sharedHTML.append($0) },
+            openDownloads: { downloadSeeds.append($0) },
+            shouldToggleFullScreen: { fullscreenAllowed },
+            toggleFullScreen: { fullscreenToggleCount += 1 }
+        )
+
+        XCTAssertFalse(router.webModalIsOpen)
+        router.reportModalState(true)
+        XCTAssertTrue(router.webModalIsOpen)
+
+        router.handleKeyDown("ArrowRight")
+        router.handleKeyDown("Escape")
+        XCTAssertEqual(nextCount, 0)
+        XCTAssertEqual(emittedEvents, ["close_modals"])
+
+        router.reportModalState(false)
+        router.handleKeyDown("ArrowLeft")
+        router.handleKeyDown("ArrowRight")
+        XCTAssertEqual(previousCount, 1)
+        XCTAssertEqual(nextCount, 1)
+
+        router.showToast("Saved")
+        router.shareHtml("<p>Shared</p>")
+        router.requestOpenDownloads(searchText: "KJV")
+        XCTAssertEqual(toasts, ["Saved"])
+        XCTAssertEqual(sharedHTML, ["<p>Shared</p>"])
+        XCTAssertEqual(downloadSeeds.count, 1)
+        XCTAssertEqual(downloadSeeds.first ?? nil, "KJV")
+
+        router.requestToggleFullScreen()
+        XCTAssertEqual(fullscreenToggleCount, 0)
+        fullscreenAllowed = true
+        router.requestToggleFullScreen()
+        XCTAssertEqual(fullscreenToggleCount, 1)
+    }
     #endif
 
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBridgeEventRouter.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBridgeEventRouter.swift
@@ -1,0 +1,202 @@
+// BibleReaderBridgeEventRouter.swift -- Host-side bridge event routing for reader panes
+
+import Foundation
+
+/**
+ Routes bridge events that only coordinate host callbacks or pane-local modal state.
+
+ `BibleReaderController` remains the orchestration boundary for document payloads, SWORD state,
+ and reader persistence. This collaborator owns the existing routing rules for simple
+ bridge events whose effects are limited to keyboard/modal handling or host UI callbacks. Keeping
+ those rules here avoids hiding controller complexity in extensions while preserving existing
+ bridge method names and payload semantics.
+
+ Side effects are injected through closures so tests can validate routing deterministically and the
+ controller can keep platform-specific UI presentation, preference lookup, and bridge emission at
+ the pane boundary.
+ */
+final class BibleReaderBridgeEventRouter {
+    private let emitBridgeEvent: (String) -> Bool
+    private let navigatePrevious: () -> Void
+    private let navigateNext: () -> Void
+    private let showToastHandler: (String) -> Void
+    private let shareHtmlHandler: (String) -> Void
+    private let openDownloadsHandler: (String?) -> Void
+    private let shouldToggleFullScreen: () -> Bool
+    private let toggleFullScreenHandler: () -> Void
+
+    /// Whether the Vue reader client currently reports an open modal for this pane.
+    private(set) var webModalIsOpen = false
+
+    /**
+     Creates a router with explicit host-side effects.
+
+     - Parameters:
+       - emitBridgeEvent: Emits a Vue event name into the pane bridge. Return value is ignored for
+         compatibility with the previous fire-and-forget close-modal behavior.
+       - navigatePrevious: Moves the pane to the previous chapter for ArrowLeft events.
+       - navigateNext: Moves the pane to the next chapter for ArrowRight events.
+       - showToast: Presents a toast/banner message through the owning SwiftUI surface.
+       - shareHtml: Presents HTML sharing through the owning SwiftUI surface.
+       - openDownloads: Presents Downloads with optional search seed semantics.
+       - shouldToggleFullScreen: Reads the current preference gate for double-tap fullscreen.
+       - toggleFullScreen: Requests the owning surface to toggle fullscreen.
+
+     Side effects:
+     - stores closures for later bridge-event handling
+
+     Failure modes:
+     - none; invalid bridge payloads are rejected by `BibleBridge` before these methods are called.
+     */
+    init(
+        emitBridgeEvent: @escaping (String) -> Bool,
+        navigatePrevious: @escaping () -> Void,
+        navigateNext: @escaping () -> Void,
+        showToast: @escaping (String) -> Void,
+        shareHtml: @escaping (String) -> Void,
+        openDownloads: @escaping (String?) -> Void,
+        shouldToggleFullScreen: @escaping () -> Bool,
+        toggleFullScreen: @escaping () -> Void
+    ) {
+        self.emitBridgeEvent = emitBridgeEvent
+        self.navigatePrevious = navigatePrevious
+        self.navigateNext = navigateNext
+        self.showToastHandler = showToast
+        self.shareHtmlHandler = shareHtml
+        self.openDownloadsHandler = openDownloads
+        self.shouldToggleFullScreen = shouldToggleFullScreen
+        self.toggleFullScreenHandler = toggleFullScreen
+    }
+
+    /**
+     Records modal visibility reported by the Vue reader.
+
+     - Parameter isOpen: Whether the web client currently reports a modal in this pane.
+     - Side effects: Updates pane-local modal state used by keyboard routing.
+     - Failure modes: Duplicate reports are accepted idempotently.
+     */
+    func reportModalState(_ isOpen: Bool) {
+        webModalIsOpen = isOpen
+    }
+
+    /**
+     Receives web-client input focus changes.
+
+     iOS currently has no host-side behavior for this signal, but keeping it on the router preserves
+     a named ownership point for future parity work without leaving a no-op delegate method in the
+     controller.
+
+     - Parameter focused: Whether a text input inside the web client is focused.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func reportInputFocus(_ focused: Bool) {}
+
+    /**
+     Handles keyboard events forwarded by the web client.
+
+     - Parameter key: Logical key name from the shared Vue reader.
+     - Side effects: Navigates chapters for left/right arrows when no modal is open, or emits
+       `close_modals` for Escape while a modal is open.
+     - Failure modes: Unsupported keys are ignored; modal-open non-Escape keys intentionally do not
+       navigate so native host navigation does not steal web modal focus.
+     */
+    func handleKeyDown(_ key: String) {
+        guard !webModalIsOpen else {
+            if key == "Escape" || key == "Esc" {
+                _ = closeWebModalIfNeeded()
+            }
+            return
+        }
+
+        switch key {
+        case "ArrowLeft":
+            navigatePrevious()
+        case "ArrowRight":
+            navigateNext()
+        default:
+            break
+        }
+    }
+
+    /**
+     Requests that the Vue reader close pane-local modals.
+
+     - Returns: `true` when a close request was emitted because the last reported modal state was
+       open; otherwise `false`.
+     - Side effects: Emits `close_modals` through `emitBridgeEvent`. The reported modal state is not
+       mutated here; the next Vue `reportModalState` callback remains authoritative.
+     - Failure modes: Returns `false` and emits nothing when no modal is reported open.
+     */
+    @discardableResult
+    func closeWebModalIfNeeded() -> Bool {
+        guard webModalIsOpen else { return false }
+        _ = emitBridgeEvent("close_modals")
+        return true
+    }
+
+    /**
+     Forwards a toast/banner request to the host UI.
+
+     - Parameter text: Localized or web-provided message text.
+     - Side effects: Invokes the injected toast handler.
+     - Failure modes: None; absent host presentation is represented by a no-op handler.
+     */
+    func showToast(_ text: String) {
+        showToastHandler(text)
+    }
+
+    /**
+     Forwards HTML sharing content to the host UI.
+
+     - Parameter html: HTML fragment supplied by the shared reader.
+     - Side effects: Invokes the injected share handler.
+     - Failure modes: None; absent host presentation is represented by a no-op handler.
+     */
+    func shareHtml(_ html: String) {
+        shareHtmlHandler(html)
+    }
+
+    /**
+     Requests the native Downloads surface.
+
+     - Parameter searchText: Optional search seed, usually module initials from a `download://`
+       pseudo-link.
+     - Side effects: Invokes the injected downloads handler.
+     - Failure modes: None; absent host presentation is represented by a no-op handler.
+     */
+    func requestOpenDownloads(searchText: String? = nil) {
+        openDownloadsHandler(searchText)
+    }
+
+    /**
+     Requests fullscreen only when the injected preference gate allows it.
+
+     - Side effects: Invokes the injected fullscreen handler when allowed.
+     - Failure modes: Returns without side effects when the preference gate is disabled.
+     */
+    func requestToggleFullScreen() {
+        guard shouldToggleFullScreen() else { return }
+        toggleFullScreenHandler()
+    }
+
+    /**
+     Extracts the module-initials search seed from a Downloads pseudo-link.
+
+     - Parameter link: A `download://` link emitted by rendered document content, optionally with
+       an `initials` query item such as `download://?initials=KJV`.
+     - Returns: The decoded, trimmed `initials` value when present and non-empty; otherwise `nil`.
+     - Side effects: None.
+     - Failure modes: Malformed or non-download links return `nil`, preserving the standard
+       unfiltered Downloads presentation path.
+     */
+    static func downloadSearchText(from link: String) -> String? {
+        guard link.hasPrefix("download://"),
+              let components = URLComponents(string: link),
+              let value = components.queryItems?.first(where: { $0.name == "initials" })?.value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -120,6 +120,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var editingInWebView = false
     /// Whether the Vue reader client currently reports an open modal for this pane.
     private(set) var webModalIsOpen = false
+    /// Router for bridge events whose behavior is limited to pane-local modal and host callbacks.
+    @ObservationIgnored
+    private lazy var bridgeEventRouter = makeBridgeEventRouter()
 
     /// SWORD module manager and active Bible module
     private(set) var swordManager: SwordManager?
@@ -618,6 +621,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         super.init()
         bridge.delegate = self
         configureSwordManager(swordManagerOverride)
+    }
+
+    /**
+     Creates the collaborator that owns pane-local bridge event routing.
+
+     The closures deliberately bounce back into controller-owned dependencies for navigation,
+     preference lookup, bridge emission, and host callbacks. This keeps the router focused on
+     dispatch rules while preserving the controller as the state/presentation orchestration boundary.
+
+     - Returns: A router configured for this controller's bridge and host callbacks.
+     - Side effects: None during creation; side effects happen when the router handles bridge events.
+     - Failure modes: Deallocated controllers or unset host callbacks become no-ops, matching the
+       previous optional-callback behavior.
+     */
+    private func makeBridgeEventRouter() -> BibleReaderBridgeEventRouter {
+        BibleReaderBridgeEventRouter(
+            emitBridgeEvent: { [weak self] event in
+                self?.bridge.emit(event: event) ?? false
+            },
+            navigatePrevious: { [weak self] in
+                self?.navigatePrevious()
+            },
+            navigateNext: { [weak self] in
+                self?.navigateNext()
+            },
+            showToast: { [weak self] text in
+                self?.onShowToast?(text)
+            },
+            shareHtml: { [weak self] html in
+                self?.onShareHtml?(html)
+            },
+            openDownloads: { [weak self] searchText in
+                self?.onRequestOpenDownloads?(searchText)
+            },
+            shouldToggleFullScreen: { [weak self] in
+                self?.appPreferenceBool(.doubleTapToFullscreen) ?? false
+            },
+            toggleFullScreen: { [weak self] in
+                self?.onToggleFullScreen?()
+            }
+        )
     }
 
     /**
@@ -2565,7 +2609,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        delegate method is called
      */
     public func bridge(_ bridge: BibleBridge, reportModalState isOpen: Bool) {
-        webModalIsOpen = isOpen
+        bridgeEventRouter.reportModalState(isOpen)
+        webModalIsOpen = bridgeEventRouter.webModalIsOpen
     }
 
     /**
@@ -2577,7 +2622,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
      - Note: iOS currently does not need this signal, so the callback is intentionally a no-op.
      */
-    public func bridge(_ bridge: BibleBridge, reportInputFocus focused: Bool) {}
+    public func bridge(_ bridge: BibleBridge, reportInputFocus focused: Bool) {
+        bridgeEventRouter.reportInputFocus(focused)
+    }
 
     /**
      Handles keyboard navigation events forwarded from the web client.
@@ -2595,21 +2642,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - ignores keys other than `ArrowLeft`, `ArrowRight`, `Escape`, and `Esc`
      */
     public func bridge(_ bridge: BibleBridge, onKeyDown key: String) {
-        guard !webModalIsOpen else {
-            if key == "Escape" || key == "Esc" {
-                closeWebModalIfNeeded()
-            }
-            return
-        }
-
-        switch key {
-        case "ArrowLeft":
-            navigatePrevious()
-        case "ArrowRight":
-            navigateNext()
-        default:
-            break
-        }
+        bridgeEventRouter.handleKeyDown(key)
     }
 
     /**
@@ -2630,9 +2663,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @discardableResult
     func closeWebModalIfNeeded() -> Bool {
-        guard webModalIsOpen else { return false }
-        bridge.emit(event: "close_modals")
-        return true
+        bridgeEventRouter.closeWebModalIfNeeded()
     }
 
     // MARK: - BibleBridgeDelegate — Navigation & Scroll
@@ -4617,7 +4648,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
         // Handle Downloads links surfaced in web-rendered help/error content.
         if link.hasPrefix("download://") {
-            onRequestOpenDownloads?(Self.downloadSearchText(from: link))
+            bridgeEventRouter.requestOpenDownloads(searchText: Self.downloadSearchText(from: link))
             return
         }
         // Handle My Notes links surfaced in bookmark metadata.
@@ -4682,13 +4713,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      `nil`, which keeps the caller on the standard unfiltered Downloads presentation path.
      */
     static func downloadSearchText(from link: String) -> String? {
-        guard link.hasPrefix("download://"),
-              let components = URLComponents(string: link),
-              let value = components.queryItems?.first(where: { $0.name == "initials" })?.value else {
-            return nil
-        }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        BibleReaderBridgeEventRouter.downloadSearchText(from: link)
     }
 
     private func handleErrorReportLink() {
@@ -6497,7 +6522,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Requests that the owning SwiftUI view present the downloads/install UI.
      */
     public func bridgeDidRequestOpenDownloads(_ bridge: BibleBridge) {
-        onRequestOpenDownloads?(nil)
+        bridgeEventRouter.requestOpenDownloads()
     }
 
     // MARK: - BibleBridgeDelegate — Dialogs
@@ -7263,14 +7288,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Forwards a toast/banner message request to the owning SwiftUI view.
      */
     public func bridge(_ bridge: BibleBridge, showToast text: String) {
-        onShowToast?(text)
+        bridgeEventRouter.showToast(text)
     }
 
     /**
      Forwards HTML sharing content to the host view so platform share UI can be presented.
      */
     public func bridge(_ bridge: BibleBridge, shareHtml html: String) {
-        onShareHtml?(html)
+        bridgeEventRouter.shareHtml(html)
     }
 
     /**
@@ -7332,9 +7357,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when the user has disabled double-tap fullscreen in preferences
      */
     public func bridgeDidRequestToggleFullScreen(_ bridge: BibleBridge) {
-        // Match Android: double-tap fullscreen can be disabled by user preference.
-        guard appPreferenceBool(.doubleTapToFullscreen) else { return }
-        onToggleFullScreen?()
+        bridgeEventRouter.requestToggleFullScreen()
     }
 
     // MARK: - EPUB Link Navigation


### PR DESCRIPTION
## Summary
- Adds `BibleReaderBridgeEventRouter` for pane-local modal/key routing and simple host callback dispatch.
- Keeps `BibleReaderController` delegate APIs and observable modal state as wrappers around the router.
- Adds focused coverage for modal keyboard routing, downloads, sharing, toast, and fullscreen dispatch.

## Android Parity
- Preserves existing bridge payload names and event semantics; this is a boundary extraction, not a behavior change.
- Android parity checks informed the scope for modal close, downloads launch, sharing, and double-tap fullscreen preference behavior.
- Comments were kept conservative where the existing iOS key-routing behavior is not a newly validated Android contract.

## Validation
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_settings_localization_guardrails.py`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_repo_standards.py docblocks`
- `python3 scripts/check_repo_standards.py commits --rev-range origin/main..HEAD`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests/AndBibleTests/testBridgeEventRouterOwnsModalKeyboardAndHostCallbackRouting -quiet`\n- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests/AndBibleTests/testReaderBridgeModalStateBlocksKeyNavigationAndRequestsClose -only-testing:AndBibleTests/AndBibleTests/testDoubleTapFullscreenPreferenceGateControlsNativeToggleRequest -only-testing:AndBibleTests/AndBibleTests/testDownloadLinkInitialsAreParsedForDownloadsSearch -only-testing:AndBibleTests/AndBibleTests/testDownloadLinkRoutesInitialsToDownloadsPresentation -quiet`\n- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests -quiet`\n- GitNexus `detect_changes`: medium risk, intended bridge/router scope\n\nRefs #146