### PR TITLE
refactor(reader): extract bible navigation coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -3064,4 +3064,222 @@ extension AndBibleTests {
         XCTAssertEqual(pageManager.bibleVerseNo, 5)
     }
 
+    /**
+     Mutable state captured by the navigation context test closures.
+
+     The production coordinator receives escaping closures owned by `BibleReaderController`. Tests
+     use this reference type to model the same lifetime explicitly without unsafe pointer captures.
+     A failure involving this helper usually means the test fixture no longer matches the
+     coordinator's closure-based dependency contract.
+     */
+    private final class NavigationCoordinatorStateBox {
+        /// Current visible Bible position.
+        var position: BibleReaderNavigationPosition
+
+        /// Recorded history keys supplied by explicit navigation.
+        var history: [String] = []
+
+        /// Number of durable persistence requests.
+        var persistCount = 0
+
+        /// Number of host content reload requests.
+        var loadCount = 0
+
+        /// Creates a fixture state box for one coordinator test.
+        init(position: BibleReaderNavigationPosition) {
+            self.position = position
+        }
+    }
+
+    /**
+     Builds a deterministic navigation context backed by in-memory state.
+
+     The fixture uses two books and synthetic ordinals (`chapter * 100 + verse`) so assertions can
+     focus on coordinator ownership rather than SWORD lookups. This mirrors the production contract:
+     the controller supplies versification lookups, while the coordinator decides when to use them
+     and when to persist PageManager state.
+     */
+    private func makeNavigationCoordinatorContext(
+        state: NavigationCoordinatorStateBox,
+        pageManager: PageManager,
+        clientReady: Bool = true,
+        isShowingAndroidMultiDocument: Bool = false
+    ) -> BibleReaderNavigationContext {
+        let books = [
+            BibleReaderNavigationBook(name: "Genesis", osisId: "Gen", chapterCount: 50),
+            BibleReaderNavigationBook(name: "Exodus", osisId: "Exod", chapterCount: 40),
+        ]
+
+        func book(named name: String) -> BibleReaderNavigationBook? {
+            books.first { $0.name == name }
+        }
+
+        func osisId(for name: String) -> String {
+            book(named: name)?.osisId ?? name
+        }
+
+        return BibleReaderNavigationContext(
+            currentPosition: { state.position },
+            setCurrentPosition: { state.position = $0 },
+            pageManager: { pageManager },
+            bookList: { books },
+            isShowingAndroidMultiDocument: { isShowingAndroidMultiDocument },
+            clientReady: { clientReady },
+            chapterCount: { book(named: $0)?.chapterCount ?? 0 },
+            nextBook: { name in
+                guard let index = books.firstIndex(where: { $0.name == name }),
+                      index + 1 < books.count else {
+                    return nil
+                }
+                return books[index + 1].name
+            },
+            previousBook: { name in
+                guard let index = books.firstIndex(where: { $0.name == name }),
+                      index > 0 else {
+                    return nil
+                }
+                return books[index - 1].name
+            },
+            bookNameForOsisId: { osisId in
+                books.first { $0.osisId == osisId }?.name
+            },
+            ordinalForVerse: { _, chapter, verse in
+                chapter * 100 + verse
+            },
+            verseReference: { bookName, ordinal in
+                BibleReaderNavigationVerseReference(
+                    chapter: ordinal / 100,
+                    verse: ordinal % 100,
+                    osisBookId: osisId(for: bookName)
+                )
+            },
+            recordHistory: { bookName, chapter, verse in
+                state.history.append("\(osisId(for: bookName)).\(chapter).\(verse)")
+            },
+            persistState: {
+                state.persistCount += 1
+            },
+            loadCurrentContent: {
+                state.loadCount += 1
+            }
+        )
+    }
+
+    /**
+     Protects the extracted direct-navigation state transition.
+
+     Setup creates an active in-memory PageManager and a client-ready context. Navigation to an
+     explicit verse should update visible state, persist the Bible position, record the Android-style
+     OSIS history key, retain the explicit ordinal range for the next render, and ask the host to
+     reload content once. A failure means direct reader navigation has drifted back into ad hoc
+     controller mutations instead of a single durable page-position transition.
+     */
+    func testReaderNavigationCoordinatorPersistsHistoryAndExplicitRestoreTarget() {
+        let coordinator = BibleReaderNavigationCoordinator()
+        let state = NavigationCoordinatorStateBox(
+            position: BibleReaderNavigationPosition(book: "Genesis", chapter: 1, verse: 1)
+        )
+        let pageManager = PageManager()
+        let context = makeNavigationCoordinatorContext(
+            state: state,
+            pageManager: pageManager
+        )
+
+        coordinator.navigateTo(book: "Exodus", chapter: 2, verse: 3, context: context)
+
+        XCTAssertEqual(state.position, BibleReaderNavigationPosition(book: "Exodus", chapter: 2, verse: 3))
+        XCTAssertEqual(pageManager.bibleBibleBook, 1)
+        XCTAssertEqual(pageManager.bibleChapterNo, 2)
+        XCTAssertEqual(pageManager.bibleVerseNo, 3)
+        XCTAssertEqual(state.history, ["Exod.2.3"])
+        XCTAssertEqual(state.persistCount, 1)
+        XCTAssertEqual(state.loadCount, 1)
+        XCTAssertEqual(coordinator.originalNavigationOrdinalRange, [203, 203])
+        XCTAssertEqual(
+            coordinator.consumeContentRestoreTarget(
+                currentPosition: state.position,
+                ordinalForVerse: { _, chapter, verse in chapter * 100 + verse }
+            ),
+            .ordinal(203)
+        )
+    }
+
+    /**
+     Protects visible-scroll state updates reported by the Vue reader.
+
+     Android treats WebView visible-position callbacks as page-manager updates, not transient UI
+     hints. This test scrolls from Genesis into an Exodus key and expects the coordinator to update
+     the visible book/chapter/verse, persist the new PageManager position immediately, and preserve a
+     restore target for the current visible verse. A failure means iOS can reopen or synchronize a
+     stale verse after infinite-scroll movement.
+     */
+    func testReaderNavigationCoordinatorVisibleScrollUpdatesBookChapterVerseAndPageManager() {
+        let coordinator = BibleReaderNavigationCoordinator()
+        let state = NavigationCoordinatorStateBox(
+            position: BibleReaderNavigationPosition(book: "Genesis", chapter: 1, verse: 1)
+        )
+        let pageManager = PageManager()
+        let context = makeNavigationCoordinatorContext(
+            state: state,
+            pageManager: pageManager
+        )
+
+        let changed = coordinator.updateVisiblePosition(
+            ordinal: 205,
+            key: "Exod.2",
+            atChapterTop: false,
+            context: context
+        )
+
+        XCTAssertTrue(changed)
+        XCTAssertEqual(state.position, BibleReaderNavigationPosition(book: "Exodus", chapter: 2, verse: 5))
+        XCTAssertEqual(pageManager.bibleBibleBook, 1)
+        XCTAssertEqual(pageManager.bibleChapterNo, 2)
+        XCTAssertEqual(pageManager.bibleVerseNo, 5)
+        XCTAssertEqual(state.persistCount, 1)
+        XCTAssertEqual(state.loadCount, 0)
+        XCTAssertEqual(
+            coordinator.consumeContentRestoreTarget(
+                currentPosition: state.position,
+                ordinalForVerse: { _, chapter, verse in chapter * 100 + verse }
+            ),
+            .ordinal(205)
+        )
+    }
+
+    /**
+     Protects Android-style chapter wrapping and synthetic multi-document blocking.
+
+     The reader host delegates next/previous chapter controls into the same coordinator used by
+     bridge navigation. Genesis 50 should wrap to Exodus 1, Exodus 1 should wrap back to Genesis 50,
+     and Android synthetic multi documents must not advertise Bible chapter navigation. A failure
+     means toolbar, keyboard, swipe, and bridge navigation can diverge.
+     */
+    func testReaderNavigationCoordinatorChapterWrappingAndMultiDocumentNavigationAvailability() {
+        let coordinator = BibleReaderNavigationCoordinator()
+        let state = NavigationCoordinatorStateBox(
+            position: BibleReaderNavigationPosition(book: "Genesis", chapter: 50, verse: 1)
+        )
+        let pageManager = PageManager()
+        let context = makeNavigationCoordinatorContext(
+            state: state,
+            pageManager: pageManager
+        )
+
+        XCTAssertTrue(coordinator.hasNext(context: context))
+        coordinator.navigateNext(context: context)
+        XCTAssertEqual(state.position, BibleReaderNavigationPosition(book: "Exodus", chapter: 1, verse: 1))
+
+        coordinator.navigatePrevious(context: context)
+        XCTAssertEqual(state.position, BibleReaderNavigationPosition(book: "Genesis", chapter: 50, verse: 1))
+
+        let multiDocumentContext = makeNavigationCoordinatorContext(
+            state: state,
+            pageManager: pageManager,
+            isShowingAndroidMultiDocument: true
+        )
+        XCTAssertFalse(coordinator.hasNext(context: multiDocumentContext))
+        XCTAssertFalse(coordinator.hasPrevious(context: multiDocumentContext))
+    }
+
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -33,11 +33,6 @@ private let logger = Logger(subsystem: "org.andbible", category: "BibleReaderCon
  */
 @Observable
 public final class BibleReaderController: NSObject, BibleBridgeDelegate {
-    private enum ScrollRestoreTarget {
-        case chapterTop
-        case ordinal(Int)
-    }
-
     let bridge: BibleBridge
     var bookmarkService: BookmarkService?
     var myDocumentStore: MyDocumentStore?
@@ -153,6 +148,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var currentCategory: DocumentCategory = .bible
     /// Pure planner for Android-style module/category PageManager transitions.
     private let moduleSwitchCoordinator = BibleReaderModuleSwitchCoordinator()
+    /// State machine for Android-style Bible navigation and visible-position persistence.
+    @ObservationIgnored
+    private let navigationCoordinator = BibleReaderNavigationCoordinator()
 
     /// Dictionary/Lexicon module support
     private(set) var installedDictionaryModules: [ModuleInfo] = []
@@ -197,15 +195,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private var maxLoadedChapter: Int = 0
     private var minLoadedBook: String = "Genesis"
     private var maxLoadedBook: String = "Genesis"
-
-    /// Last rendered reading position, preserving chapter-top context separately from verse ordinals.
-    private var lastScrollTarget: ScrollRestoreTarget = .chapterTop
-    /// Whether the next loadCurrentChapter should restore scroll position (true = settings reload).
-    private var shouldRestoreScroll = false
-    /// Coalesces intra-chapter scroll persistence so visible-verse updates do not save SwiftData on every tick.
-    private var pendingVisibleVersePersistWorkItem: DispatchWorkItem?
-    /// Optional verse range that should render as the explicit navigation target on the next load.
-    private var originalNavigationOrdinalRange: [Int]? = nil
 
     /**
      Captures a transient Vue `MultiDocument` load until the web client can receive it.
@@ -738,19 +727,100 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Persists the current page-manager state either immediately or after a short debounce for scroll updates.
     private func persistVisibleVerseState(immediate: Bool) {
-        pendingVisibleVersePersistWorkItem?.cancel()
-        pendingVisibleVersePersistWorkItem = nil
-
-        guard let onPersistState else { return }
-
-        if immediate {
-            onPersistState()
-            return
+        navigationCoordinator.persistVisibleVerseState(immediate: immediate) { [weak self] in
+            self?.onPersistState?()
         }
+    }
 
-        let workItem = DispatchWorkItem(block: onPersistState)
-        pendingVisibleVersePersistWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
+    /**
+     Builds the controller-owned dependency context used by the navigation coordinator.
+
+     The coordinator owns the Bible position transition rules while this controller remains the
+     owner of observed reader state, SWORD/JSword-compatible versification lookups, history storage,
+     active-window PageManager access, and WebView reloads. Weak captures prevent deferred
+     visible-verse persistence from extending pane lifetime.
+     */
+    private func makeNavigationContext() -> BibleReaderNavigationContext {
+        BibleReaderNavigationContext(
+            currentPosition: { [weak self] in
+                BibleReaderNavigationPosition(
+                    book: self?.currentBook ?? "Genesis",
+                    chapter: self?.currentChapter ?? 1,
+                    verse: self?.currentVerse ?? 1
+                )
+            },
+            setCurrentPosition: { [weak self] position in
+                self?.currentBook = position.book
+                self?.currentChapter = position.chapter
+                self?.currentVerse = position.verse
+            },
+            pageManager: { [weak self] in
+                self?.activeWindow?.pageManager
+            },
+            bookList: { [weak self] in
+                self?.bookList.map {
+                    BibleReaderNavigationBook(
+                        name: $0.name,
+                        osisId: $0.osisId,
+                        chapterCount: $0.chapterCount
+                    )
+                } ?? []
+            },
+            isShowingAndroidMultiDocument: { [weak self] in
+                self?.isShowingAndroidMultiDocument ?? false
+            },
+            clientReady: { [weak self] in
+                self?.clientReady ?? false
+            },
+            chapterCount: { [weak self] book in
+                self?.chapterCount(for: book) ?? 0
+            },
+            nextBook: { [weak self] book in
+                self?.nextBook(after: book)
+            },
+            previousBook: { [weak self] book in
+                self?.previousBook(before: book)
+            },
+            bookNameForOsisId: { [weak self] osisId in
+                self?.bookName(forOsisId: osisId)
+            },
+            ordinalForVerse: { [weak self] book, chapter, verse in
+                guard let self else { return nil }
+                return self.verseOrdinal(
+                    osisBookId: self.osisBookId(for: book),
+                    chapter: chapter,
+                    verse: verse
+                )
+            },
+            verseReference: { [weak self] book, ordinal in
+                self?.verseReference(book: book, ordinal: ordinal).map {
+                    BibleReaderNavigationVerseReference(
+                        chapter: $0.chapter,
+                        verse: $0.verse,
+                        osisBookId: $0.osisBookId
+                    )
+                }
+            },
+            recordHistory: { [weak self] book, chapter, verse in
+                guard let self,
+                      let store = self.workspaceStore,
+                      let window = self.activeWindow else {
+                    return
+                }
+                let osisId = self.osisBookId(for: book)
+                store.addHistoryItem(
+                    to: window,
+                    document: self.activeModuleName,
+                    key: "\(osisId).\(chapter).\(verse)"
+                )
+            },
+            persistState: { [weak self] in
+                self?.onPersistState?()
+            },
+            loadCurrentContent: { [weak self] in
+                self?.loadCurrentContent()
+            }
+        )
     }
 
     /**
@@ -816,7 +886,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         guard clientReady else { return }
         bridge.emit(event: "set_config", data: buildConfigJSON())
         // Reload to re-render with new options; restore scroll position for same-chapter reload
-        shouldRestoreScroll = true
+        navigationCoordinator.prepareForContentReload()
         loadCurrentContent()
     }
 
@@ -2345,12 +2415,19 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         } else {
             currentVerse = 1
         }
-        originalNavigationOrdinalRange = nil
-        if currentVerse > 1,
-           let ordinal = ordinal(forChapter: currentChapter, verse: currentVerse) {
-            lastScrollTarget = .ordinal(ordinal)
-        } else {
-            lastScrollTarget = .chapterTop
+        navigationCoordinator.restoreSavedPosition(
+            BibleReaderNavigationPosition(
+                book: currentBook,
+                chapter: currentChapter,
+                verse: currentVerse
+            )
+        ) { [weak self] book, chapter, verse in
+            guard let self else { return nil }
+            return self.verseOrdinal(
+                osisBookId: self.osisBookId(for: book),
+                chapter: chapter,
+                verse: verse
+            )
         }
         logger.info("Restored position: \(self.currentBook) \(self.currentChapter):\(self.currentVerse)")
     }
@@ -2373,67 +2450,22 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Navigate to a specific book and chapter. Sends content to the WebView.
     public func navigateTo(book: String, chapter: Int, verse: Int? = nil) {
-        currentBook = book
-        currentChapter = chapter
-        let resolvedVerse = max(1, verse ?? 1)
-        currentVerse = resolvedVerse
-        if let explicitVerse = verse {
-            if let ordinal = ordinal(forChapter: chapter, verse: max(1, explicitVerse)) {
-                originalNavigationOrdinalRange = [ordinal, ordinal]
-            } else {
-                originalNavigationOrdinalRange = nil
-            }
-        } else {
-            originalNavigationOrdinalRange = nil
-        }
-        if resolvedVerse > 1,
-           let ordinal = ordinal(forChapter: chapter, verse: resolvedVerse) {
-            lastScrollTarget = .ordinal(ordinal)
-            shouldRestoreScroll = true
-        } else {
-            lastScrollTarget = .chapterTop
-            shouldRestoreScroll = false
-        }
-
-        // Record history
-        if let store = workspaceStore, let window = activeWindow {
-            let osisId = osisBookId(for: book)
-            store.addHistoryItem(to: window, document: activeModuleName, key: "\(osisId).\(chapter).\(resolvedVerse)")
-        }
-
-        // Persist position to PageManager
-        if let pm = activeWindow?.pageManager {
-            pm.bibleBibleBook = bookList.firstIndex(where: { $0.name == book })
-            pm.bibleChapterNo = chapter
-            pm.bibleVerseNo = resolvedVerse
-            onPersistState?()
-        }
-
-        guard clientReady else { return }
-        loadCurrentContent()
+        navigationCoordinator.navigateTo(
+            book: book,
+            chapter: chapter,
+            verse: verse,
+            context: makeNavigationContext()
+        )
     }
 
     /// Navigate to the next chapter, wrapping to the next book if needed.
     public func navigateNext() {
-        guard !isShowingAndroidMultiDocument else { return }
-        let maxChapter = chapterCount(for: currentBook)
-        if currentChapter < maxChapter {
-            navigateTo(book: currentBook, chapter: currentChapter + 1)
-        } else if let nextBook = nextBook(after: currentBook) {
-            navigateTo(book: nextBook, chapter: 1)
-        }
-        // At Revelation's last chapter, do nothing
+        navigationCoordinator.navigateNext(context: makeNavigationContext())
     }
 
     /// Navigate to the previous chapter, wrapping to the previous book if needed.
     public func navigatePrevious() {
-        guard !isShowingAndroidMultiDocument else { return }
-        if currentChapter > 1 {
-            navigateTo(book: currentBook, chapter: currentChapter - 1)
-        } else if let prevBook = previousBook(before: currentBook) {
-            navigateTo(book: prevBook, chapter: chapterCount(for: prevBook))
-        }
-        // At Genesis 1, do nothing
+        navigationCoordinator.navigatePrevious(context: makeNavigationContext())
     }
 
     /// Scroll down by one viewport page (Android parity: PAGE swipe mode).
@@ -2450,15 +2482,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Whether there's a next chapter available.
     public var hasNext: Bool {
-        guard !isShowingAndroidMultiDocument else { return false }
-        let maxChapter = chapterCount(for: currentBook)
-        return currentChapter < maxChapter || nextBook(after: currentBook) != nil
+        navigationCoordinator.hasNext(context: makeNavigationContext())
     }
 
     /// Whether there's a previous chapter available.
     public var hasPrevious: Bool {
-        guard !isShowingAndroidMultiDocument else { return false }
-        return currentChapter > 1 || previousBook(before: currentBook) != nil
+        navigationCoordinator.hasPrevious(context: makeNavigationContext())
     }
 
     // MARK: - BibleBridgeDelegate — State
@@ -2688,62 +2717,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         let previousChapter = currentChapter
         let previousVerse = currentVerse
         let acknowledgedSynchronizedScroll = consumePendingSynchronizedScroll(ordinal: ordinal)
-        // Track scroll position for restoration.
-        lastScrollTarget = atChapterTop ? .chapterTop : .ordinal(ordinal)
-
-        // Update toolbar header when scrolling into a different chapter/book (infinite scroll)
-        let keyParts = key.split(separator: ".", omittingEmptySubsequences: true)
-        if keyParts.count >= 2 {
-            let osisId = String(keyParts[0])
-            let chapterStr = String(keyParts[1])
-            if let chapter = Int(chapterStr), chapter != currentChapter {
-                currentChapter = chapter
-                if let name = bookName(forOsisId: osisId), name != currentBook {
-                    currentBook = name
-                }
-                // Persist updated position to PageManager
-                if let pm = activeWindow?.pageManager {
-                    pm.bibleChapterNo = chapter
-                    if let bookIdx = bookList.firstIndex(where: { $0.name == currentBook }) {
-                        pm.bibleBibleBook = bookIdx
-                    }
-                    if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
-                        currentVerse = verse
-                        pm.bibleVerseNo = verse
-                    }
-                    persistVisibleVerseState(immediate: true)
-                }
-            } else if let name = bookName(forOsisId: osisId), name != currentBook {
-                currentBook = name
-                if let pm = activeWindow?.pageManager {
-                    if let bookIdx = bookList.firstIndex(where: { $0.name == currentBook }) {
-                        pm.bibleBibleBook = bookIdx
-                    }
-                    if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
-                        currentVerse = verse
-                        pm.bibleVerseNo = verse
-                    }
-                    persistVisibleVerseState(immediate: true)
-                }
-            } else if let pm = activeWindow?.pageManager {
-                if let verse = verseReference(book: currentBook, ordinal: ordinal)?.verse {
-                    currentVerse = verse
-                    pm.bibleVerseNo = verse
-                }
-                persistVisibleVerseState(immediate: false)
-            }
-        } else if let reference = verseReference(book: currentBook, ordinal: ordinal) {
-            currentChapter = reference.chapter
-            currentVerse = reference.verse
-            if let pm = activeWindow?.pageManager {
-                pm.bibleChapterNo = reference.chapter
-                if let bookIdx = bookList.firstIndex(where: { $0.name == currentBook }) {
-                    pm.bibleBibleBook = bookIdx
-                }
-                pm.bibleVerseNo = reference.verse
-                persistVisibleVerseState(immediate: false)
-            }
-        }
+        navigationCoordinator.updateVisiblePosition(
+            ordinal: ordinal,
+            key: key,
+            atChapterTop: atChapterTop,
+            context: makeNavigationContext()
+        )
 
         let visibleVerseChanged = previousBook != currentBook
             || previousChapter != currentChapter
@@ -2957,18 +2936,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Failure modes: none.
      */
     private func applySynchronizedVersePosition(book: String, chapter: Int, verse: Int, ordinal: Int) {
-        currentBook = book
-        currentChapter = chapter
-        currentVerse = verse
-        lastScrollTarget = .ordinal(ordinal)
-        shouldRestoreScroll = true
-
-        if let pm = activeWindow?.pageManager {
-            pm.bibleBibleBook = bookList.firstIndex(where: { $0.name == book })
-            pm.bibleChapterNo = chapter
-            pm.bibleVerseNo = verse
-            persistVisibleVerseState(immediate: false)
-        }
+        navigationCoordinator.applySynchronizedVersePosition(
+            book: book,
+            chapter: chapter,
+            verse: verse,
+            ordinal: ordinal,
+            context: makeNavigationContext()
+        )
     }
 
     /**
@@ -7598,7 +7572,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             xml: xml,
             bookmarks: chapterBookmarks,
             addChapter: addChapter,
-            originalOrdinalRange: originalNavigationOrdinalRange
+            originalOrdinalRange: navigationCoordinator.originalNavigationOrdinalRange
         ) else { return }
         bridge.emit(event: "add_documents", data: document)
 
@@ -7609,16 +7583,20 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         maxLoadedBook = currentBook
 
         // Restore either the exact verse anchor or the chapter-top reading context.
-        let restoreTarget: ScrollRestoreTarget
-        if shouldRestoreScroll {
-            restoreTarget = lastScrollTarget
-        } else if currentVerse > 1,
-                  let ordinal = ordinal(forChapter: currentChapter, verse: currentVerse) {
-            restoreTarget = .ordinal(ordinal)
-        } else {
-            restoreTarget = .chapterTop
+        let restoreTarget = navigationCoordinator.consumeContentRestoreTarget(
+            currentPosition: BibleReaderNavigationPosition(
+                book: currentBook,
+                chapter: currentChapter,
+                verse: currentVerse
+            )
+        ) { [weak self] book, chapter, verse in
+            guard let self else { return nil }
+            return self.verseOrdinal(
+                osisBookId: self.osisBookId(for: book),
+                chapter: chapter,
+                verse: verse
+            )
         }
-        shouldRestoreScroll = false
         let jumpOrdinal: String
         let jumpToId: String
         switch restoreTarget {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderNavigationCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderNavigationCoordinator.swift
@@ -1,0 +1,550 @@
+// BibleReaderNavigationCoordinator.swift -- Reader navigation and visible-position state machine
+
+import Foundation
+import BibleCore
+
+/**
+ Minimal book metadata required by reader navigation.
+
+ The controller converts SWORD `BookInfo` values into this DTO so the navigation coordinator can
+ own book-order and chapter-boundary rules without depending on SWORD module instances. This keeps
+ Android/JSword-compatible versification lookups in the controller while letting navigation state
+ transitions be tested independently.
+ */
+struct BibleReaderNavigationBook: Equatable {
+    /// User-facing book name stored by the reader controller.
+    let name: String
+
+    /// OSIS identifier used in Vue scroll keys and history persistence.
+    let osisId: String
+
+    /// One-based chapter count for wrapping next/previous navigation.
+    let chapterCount: Int
+}
+
+/**
+ Current visible Bible position for a reader pane.
+
+ The value is copied into and out of `BibleReaderController` through closures so the coordinator can
+ plan mutations without retaining an observable controller. All numbers are one-based and already
+ validated by the caller's active module/compatibility lookup.
+ */
+struct BibleReaderNavigationPosition: Equatable {
+    /// User-facing book name.
+    let book: String
+
+    /// One-based chapter number.
+    let chapter: Int
+
+    /// One-based verse number.
+    let verse: Int
+}
+
+/**
+ Verse identity resolved from a module-local ordinal.
+
+ The controller supplies this value after converting through the active SWORD/JSword-compatible
+ versification. The coordinator only needs the resulting chapter and verse, plus the OSIS id when a
+ test or host wants to assert the source identity.
+ */
+struct BibleReaderNavigationVerseReference: Equatable {
+    /// One-based chapter resolved from the ordinal.
+    let chapter: Int
+
+    /// One-based verse resolved from the ordinal.
+    let verse: Int
+
+    /// OSIS book identifier associated with the resolved verse.
+    let osisBookId: String
+}
+
+/**
+ Scroll target sent to the Vue reader after a chapter document is loaded.
+
+ Chapter-top restoration and verse-anchor restoration are intentionally distinct because Android
+ preserves chapter-top context separately from verse one. Treating both as ordinal `1` causes
+ reloads and restored positions to jump to a verse anchor when they should land on the top marker.
+ */
+enum BibleReaderScrollRestoreTarget: Equatable {
+    /// Restore to the document's top marker.
+    case chapterTop
+
+    /// Restore to an exact module-local verse ordinal.
+    case ordinal(Int)
+}
+
+/**
+ Controller-owned dependencies used by the navigation coordinator.
+
+ The coordinator owns navigation rules and PageManager writes; the reader controller still owns
+ observed state, SWORD/JSword-compatible lookup functions, history storage, bridge reloads, and
+ Android synthetic document detection. Closures make those dependencies explicit and prevent the
+ coordinator from retaining a controller.
+ */
+struct BibleReaderNavigationContext {
+    /// Reads the current controller-visible position.
+    let currentPosition: () -> BibleReaderNavigationPosition
+
+    /// Writes a new controller-visible position.
+    let setCurrentPosition: (BibleReaderNavigationPosition) -> Void
+
+    /// Returns the active pane PageManager, if the pane is backed by durable workspace state.
+    let pageManager: () -> PageManager?
+
+    /// Returns the active module's ordered book list.
+    let bookList: () -> [BibleReaderNavigationBook]
+
+    /// Indicates whether the pane is showing Android's synthetic Multi document.
+    let isShowingAndroidMultiDocument: () -> Bool
+
+    /// Indicates whether the Vue reader client can receive reload events.
+    let clientReady: () -> Bool
+
+    /// Resolves chapter count for a user-facing book name.
+    let chapterCount: (String) -> Int
+
+    /// Resolves the next book in active module order.
+    let nextBook: (String) -> String?
+
+    /// Resolves the previous book in active module order.
+    let previousBook: (String) -> String?
+
+    /// Converts a scroll key OSIS identifier into the active module's user-facing book name.
+    let bookNameForOsisId: (String) -> String?
+
+    /// Resolves an exact verse ordinal in the active module's versification.
+    let ordinalForVerse: (_ book: String, _ chapter: Int, _ verse: Int) -> Int?
+
+    /// Resolves a module-local ordinal into a chapter/verse identity.
+    let verseReference: (_ book: String, _ ordinal: Int) -> BibleReaderNavigationVerseReference?
+
+    /// Records an Android-style history checkpoint after explicit navigation.
+    let recordHistory: (_ book: String, _ chapter: Int, _ verse: Int) -> Void
+
+    /// Persists mutated workspace/page state.
+    let persistState: () -> Void
+
+    /// Reloads visible content through the reader controller.
+    let loadCurrentContent: () -> Void
+}
+
+/**
+ Owns Bible reader navigation state transitions for one pane.
+
+ Android keeps current Bible page state, visible scroll callbacks, explicit navigation anchors, and
+ next/previous chapter wrapping tied to one current-page manager workflow. This coordinator mirrors
+ that shape on iOS: it updates `PageManager` Bible fields, records explicit navigation history,
+ tracks the next render's highlight/restore target, and debounces intra-chapter visible-verse saves.
+
+ - Important: Callers are expected to use this from the main actor/thread with the owning
+   `BibleReaderController`. The class is intentionally not thread-safe because it mutates
+   controller-adjacent state and schedules main-queue persistence work.
+ */
+final class BibleReaderNavigationCoordinator {
+    /// Optional ordinal range rendered as the explicit navigation target on the next content load.
+    private(set) var originalNavigationOrdinalRange: [Int]? = nil
+
+    /// Last visible scroll target, preserving chapter-top context separately from verse ordinals.
+    private var lastScrollTarget: BibleReaderScrollRestoreTarget = .chapterTop
+
+    /// Whether the next content load should prefer `lastScrollTarget`.
+    private var shouldRestoreScroll = false
+
+    /// Pending debounced persistence work for noisy intra-chapter visible-verse callbacks.
+    private var pendingVisibleVersePersistWorkItem: DispatchWorkItem?
+
+    /**
+     Restores the initial Bible scroll target from durable PageManager state.
+
+     - Parameters:
+       - position: Restored Bible book/chapter/verse.
+       - ordinalForVerse: Active-module lookup used to convert the restored verse into an anchor.
+     - Side effects: Clears explicit navigation highlighting and replaces the stored scroll target.
+     - Failure modes: If the verse has no ordinal or is verse one, restoration falls back to the
+       chapter top to preserve Android's top-of-chapter behavior.
+     */
+    func restoreSavedPosition(
+        _ position: BibleReaderNavigationPosition,
+        ordinalForVerse: (_ book: String, _ chapter: Int, _ verse: Int) -> Int?
+    ) {
+        originalNavigationOrdinalRange = nil
+        shouldRestoreScroll = false
+        if position.verse > 1,
+           let ordinal = ordinalForVerse(position.book, position.chapter, position.verse) {
+            lastScrollTarget = .ordinal(ordinal)
+        } else {
+            lastScrollTarget = .chapterTop
+        }
+    }
+
+    /**
+     Marks the next content load as a same-position reload that should preserve the last scroll target.
+
+     Display-setting changes rebuild the currently visible document without changing the Bible
+     reference. Android preserves the active scroll context for that rebuild, so iOS keeps the
+     existing target and only flips the one-shot restore flag.
+
+     - Side effects: Updates coordinator state consumed by `consumeContentRestoreTarget`.
+     - Failure modes: None; if no visible verse has ever been captured, the stored target remains
+       chapter top.
+     */
+    func prepareForContentReload() {
+        shouldRestoreScroll = true
+    }
+
+    /**
+     Navigates to an explicit Bible location and persists the resulting PageManager state.
+
+     - Parameters:
+       - book: User-facing book name to make visible.
+       - chapter: One-based chapter number.
+       - verse: Optional one-based verse; omitted navigation lands at the chapter top.
+       - context: Controller-owned lookup, persistence, history, and reload callbacks.
+     - Side effects: Mutates controller position through `context`, writes PageManager Bible fields,
+       records history, persists workspace state, and reloads content when the Vue client is ready.
+     - Failure modes: If no PageManager is available, controller state and history still update but
+       no durable page-position write occurs; if the explicit verse has no ordinal, highlighting is
+       skipped while navigation still lands on the requested verse number.
+     */
+    func navigateTo(book: String, chapter: Int, verse: Int? = nil, context: BibleReaderNavigationContext) {
+        let resolvedVerse = max(1, verse ?? 1)
+        let position = BibleReaderNavigationPosition(book: book, chapter: chapter, verse: resolvedVerse)
+        context.setCurrentPosition(position)
+
+        if let explicitVerse = verse,
+           let ordinal = context.ordinalForVerse(book, chapter, max(1, explicitVerse)) {
+            originalNavigationOrdinalRange = [ordinal, ordinal]
+        } else {
+            originalNavigationOrdinalRange = nil
+        }
+
+        if resolvedVerse > 1,
+           let ordinal = context.ordinalForVerse(book, chapter, resolvedVerse) {
+            lastScrollTarget = .ordinal(ordinal)
+            shouldRestoreScroll = true
+        } else {
+            lastScrollTarget = .chapterTop
+            shouldRestoreScroll = false
+        }
+
+        context.recordHistory(book, chapter, resolvedVerse)
+        if let pageManager = context.pageManager() {
+            write(position: position, to: pageManager, bookList: context.bookList())
+            context.persistState()
+        }
+
+        guard context.clientReady() else { return }
+        context.loadCurrentContent()
+    }
+
+    /**
+     Navigates to the next Bible chapter, wrapping into the next book when available.
+
+     - Parameter context: Controller-owned state and lookup callbacks.
+     - Side effects: Delegates to `navigateTo` when a next chapter exists.
+     - Failure modes: Does nothing at the final chapter or while Android synthetic Multi content is
+       visible, matching the existing reader controls.
+     */
+    func navigateNext(context: BibleReaderNavigationContext) {
+        guard !context.isShowingAndroidMultiDocument() else { return }
+        let position = context.currentPosition()
+        let maxChapter = context.chapterCount(position.book)
+        if position.chapter < maxChapter {
+            navigateTo(book: position.book, chapter: position.chapter + 1, context: context)
+        } else if let nextBook = context.nextBook(position.book) {
+            navigateTo(book: nextBook, chapter: 1, context: context)
+        }
+    }
+
+    /**
+     Navigates to the previous Bible chapter, wrapping into the previous book when available.
+
+     - Parameter context: Controller-owned state and lookup callbacks.
+     - Side effects: Delegates to `navigateTo` when a previous chapter exists.
+     - Failure modes: Does nothing at the first chapter or while Android synthetic Multi content is
+       visible, matching the existing reader controls.
+     */
+    func navigatePrevious(context: BibleReaderNavigationContext) {
+        guard !context.isShowingAndroidMultiDocument() else { return }
+        let position = context.currentPosition()
+        if position.chapter > 1 {
+            navigateTo(book: position.book, chapter: position.chapter - 1, context: context)
+        } else if let previousBook = context.previousBook(position.book) {
+            navigateTo(book: previousBook, chapter: context.chapterCount(previousBook), context: context)
+        }
+    }
+
+    /**
+     Reports whether a next chapter is available for host controls.
+
+     - Parameter context: Controller-owned state and lookup callbacks.
+     - Returns: `true` when navigation can move forward from the current Bible position.
+     - Side effects: None.
+     - Failure modes: Returns `false` for Android synthetic Multi content so Bible-only controls do
+       not advertise unavailable chapter movement.
+     */
+    func hasNext(context: BibleReaderNavigationContext) -> Bool {
+        guard !context.isShowingAndroidMultiDocument() else { return false }
+        let position = context.currentPosition()
+        return position.chapter < context.chapterCount(position.book) || context.nextBook(position.book) != nil
+    }
+
+    /**
+     Reports whether a previous chapter is available for host controls.
+
+     - Parameter context: Controller-owned state and lookup callbacks.
+     - Returns: `true` when navigation can move backward from the current Bible position.
+     - Side effects: None.
+     - Failure modes: Returns `false` for Android synthetic Multi content so Bible-only controls do
+       not advertise unavailable chapter movement.
+     */
+    func hasPrevious(context: BibleReaderNavigationContext) -> Bool {
+        guard !context.isShowingAndroidMultiDocument() else { return false }
+        let position = context.currentPosition()
+        return position.chapter > 1 || context.previousBook(position.book) != nil
+    }
+
+    /**
+     Applies visible-verse telemetry reported by the Vue reader.
+
+     - Parameters:
+       - ordinal: Module-local verse ordinal near the viewport focus.
+       - key: Vue document key, usually `OSIS.chapter` or `OSIS.chapter.verse`.
+       - atChapterTop: Whether the viewport is at the chapter-top marker.
+       - context: Controller-owned lookup, state, and persistence callbacks.
+     - Returns: `true` when the visible Bible book/chapter/verse changed.
+     - Side effects: Mutates controller position, writes PageManager Bible fields, updates the last
+       scroll restore target, and persists immediately for chapter/book changes or debounced for
+       same-chapter verse movement.
+     - Failure modes: Invalid keys fall back to ordinal resolution in the current book; unresolved
+       ordinals leave visible position unchanged.
+     */
+    @discardableResult
+    func updateVisiblePosition(
+        ordinal: Int,
+        key: String,
+        atChapterTop: Bool,
+        context: BibleReaderNavigationContext
+    ) -> Bool {
+        let previousPosition = context.currentPosition()
+        lastScrollTarget = atChapterTop ? .chapterTop : .ordinal(ordinal)
+
+        let keyParts = key.split(separator: ".", omittingEmptySubsequences: true)
+        if keyParts.count >= 2 {
+            updateVisiblePositionFromKey(
+                osisId: String(keyParts[0]),
+                chapterText: String(keyParts[1]),
+                ordinal: ordinal,
+                context: context
+            )
+        } else if let reference = context.verseReference(previousPosition.book, ordinal) {
+            var position = previousPosition
+            position = BibleReaderNavigationPosition(
+                book: position.book,
+                chapter: reference.chapter,
+                verse: reference.verse
+            )
+            context.setCurrentPosition(position)
+            if let pageManager = context.pageManager() {
+                write(position: position, to: pageManager, bookList: context.bookList())
+                persistVisibleVerseState(immediate: false, persistState: context.persistState)
+            }
+        }
+
+        return context.currentPosition() != previousPosition
+    }
+
+    /**
+     Applies a synchronized target verse that has already been converted into this pane's ordinal
+     space.
+
+     - Parameters:
+       - book: Target pane book name.
+       - chapter: Target chapter.
+       - verse: Target verse.
+       - ordinal: Target-local ordinal for the verse.
+       - context: Controller-owned state and persistence callbacks.
+     - Side effects: Updates controller position, writes PageManager Bible fields, records the
+       target ordinal as the next content restore anchor, and schedules visible-position persistence.
+     - Failure modes: If no PageManager is available, native position and restore target still update
+       while durable persistence is skipped.
+     */
+    func applySynchronizedVersePosition(
+        book: String,
+        chapter: Int,
+        verse: Int,
+        ordinal: Int,
+        context: BibleReaderNavigationContext
+    ) {
+        let position = BibleReaderNavigationPosition(book: book, chapter: chapter, verse: verse)
+        context.setCurrentPosition(position)
+        lastScrollTarget = .ordinal(ordinal)
+        shouldRestoreScroll = true
+
+        if let pageManager = context.pageManager() {
+            write(position: position, to: pageManager, bookList: context.bookList())
+            persistVisibleVerseState(immediate: false, persistState: context.persistState)
+        }
+    }
+
+    /**
+     Returns and consumes the scroll target for a newly loaded chapter document.
+
+     - Parameters:
+       - currentPosition: Current Bible position after the document has been built.
+       - ordinalForVerse: Active-module lookup for the current verse.
+     - Returns: The exact ordinal or chapter-top marker to pass to Vue `setup_content`.
+     - Side effects: Clears the one-shot `shouldRestoreScroll` flag.
+     - Failure modes: If no ordinal can be resolved for the current verse, returns `.chapterTop`.
+     */
+    func consumeContentRestoreTarget(
+        currentPosition: BibleReaderNavigationPosition,
+        ordinalForVerse: (_ book: String, _ chapter: Int, _ verse: Int) -> Int?
+    ) -> BibleReaderScrollRestoreTarget {
+        let restoreTarget: BibleReaderScrollRestoreTarget
+        if shouldRestoreScroll {
+            restoreTarget = lastScrollTarget
+        } else if currentPosition.verse > 1,
+                  let ordinal = ordinalForVerse(
+                    currentPosition.book,
+                    currentPosition.chapter,
+                    currentPosition.verse
+                  ) {
+            restoreTarget = .ordinal(ordinal)
+        } else {
+            restoreTarget = .chapterTop
+        }
+        shouldRestoreScroll = false
+        return restoreTarget
+    }
+
+    /**
+     Persists visible-verse state immediately or after a short debounce.
+
+     - Parameters:
+       - immediate: Whether persistence should happen synchronously.
+       - persistState: Controller callback that saves mutated workspace state.
+     - Side effects: Cancels any older debounced work item and may enqueue a main-queue save.
+     - Failure modes: If the caller's persistence closure is a no-op because the controller has gone
+       away, queued work harmlessly does nothing.
+     */
+    func persistVisibleVerseState(immediate: Bool, persistState: @escaping () -> Void) {
+        pendingVisibleVersePersistWorkItem?.cancel()
+        pendingVisibleVersePersistWorkItem = nil
+
+        if immediate {
+            persistState()
+            return
+        }
+
+        let workItem = DispatchWorkItem(block: persistState)
+        pendingVisibleVersePersistWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
+    }
+
+    /**
+     Applies a parsed Vue key to the visible position.
+
+     - Parameters:
+       - osisId: OSIS book id from the Vue key.
+       - chapterText: Chapter component from the Vue key.
+       - ordinal: Visible ordinal reported with the key.
+       - context: Controller-owned lookup, state, and persistence callbacks.
+     - Side effects: Mutates controller position and PageManager fields when the key identifies a
+       changed book/chapter or when the same-chapter ordinal resolves to a different verse.
+     - Failure modes: Non-numeric chapter strings are ignored to preserve the previous position.
+     */
+    private func updateVisiblePositionFromKey(
+        osisId: String,
+        chapterText: String,
+        ordinal: Int,
+        context: BibleReaderNavigationContext
+    ) {
+        var position = context.currentPosition()
+        guard let chapter = Int(chapterText) else {
+            return
+        }
+
+        if chapter != position.chapter {
+            position = BibleReaderNavigationPosition(
+                book: context.bookNameForOsisId(osisId) ?? position.book,
+                chapter: chapter,
+                verse: position.verse
+            )
+            if let pageManager = context.pageManager() {
+                position = positionByResolvingVerse(
+                    from: position,
+                    ordinal: ordinal,
+                    context: context
+                )
+                write(position: position, to: pageManager, bookList: context.bookList())
+                persistVisibleVerseState(immediate: true, persistState: context.persistState)
+            }
+            context.setCurrentPosition(position)
+        } else if let name = context.bookNameForOsisId(osisId), name != position.book {
+            position = BibleReaderNavigationPosition(book: name, chapter: position.chapter, verse: position.verse)
+            if let pageManager = context.pageManager() {
+                position = positionByResolvingVerse(
+                    from: position,
+                    ordinal: ordinal,
+                    context: context
+                )
+                write(position: position, to: pageManager, bookList: context.bookList())
+                persistVisibleVerseState(immediate: true, persistState: context.persistState)
+            }
+            context.setCurrentPosition(position)
+        } else if let pageManager = context.pageManager() {
+            position = positionByResolvingVerse(from: position, ordinal: ordinal, context: context)
+            context.setCurrentPosition(position)
+            pageManager.bibleVerseNo = position.verse
+            persistVisibleVerseState(immediate: false, persistState: context.persistState)
+        }
+    }
+
+    /**
+     Resolves a visible ordinal into a position update.
+
+     - Parameters:
+       - position: Current candidate position.
+       - ordinal: Visible ordinal reported by Vue.
+       - context: Controller-owned ordinal resolver.
+     - Returns: A position with the resolved verse when available, otherwise the original position.
+     - Side effects: None.
+     - Failure modes: Unresolved ordinals preserve the candidate position unchanged.
+     */
+    private func positionByResolvingVerse(
+        from position: BibleReaderNavigationPosition,
+        ordinal: Int,
+        context: BibleReaderNavigationContext
+    ) -> BibleReaderNavigationPosition {
+        guard let reference = context.verseReference(position.book, ordinal) else {
+            return position
+        }
+        return BibleReaderNavigationPosition(
+            book: position.book,
+            chapter: position.chapter,
+            verse: reference.verse
+        )
+    }
+
+    /**
+     Writes a Bible position to a PageManager.
+
+     - Parameters:
+       - position: Current visible Bible position.
+       - pageManager: Durable page state for the owning window.
+       - bookList: Active module book order used to persist Android-style book index.
+     - Side effects: Mutates `bibleBibleBook`, `bibleChapterNo`, and `bibleVerseNo`.
+     - Failure modes: If the book is absent from `bookList`, the book index is written as `nil`
+       while chapter and verse still persist.
+     */
+    private func write(
+        position: BibleReaderNavigationPosition,
+        to pageManager: PageManager,
+        bookList: [BibleReaderNavigationBook]
+    ) {
+        pageManager.bibleBibleBook = bookList.firstIndex { $0.name == position.book }
+        pageManager.bibleChapterNo = position.chapter
+        pageManager.bibleVerseNo = position.verse
+    }
+}


### PR DESCRIPTION
## Summary

Extracts Bible reader navigation and visible-position persistence from `BibleReaderController` into a focused coordinator while preserving existing Android-style behavior.

## Scope

- Adds `BibleReaderNavigationCoordinator` for explicit Bible navigation, next/previous wrapping, visible-scroll PageManager writes, restore targets, and debounced visible-verse persistence.
- Keeps SWORD/JSword-compatible lookup behavior in `BibleReaderController` and passes it into the coordinator through an explicit context.
- Adds simulator unit coverage in the existing `AndBibleTests+ReaderNavigation.swift` suite so CI exercises the new boundary.

## Contract References

- Refs #146; this PR covers the reader navigation / visible-position persistence checklist item but does not close the parent decomposition issue because other checklist items remain open.
- Stacked on #234 / `issue-146-bridge-routing`.
- Android parity contract: this is a behavior-preserving extraction of current Android-style navigation semantics, including synthetic Multi navigation blocking and visible-position persistence.

## Change Details

- Moved navigation state (`originalNavigationOrdinalRange`, restore target, same-content reload preservation, and visible-verse persistence debounce) into `BibleReaderNavigationCoordinator`.
- Delegated controller methods for `navigateTo`, `navigateNext`, `navigatePrevious`, `hasNext`, `hasPrevious`, visible-scroll callbacks, synchronized verse application, and chapter-content restore target selection.
- Added tests for explicit navigation persistence/history, scroll-key visible-position persistence, chapter wrapping, and synthetic Multi navigation availability.

## Validation Evidence

- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref issue-146-bridge-routing --head-ref HEAD`
- Focused simulator tests: 3 selected coordinator tests passed.
- Full simulator unit suite: 579 tests passed, 0 failures.
- GitNexus `detect_changes` reported high risk across reader-controller navigation/config flows; local unit coverage passed.

## Risks / Follow-ups

- Risk is reviewer complexity rather than intended behavior change: this touches `BibleReaderController` navigation and load paths, but the coordinator is covered by focused unit tests plus the existing reader-navigation suite.
- Follow-up remains in #146 for the next controller-decomposition slice after #234 and this PR land.
