### PR TITLE
refactor(reader): extract transient document coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -1986,6 +1986,52 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Protects pending/active transient `MultiDocument` state as a coordinator-owned reader concern.
+
+     Android links-window `Multi` documents can be requested before the WebView client is ready, so
+     iOS must remember the same transient document as both the active special document and the
+     pending client-ready replay. The test then consumes that pending replay once and verifies that a
+     later client-ready request remains active without leaving stale pending replay state. A failure
+     means the controller has regained hidden transient state ownership or the Android `Multi`
+     restore/replay contract can duplicate or lose special documents.
+     */
+    func testReaderTransientDocumentCoordinatorStoresActiveAndPendingReplayState() {
+        var coordinator = BibleReaderTransientDocumentCoordinator()
+        let pendingRequest = BibleReaderTransientDocumentRequest(
+            documentJSON: #"{"id":"pending"}"#,
+            renderedBook: "Multi",
+            renderedKey: "multi",
+            renderedCategory: .generalBook,
+            renderedModuleName: "Multi",
+            pageCategory: .generalBook,
+            pageDocumentInitials: "Multi",
+            pageKey: "KJV:Gen.1.1"
+        )
+        let readyRequest = BibleReaderTransientDocumentRequest(
+            documentJSON: #"{"id":"ready"}"#,
+            renderedBook: "Compare",
+            renderedKey: "compare",
+            renderedCategory: .bible,
+            renderedModuleName: nil,
+            pageCategory: nil,
+            pageDocumentInitials: nil,
+            pageKey: nil
+        )
+
+        coordinator.store(pendingRequest, clientReady: false)
+
+        XCTAssertEqual(coordinator.activeRequest(isShowingAndroidMultiDocument: true)?.documentJSON, pendingRequest.documentJSON)
+        XCTAssertNil(coordinator.activeRequest(isShowingAndroidMultiDocument: false))
+        XCTAssertEqual(coordinator.consumePendingClientReadyRequest()?.documentJSON, pendingRequest.documentJSON)
+        XCTAssertNil(coordinator.consumePendingClientReadyRequest())
+
+        coordinator.store(readyRequest, clientReady: true)
+
+        XCTAssertEqual(coordinator.activeRequest(isShowingAndroidMultiDocument: true)?.documentJSON, readyRequest.documentJSON)
+        XCTAssertNil(coordinator.consumePendingClientReadyRequest())
+    }
+
     @MainActor
     func testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -130,10 +130,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     static let emptyRenderedContentState = BibleReaderRenderedContentState.empty.encodedValue
     private static let issueTrackerURLString = "https://github.com/AndBible/and-bible/issues"
     private(set) var renderedContentState: String = BibleReaderController.emptyRenderedContentState
-    /// Transient document that should be replayed once the Vue client has finished bootstrapping.
-    private var pendingClientReadyTransientMultiDocument: TransientMultiDocumentRequest?
-    /// Last transient special document visible in this controller, used for same-session reloads.
-    private var activeTransientMultiDocument: TransientMultiDocumentRequest?
+    /// State machine for pending and active Android-style transient `MultiDocument` pages.
+    private var transientDocumentCoordinator = BibleReaderTransientDocumentCoordinator()
     /// Current My Documents page rendered through the local store rather than a SWORD module.
     private var activeMyDocumentBookInitials: String?
     /// Current My Documents page key rendered through the local store rather than a SWORD module.
@@ -144,40 +142,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private var maxLoadedChapter: Int = 0
     private var minLoadedBook: String = "Genesis"
     private var maxLoadedBook: String = "Genesis"
