### PR TITLE
refactor(reader): extract sword setup coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -267,6 +267,103 @@ extension AndBibleTests {
         XCTAssertEqual(resolved.dayTextColor, TextDisplaySettings.appDefaults.dayTextColor)
     }
 
+    /**
+     Protects the extracted SWORD setup boundary for installed-module catalog and active-module
+     resolution.
+
+     The controller currently configures SWORD, splits installed modules by Android document
+     category, chooses active module handles, and builds the active Bible book list in one large
+     method. This test defines the collaborator contract before extraction: requested modules must
+     be resolved through the shared `SwordManager`, commentaries keep the existing first-installed
+     fallback, optional auxiliary modules remain explicit, and Bible books must come from the active
+     module instead of a static fallback while a SWORD Bible is installed. A failure means the
+     extraction changed the reader's module inventory or versification source.
+     */
+    func testReaderSwordCoordinatorBuildsCatalogSelectionsAndBookList() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        try seedBibleAliasModule(named: "WEB", description: "World English Bible", in: modulePath)
+        try seedEmptyRawCommentaryModule(named: "UITestComm", in: modulePath)
+        try seedEmptyRawDictionaryModule(named: "UITestDict", in: modulePath)
+        try seedEmptyRawGeneralBookModule(named: "UITestGB", in: modulePath)
+        try seedEmptyRawMapModule(named: "UITestMap", in: modulePath)
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+
+        let state = BibleReaderSwordCoordinator().configure(
+            manager: manager,
+            selection: BibleReaderSwordSelection(
+                activeModuleName: "WEB",
+                activeCommentaryModuleName: nil,
+                activeDictionaryModuleName: "UITestDict",
+                activeGeneralBookModuleName: "UITestGB",
+                activeMapModuleName: "UITestMap"
+            ),
+            displaySettings: .appDefaults
+        )
+
+        XCTAssertEqual(Set(state.installedBibleModules.map(\.name)), Set(["KJV", "WEB"]))
+        XCTAssertEqual(state.installedCommentaryModules.map(\.name), ["UITestComm"])
+        XCTAssertEqual(state.installedDictionaryModules.map(\.name), ["UITestDict"])
+        XCTAssertEqual(state.installedGeneralBookModules.map(\.name), ["UITestGB"])
+        XCTAssertEqual(state.installedMapModules.map(\.name), ["UITestMap"])
+        XCTAssertEqual(state.activeModuleName, "WEB")
+        XCTAssertEqual(state.activeModule?.info.name, "WEB")
+        XCTAssertEqual(state.activeCommentaryModuleName, "UITestComm")
+        XCTAssertEqual(state.activeDictionaryModuleName, "UITestDict")
+        XCTAssertEqual(state.activeGeneralBookModuleName, "UITestGB")
+        XCTAssertEqual(state.activeMapModuleName, "UITestMap")
+        XCTAssertEqual(state.moduleBookList.count, 66)
+        XCTAssertEqual(state.moduleBookList.first?.osisId, "Gen")
+    }
+
+    /**
+     Protects the SWORD global option mapping used by reader rendering.
+
+     Android applies reader display settings through JSword filters; iOS mirrors those options with
+     SWORD global options. The setup collaborator must keep the always-on heading/red-letter base
+     configuration and the setting-driven Strong's, morphology, footnote, and cross-reference
+     toggles together so future controller refactors cannot silently stop applying display changes
+     to the SWORD manager.
+     */
+    func testReaderSwordCoordinatorAppliesBaseAndDisplayGlobalOptions() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        var settings = TextDisplaySettings()
+        settings.strongsMode = 1
+        settings.showMorphology = true
+        settings.showFootNotes = true
+        settings.showXrefs = true
+
+        _ = BibleReaderSwordCoordinator().configure(
+            manager: manager,
+            selection: BibleReaderSwordSelection(
+                activeModuleName: "KJV",
+                activeCommentaryModuleName: nil,
+                activeDictionaryModuleName: nil,
+                activeGeneralBookModuleName: nil,
+                activeMapModuleName: nil
+            ),
+            displaySettings: settings
+        )
+
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.headings))
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.redLetterWords))
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.strongsNumbers))
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.morphology))
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.footnotes))
+        XCTAssertTrue(manager.isGlobalOptionEnabled(.crossReferences))
+
+        settings.strongsMode = 0
+        settings.showMorphology = false
+        settings.showFootNotes = false
+        settings.showXrefs = false
+        BibleReaderSwordCoordinator().applyDisplayOptions(to: manager, settings: settings)
+
+        XCTAssertFalse(manager.isGlobalOptionEnabled(.strongsNumbers))
+        XCTAssertFalse(manager.isGlobalOptionEnabled(.morphology))
+        XCTAssertFalse(manager.isGlobalOptionEnabled(.footnotes))
+        XCTAssertFalse(manager.isGlobalOptionEnabled(.crossReferences))
+    }
+
     func testTextDisplaySettingsChangedFieldsOnlyClearMatchingDirtyOverrides() {
         var previousGlobal = TextDisplaySettings()
         previousGlobal.fontSize = 18

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -188,14 +188,10 @@ extension AndBibleUITests {
                 }
                 return prompt.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.52))
             case "workspaceNamePromptTextField":
