### PR TITLE
fix(downloads): clear installable status icon

### DIFF
--- a/AndBibleTests/AndBibleTests+Downloads.swift
+++ b/AndBibleTests/AndBibleTests+Downloads.swift
@@ -24,6 +24,28 @@ extension AndBibleTests {
         XCTAssertEqual(deleteIndex.message, "Delete the search index for King James Version?")
     }
 
+    /**
+     Verifies Downloads status-slot icons preserve Android's NOT_INSTALLED versus UPGRADE_AVAILABLE
+     distinction.
+
+     Android `DocumentListItem.updateControlState` clears the status icon for
+     `DocumentInstallStatus.NOT_INSTALLED` and only shows `ic_arrow_upward_amber_24dp` for
+     `UPGRADE_AVAILABLE`. A failure means iOS is visually reporting ordinary installable modules as
+     updates even though row taps should still install them.
+     */
+    func testModuleBrowserStatusSlotPresentationKeepsInstallableDistinctFromUpdate() {
+        XCTAssertEqual(
+            ModuleBrowserStatusSlotPresentation(status: .installable).statusIconSystemName,
+            nil
+        )
+        XCTAssertFalse(ModuleBrowserStatusSlotPresentation(status: .installable).isActionControl)
+        XCTAssertEqual(
+            ModuleBrowserStatusSlotPresentation(status: .updateAvailable).statusIconSystemName,
+            "arrow.up.circle.fill"
+        )
+        XCTAssertTrue(ModuleBrowserStatusSlotPresentation(status: .updateAvailable).isActionControl)
+    }
+
     func testSearchIndexDeleteIndexAwaitsQueuedMutation() async throws {
         let databaseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("search-index-\(UUID().uuidString).sqlite")

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
@@ -4,6 +4,120 @@ import SwiftUI
 import SwordKit
 
 /**
+ Android-compatible presentation contract for the Downloads status slot.
+
+ Android keeps row action behavior separate from the status icon: `NOT_INSTALLED` rows are
+ installable when tapped, but `DocumentListItem.updateControlState` clears the status icon rather
+ than showing an update affordance. iOS uses this value to keep the SwiftUI row controls and tests
+ anchored to that platform contract instead of coupling tests to private view internals.
+
+ Side effects:
+ - none; the value is a pure projection of `ModuleBrowserDownloadStatus`
+
+ Failure modes:
+ - none; unknown states are not representable by `ModuleBrowserDownloadStatus`
+ */
+struct ModuleBrowserStatusSlotPresentation: Equatable {
+    /**
+     Canonical status-slot branch used by the SwiftUI row.
+
+     Cases intentionally mirror Android's row rendering branches. `emptyInstallableSlot` represents
+     Android `NOT_INSTALLED`, where the row remains installable through the row action but the status
+     icon drawable is `null`.
+     */
+    enum Kind: Equatable {
+        /// Android `INSTALLED`, shown as a completed status icon.
+        case installed
+
+        /// Android `BEING_INSTALLED`, shown with progress and a cancel affordance.
+        case progress(progressPercent: Int)
+
+        /// Android `ERROR_DOWNLOADING`, shown with a warning and retry affordance.
+        case retryError
+
+        /// Android `UPGRADE_AVAILABLE`, shown with the update arrow affordance.
+        case update
+
+        /// Non-installable metadata row.
+        case unavailable
+
+        /// Android `NOT_INSTALLED`, which has no status icon in the trailing slot.
+        case emptyInstallableSlot
+    }
+
+    /// Canonical Android row-rendering branch for the status slot.
+    let kind: Kind
+
+    /**
+     Creates a status-slot presentation from the Android-equivalent download status.
+
+     - Parameter status: Resolved row status from `ModuleBrowserView.displayStatus`.
+     - Returns: A presentation value for the row's status slot.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(status: ModuleBrowserDownloadStatus) {
+        switch status {
+        case .installed:
+            kind = .installed
+        case .beingInstalled(let progressPercent):
+            kind = .progress(progressPercent: progressPercent)
+        case .errorDownloading:
+            kind = .retryError
+        case .updateAvailable:
+            kind = .update
+        case .unavailable:
+            kind = .unavailable
+        case .installable:
+            kind = .emptyInstallableSlot
+        }
+    }
+
+    /**
+     System image used for standalone status-icon states.
+
+     Composite branches that render progress/cancel controls return `nil`. Android
+     `NOT_INSTALLED` also returns `nil` because that branch intentionally clears the status icon.
+
+     - Returns: SF Symbol name for standalone icon-backed states, otherwise `nil`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    var statusIconSystemName: String? {
+        switch kind {
+        case .installed:
+            return "checkmark.circle.fill"
+        case .progress:
+            return nil
+        case .retryError:
+            return "exclamationmark.triangle.fill"
+        case .update:
+            return "arrow.up.circle.fill"
+        case .unavailable:
+            return "lock.slash"
+        case .emptyInstallableSlot:
+            return nil
+        }
+    }
+
+    /**
+     Whether the status slot itself exposes an action control.
+
+     - Returns: `true` for retry, update, and cancel controls; `false` for passive or empty slots.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    var isActionControl: Bool {
+        switch kind {
+        case .progress, .retryError, .update:
+            return true
+        case .installed, .unavailable, .emptyInstallableSlot:
+            return false
+        }
+    }
+}
+
+/**
  Details payload for Android's Downloads row About action.
 
  Android expands SWORD metadata for the selected row and displays its about/copyright/version

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -1754,7 +1754,9 @@ public struct ModuleBrowserView: View {
        - module: Remote catalog row being rendered.
        - status: Current Android-equivalent install status.
      - Returns: SwiftUI control matching Android's status branch for the row.
-     - Side effects: Buttons may start, retry, update, or cancel module installs.
+     - Side effects: Buttons may retry, update, or cancel module installs. Installable rows use
+       `performPrimaryRowAction(for:status:)` from the row tap while this slot stays empty to match
+       Android `NOT_INSTALLED`.
      - Failure modes: Install failures are caught and retained as row error state by
        `installModule(_:)`.
      */
@@ -1763,12 +1765,14 @@ public struct ModuleBrowserView: View {
         for module: RemoteModuleInfo,
         status: ModuleBrowserDownloadStatus
     ) -> some View {
-        switch status {
+        let presentation = ModuleBrowserStatusSlotPresentation(status: status)
+
+        switch presentation.kind {
         case .installed:
-            Image(systemName: "checkmark.circle.fill")
+            Image(systemName: presentation.statusIconSystemName ?? "checkmark.circle.fill")
                 .font(.system(size: 24, weight: .bold))
                 .foregroundStyle(ModuleBrowserPalette.installed)
-        case .beingInstalled(let progressPercent):
+        case .progress(let progressPercent):
             VStack(alignment: .trailing, spacing: 6) {
                 Text("\(progressPercent)%")
                     .font(.caption)
@@ -1786,9 +1790,9 @@ public struct ModuleBrowserView: View {
                 .foregroundStyle(ModuleBrowserPalette.secondaryText)
                 .accessibilityLabel(String(localized: "cancel"))
             }
-        case .errorDownloading:
+        case .retryError:
             VStack(alignment: .trailing, spacing: 6) {
-                Image(systemName: "exclamationmark.triangle.fill")
+                Image(systemName: presentation.statusIconSystemName ?? "exclamationmark.triangle.fill")
                     .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(.red)
                 Button {
@@ -1801,11 +1805,11 @@ public struct ModuleBrowserView: View {
                 .foregroundStyle(ModuleBrowserPalette.install)
                 .accessibilityLabel(String(localized: "retry", defaultValue: "Retry"))
             }
-        case .updateAvailable:
+        case .update:
             Button {
                 installModule(module)
             } label: {
-                Image(systemName: "arrow.up.circle.fill")
+                Image(systemName: presentation.statusIconSystemName ?? "arrow.up.circle.fill")
                     .font(.system(size: 24, weight: .bold))
             }
             .buttonStyle(.plain)
@@ -1815,16 +1819,10 @@ public struct ModuleBrowserView: View {
             Label(String(localized: "unavailable"), systemImage: "lock.slash")
                 .font(.caption)
                 .foregroundStyle(ModuleBrowserPalette.tertiaryText)
-        case .installable:
-            Button {
-                installModule(module)
-            } label: {
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 24, weight: .bold))
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(ModuleBrowserPalette.install)
-            .accessibilityLabel(String(localized: "install_module", defaultValue: "Install"))
+        case .emptyInstallableSlot:
+            Color.clear
+                .frame(width: 24, height: 24)
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes the Downloads row status affordance for not-installed modules so iOS no longer shows an update arrow for ordinary installable rows.

## Scope
- Downloads module row status-slot presentation
- Installable versus update-available row rendering
- Focused Downloads regression coverage

## Contract references
- Android `DownloadControl.getDocumentStatus`: missing installed module resolves to `NOT_INSTALLED`; newer installed module resolves to `UPGRADE_AVAILABLE`.
- Android `DocumentListItem.updateControlState`: `NOT_INSTALLED` clears the status icon; `UPGRADE_AVAILABLE` shows the upward amber arrow.
- iOS `ModuleBrowserView.displayStatus`: already distinguishes `.installable` from `.updateAvailable`; this PR fixes the visual mapping.

## Change details
- Added `ModuleBrowserStatusSlotPresentation` to make the Downloads status-slot mapping explicit and testable.
- Changed `.installable` rows to render an empty 24-point trailing status slot instead of an up-arrow button.
- Kept row-tap install behavior through `performPrimaryRowAction(for:status:)`.
- Left `.updateAvailable` as the only update-arrow branch.

## Validation evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer /usr/bin/xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath /tmp/andbible-issue235-build -only-testing:AndBibleTests/AndBibleTests/testModuleBrowserStatusSlotPresentationKeepsInstallableDistinctFromUpdate -only-testing:AndBibleTests/AndBibleTests/testModuleBrowserDownloadActivityDrivesAndroidProgressAndErrorStatus -only-testing:AndBibleTests/AndBibleTests/testModuleBrowserFiltersAndSortsAndroidDownloadRows`
- `git diff --cached --check`
- GitNexus staged `detect_changes`: low risk, no affected execution flows.

## Risks/follow-ups
- The change intentionally removes the explicit trailing install icon for not-installed rows. Install remains available through the row tap, matching Android row behavior.
- No unrelated Downloads progress/error behavior was changed.

## Issue closure reference
Closes #235
