### PR TITLE
docs(parity): define modal presentation ownership matrix

### DIFF
--- a/docs/adr/0006-modal-presentation-ownership-for-android-parity.md
+++ b/docs/adr/0006-modal-presentation-ownership-for-android-parity.md
@@ -1,0 +1,95 @@
+# 0006: Modal Presentation Ownership For Android Parity
+
+Status: Accepted
+
+Date: 2026-06-23
+
+## Context
+
+The iOS app has several user-visible presentation surfaces implemented with
+SwiftUI sheets, confirmation dialogs, alerts, UIKit wrappers, and reader-owned
+modal coordinators. Some of those are legitimate iOS platform boundaries, such
+as share sheets and file import/export pickers. Others are app-owned AndBible
+flows that Android presents through the reader WebView bridge, Android
+activities, popup menus, or domain-specific dialogs.
+
+Treating every Android dialog or activity as interchangeable with a SwiftUI
+sheet creates parity drift. It can preserve a rough user outcome while changing
+the ownership model, visual hierarchy, available actions, default/cancel
+semantics, state persistence, or follow-up routing. The risk is highest in the
+reader because reader actions can cross WebView state, module selection,
+bookmark and StudyPad mutation, settings inheritance, and platform services.
+
+The Android parity contract allows native iOS presentation only when it
+preserves the same visible information architecture and user outcome. That rule
+needs a concrete ownership matrix so future PRs can decide whether a sheet is a
+valid parity implementation, a temporary gap, or an intentional platform
+adaptation.
+
+## Decision
+
+iOS presentation work must classify each parity-sensitive modal, sheet, dialog,
+popover, alert, file picker, and share surface by ownership before adding,
+preserving, or replacing it.
+
+Use these ownership categories:
+
+| Owner category | Definition | iOS rule |
+| --- | --- | --- |
+| `Vue/WebView-owned` | Android owns the interaction from the shared document client or `BibleJavascriptInterface`, and the flow depends on WebView document state or bridge callbacks. | Prefer the same WebView/bridge-owned route on iOS. A native SwiftUI sheet is a parity gap unless a product decision documents why the bridge-owned surface cannot be used. |
+| `Android app-owned` | Android presents an AndBible activity, fragment, popup menu, or custom dialog for an app workflow. | Build or reuse an iOS app-owned surface that matches Android behavior and visual structure. Do not substitute a generic iOS sheet merely because it is easier to present. |
+| `iOS system boundary` | The action crosses into an operating-system service such as sharing, file import/export, document picker, clipboard, or external URL handling. | Native iOS APIs are acceptable when they only replace the OS boundary and do not skip an AndBible-owned preview, confirmation, selection, or import step. |
+| `Platform adaptation` | Android's exact surface is unavailable, unsafe, or intentionally out of scope on iOS, but the user outcome is equivalent. | Document the Android behavior, iOS behavior, reason, validation boundary, and re-evaluation trigger. |
+| `Undecided parity gap` | Ownership has not been classified or Android behavior has not been inspected. | Treat as incomplete. Do not claim `Pass` or `Adapted Pass` until the owner is resolved. |
+
+The initial cross-domain matrix is:
+
+| Surface area | Current iOS pattern | Android owner or target | Required iOS direction | Follow-up |
+| --- | --- | --- | --- | --- |
+| Reader modal routing | `BibleReaderView` sheet and modal coordinator | Mixed: WebView bridge, app activities, popup menus, dialogs | Classify each reader action before preserving sheet usage | #244 |
+| Document/module chooser | SwiftUI sheet with `BibleReaderModulePicker` | `ChooseDocument` activity backed by `DocumentSelectionBase` | App-owned chooser matching Android behavior, or documented adaptation | #245 |
+| Bookmarks, labels, StudyPad | SwiftUI sheets for label assignment, label manager, and note editing | WebView events, `BibleView`, `ManageLabels`, StudyPad document updates | WebView/app-owned surfaces according to Android ownership | #246 |
+| Search translation picker | SwiftUI sheet/list | Android multiselect `AlertDialog` from `Search.showTranslationSelector` | Android-equivalent multiselect surface, or documented adaptation | #247 |
+| Text display editors | SwiftUI sheets and `UIFontPickerViewController` | Preference rows plus custom Android widgets/dialogs | Android-equivalent editor widgets where behavior or choices differ | #248 |
+| Share/export/import file boundaries | `UIActivityViewController`, `fileImporter`, `fileExporter` | Android intents, content pickers, and share flows | iOS system boundary is acceptable when only the OS boundary is replaced | Document per feature when touched |
+| Alerts and confirmation dialogs | SwiftUI `.alert` and `.confirmationDialog` | Android `AlertDialog` and `PopupMenu` | Acceptable only when labels, choices, defaults, destructive/cancel semantics, and follow-up behavior match | Document high-impact cases when touched |
+
+Every PR that adds or materially changes a parity-sensitive presentation surface
+must identify the owner category in one of:
+
+- an ADR when the decision is durable or cross-cutting
+- the relevant parity domain doc when the decision is domain-local
+- source comments or tests when the route is easy to regress
+- the PR description when the change is small and already covered by an ADR or
+  domain doc
+
+## Consequences
+
+- A SwiftUI sheet is not automatically a parity problem, but it is also not
+  automatically a valid adaptation. Ownership decides the bar.
+- Reader presentation changes need extra scrutiny because they often sit at the
+  boundary between native SwiftUI routing and WebView-owned Android behavior.
+- Platform-native share and file pickers remain acceptable when they are only
+  replacing platform services, but they must not swallow AndBible-owned
+  selection, confirmation, preview, or import/export behavior.
+- Domain issues for the highest-risk surfaces stay separate so fixes can be
+  implemented and validated without one large presentation rewrite.
+- Parity status should use `Partial`, `Documented Divergence`, or `Automation
+  Gap` when a surface has equivalent behavior but no ownership classification or
+  visual validation.
+- If Android changes a surface owner, this ADR and the affected domain docs
+  should be updated before iOS preserves the older route.
+
+## Related
+
+- [Android parity contract](../parity/android-parity-contract.md)
+- [Parity documentation](../parity/README.md)
+- [Reader parity docs](../parity/reader/README.md)
+- [Search parity docs](../parity/search/README.md)
+- [Settings parity docs](../parity/settings/README.md)
+- #244
+- #245
+- #246
+- #247
+- #248
+- #249

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ Use these sections:
 - [0003: Android Database Backup Restore Parity](0003-android-database-backup-restore-parity.md)
 - [0004: Reader Pointer Affordances And Upstream Bug Handling](0004-reader-pointer-affordances-and-upstream-bug-handling.md)
 - [0005: Workspace Color Scope And Reader Chrome](0005-workspace-color-scope-and-reader-chrome.md)
