### PR TITLE
refactor(reader): extract synchronized scroll coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2611,6 +2611,43 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the synchronized-scroll feedback state machine used by reader panes.
+
+     Android keeps secondary synchronized panes passive until explicit user interaction, including
+     when a target scroll arrives before the Vue client is ready. The setup drives the extracted
+     state machine without a WebView: it defers a target ordinal, promotes it after client-ready
+     replay, acknowledges intermediate and matching callbacks, and finally clears through explicit
+     interaction. The expected result is that sync-origin callbacks and native deltas stay passive
+     until interaction. A failure means the state owner can reintroduce target-pane ping-pong even
+     when controller-level tests pass through incidental state.
+     */
+    func testReaderSynchronizedScrollCoordinatorPreservesPassiveTargetStateUntilInteraction() {
+        let coordinator = BibleReaderSynchronizedScrollCoordinator()
+
+        XCTAssertTrue(coordinator.shouldTreatNativeScrollDeltaAsUserInteraction)
+
+        coordinator.deferUntilClientReady(ordinal: 105)
+        XCTAssertFalse(coordinator.shouldTreatNativeScrollDeltaAsUserInteraction)
+
+        let deferredOrdinal = coordinator.consumeDeferredClientReadyOrdinalForReplay()
+        XCTAssertEqual(deferredOrdinal, 105)
+        if let deferredOrdinal {
+            coordinator.markClientReadyReplayPending(ordinal: deferredOrdinal)
+        }
+
+        XCTAssertTrue(coordinator.acknowledgeVisibleOrdinal(104))
+        XCTAssertFalse(coordinator.shouldTreatNativeScrollDeltaAsUserInteraction)
+        XCTAssertTrue(coordinator.acknowledgeVisibleOrdinal(105))
+        XCTAssertFalse(coordinator.shouldTreatNativeScrollDeltaAsUserInteraction)
+        XCTAssertTrue(coordinator.acknowledgeVisibleOrdinal(106))
+
+        coordinator.clearForUserInteraction()
+
+        XCTAssertTrue(coordinator.shouldTreatNativeScrollDeltaAsUserInteraction)
+        XCTAssertFalse(coordinator.acknowledgeVisibleOrdinal(105))
+    }
+
+    /**
      Protects Android's secondary-window synchronized scroll contract.
 
      Android posts a secondary scroll event to synced inactive windows and does not let the web

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -40,59 +40,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var currentChapter: Int = 1
     private(set) var currentVerse: Int = 1
     private var clientReady = false
-    /**
-     Latest ordinal for a synchronized scroll request that this pane received from another source pane.
-
-     `scrollToOrdinal(_:)` records the latest target ordinal after applying native sync state.
-     `consumePendingSynchronizedScroll(ordinal:)` uses it to detect the matching target callback
-     while all sync-origin visible-verse telemetry remains passive until explicit user interaction
-     clears `synchronizedScrollFeedbackSuppressionActive`.
-
-     Side effects:
-     - value is replaced by each sync-origin native scroll request
-     - value is cleared when the matching target callback arrives or explicit user interaction
-       cancels sync-feedback suppression
-
-     Failure modes:
-     - nonmatching callbacks are still treated as sync-origin feedback while suppression is active,
-       avoiding target-pane ping-pong from intermediate WebKit scroll telemetry
-     */
-    private var pendingSynchronizedScrollOrdinal: Int?
-    /**
-     Tracks whether this pane is currently receiving scroll telemetry from a synchronized peer.
-
-     Android keeps inactive synchronized windows passive while source-window scrolls move them; only
-     a real touch or active web interaction in the target pane should make it the new source.
-     Matching iOS behavior requires a stateful guard that survives intermediate visible-verse
-     callbacks and native scroll deltas instead of clearing on the first nonmatching ordinal.
-
-     Side effects:
-     - set by synchronized scroll requests after native sync state is applied
-     - cleared only by explicit user interaction in this pane
-
-     Failure modes:
-     - if the WebView never reports the exact target ordinal, feedback remains suppressed until the
-       user interacts with the pane, matching Android's touch-driven source handoff
-     */
-    private var synchronizedScrollFeedbackSuppressionActive = false
-    /**
-     Latest synchronized-scroll target received before the Vue reader reports `clientReady`.
-
-     Android updates the inactive window's verse key even when the secondary WebView cannot yet be
-     scrolled, then lets the next content load land on that key. iOS mirrors that by updating native
-     state immediately but delaying feedback suppression until `bridgeDidSetClientReady(_:)`
-     replays content into a mounted Vue client.
-
-     Side effects:
-     - replaced by newer pre-ready sync requests
-     - promoted to `pendingSynchronizedScrollOrdinal` during client-ready content replay
-     - cleared when explicit user interaction makes the pane a source before replay completes
-
-     Failure modes:
-     - if the ready replay never produces scroll telemetry, feedback suppression remains active until
-       explicit user interaction makes this pane a source again
-     */
-    private var pendingClientReadySynchronizedScrollOrdinal: Int?
+    /// Sync-scroll feedback state used to keep inactive target panes passive until interaction.
+    private let synchronizedScrollCoordinator = BibleReaderSynchronizedScrollCoordinator()
 
     /// Whether the WebView is currently showing the My Notes document (vs Bible text).
     private(set) var showingMyNotes = false
