### PR TITLE
refactor(reader): extract recent label coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -1950,6 +1950,42 @@ extension AndBibleTests {
         XCTAssertEqual(persistCount, 1)
     }
 
+    /**
+     Protects recent bookmark-label state as a coordinator-owned reader configuration input.
+
+     Android exposes recently used bookmark labels through reader configuration without making the
+     top-level reader controller own the de-duplication, ordering, and persisted setting value. The
+     setup starts from the legacy comma-separated setting, reuses one older label, then adds enough
+     labels to exceed the five-label cap. The expected result is most-recent-first ordering, no
+     duplicate reused label, cap enforcement, and one persisted comma-separated value per tracked
+     label. A failure means #146 regressed by leaving state semantics in the controller or changing
+     the config payload behavior that Vue receives.
+     */
+    func testReaderRecentLabelCoordinatorLoadsDeduplicatesCapsAndPersistsRecentLabels() {
+        var coordinator = BibleReaderRecentLabelCoordinator()
+        var persistedValues: [String] = []
+
+        coordinator.load(storedValue: "oldA,oldB")
+        XCTAssertEqual(coordinator.labelIds, ["oldA", "oldB"])
+
+        for labelId in ["oldC", "oldA", "oldD", "oldE", "oldF", "oldG"] {
+            coordinator.track(labelId) { persistedValues.append($0) }
+        }
+
+        XCTAssertEqual(coordinator.labelIds, ["oldG", "oldF", "oldE", "oldD", "oldA"])
+        XCTAssertEqual(
+            persistedValues,
+            [
+                "oldC,oldA,oldB",
+                "oldA,oldC,oldB",
+                "oldD,oldA,oldC,oldB",
+                "oldE,oldD,oldA,oldC,oldB",
+                "oldF,oldE,oldD,oldA,oldC",
+                "oldG,oldF,oldE,oldD,oldA"
+            ]
+        )
+    }
+
     @MainActor
     func testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -6853,22 +6853,36 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Fixed UUID for the "Unlabeled" system label, sent to Vue.js so bookmarks always have a valid label reference.
     private static let unlabeledLabelId = BibleCore.Label.unlabeledId.uuidString
 
-    /// Recently used label IDs (most recent first, max 5).
-    private var recentLabelIds: [String] = []
+    /// Owns recent-label ordering, de-duplication, and persisted settings representation.
+    private var recentLabelCoordinator = BibleReaderRecentLabelCoordinator()
 
-    /// Track a label as recently used (for Vue.js recentLabels config).
+    /**
+     Delegates recent-label tracking for bookmark actions that selected or created a label.
+
+     - Parameter labelId: Opaque label UUID string produced by the bookmark action coordinator.
+     - Side effects: Updates the recent-label coordinator and persists the joined label IDs through
+       `SettingsStore` using the legacy key consumed by reader configuration.
+     - Failure modes: If `settingsStore` is unavailable, the in-memory recent-label list still
+       updates for the current config payload, matching other controller-owned optional stores.
+     */
     private func trackRecentLabel(_ labelId: String) {
-        recentLabelIds.removeAll { $0 == labelId }
-        recentLabelIds.insert(labelId, at: 0)
-        if recentLabelIds.count > 5 { recentLabelIds = Array(recentLabelIds.prefix(5)) }
-        // Persist to settings
-        settingsStore?.setString("recent_labels", value: recentLabelIds.joined(separator: ","))
+        recentLabelCoordinator.track(labelId) { [settingsStore] persistedValue in
+            settingsStore?.setString(BibleReaderRecentLabelCoordinator.settingsKey, value: persistedValue)
+        }
     }
 