+- [0006: Modal Presentation Ownership For Android Parity](0006-modal-presentation-ownership-for-android-parity.md)

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -15,6 +15,11 @@ Decision records that explain durable parity choices live in
 parity decisions should gradually move into ADRs so this subtree does not become
 an endlessly growing tracker.
 
+Presentation-surface ownership is governed by
+[ADR 0006](../adr/0006-modal-presentation-ownership-for-android-parity.md).
+Use that matrix before treating a SwiftUI sheet, native dialog, file picker, or
+share sheet as Android parity.
+
 Use domain folders so each parity area can carry, as needed:
 
 - current contract summaries

--- a/docs/parity/android-parity-contract.md
+++ b/docs/parity/android-parity-contract.md
@@ -21,6 +21,10 @@ for current status, verification evidence, and next actions during migration,
 but durable decisions should move into ADRs over time rather than expanding
 tracker-style docs indefinitely.
 
+[ADR 0006](../adr/0006-modal-presentation-ownership-for-android-parity.md)
+defines the required ownership classification for parity-sensitive modal,
+sheet, dialog, picker, and transient presentation surfaces.
+
 ## Source Of Truth
 
 The Android checkout is the behavior and visual oracle.
@@ -205,6 +209,9 @@ When changing parity-sensitive code:
 7. Add or update an ADR when the change records a durable architecture,
    platform-divergence, or documentation-ownership decision. Keep parity docs
    focused on current status, evidence, and links back to the ADR.
+8. For modal, sheet, dialog, picker, popover, alert, and share/file surfaces,
+   classify the owner using ADR 0006 before claiming parity or documenting an
+   adaptation.
 
 ## Current Priority Interpretation
 

--- a/docs/parity/status-overview.md
+++ b/docs/parity/status-overview.md
@@ -19,7 +19,9 @@ answer four questions without having to reconstruct repo history first:
 For durable decisions behind the docs, use
 [`../adr/`](../adr/README.md). ADR 0001 defines the gradual migration of
 durable parity decisions into ADRs, and ADR 0002 records the current reader
-document/modal routing decision from the #122 audit.
+document/modal routing decision from the #122 audit. ADR 0006 defines the
+cross-domain modal and presentation ownership matrix used to distinguish
+WebView-owned, app-owned, platform-boundary, and adapted iOS surfaces.
 
 ## Domain Snapshot
 


### PR DESCRIPTION
## Summary
Defines a durable ADR for modal and presentation ownership across Android/iOS parity work so sheets, dialogs, pickers, and platform boundaries are classified before future implementation changes claim parity.

## Scope
- Adds ADR 0006 for modal presentation ownership.
- Links the ADR from the ADR index, parity README, Android parity contract, and parity status overview.
- Documentation only; no Swift code or runtime behavior changes.

## Contract references
- docs/adr/0001-gradually-convert-parity-decisions-to-adrs.md
- docs/parity/android-parity-contract.md
- GitHub issue #249

## Change details
- Defines owner categories for Vue/WebView-owned, Android app-owned, iOS system boundary, platform adaptation, and undecided parity gap surfaces.
- Adds the initial matrix for reader modal routing, document chooser, bookmarks/labels/StudyPad, search translation picker, text display editors, share/import/export boundaries, and alert-style dialogs.
- Adds a parity contract rule requiring owner classification before claiming parity for modal/presentation surfaces.

## Validation evidence
- git diff --check
- python3 scripts/check_repo_standards.py docblocks
- python3 scripts/check_repo_standards.py commits --base-ref origin/main
- Verified ADR links and issue references with rg.
- GitNexus index refreshed successfully. MCP detect_changes transport closed, and CLI detect-changes could not resolve the registered worktree after cleanup; the earlier CLI detect-changes run reported low risk and 0 affected processes before unrelated generated files were cleaned.

## Risks/follow-ups
- Low risk: documentation-only change.
- Follow-up implementation issues remain open: #244, #245, #246, #247, #248.

## Issue closure reference
Closes #249