@@ -2503,15 +2452,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     public func bridgeDidSetClientReady(_ bridge: BibleBridge) {
         logger.info("Client ready, sending initial content")
         clientReady = true
-        let deferredSynchronizedScrollOrdinal = pendingClientReadySynchronizedScrollOrdinal
-        pendingClientReadySynchronizedScrollOrdinal = nil
+        let deferredSynchronizedScrollOrdinal = synchronizedScrollCoordinator
+            .consumeDeferredClientReadyOrdinalForReplay()
         loadRecentLabels()
         applyNightModeBackground()
         updateActiveLanguages()
         bridge.emit(event: "set_config", data: buildConfigJSON())
         reloadVisibleDocumentAfterClientReady()
         if let deferredSynchronizedScrollOrdinal {
-            pendingSynchronizedScrollOrdinal = deferredSynchronizedScrollOrdinal
+            synchronizedScrollCoordinator.markClientReadyReplayPending(
+                ordinal: deferredSynchronizedScrollOrdinal
+            )
         }
     }
 
@@ -2715,7 +2666,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         let previousBook = currentBook
         let previousChapter = currentChapter
         let previousVerse = currentVerse
-        let acknowledgedSynchronizedScroll = consumePendingSynchronizedScroll(ordinal: ordinal)
+        let acknowledgedSynchronizedScroll = synchronizedScrollCoordinator
+            .acknowledgeVisibleOrdinal(ordinal)
         navigationCoordinator.updateVisiblePosition(
             ordinal: ordinal,
             key: key,
@@ -2753,9 +2705,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        focus state is changed
      */
     func handleUserInteraction() {
-        pendingSynchronizedScrollOrdinal = nil
-        pendingClientReadySynchronizedScrollOrdinal = nil
-        synchronizedScrollFeedbackSuppressionActive = false
+        synchronizedScrollCoordinator.clearForUserInteraction()
         onInteraction?()
     }
 
@@ -2764,7 +2714,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
      UIKit can report `UIScrollView` deltas while WebKit is applying a synchronized secondary
      scroll. Those deltas are passive feedback, not a source-window handoff, until explicit user
-     interaction clears `synchronizedScrollFeedbackSuppressionActive`.
+     interaction clears the synchronized-scroll coordinator's feedback guard.
 
      - Returns: `true` when no synchronized secondary-scroll feedback guard is active.
 
@@ -2775,7 +2725,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        or auto-hiding chrome from passive target-pane motion
      */
     func shouldTreatNativeScrollDeltaAsUserInteraction() -> Bool {
-        !synchronizedScrollFeedbackSuppressionActive
+        synchronizedScrollCoordinator.shouldTreatNativeScrollDeltaAsUserInteraction
     }
 
     /**
@@ -2801,13 +2751,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     public func scrollToOrdinal(_ ordinal: Int) {
         applySynchronizedScrollPosition(ordinal: ordinal)
         guard clientReady else {
-            pendingClientReadySynchronizedScrollOrdinal = ordinal
-            synchronizedScrollFeedbackSuppressionActive = true
+            synchronizedScrollCoordinator.deferUntilClientReady(ordinal: ordinal)
             return
         }
-        pendingClientReadySynchronizedScrollOrdinal = nil
-        pendingSynchronizedScrollOrdinal = ordinal
-        synchronizedScrollFeedbackSuppressionActive = true
+        synchronizedScrollCoordinator.armSynchronizedFeedback(ordinal: ordinal)
         bridge.emit(event: "scroll_to_verse", data: "{\"ordinal\":\(ordinal),\"now\":false}")
     }
 
@@ -2840,14 +2787,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
 
         let alreadyShowingChapter = currentBook == book && currentChapter == chapter
-        pendingSynchronizedScrollOrdinal = targetOrdinal
-        pendingClientReadySynchronizedScrollOrdinal = nil
-        synchronizedScrollFeedbackSuppressionActive = true
+        synchronizedScrollCoordinator.armSynchronizedFeedback(ordinal: targetOrdinal)
 
         if alreadyShowingChapter {
             applySynchronizedVersePosition(book: book, chapter: chapter, verse: verse, ordinal: targetOrdinal)
             guard clientReady else {
-                pendingClientReadySynchronizedScrollOrdinal = targetOrdinal
+                synchronizedScrollCoordinator.deferUntilClientReady(ordinal: targetOrdinal)
                 return
             }
             bridge.emit(event: "scroll_to_verse", data: "{\"ordinal\":\(targetOrdinal),\"now\":false}")
@@ -2888,9 +2833,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return
         }
 
-        pendingSynchronizedScrollOrdinal = ordinal
-        pendingClientReadySynchronizedScrollOrdinal = nil
-        synchronizedScrollFeedbackSuppressionActive = true
+        synchronizedScrollCoordinator.armSynchronizedFeedback(ordinal: ordinal)
         navigateTo(book: book, chapter: chapter, verse: verse)
     }
 
@@ -2942,29 +2885,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             ordinal: ordinal,
             context: makeNavigationContext()
         )
-    }
-
-    /**
-     Classifies a web-visible ordinal callback while a synchronized secondary scroll is in flight.
-
-     - Parameter ordinal: Ordinal reported by the web client after a scroll position change.
-     - Returns: `true` when the pane is suppressing sync-origin feedback; otherwise `false`.
-
-     Side effects:
-     - clears the pending target ordinal when the matching callback arrives
-     - keeps suppression active for intermediate/nonmatching callbacks until explicit interaction
-
-     Failure modes:
-     - returns `false` only when no sync-origin suppression is active, so normal user-origin scrolls
-       continue to rebroadcast after explicit interaction has made this pane active
-     */
-    private func consumePendingSynchronizedScroll(ordinal: Int) -> Bool {
-        guard synchronizedScrollFeedbackSuppressionActive else { return false }
-        if pendingSynchronizedScrollOrdinal == ordinal {
-            pendingSynchronizedScrollOrdinal = nil
-            pendingClientReadySynchronizedScrollOrdinal = nil
-        }
-        return true
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSynchronizedScrollCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSynchronizedScrollCoordinator.swift
@@ -1,0 +1,127 @@
+// BibleReaderSynchronizedScrollCoordinator.swift -- Sync-scroll feedback state for reader panes
+
+import Foundation
+
+/**
+ Owns synchronized-scroll feedback suppression for one reader pane.
+
+ Android keeps inactive synchronized windows passive while a source pane scrolls them. The target
+ pane may report intermediate visible-verse callbacks and native scroll deltas while WebKit is
+ settling, but those signals are still feedback until explicit interaction makes the pane a new
+ source. This coordinator isolates that state machine from `BibleReaderController` so the
+ controller can orchestrate bridge and navigation work without directly owning the feedback guard.
+
+ Side effects:
+ - stores pending synchronized target ordinals for client-ready replay and scroll acknowledgement
+ - tracks whether native/WebView scroll telemetry should remain passive
+
+ Failure modes:
+ - if the exact target ordinal never arrives, feedback remains suppressed until explicit
+   interaction clears it, matching Android's touch-driven source handoff
+ */
+final class BibleReaderSynchronizedScrollCoordinator {
+    /// Latest ordinal expected from a sync-origin visible-verse callback.
+    private var pendingSynchronizedScrollOrdinal: Int?
+
+    /// Latest sync-origin scroll target received before the Vue reader reports client-ready.
+    private var pendingClientReadySynchronizedScrollOrdinal: Int?
+
+    /// Whether target-pane scroll telemetry should remain passive feedback.
+    private var feedbackSuppressionActive = false
+
+    /**
+     Indicates whether native scroll deltas should be forwarded as user-origin input.
+
+     - Returns: `true` when no synchronized feedback guard is active.
+     - Side effects: None.
+     - Failure modes: Returns `false` for programmatic target-pane movement until explicit
+       interaction clears the guard.
+     */
+    var shouldTreatNativeScrollDeltaAsUserInteraction: Bool {
+        !feedbackSuppressionActive
+    }
+
+    /**
+     Arms feedback suppression for a synchronized target ordinal.
+
+     - Parameter ordinal: Target-local SWORD/JSword ordinal expected from the web client.
+     - Side effects: Replaces the pending acknowledgement ordinal, clears stale client-ready
+       deferrals, and suppresses native/WebView feedback.
+     - Failure modes: None.
+     */
+    func armSynchronizedFeedback(ordinal: Int) {
+        pendingSynchronizedScrollOrdinal = ordinal
+        pendingClientReadySynchronizedScrollOrdinal = nil
+        feedbackSuppressionActive = true
+    }
+
+    /**
+     Defers a synchronized scroll target until the Vue reader reports client-ready.
+
+     - Parameter ordinal: Target-local SWORD/JSword ordinal that content replay should land on.
+     - Side effects: Replaces the pending client-ready ordinal and suppresses feedback immediately
+       so bootstrap scroll telemetry cannot become a source-window handoff.
+     - Failure modes: Does not clear the current acknowledgement ordinal, preserving existing
+       controller behavior when a ready scroll is superseded by a pre-ready replay request.
+     */
+    func deferUntilClientReady(ordinal: Int) {
+        pendingClientReadySynchronizedScrollOrdinal = ordinal
+        feedbackSuppressionActive = true
+    }
+
+    /**
+     Consumes the pending client-ready replay target.
+
+     - Returns: Deferred target ordinal, or `nil` when no pre-ready synchronized target is pending.
+     - Side effects: Clears the client-ready deferral slot so replay happens once.
+     - Failure modes: Does not change feedback suppression; callers promote the returned ordinal
+       after the content replay has been queued.
+     */
+    func consumeDeferredClientReadyOrdinalForReplay() -> Int? {
+        let ordinal = pendingClientReadySynchronizedScrollOrdinal
+        pendingClientReadySynchronizedScrollOrdinal = nil
+        return ordinal
+    }
+
+    /**
+     Marks a just-replayed client-ready synchronized target as awaiting visible-verse feedback.
+
+     - Parameter ordinal: Target-local SWORD/JSword ordinal replayed into the web client.
+     - Side effects: Replaces the pending acknowledgement ordinal.
+     - Failure modes: None.
+     */
+    func markClientReadyReplayPending(ordinal: Int) {
+        pendingSynchronizedScrollOrdinal = ordinal
+    }
+
+    /**
+     Classifies a visible-verse callback while synchronized feedback may be active.
+
+     - Parameter ordinal: Ordinal reported by the web client after visible-position movement.
+     - Returns: `true` when the callback should be treated as sync-origin feedback; otherwise
+       `false` so normal user-origin scrolling may broadcast.
+     - Side effects: Clears pending target and client-ready state when the matching ordinal arrives.
+     - Failure modes: Nonmatching/intermediate ordinals remain passive while suppression is active.
+     */
+    func acknowledgeVisibleOrdinal(_ ordinal: Int) -> Bool {
+        guard feedbackSuppressionActive else { return false }
+        if pendingSynchronizedScrollOrdinal == ordinal {
+            pendingSynchronizedScrollOrdinal = nil
+            pendingClientReadySynchronizedScrollOrdinal = nil
+        }
+        return true
+    }
+
+    /**
+     Clears synchronized feedback state because this pane received explicit user interaction.
+
+     - Side effects: Drops pending synchronized ordinals and allows future native/WebView scroll
+       telemetry to become source-window input.
+     - Failure modes: None.
+     */
+    func clearForUserInteraction() {
+        pendingSynchronizedScrollOrdinal = nil
+        pendingClientReadySynchronizedScrollOrdinal = nil
+        feedbackSuppressionActive = false
+    }
+}


### PR DESCRIPTION
## Summary

Extracts synchronized-scroll feedback state from `BibleReaderController` into a focused coordinator while preserving Android-parity behavior for inactive synchronized panes.

## Scope

- Adds `BibleReaderSynchronizedScrollCoordinator` for feedback suppression, client-ready deferred targets, and visible-ordinal acknowledgement.
- Updates `BibleReaderController` to orchestrate sync-scroll calls through that coordinator instead of owning raw state fields.
- Adds a focused regression test for the extracted state machine.

## Contract References

- Continues #146.
- Does not close #146 because the issue checklist still includes final controller reassessment and broader final-slice validation.
- Android parity contract: synchronized target panes remain passive until explicit user interaction, including during client-ready replay and intermediate WebView callbacks.

## Change Details

- Preserves existing scroll-to-ordinal, client-ready replay, native delta, and visible-verse acknowledgement semantics.
- Removes controller-owned sync feedback fields and the private consume helper.
- Keeps behavior scoped to reader/window state ownership; no feature behavior is intentionally changed.

## Validation Evidence

- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `git diff --check`
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests/AndBibleTests/testReaderSynchronizedScrollCoordinatorPreservesPassiveTargetStateUntilInteraction`
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'` with the synchronized-scroll regression subset
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests`
- GitNexus `detect_changes` on staged diff: medium risk, affected processes limited to synchronized-scroll test flows.

## Risks / Follow-ups

- `BibleReaderController` remains CRITICAL impact overall because it is still central reader orchestration; this PR deliberately limits the changed behavior surface to synchronized-scroll feedback ownership.
- Remaining #146 checklist work is still open after this PR.

## Issue Closure Reference

Refs #146. Does not close.