-
-    /**
-     Captures a transient Vue `MultiDocument` load until the web client can receive it.
-
-     Link-result panes may be created before their `BibleWebView` has sent `setClientReady`. The
-     request stores both the serialized Vue document and the Android page identity that should be
-     persisted on the links-window target, so client-ready replay, settings reloads, and bottom tabs
-     agree on the same special document.
-     */
-    private struct TransientMultiDocumentRequest {
-        /// Serialized Vue `MultiDocument` payload to emit.
-        let documentJSON: String
-
-        /// Rendered-content book token for accessibility and tab display.
-        let renderedBook: String
-
-        /// Rendered-content key token for accessibility and tab display.
-        let renderedKey: String
-
-        /// Rendered-content category token.
-        let renderedCategory: DocumentCategory
-
-        /// Optional rendered module token.
-        let renderedModuleName: String?
-
-        /// Optional PageManager category to persist for Android fake-document parity.
-        let pageCategory: DocumentCategory?
-
-        /// Optional PageManager document initials to persist for Android fake-document parity.
-        let pageDocumentInitials: String?
-
-        /// Optional PageManager key to persist for Android fake-document parity.
-        let pageKey: String?
-    }
 
     /**
      Serialized payload rebuilt from Android's durable `Multi` PageManager key.
@@ -1110,8 +1074,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Load the appropriate content for the current category.
     public func loadCurrentContent() {
         if isShowingAndroidMultiDocument {
-            if let activeTransientMultiDocument {
-                emitTransientMultiDocument(activeTransientMultiDocument)
+            if let activeRequest = transientDocumentCoordinator.activeRequest(
+                isShowingAndroidMultiDocument: isShowingAndroidMultiDocument
+            ) {
+                emitTransientMultiDocument(activeRequest)
                 return
             }
             if loadRestoredAndroidMultiDocument() {
@@ -1493,7 +1459,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         pageDocumentInitials: String? = nil,
         pageKey: String? = nil
     ) {
-        let request = TransientMultiDocumentRequest(
+        let request = BibleReaderTransientDocumentRequest(
             documentJSON: documentJSON,
             renderedBook: renderedBook,
             renderedKey: renderedKey,
@@ -1503,12 +1469,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             pageDocumentInitials: pageDocumentInitials,
             pageKey: pageKey
         )
-        activeTransientMultiDocument = request
-        if clientReady {
-            pendingClientReadyTransientMultiDocument = nil
-        } else {
-            pendingClientReadyTransientMultiDocument = request
-        }
+        transientDocumentCoordinator.store(request, clientReady: clientReady)
         emitTransientMultiDocument(request)
     }
 
@@ -1522,7 +1483,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Failure modes: Invalid JSON is forwarded unchanged to the bridge, matching the existing
        transient document contract.
      */
