### PR TITLE
refactor(reader): extract word lookup document builder

### DIFF
--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -976,6 +976,63 @@ extension AndBibleTests {
         XCTAssertTrue(BibleReaderStrongsDocumentBuilder.isSupportedStrongsDictionaryModuleName("InvStrongsRealHebrew"))
     }
 
+    /**
+     Verifies selected-word lookup preserves Android's dictionary rendering contract.
+
+     Android `LinkControl.lookupInDictionaries` resolves exact dictionary keys through JSword and
+     opens a `MultiDocument` made from the matched entries. The iOS builder must therefore project
+     the rendered entry text into the bridge payload; a failure here means users would see Swift
+     diagnostic text or lose dictionary body content even though the dictionary lookup succeeded.
+     */
+    func testWordLookupDocumentUsesRenderedDictionaryText() throws {
+        let builder = BibleReaderWordLookupDocumentBuilder(modules: {
+            [
+                BibleReaderWordLookupDocumentBuilder.DictionaryModule(
+                    name: "Websters",
+                    abbreviation: "Websters",
+                    lookup: { keyOptions in
+                        XCTAssertEqual(keyOptions, ["Grace", "grace", "Grace"])
+                        return BibleReaderStrongsDocumentBuilder.DictionaryLookupResult(
+                            actualKey: "Grace",
+                            rawEntry: "raw dictionary bytes",
+                            renderedText: "<p>Grace rendered from SWORD</p>"
+                        )
+                    }
+                )
+            ]
+        })
+
+        let json = try XCTUnwrap(builder.buildWordLookupMultiDocumentJSON(query: "Grace"))
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let fragments = try XCTUnwrap(payload["osisFragments"] as? [[String: Any]])
+        let fragment = try XCTUnwrap(fragments.first)
+        let xml = try XCTUnwrap(fragment["xml"] as? String)
+
+        XCTAssertEqual(payload["type"] as? String, "multi")
+        XCTAssertEqual(fragment["key"] as? String, "Websters--Grace")
+        XCTAssertEqual(fragment["bookInitials"] as? String, "Websters")
+        XCTAssertTrue(xml.contains("Grace rendered from SWORD"))
+        XCTAssertFalse(xml.contains("DictionaryLookupResult"))
+    }
+
+    /**
+     Verifies iOS selected-word normalization stays aligned with Android `LinkControl`.
+
+     Android trims surrounding whitespace and removes trailing punctuation before calling
+     `Book.getKey`. A failure means selected text with punctuation could resolve differently on iOS
+     than Android, causing avoidable "not found" feedback for the same installed dictionaries.
+     */
+    func testWordLookupQueryNormalizationMatchesAndroid() {
+        XCTAssertEqual(
+            BibleReaderWordLookupDocumentBuilder.normalizeQuery("  Grace?!  "),
+            "Grace"
+        )
+        XCTAssertEqual(
+            BibleReaderWordLookupDocumentBuilder.normalizeQuery("faith."),
+            "faith"
+        )
+    }
+
     func testRenderedContentStateDefaultsToNeutralToken() {
         let controller = BibleReaderController(bridge: BibleBridge())
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -3846,7 +3846,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     func lookupSelectionInDictionaries() {
         guard !selectedText.isEmpty else { return }
-        let query = normalizeWordLookupQuery(selectedText)
+        let query = BibleReaderWordLookupDocumentBuilder.normalizeQuery(selectedText)
         guard !query.isEmpty else {
             onShowToast?(String(
                 localized: "word_not_found_in_dictionaries",
@@ -3854,7 +3854,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             ))
             return
         }
-        guard let multiDocJSON = buildWordLookupMultiDocJSON(query: query) else {
+        guard let multiDocJSON = wordLookupDocumentBuilder()
+            .buildWordLookupMultiDocumentJSON(query: query) else {
             onShowToast?(String(
                 localized: "word_not_found_in_dictionaries",
                 defaultValue: "Word not found in any dictionary"
@@ -3888,7 +3889,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// The currently selected text.
     private(set) var selectedText: String = ""
     /// Whether any plain word-lookup dictionaries are currently available.
-    var hasWordLookupDictionaries: Bool { !findWordLookupDictionaryModules().isEmpty }
+    var hasWordLookupDictionaries: Bool { wordLookupDocumentBuilder().hasWordLookupDictionaries }
 
     /**
      Builds a shareable verse string for the current module and forwards it to native sharing UI.
@@ -4898,6 +4899,21 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         )
     }
 
+    /**
+     Creates the selected-word lookup document builder bound to this pane's SWORD and settings state.
+
+     The controller keeps orchestration concerns while `BibleReaderWordLookupDocumentBuilder` owns
+     Android-parity dictionary discovery, query normalization, and multi-document payload assembly.
+     */
+    private func wordLookupDocumentBuilder() -> BibleReaderWordLookupDocumentBuilder {
+        BibleReaderWordLookupDocumentBuilder(
+            swordManager: swordManager,
+            disabledDictionaryNames: { [weak self] in
+                Set(self?.settingsStore?.getStringSet(.disabledWordLookupDictionaries) ?? [])
+            }
+        )
+    }
+
     /// Handle "Find all occurrences" links: ab-find-all://?type=hebrew&name=H05775
     private func handleFindAllLink(_ link: String) {
         logger.info("handleFindAllLink: \(link)")
@@ -4951,30 +4967,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             ?? items.first(where: { $0.name == "entryId" })?.value
         let bookmarkUUID = entryId.flatMap(UUID.init(uuidString:))
         loadStudyPadDocument(labelId: labelUUID, bookmarkId: bookmarkUUID)
-    }
-
-    /**
-     Build a typed MultiFragmentDocument JSON string for rendering in Vue.js document views.
-
-     - Parameters:
-       - fragments: Dictionary fragments to project into Vue `OsisFragment` values.
-       - contentType: Optional document content type such as `strongs`.
-       - stateJSON: Optional saved Vue state JSON to attach to the document.
-     - Returns: Serialized bridge JSON, or `nil` if typed encoding unexpectedly fails.
-     - Side effects: none.
-     - Failure modes: logs and returns `nil` when the payload cannot be encoded, allowing callers
-       to avoid emitting an invalid Vue document shape.
-     */
-    private func buildMultiFragmentJSON(
-        fragments: [(xml: String, key: String, keyName: String, bookInitials: String, bookAbbreviation: String, features: OsisFeatures)],
-        contentType: String? = nil,
-        stateJSON: String? = nil
-    ) -> String? {
-        BibleReaderMultiFragmentDocumentBuilder.buildJSON(
-            fragments: fragments,
-            contentType: contentType,
-            stateJSON: stateJSON
-        )
     }
 
     /**
@@ -5384,75 +5376,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         keyOptions: [String]
     ) -> BibleReaderStrongsDocumentBuilder.DictionaryLookupResult? {
         BibleReaderStrongsDocumentBuilder.lookupInModule(module, keyOptions: keyOptions)
-    }
-
-    /**
-     Find plain dictionaries used by "Lookup in dictionaries".
-     Mirrors Android `SwordDocumentFacade.wordLookupDictionaries`.
-     */
-    private func findWordLookupDictionaryModules() -> [SwordModule] {
-        guard let mgr = swordManager else { return [] }
-        let disabled = Set(settingsStore?.getStringSet(.disabledWordLookupDictionaries) ?? [])
-        let allModules = mgr.installedModules()
-
-        var result: [SwordModule] = []
-        for info in allModules where
-            info.category == .dictionary &&
-                !info.features.contains(.greekDef) &&
-                !info.features.contains(.hebrewDef) &&
-                !info.features.contains(.greekParse) &&
-                !disabled.contains(info.name) {
-            if let module = mgr.module(named: info.name) {
-                result.append(module)
-            }
-        }
-        return result
-    }
-
-    /**
-     Normalizes selected text before dictionary lookup by trimming whitespace and trailing punctuation.
-
-     - Parameter text: Raw selected text from the web client.
-     - Returns: Sanitized lookup key used against plain dictionary modules.
-     */
-    private func normalizeWordLookupQuery(_ text: String) -> String {
-        text.trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: #"[.,;:!?"'()\[\]]+$"#, with: "", options: .regularExpression)
-    }
-
-    /**
-     Builds a multi-fragment dictionary document for the current word-lookup query.
-
-     - Parameter query: Normalized lookup key to resolve across enabled plain dictionaries.
-     - Returns: Multi-document JSON for the lookup results, or `nil` when nothing matches.
-
-     Failure modes:
-     - returns `nil` when no enabled lookup dictionaries are installed or when none contain the key
-     */
-    private func buildWordLookupMultiDocJSON(query: String) -> String? {
-        let modules = findWordLookupDictionaryModules()
-        guard !modules.isEmpty else { return nil }
-
-        // Try common case variants, while still requiring exact key match after normalization.
-        let keyOptions = [query, query.lowercased(), query.capitalized]
-        var fragments: [(xml: String, key: String, keyName: String, bookInitials: String, bookAbbreviation: String, features: OsisFeatures)] = []
-
-        for mod in modules {
-            guard let html = lookupInModule(mod, keyOptions: keyOptions) else { continue }
-            let escapedTitle = escapeXML(query)
-            let xml = "<div><title type=\"x-gen\">\(escapedTitle)</title><div type=\"paragraph\">\(html)</div></div>"
-            fragments.append((
-                xml: xml,
-                key: "\(mod.info.name)--\(query)",
-                keyName: query,
-                bookInitials: mod.info.name,
-                bookAbbreviation: String(mod.info.name.prefix(10)),
-                features: OsisFeatures()
-            ))
-        }
-
-        guard !fragments.isEmpty else { return nil }
-        return buildMultiFragmentJSON(fragments: fragments)
     }
 
     /// Handle a single cross-reference link: osis://?osis=Matt.1.1&v11n=KJV

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderWordLookupDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderWordLookupDocumentBuilder.swift
@@ -1,0 +1,228 @@
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+
+/**
+ Builds Android-style selected-word dictionary `MultiDocument` payloads.
+
+ `BibleReaderController` owns reader orchestration and bridge routing. This builder owns the
+ selected-word lookup rules that Android implements in `LinkControl.lookupInDictionaries` and
+ `SwordDocumentFacade.wordLookupDictionaries`: trim the selected text, remove trailing punctuation,
+ search enabled plain dictionaries, and render successful matches as one transient multi-document.
+ */
+struct BibleReaderWordLookupDocumentBuilder {
+    /// Supplies currently enabled dictionary modules for selected-word lookup.
+    typealias DictionaryModulesProvider = () -> [DictionaryModule]
+
+    /// Active dictionary module projection used by the builder without exposing SWORD to tests.
+    struct DictionaryModule {
+        /// Module initials used as Vue fragment document identity.
+        let name: String
+
+        /// Short module label shown in Vue tabs.
+        let abbreviation: String
+
+        /// Resolves the first matching dictionary key variant for this module.
+        let lookup: ([String]) -> BibleReaderStrongsDocumentBuilder.DictionaryLookupResult?
+
+        /**
+         Creates a lightweight dictionary module projection.
+
+         - Parameters:
+           - name: SWORD module initials used for fragment identity.
+           - abbreviation: User-facing short module label for tabs.
+           - lookup: Closure that returns the exact dictionary entry for ordered key options.
+         - Side effects: None during construction; the lookup closure may move a module cursor when
+           invoked by `buildWordLookupMultiDocumentJSON(query:)`.
+         - Failure modes: The lookup closure returns `nil` when no exact-enough key match exists.
+         */
+        init(
+            name: String,
+            abbreviation: String,
+            lookup: @escaping ([String]) -> BibleReaderStrongsDocumentBuilder.DictionaryLookupResult?
+        ) {
+            self.name = name
+            self.abbreviation = abbreviation
+            self.lookup = lookup
+        }
+    }
+
+    /// Deferred provider so preference changes and installed-module changes are observed per call.
+    private let modules: DictionaryModulesProvider
+
+    /**
+     Creates a testable word-lookup builder from a module provider.
+
+     - Parameter modules: Closure returning the currently enabled plain dictionary modules.
+     - Side effects: None during construction.
+     - Failure modes: An empty provider result makes availability false and payload creation return
+       `nil`, matching Android's not-found behavior for missing lookup dictionaries.
+     */
+    init(modules: @escaping DictionaryModulesProvider) {
+        self.modules = modules
+    }
+
+    /**
+     Creates a production builder bound to SWORD and settings state.
+
+     - Parameters:
+       - swordManager: Active SWORD manager used to enumerate and resolve installed modules.
+       - disabledDictionaryNames: Closure returning Android's inverse selected-word dictionary
+         preference set, `disabled_word_lookup_dictionaries`.
+     - Side effects: None during construction; module enumeration and SWORD cursor movement happen
+       when availability or payload methods are called.
+     - Failure modes: Missing SWORD returns no modules, producing the same user-facing not-found path
+       as Android when no word lookup dictionaries are available.
+     */
+    init(
+        swordManager: SwordManager?,
+        disabledDictionaryNames: @escaping () -> Set<String>
+    ) {
+        self.modules = {
+            guard let manager = swordManager else { return [] }
+            let disabled = disabledDictionaryNames()
+            return Self.wordLookupDictionaryModules(
+                swordManager: manager,
+                disabledDictionaryNames: disabled
+            )
+        }
+    }
+
+    /**
+     Whether any enabled plain dictionary is available for selected-word lookup.
+
+     - Returns: `true` when at least one installed plain dictionary is not disabled by preferences.
+     - Side effects: Reads installed module metadata and the disabled-dictionary preference closure.
+     - Failure modes: Missing SWORD or no enabled dictionaries returns `false`.
+     */
+    var hasWordLookupDictionaries: Bool {
+        !modules().isEmpty
+    }
+
+    /**
+     Normalizes selected text before dictionary lookup using Android's `normalizeSearchText` rules.
+
+     Android trims whitespace and strips trailing punctuation before calling JSword `Book.getKey`.
+     iOS applies the same text transform, then compensates for libsword case handling through ordered
+     key variants during lookup.
+
+     - Parameter text: Raw selected text from the web client.
+     - Returns: Sanitized lookup key used against plain dictionary modules.
+     - Side effects: None.
+     - Failure modes: Whitespace-only or punctuation-only input returns an empty string.
+     */
+    static func normalizeQuery(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"[.,;:!?"'()\[\]]+$"#, with: "", options: .regularExpression)
+    }
+
+    /**
+     Builds a selected-word dictionary `MultiDocument` payload for Vue.
+
+     - Parameter query: Normalized lookup key to resolve across enabled plain dictionaries.
+     - Returns: Serialized bridge JSON for matching dictionary entries, or `nil` when no enabled
+       dictionary contains the key.
+     - Side effects: Reads enabled dictionary modules and invokes each lookup closure, which may move
+       SWORD cursors.
+     - Failure modes: Empty module sets, lookup misses, or JSON encoding failure return `nil` so the
+       controller can show the existing Android-parity not-found toast.
+     */
+    func buildWordLookupMultiDocumentJSON(query: String) -> String? {
+        let enabledModules = modules()
+        guard !enabledModules.isEmpty else { return nil }
+
+        let keyOptions = wordLookupKeyOptions(for: query)
+        let escapedTitle = Self.escapeXML(query)
+        var fragments: [BibleReaderMultiFragmentDocumentBuilder.Fragment] = []
+
+        for module in enabledModules {
+            guard let lookup = module.lookup(keyOptions) else { continue }
+            let xml = "<div><title type=\"x-gen\">\(escapedTitle)</title><div type=\"paragraph\">\(lookup.renderedText)</div></div>"
+            fragments.append((
+                xml: xml,
+                key: "\(module.name)--\(query)",
+                keyName: query,
+                bookInitials: module.name,
+                bookAbbreviation: module.abbreviation,
+                features: OsisFeatures()
+            ))
+        }
+
+        guard !fragments.isEmpty else { return nil }
+        return BibleReaderMultiFragmentDocumentBuilder.buildJSON(fragments: fragments)
+    }
+
+    /**
+     Projects installed SWORD modules into selected-word lookup dictionary modules.
+
+     Android includes plain dictionary books and excludes Strong's Greek definitions, Strong's Hebrew
+     definitions, and Greek morphology parsers. The disabled set is inverse selection state, so names
+     present in the set are removed from the result.
+
+     - Parameters:
+       - swordManager: SWORD manager used to enumerate and resolve modules.
+       - disabledDictionaryNames: Module initials disabled by the user.
+     - Returns: Enabled plain dictionary modules in installed-module order.
+     - Side effects: Reads SWORD installed-module metadata and resolves matching modules.
+     - Failure modes: Modules that disappear between metadata enumeration and resolution are skipped.
+     */
+    private static func wordLookupDictionaryModules(
+        swordManager: SwordManager,
+        disabledDictionaryNames: Set<String>
+    ) -> [DictionaryModule] {
+        var result: [DictionaryModule] = []
+        for info in swordManager.installedModules() where
+            info.category == .dictionary &&
+                !info.features.contains(.greekDef) &&
+                !info.features.contains(.hebrewDef) &&
+                !info.features.contains(.greekParse) &&
+                !disabledDictionaryNames.contains(info.name) {
+            guard let module = swordManager.module(named: info.name) else { continue }
+            result.append(
+                DictionaryModule(
+                    name: module.info.name,
+                    abbreviation: String(module.info.name.prefix(10)),
+                    lookup: { keyOptions in
+                        BibleReaderStrongsDocumentBuilder.lookupInModule(
+                            module,
+                            keyOptions: keyOptions
+                        )
+                    }
+                )
+            )
+        }
+        return result
+    }
+
+    /**
+     Produces lookup key variants that compensate for libsword case sensitivity.
+
+     Android delegates case normalization to JSword `Book.getKey`. SWORD on iOS can be stricter, so
+     the builder tries the selected spelling, lowercase, and title-case forms while still requiring
+     the shared dictionary lookup validator to confirm the resolved key.
+
+     - Parameter query: Normalized selected-word lookup key.
+     - Returns: Ordered key variants to try against each dictionary module.
+     - Side effects: None.
+     - Failure modes: Empty query returns empty variants.
+     */
+    private func wordLookupKeyOptions(for query: String) -> [String] {
+        [query, query.lowercased(), query.capitalized]
+    }
+
+    /**
+     Escapes XML-sensitive characters in generated title text.
+
+     - Parameter text: Raw title text.
+     - Returns: XML-safe text for insertion into generated OSIS fragment XML.
+     - Side effects: None.
+     - Failure modes: None; all input strings produce deterministic escaped output.
+     */
+    private static func escapeXML(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}


### PR DESCRIPTION
## Summary

Extracts selected-word dictionary lookup document construction out of BibleReaderController into BibleReaderWordLookupDocumentBuilder.

## Scope

- Moves selected-word query normalization, plain dictionary discovery, and MultiDocument JSON assembly into a focused collaborator.
- Keeps BibleReaderController responsible for selected-text orchestration, not-found toast behavior, document routing, and selection clearing.
- Adds focused regression tests for Android-aligned normalization and rendered dictionary payload content.

## Contract References

- Android LinkControl.lookupInDictionaries normalizes selected text, resolves exact keys, and opens a MultiDocument.
- Android SwordDocumentFacade.wordLookupDictionaries includes plain dictionaries and excludes Greek definitions, Hebrew definitions, Greek parse modules, and user-disabled modules.
- Issue #146 tracks incremental decomposition of BibleReaderController without artificial iOS behavior drift.

## Change Details

- Added BibleReaderWordLookupDocumentBuilder with production and testable module-provider initializers.
- Delegated hasWordLookupDictionaries and lookupSelectionInDictionaries payload construction to the new builder.
- Removed selected-word lookup normalization, dictionary discovery, and payload assembly helpers from BibleReaderController.
- Preserved the existing selected-word user flow while fixing the payload bug where the lookup result object could be interpolated instead of rendered SWORD text.

## Validation Evidence

- RED: xcodebuild test failed because BibleReaderWordLookupDocumentBuilder did not exist yet.
- PASS: DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 with the two selected word lookup tests.
- PASS: DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 17,OS=26.5 with selected word lookup plus neighboring Strongs/dictionary tests.
- PASS: python3 scripts/check_repo_standards.py docblocks --all-files.
- PASS: git diff --cached --check.
- PASS: python3 scripts/check_repo_standards.py commits --rev-range HEAD~1..HEAD.
- PASS: GitNexus detect_changes staged scope reported low risk and no affected execution flows.

## Risks / Follow-ups

- This PR is intentionally scoped to selected-word dictionary lookup; restored Android MultiDocument dictionary handling still uses the existing shared lookup wrapper.
- Issue #146 still has remaining audit/final-verification checklist items after this slice.

## Issue Closure Reference

Closes: none. Continues #146, but does not complete the full issue checklist.