-    /// Load recent label IDs from settings.
+    /**
+     Loads recently used bookmark labels before reader configuration is emitted to Vue.
+
+     - Side effects: Reads `SettingsStore` and updates `recentLabelCoordinator` when the legacy
+       setting exists and is non-empty.
+     - Failure modes: Missing or empty settings leave the coordinator unchanged, preserving the
+       prior controller behavior.
+     */
     private func loadRecentLabels() {
-        guard let stored = settingsStore?.getString("recent_labels"), !stored.isEmpty else { return }
-        recentLabelIds = stored.components(separatedBy: ",")
+        recentLabelCoordinator.load(
+            storedValue: settingsStore?.getString(BibleReaderRecentLabelCoordinator.settingsKey)
+        )
     }
 
     /**
@@ -7301,7 +7315,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             favouriteLabelIds: bookmarkService?.allLabels()
                 .filter { $0.favourite }
                 .map { $0.id.uuidString } ?? [],
-            recentLabelIds: recentLabelIds,
+            recentLabelIds: recentLabelCoordinator.labelIds,
             studyPadCursors: activeWindow?.workspace?.workspaceSettings?.studyPadCursors ?? [:],
             autoAssignLabelIds: activeWindow?.workspace?.workspaceSettings?.autoAssignLabels ?? [],
             hiddenCompareDocuments: currentHiddenCompareDocuments(),

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderRecentLabelCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderRecentLabelCoordinator.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/**
+ Coordinates the reader's recently used bookmark-label state for configuration payloads.
+
+ `BibleReaderController` owns bridge orchestration, while this value owns the state rules for the
+ label IDs that Vue receives as `recentLabels`: load the legacy setting, keep the newest label at
+ the front, remove duplicates, cap the list at five entries, and provide the value to persist.
+
+ - Side effects: The coordinator mutates only its in-memory `labelIds`; persistence is performed by
+   the caller through the closure passed to `track(_:persist:)`.
+ - Failure modes: Invalid or empty label identifiers are not validated here, matching the previous
+   controller behavior that treated stored and bridge-provided IDs as opaque strings.
+ - Note: Stored values are parsed with the legacy comma-separated format without trimming or
+   filtering so existing settings continue to round-trip unchanged.
+ */
+struct BibleReaderRecentLabelCoordinator {
+    /// Settings key used by the legacy reader configuration path.
+    static let settingsKey = "recent_labels"
+
+    /// Most-recent-first label IDs to send in the reader configuration payload.
+    private(set) var labelIds: [String] = []
+
+    /**
+     Restores recently used labels from the legacy persisted setting.
+
+     - Parameter storedValue: Optional comma-separated setting value from `SettingsStore`.
+     - Side effects: Replaces `labelIds` only when `storedValue` is non-empty, preserving the prior
+       controller behavior for missing and empty settings.
+     - Failure modes: No parsing errors are surfaced because the legacy format is a plain string.
+     */
+    mutating func load(storedValue: String?) {
+        guard let storedValue, !storedValue.isEmpty else { return }
+        labelIds = storedValue.components(separatedBy: ",")
+    }
+
+    /**
+     Marks a label ID as recently used and returns the new persisted representation.
+
+     - Parameters:
+       - labelId: Opaque bookmark label ID selected by the user or bridge action.
+       - persist: Non-escaping sink that writes the comma-separated label list.
+     - Side effects: Mutates `labelIds` and invokes `persist` exactly once with the joined value.
+     - Failure modes: The coordinator does not validate label existence; stale IDs are preserved
+       until caller-provided configuration consumers ignore or replace them.
+     - Note: The list is capped at five entries to match the previous controller-owned state rule.
+     */
+    mutating func track(_ labelId: String, persist: (String) -> Void) {
+        labelIds.removeAll { $0 == labelId }
+        labelIds.insert(labelId, at: 0)
+        if labelIds.count > 5 {
+            labelIds = Array(labelIds.prefix(5))
+        }
+        persist(labelIds.joined(separator: ","))
+    }
+}


### PR DESCRIPTION
## Summary

Extracts recently used bookmark-label state from `BibleReaderController` into a focused coordinator while preserving the existing reader configuration payload and settings key.

## Scope

- Adds `BibleReaderRecentLabelCoordinator` for loading, tracking, de-duplicating, capping, and serializing recent label IDs.
- Updates `BibleReaderController` to orchestrate recent-label load/track calls through the coordinator instead of owning the state rules directly.
- Adds a focused unit test for the extracted recent-label behavior.

## Contract References

- Continues #146.
- Does not close #146 because the issue checklist still includes remaining state-ownership audit and final controller reassessment.
- Android parity contract: reader configuration still exposes recent bookmark labels without changing payload semantics or the persisted setting representation.

## Change Details

- Preserves the legacy `recent_labels` settings key and comma-separated value format.
- Preserves most-recent-first ordering, duplicate removal, and the five-label cap.
- Keeps settings persistence in the controller boundary while moving the state rules into a test-covered collaborator.
- Does not intentionally change bookmark, label, or Vue configuration behavior.

## Validation Evidence

- `python3 scripts/check_repo_standards.py docblocks`
- `python3 scripts/check_repo_standards.py commits`
- `git diff --cached --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests/AndBibleTests/testReaderRecentLabelCoordinatorLoadsDeduplicatesCapsAndPersistsRecentLabels`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'` with the GitNexus-identified config/client-ready/bookmark subset
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5'` with the synchronized-scroll smoke subset from the transitive impact list
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests`
- GitNexus `detect_changes` on staged diff: medium risk; direct production impact is the reader config/client-ready path.

## Risks / Follow-ups

- GitNexus marks `buildConfigContext` as CRITICAL impact because config emission fans into client-ready, display settings, bookmark refresh, and reading-progress paths; this PR keeps behavior unchanged and validates the affected unit/config paths locally.
- `BibleReaderController` still has remaining state ownership to audit under #146.

## Issue Closure Reference

Refs #146. Does not close.