-                guard let prompt = firstExistingElement(
-                    workspaceNamePromptScreenCandidates(in: app),
-                    timeout: 0.2
-                ),
-                    elementFrameIsUsable(prompt.frame) else {
-                    return nil
-                }
-                return prompt.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.18))
+                // The workspace prompt resolver already found the text field. Re-sampling the
+                // custom SwiftUI prompt root for its frame can wedge hosted XCTest snapshots, so
+                // let `focusResolvedPromptTextEntryElement` use the resolved field directly.
+                return nil
             default:
                 return nil
             }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -567,6 +567,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     var speakService: SpeakService?
     /// Speech-specific collaborator that builds TTS payloads and owns word-highlight state.
     private let speechCoordinator = BibleReaderSpeechCoordinator()
+    /// SWORD setup collaborator that owns manager option mapping and module-state projection.
+    private let swordCoordinator = BibleReaderSwordCoordinator()
     /// Workspace store for history recording
     var workspaceStore: WorkspaceStore?
     /// The current window (for history recording)
@@ -2196,67 +2198,70 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private func configureSwordManager(_ mgr: SwordManager) {
         swordManager = mgr
 
-        // Enable headings and verse-level rendering
-        mgr.setGlobalOption(.headings, enabled: true)
-        mgr.setGlobalOption(.redLetterWords, enabled: true)
-        applySwordOptions()
-
-        let modules = mgr.installedModules()
-        logger.info("SWORD found \(modules.count) installed modules")
-        for mod in modules {
+        let state = swordCoordinator.configure(
+            manager: mgr,
+            selection: currentSwordSelection(),
+            displaySettings: displaySettings
+        )
+        logger.info("SWORD found \(state.installedModules.count) installed modules")
+        for mod in state.installedModules {
             let hasStrongs = mod.features.contains(.strongsNumbers)
             logger.info("  Module: \(mod.name) (\(mod.description)) [\(mod.category.rawValue)] strongs=\(hasStrongs)")
         }
 
-        installedBibleModules = modules.filter { $0.category == .bible }
-        installedCommentaryModules = modules.filter { $0.category == .commentary }
-        installedDictionaryModules = modules.filter { $0.category == .dictionary }
-        installedGeneralBookModules = modules.filter { $0.category == .generalBook }
-        installedMapModules = modules.filter { $0.category == .map }
-
-        if let mod = mgr.module(named: activeModuleName) {
-            activeModule = mod
-        } else if let kjv = mgr.module(named: "KJV") {
-            activeModule = kjv
-            activeModuleName = kjv.info.name
-            logger.info("Using Bible module: \(kjv.info.name)")
-        } else if let firstBible = installedBibleModules.first {
-            activeModule = mgr.module(named: firstBible.name)
-            activeModuleName = firstBible.name
-            logger.info("Using Bible module: \(firstBible.name)")
-        } else {
-            activeModule = nil
+        applySwordState(state)
+        if activeModule == nil {
             logger.warning("No Bible modules installed — using placeholder text")
-        }
-
-        if let name = activeCommentaryModuleName, let mod = mgr.module(named: name) {
-            activeCommentaryModule = mod
-        } else if let firstComm = installedCommentaryModules.first {
-            activeCommentaryModule = mgr.module(named: firstComm.name)
-            activeCommentaryModuleName = firstComm.name
         } else {
-            activeCommentaryModule = nil
+            logger.info("Using Bible module: \(self.activeModuleName)")
         }
 
-        if let name = activeDictionaryModuleName, let mod = mgr.module(named: name) {
-            activeDictionaryModule = mod
-        } else {
-            activeDictionaryModule = nil
-        }
+        logBookListRefresh(module: activeModule, books: moduleBookList)
+    }
 
-        if let name = activeGeneralBookModuleName, let mod = mgr.module(named: name) {
-            activeGeneralBookModule = mod
-        } else {
-            activeGeneralBookModule = nil
-        }
+    /**
+     Builds the current module-selection DTO consumed by the SWORD setup coordinator.
 
-        if let name = activeMapModuleName, let mod = mgr.module(named: name) {
-            activeMapModule = mod
-        } else {
-            activeMapModule = nil
-        }
+     - Returns: The category-owned module initials currently stored on this controller.
+     - Side effects: None.
+     - Failure modes: None; nil optional categories indicate no explicit auxiliary selection.
+     */
+    private func currentSwordSelection() -> BibleReaderSwordSelection {
+        BibleReaderSwordSelection(
+            activeModuleName: activeModuleName,
+            activeCommentaryModuleName: activeCommentaryModuleName,
+            activeDictionaryModuleName: activeDictionaryModuleName,
+            activeGeneralBookModuleName: activeGeneralBookModuleName,
+            activeMapModuleName: activeMapModuleName
+        )
+    }
 
-        refreshBookList()
+    /**
+     Applies a SWORD setup projection to controller-owned observable state.
+
+     - Parameter state: Installed-module catalog and active module handles generated from the
+       current `SwordManager`.
+     - Side effects: Mutates installed-module arrays, active module references, selected initials,
+       and `moduleBookList` on the controller.
+     - Failure modes: None; absent modules are represented by nil handles in `state`.
+     */
+    private func applySwordState(_ state: BibleReaderSwordState) {
+        installedBibleModules = state.installedBibleModules
+        installedCommentaryModules = state.installedCommentaryModules
+        installedDictionaryModules = state.installedDictionaryModules
+        installedGeneralBookModules = state.installedGeneralBookModules
+        installedMapModules = state.installedMapModules
+        activeModule = state.activeModule
+        activeModuleName = state.activeModuleName
+        activeCommentaryModule = state.activeCommentaryModule
+        activeCommentaryModuleName = state.activeCommentaryModuleName
+        activeDictionaryModule = state.activeDictionaryModule
+        activeDictionaryModuleName = state.activeDictionaryModuleName
+        activeGeneralBookModule = state.activeGeneralBookModule
+        activeGeneralBookModuleName = state.activeGeneralBookModuleName
+        activeMapModule = state.activeMapModule
+        activeMapModuleName = state.activeMapModuleName
+        moduleBookList = state.moduleBookList
     }
 
     /**
@@ -2308,9 +2313,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             self.activeMapModuleName = mapName
         }
 
-        // Apply global options to match
-        mgr.setGlobalOption(.headings, enabled: true)
-        mgr.setGlobalOption(.redLetterWords, enabled: true)
+        swordCoordinator.applyBaseOptions(to: mgr)
         applySwordOptions()
         return true
     }
@@ -2435,15 +2438,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Apply SWORD global options based on current display settings.
     private func applySwordOptions() {
         guard let mgr = swordManager else { return }
-        let s = displaySettings
-        let d = TextDisplaySettings.appDefaults
-        let strongsOn = (s.strongsMode ?? d.strongsMode ?? 0) > 0
-        let xrefsOn = s.showXrefs ?? d.showXrefs ?? false
-        let footnotesOn = s.showFootNotes ?? d.showFootNotes ?? false
-        mgr.setGlobalOption(.strongsNumbers, enabled: strongsOn)
-        mgr.setGlobalOption(.morphology, enabled: s.showMorphology ?? d.showMorphology ?? false)
-        mgr.setGlobalOption(.footnotes, enabled: footnotesOn)
-        mgr.setGlobalOption(.crossReferences, enabled: xrefsOn)
+        swordCoordinator.applyDisplayOptions(to: mgr, settings: displaySettings)
     }
 
     // MARK: - Public Navigation API
@@ -8707,13 +8702,26 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             moduleBookList = []
             return
         }
-        let books = mod.getBookList()
+        moduleBookList = swordCoordinator.bookList(for: mod)
+        logBookListRefresh(module: mod, books: moduleBookList)
+    }
+
+    /**
+     Logs the outcome of an active-module book-list refresh.
+
+     - Parameters:
+       - module: Active Bible module used to read the list.
+       - books: Books returned by SWORD for that module.
+     - Side effects: Writes diagnostic log entries only.
+     - Failure modes: Empty book lists are logged as errors because static-canon fallback while a
+       SWORD Bible is active would diverge from Android/JSword versification behavior.
+     */
+    private func logBookListRefresh(module: SwordModule?, books: [BookInfo]) {
+        guard let module else { return }
         if books.isEmpty {
-            logger.error("Module \(mod.info.name, privacy: .public) returned no books; refusing static canon fallback while active")
-            moduleBookList = []
+            logger.error("Module \(module.info.name, privacy: .public) returned no books; refusing static canon fallback while active")
         } else {
-            logger.info("Module \(mod.info.name) has \(books.count) books (versification: \(mod.configEntry("Versification") ?? "KJV"))")
-            moduleBookList = books
+            logger.info("Module \(module.info.name) has \(books.count) books (versification: \(module.configEntry("Versification") ?? "KJV"))")
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
@@ -1,0 +1,293 @@
+// BibleReaderSwordCoordinator.swift -- SWORD setup and module-state projection for reader panes
+
+import BibleCore
+import SwordKit
+
+/**
+ Current controller-owned SWORD module selections.
+
+ The setup coordinator uses these initials as inputs when rebuilding module handles from a
+ `SwordManager`. The value keeps selection identity separate from `SwordModule` instances so pane
+ controllers can resolve independent module cursors from a shared manager while preserving Android's
+ category-owned document fields.
+ */
+struct BibleReaderSwordSelection {
+    /// Preferred Bible module initials. The controller keeps `"KJV"` as its default seed.
+    let activeModuleName: String
+
+    /// Preferred commentary module initials, if the pane has one selected.
+    let activeCommentaryModuleName: String?
+
+    /// Preferred dictionary module initials, if the pane has one selected.
+    let activeDictionaryModuleName: String?
+
+    /// Preferred general-book module initials, if the pane has one selected.
+    let activeGeneralBookModuleName: String?
+
+    /// Preferred map module initials, if the pane has one selected.
+    let activeMapModuleName: String?
+}
+
+/**
+ Result of configuring a reader pane against a SWORD manager.
+
+ This projection contains the installed-module catalog, resolved active module handles, selected
+ module initials, and active Bible book list that the controller publishes to SwiftUI and the Vue
+ bridge. It is a copied snapshot of SWORD-derived state; the controller remains responsible for
+ storing it and for logging or rendering follow-up work.
+ */
+struct BibleReaderSwordState {
+    /// Flat installed-module list used for setup logging and diagnostics.
+    let installedModules: [ModuleInfo]
+
+    /// Installed Bible modules shown in Bible pickers.
+    let installedBibleModules: [ModuleInfo]
+
+    /// Installed commentary modules shown in commentary/document pickers.
+    let installedCommentaryModules: [ModuleInfo]
+
+    /// Installed dictionary modules shown in dictionary/document pickers.
+    let installedDictionaryModules: [ModuleInfo]
+
+    /// Installed general-book modules shown in document pickers.
+    let installedGeneralBookModules: [ModuleInfo]
+
+    /// Installed map modules shown in map/document pickers.
+    let installedMapModules: [ModuleInfo]
+
+    /// Active Bible module handle, or nil when no Bible module is installed.
+    let activeModule: SwordModule?
+
+    /// Active Bible module initials to persist and display.
+    let activeModuleName: String
+
+    /// Active commentary module handle, if selected or defaulted.
+    let activeCommentaryModule: SwordModule?
+
+    /// Active commentary module initials, preserved even if the module is temporarily unavailable.
+    let activeCommentaryModuleName: String?
+
+    /// Active dictionary module handle, if explicitly selected and installed.
+    let activeDictionaryModule: SwordModule?
+
+    /// Active dictionary module initials, preserved even if the module is temporarily unavailable.
+    let activeDictionaryModuleName: String?
+
+    /// Active general-book module handle, if explicitly selected and installed.
+    let activeGeneralBookModule: SwordModule?
+
+    /// Active general-book module initials, preserved even if the module is temporarily unavailable.
+    let activeGeneralBookModuleName: String?
+
+    /// Active map module handle, if explicitly selected and installed.
+    let activeMapModule: SwordModule?
+
+    /// Active map module initials, preserved even if the module is temporarily unavailable.
+    let activeMapModuleName: String?
+
+    /// Ordered Bible book list from the active module's SWORD/JSword-compatible versification.
+    let moduleBookList: [BookInfo]
+}
+
+/**
+ Owns SWORD manager setup rules for `BibleReaderController`.
+
+ The coordinator applies global SWORD rendering options, splits installed modules by Android
+ document category, resolves category-specific active module handles, and reads the active Bible
+ book list. It does not retain the controller, mutate `PageManager`, or emit bridge events; those
+ side effects remain in the controller and existing module/navigation coordinators.
+ */
+struct BibleReaderSwordCoordinator {
+    /**
+     Builds a complete reader SWORD state projection from a manager and prior selections.
+
+     - Parameters:
+       - manager: Shared `SwordManager` whose modules should back the reader pane.
+       - selection: Previously selected module initials owned by the pane controller.
+       - displaySettings: Resolved reader settings used to configure SWORD filters.
+       - defaults: Application defaults used when a setting is unset.
+     - Returns: Installed-module catalog, resolved module handles, selected initials, and active
+       module book list.
+     - Side effects: Sets SWORD global options on `manager`.
+     - Failure modes: Missing modules produce nil handles while preserving selected initials;
+       missing Bible modules produce an empty book list instead of static-canon fallback.
+     */
+    func configure(
+        manager: SwordManager,
+        selection: BibleReaderSwordSelection,
+        displaySettings: TextDisplaySettings,
+        defaults: TextDisplaySettings = .appDefaults
+    ) -> BibleReaderSwordState {
+        applyBaseOptions(to: manager)
+        applyDisplayOptions(to: manager, settings: displaySettings, defaults: defaults)
+
+        let modules = manager.installedModules()
+        let bibleModules = modules.filter { $0.category == .bible }
+        let commentaryModules = modules.filter { $0.category == .commentary }
+        let dictionaryModules = modules.filter { $0.category == .dictionary }
+        let generalBookModules = modules.filter { $0.category == .generalBook }
+        let mapModules = modules.filter { $0.category == .map }
+
+        let bible = activeBibleModule(
+            manager: manager,
+            requestedName: selection.activeModuleName,
+            installedBibleModules: bibleModules
+        )
+        let commentary = activeCommentaryModule(
+            manager: manager,
+            requestedName: selection.activeCommentaryModuleName,
+            installedCommentaryModules: commentaryModules
+        )
+        let dictionary = activeOptionalModule(
+            manager: manager,
+            requestedName: selection.activeDictionaryModuleName
+        )
+        let generalBook = activeOptionalModule(
+            manager: manager,
+            requestedName: selection.activeGeneralBookModuleName
+        )
+        let map = activeOptionalModule(
+            manager: manager,
+            requestedName: selection.activeMapModuleName
+        )
+
+        return BibleReaderSwordState(
+            installedModules: modules,
+            installedBibleModules: bibleModules,
+            installedCommentaryModules: commentaryModules,
+            installedDictionaryModules: dictionaryModules,
+            installedGeneralBookModules: generalBookModules,
+            installedMapModules: mapModules,
+            activeModule: bible.module,
+            activeModuleName: bible.name,
+            activeCommentaryModule: commentary.module,
+            activeCommentaryModuleName: commentary.name,
+            activeDictionaryModule: dictionary.module,
+            activeDictionaryModuleName: selection.activeDictionaryModuleName,
+            activeGeneralBookModule: generalBook.module,
+            activeGeneralBookModuleName: selection.activeGeneralBookModuleName,
+            activeMapModule: map.module,
+            activeMapModuleName: selection.activeMapModuleName,
+            moduleBookList: bookList(for: bible.module)
+        )
+    }
+
+    /**
+     Applies SWORD options that the reader always expects before rendering.
+
+     - Parameter manager: Manager whose global options should be updated.
+     - Side effects: Enables SWORD headings and red-letter rendering.
+     - Failure modes: None surfaced by SwordKit; SWORD option writes are process-global.
+     */
+    func applyBaseOptions(to manager: SwordManager) {
+        manager.setGlobalOption(.headings, enabled: true)
+        manager.setGlobalOption(.redLetterWords, enabled: true)
+    }
+
+    /**
+     Applies display-setting-driven SWORD filter options.
+
+     - Parameters:
+       - manager: Manager whose global options should be updated.
+       - settings: Resolved reader settings for the pane.
+       - defaults: Fallback settings used when a value is unset.
+     - Side effects: Mutates SWORD global options for Strong's numbers, morphology, footnotes, and
+       cross references.
+     - Failure modes: None surfaced by SwordKit; SWORD option writes are process-global.
+     */
+    func applyDisplayOptions(
+        to manager: SwordManager,
+        settings: TextDisplaySettings,
+        defaults: TextDisplaySettings = .appDefaults
+    ) {
+        let strongsOn = (settings.strongsMode ?? defaults.strongsMode ?? 0) > 0
+        let xrefsOn = settings.showXrefs ?? defaults.showXrefs ?? false
+        let footnotesOn = settings.showFootNotes ?? defaults.showFootNotes ?? false
+        manager.setGlobalOption(.strongsNumbers, enabled: strongsOn)
+        manager.setGlobalOption(.morphology, enabled: settings.showMorphology ?? defaults.showMorphology ?? false)
+        manager.setGlobalOption(.footnotes, enabled: footnotesOn)
+        manager.setGlobalOption(.crossReferences, enabled: xrefsOn)
+    }
+
+    /**
+     Reads the active Bible module's versification book list.
+
+     - Parameter module: Active Bible module handle, or nil when no Bible is installed.
+     - Returns: SWORD-provided ordered books, or an empty list when no module is active or the module
+       reports no books.
+     - Side effects: Calls into SWORD through `SwordModule.getBookList()`.
+     - Failure modes: Empty SWORD results are propagated as empty so callers do not silently fall
+       back to a static canon while an active module exists.
+     */
+    func bookList(for module: SwordModule?) -> [BookInfo] {
+        module?.getBookList() ?? []
+    }
+
+    /**
+     Resolves the active Bible module using the controller's historical fallback order.
+
+     - Parameters:
+       - manager: Manager used for module lookup.
+       - requestedName: Previously selected Bible initials.
+       - installedBibleModules: Installed Bible catalog used for first-installed fallback.
+     - Returns: A module/name pair. If no Bible can be resolved, the returned module is nil and the
+       requested name is preserved.
+     - Side effects: May create or reuse a cached `SwordModule` through `SwordManager`.
+     */
+    private func activeBibleModule(
+        manager: SwordManager,
+        requestedName: String,
+        installedBibleModules: [ModuleInfo]
+    ) -> (module: SwordModule?, name: String) {
+        if let module = manager.module(named: requestedName) {
+            return (module, requestedName)
+        }
+        if let kjv = manager.module(named: "KJV") {
+            return (kjv, kjv.info.name)
+        }
+        if let firstBible = installedBibleModules.first {
+            return (manager.module(named: firstBible.name), firstBible.name)
+        }
+        return (nil, requestedName)
+    }
+
+    /**
+     Resolves commentary selection with the existing first-installed fallback.
+
+     - Parameters:
+       - manager: Manager used for module lookup.
+       - requestedName: Previously selected commentary initials.
+       - installedCommentaryModules: Installed commentary catalog used for fallback.
+     - Returns: A commentary module/name pair, preserving the requested initials when no fallback is
+       available.
+     - Side effects: May create or reuse a cached `SwordModule` through `SwordManager`.
+     */
+    private func activeCommentaryModule(
+        manager: SwordManager,
+        requestedName: String?,
+        installedCommentaryModules: [ModuleInfo]
+    ) -> (module: SwordModule?, name: String?) {
+        if let requestedName, let module = manager.module(named: requestedName) {
+            return (module, requestedName)
+        }
+        if let firstCommentary = installedCommentaryModules.first {
+            return (manager.module(named: firstCommentary.name), firstCommentary.name)
+        }
+        return (nil, requestedName)
+    }
+
+    /**
+     Resolves optional auxiliary module selections without inventing defaults.
+
+     Dictionaries, general books, and maps are only active when a pane has selected one. Android's
+     durable page-manager fields keep those choices category-specific, so this helper preserves the
+     requested initials while returning a nil handle if the module is absent.
+     */
+    private func activeOptionalModule(
+        manager: SwordManager,
+        requestedName: String?
+    ) -> (module: SwordModule?, name: String?) {
+        guard let requestedName else { return (nil, nil) }
+        return (manager.module(named: requestedName), requestedName)
+    }
+}

--- a/scripts/test_workspace_prompt_ui_contract.py
+++ b/scripts/test_workspace_prompt_ui_contract.py
@@ -58,12 +58,14 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         self.assertNotIn("prompt.textFields", candidates_body)
 
     def test_workspace_prompt_screen_uses_prompt_specific_container_lookup(self) -> None:
-        """The prompt surface lookup must not ask XCTest to resolve absent scroll/list containers.
+        """The prompt surface lookup must stay bounded and must not drive text-entry focus.
 
         The CI shard failure timed out while `waitForAnyElement(["workspaceNamePromptScreen"])`
         evaluated generic table/collection/scroll candidates before reaching the SwiftUI prompt's
-        actual accessibility node. A failure here means the create-workspace test can regress to
-        the hosted XCTest snapshot path that stalls before the field lookup starts.
+        actual accessibility node. A later shard failure showed that even the bounded prompt-root
+        query can wedge if the typing helper reads the root frame for a tap coordinate after the
+        text field is already resolved. A failure here means the create-workspace test can regress
+        to a hosted XCTest snapshot path that stalls before text entry.
         """
         source = (
             REPO_ROOT / "AndBibleUITests" / "AndBibleUITestElementSupport.swift"
@@ -87,9 +89,10 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         self.assertIn("app.otherElements[identifier].firstMatch", prompt_candidates_body)
         self.assertNotIn("app.collectionViews[identifier]", prompt_candidates_body)
         self.assertNotIn("app.scrollViews[identifier]", prompt_candidates_body)
-        self.assertIn("workspaceNamePromptScreenCandidates(in: app)", coordinate_body)
+        self.assertNotIn("workspaceNamePromptScreenCandidates(in: app)", coordinate_body)
         self.assertNotIn('app.collectionViews["workspaceNamePromptScreen"]', coordinate_body)
         self.assertNotIn('app.scrollViews["workspaceNamePromptScreen"]', coordinate_body)
+        self.assertIn("return nil", coordinate_body)
         self.assertIn(
             'case "workspaceNamePromptScreen":\n'
             "            return workspaceNamePromptScreenCandidates(in: app)",


### PR DESCRIPTION
## Summary
Extracts SWORD setup and module-state projection out of `BibleReaderController` into a focused `BibleReaderSwordCoordinator`.

## Scope
- Adds a reader SWORD coordinator for manager option mapping, installed-module category splitting, active module resolution, and active Bible book-list reads.
- Keeps controller ownership of observable state, logging, bridge behavior, workspace state, and page-manager interactions.
- Adds tests that lock the coordinator contract for category catalogs, active selections, book-list sourcing, and SWORD global display options.

## Contract References
- Issue: refs #146.
- Base: `main`; originally stacked on PR #237 before that branch merged.
- Android parity: preserves category-owned document selection and keeps SWORD/JSword-derived book lists authoritative instead of reintroducing a static canon fallback while a module is active.

## Change Details
- `BibleReaderSwordCoordinator` now builds a `BibleReaderSwordState` snapshot from a `SwordManager` and controller selection DTO.
- `BibleReaderController.configureSwordManager`, `applySwordOptions`, `copyModuleState`, and `refreshBookList` now delegate SWORD-specific logic through the coordinator.
- Tests cover Bible/commentary/dictionary/general-book/map catalog projection, commentary fallback, explicit auxiliary-module selection, active Bible book list count, and display option toggles.

## Validation Evidence
- Focused SWORD coordinator tests passed on iPhone 17 simulator.
- Impacted reader/module controller tests passed on iPhone 17 simulator.
- Full `AndBibleTests` suite passed: 582 tests, 0 failures, iPhone 17 / iOS 26.5.
- `python3 -m unittest discover -s scripts -p 'test_*.py'`.
- `python3 scripts/check_repo_standards.py docblocks --base-ref origin/issue-146-reader-navigation --head-ref HEAD --all-files`.
- `python3 scripts/check_bridge_parity_inventory.py`.
- `python3 scripts/check_settings_localization_guardrails.py`.
- `python3 scripts/check_repo_standards.py commits --base-ref origin/issue-146-reader-navigation --head-ref HEAD`.
- `git diff --check --cached`.
- `npx gitnexus detect-changes --scope staged --base-ref origin/issue-146-reader-navigation --repo /Users/primetheus/Desktop/and-bible-convert/and-bible-ios/.worktrees/issue-146-sword-setup` reported medium risk, 64 changed symbols, one affected test-only flow.

## Risks / Follow-ups
- This is intentionally a behavior-preserving extraction; it does not complete all remaining #146 checklist items.
- SWORD option writes remain process-global because that is the existing SwordKit contract; this PR narrows ownership but does not redesign SwordKit state.

## Issue Closure Reference
Refs #146. Does not close #146 because remaining checklist items are still open.