-    private func emitTransientMultiDocument(_ request: TransientMultiDocumentRequest) {
+    private func emitTransientMultiDocument(_ request: BibleReaderTransientDocumentRequest) {
         showingMyNotes = false
         showingStudyPad = false
         activeStudyPadLabelId = nil
@@ -1568,7 +1529,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        durable document/key update only the transient controller category so malformed bridge
        payloads cannot erase the last restorable Android `Multi` key.
      */
-    private func applyTransientPageIdentity(_ request: TransientMultiDocumentRequest) {
+    private func applyTransientPageIdentity(_ request: BibleReaderTransientDocumentRequest) {
         guard let pageCategory = request.pageCategory else {
             currentCategory = .bible
             return
@@ -2476,9 +2437,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      accessibility/export state aligned.
      */
     private func reloadVisibleDocumentAfterClientReady() {
-        if let pendingClientReadyTransientMultiDocument {
-            self.pendingClientReadyTransientMultiDocument = nil
-            emitTransientMultiDocument(pendingClientReadyTransientMultiDocument)
+        if let pendingClientReadyRequest = transientDocumentCoordinator.consumePendingClientReadyRequest() {
+            emitTransientMultiDocument(pendingClientReadyRequest)
             return
         }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderTransientDocumentCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderTransientDocumentCoordinator.swift
@@ -1,0 +1,106 @@
+import BibleCore
+
+/**
+ Immutable description of a transient Vue `MultiDocument` render request.
+
+ Android stores special links-window pages as fake documents while Vue renders the actual
+ `MultiDocument` payload. This request carries both halves of that contract: the serialized Vue
+ document plus the native rendered-content and optional PageManager identity that must survive
+ client-ready replay and same-session reloads.
+
+ - Side effects: None; this type is a value payload.
+ - Failure modes: The coordinator does not validate `documentJSON`; callers keep responsibility for
+   building valid bridge payloads before storing or emitting the request.
+ */
+struct BibleReaderTransientDocumentRequest: Equatable {
+    /// Serialized Vue `MultiDocument` payload to emit.
+    let documentJSON: String
+
+    /// Rendered-content book token for accessibility and tab display.
+    let renderedBook: String
+
+    /// Rendered-content key token for accessibility and tab display.
+    let renderedKey: String
+
+    /// Rendered-content category token.
+    let renderedCategory: DocumentCategory
+
+    /// Optional rendered module token.
+    let renderedModuleName: String?
+
+    /// Optional PageManager category to persist for Android fake-document parity.
+    let pageCategory: DocumentCategory?
+
+    /// Optional PageManager document initials to persist for Android fake-document parity.
+    let pageDocumentInitials: String?
+
+    /// Optional PageManager key to persist for Android fake-document parity.
+    let pageKey: String?
+}
+
+/**
+ Owns pending and active transient `MultiDocument` state for one reader pane.
+
+ `BibleReaderController` still builds and emits bridge payloads, but this coordinator owns the
+ state rule for special documents that can be requested before the WebView client is ready. A
+ pre-ready request must be active immediately for same-session reload checks and pending exactly
+ once for client-ready replay; a client-ready request remains active without creating stale replay
+ work. This mirrors Android links-window fake-document behavior without making the controller own
+ hidden pending slots.
+
+ - Side effects: Mutates only in-memory pending/active request slots.
+ - Failure modes: None; invalid bridge payloads are treated as opaque strings and remain caller
+   responsibility, preserving the previous controller contract.
+ - Note: `activeRequest(isShowingAndroidMultiDocument:)` intentionally gates the stored active
+   request on the caller's current Android fake-document predicate so stale active requests cannot
+   override ordinary category loading.
+ */
+struct BibleReaderTransientDocumentCoordinator {
+    /// Last transient special document visible in this pane, used for same-session reloads.
+    private var activeRequest: BibleReaderTransientDocumentRequest?
+
+    /// Transient document that should be replayed once the Vue client has finished bootstrapping.
+    private var pendingClientReadyRequest: BibleReaderTransientDocumentRequest?
+
+    /**
+     Stores a transient document request using the current client-ready state.
+
+     - Parameters:
+       - request: Opaque transient document payload and native identity to remember.
+       - clientReady: Whether the Vue client can currently receive bridge document events.
+     - Side effects: Replaces the active request and either stores or clears the pending replay
+       request.
+     - Failure modes: None; callers emit the request separately after storage.
+     */
+    mutating func store(_ request: BibleReaderTransientDocumentRequest, clientReady: Bool) {
+        activeRequest = request
+        pendingClientReadyRequest = clientReady ? nil : request
+    }
+
+    /**
+     Returns the active transient request only while native state is on Android's fake document.
+
+     - Parameter isShowingAndroidMultiDocument: Caller-computed predicate for the current
+       PageManager/controller category and document identity.
+     - Returns: Stored active request when the caller is still showing Android `Multi`; otherwise
+       `nil`.
+     - Side effects: None.
+     - Failure modes: None; stale active requests are suppressed by the predicate.
+     */
+    func activeRequest(isShowingAndroidMultiDocument: Bool) -> BibleReaderTransientDocumentRequest? {
+        isShowingAndroidMultiDocument ? activeRequest : nil
+    }
+
+    /**
+     Consumes the pending client-ready replay request.
+
+     - Returns: The pre-ready transient request to replay, or `nil` when none is pending.
+     - Side effects: Clears the pending replay slot so client-ready replay happens once.
+     - Failure modes: None.
+     */
+    mutating func consumePendingClientReadyRequest() -> BibleReaderTransientDocumentRequest? {
+        let request = pendingClientReadyRequest
+        pendingClientReadyRequest = nil
+        return request
+    }
+}


### PR DESCRIPTION
## Summary

- Refs #146
- Extract the pending/active Android-style transient MultiDocument state from BibleReaderController into BibleReaderTransientDocumentCoordinator.
- Keep the controller responsible for building/emitting bridge payloads while the coordinator owns the client-ready replay and same-session active-request state rule.
- Add a focused unit test for pre-ready replay, active Android Multi gating, stale replay clearing, and ready-state storage.

## Android Parity

- Preserves Android fake-document behavior for links-window Multi pages: the native page identity remains an Android-style Multi document while Vue receives the serialized MultiDocument payload.
- Does not introduce new iOS-only behavior; this is an ownership extraction of existing replay semantics.

## Validation

- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests/AndBibleTests/testReaderTransientDocumentCoordinatorStoresActiveAndPendingReplayState`
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5"` with 17 affected reader/client-ready/sync tests
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests`
- `python3 scripts/check_repo_standards.py docblocks`
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main --head-ref HEAD`
- `git diff --check`
- `npx gitnexus analyze`
- GitNexus staged change detection: medium risk, intended 3 Swift files only