### PR TITLE
refactor(reader): extract my documents coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2032,6 +2032,88 @@ extension AndBibleTests {
         XCTAssertNil(coordinator.consumePendingClientReadyRequest())
     }
 
+    /**
+     Protects My Documents active-page identity as a coordinator-owned reader state rule.
+
+     Android treats My Documents as generated general-book modules, so iOS must keep the active
+     local page only while the rendered content still points at the same general-book document. The
+     setup records one active page, exercises an unrelated module/category render, and expects the
+     coordinator to preserve or clear the page key exactly where the controller previously did. A
+     failure means #146 moved state ownership without preserving the reload/delete guard that keeps
+     My Documents bridge actions scoped to the visible local document.
+     */
+    func testReaderMyDocumentCoordinatorTracksActivePageUntilDifferentRenderedContent() {
+        var coordinator = BibleReaderMyDocumentCoordinator()
+
+        coordinator.setActivePage(bookInitials: "MYDOC", pageKey: "intro")
+
+        XCTAssertEqual(coordinator.activePageKey(for: "MYDOC"), "intro")
+        XCTAssertNil(coordinator.activePageKey(for: "OTHER"))
+
+        coordinator.clearActivePageUnless(category: .generalBook, moduleName: "MYDOC")
+        XCTAssertEqual(coordinator.activePageKey(for: "MYDOC"), "intro")
+
+        coordinator.clearActivePageUnless(category: .commentary, moduleName: "MYDOC")
+        XCTAssertNil(coordinator.activePageKey(for: "MYDOC"))
+
+        coordinator.setActivePage(bookInitials: "MYDOC", pageKey: "intro")
+        coordinator.clearActivePageUnless(category: .generalBook, moduleName: "OTHER")
+
+        XCTAssertNil(coordinator.activePageKey(for: "MYDOC"))
+    }
+
+    /**
+     Protects the Android-compatible My Documents document payload outside the reader controller.
+
+     Android exposes My Documents through the general-book document pipeline while retaining raw
+     editable content behind bridge calls. The setup builds a Markdown page containing XML-sensitive
+     characters and expects the coordinator to emit a valid Vue `OsisDocument` JSON payload with the
+     same category, identity, AI metadata, and escaped markup fields used by the current reader. A
+     failure means the extraction changed the WebView payload contract rather than simply moving it
+     out of `BibleReaderController`.
+     */
+    func testReaderMyDocumentCoordinatorBuildsAndroidGeneralBookDocumentPayload() throws {
+        let coordinator = BibleReaderMyDocumentCoordinator()
+        let pageId = try XCTUnwrap(UUID(uuidString: "77777777-7777-7777-7777-777777777777"))
+        let sourcePromptId = try XCTUnwrap(UUID(uuidString: "88888888-8888-8888-8888-888888888888"))
+        let document = MyDocument(name: "My Document", initials: "MYDOC")
+        let page = MyDocumentPage(
+            id: pageId,
+            title: "Intro",
+            pageKey: "intro",
+            contentType: .markdown,
+            sourcePromptId: sourcePromptId,
+            languageCode: "en"
+        )
+        let content = MyDocumentPageContent(pageId: pageId, content: "Raw <markdown> & \"quoted\"")
+        page.pageContent = content
+        page.document = document
+
+        let json = try XCTUnwrap(coordinator.documentJSON(document: document, page: page))
+        let renderedDocument = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        let osisFragment = try XCTUnwrap(renderedDocument["osisFragment"] as? [String: Any])
+
+        XCTAssertEqual(renderedDocument["type"] as? String, "osis")
+        XCTAssertEqual(renderedDocument["bookInitials"] as? String, "MYDOC")
+        XCTAssertEqual(renderedDocument["bookCategory"] as? String, DocumentCategory.generalBook.rawValue)
+        XCTAssertEqual(renderedDocument["bookName"] as? String, "My Document")
+        XCTAssertEqual(renderedDocument["key"] as? String, "intro")
+        XCTAssertEqual(renderedDocument["isMyDocument"] as? Bool, true)
+        XCTAssertEqual(renderedDocument["isAiDocument"] as? Bool, false)
+        XCTAssertEqual(renderedDocument["myDocumentPageId"] as? String, pageId.uuidString)
+        XCTAssertEqual(renderedDocument["sourcePromptId"] as? String, sourcePromptId.uuidString)
+        XCTAssertEqual(osisFragment["bookCategory"] as? String, DocumentCategory.generalBook.rawValue)
+        XCTAssertEqual(osisFragment["bookInitials"] as? String, "MYDOC")
+        XCTAssertEqual(osisFragment["keyName"] as? String, "Intro")
+        XCTAssertEqual(osisFragment["language"] as? String, "en")
+        XCTAssertEqual(
+            osisFragment["xml"] as? String,
+            "<div class=\"mydoc-markdown\"><markdown>Raw &lt;markdown&gt; &amp; &quot;quoted&quot;</markdown></div>"
+        )
+    }
+
     @MainActor
     func testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -141,6 +141,26 @@ extension AndBibleUITests {
             usesPromptScopedResolvedField ? [] : focusedTextEntryCandidates(in: app)
         }
 
+        func appCoordinate(for frame: CGRect, normalizedOffset: CGVector) -> XCUICoordinate? {
+            let appFrame = app.frame
+            guard elementFrameIsUsable(frame),
+                  elementFrameIsUsable(appFrame),
+                  appFrame.width > 0,
+                  appFrame.height > 0
+            else {
+                return nil
+            }
+
+            let absoluteX = frame.minX + frame.width * normalizedOffset.dx
+            let absoluteY = frame.minY + frame.height * normalizedOffset.dy
+            return app.coordinate(
+                withNormalizedOffset: CGVector(
+                    dx: absoluteX / appFrame.width,
+                    dy: absoluteY / appFrame.height
+                )
+            )
+        }
+
         func resolvedPromptTextField() -> XCUIElement {
             if usesPromptScopedResolvedField {
                 return element
@@ -186,7 +206,10 @@ extension AndBibleUITests {
                       elementFrameIsUsable(prompt.frame) else {
                     return nil
                 }
-                return prompt.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.52))
+                return appCoordinate(
+                    for: prompt.frame,
+                    normalizedOffset: CGVector(dx: 0.5, dy: 0.52)
+                )
             case "workspaceNamePromptTextField":
                 // The workspace prompt resolver already found the text field. Re-sampling the
                 // custom SwiftUI prompt root for its frame can wedge hosted XCTest snapshots, so

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderActiveSheetContent.swift
@@ -55,6 +55,7 @@ struct BibleReaderActiveSheetContent: View {
                         controller?.navigateTo(book: book, chapter: chapter)
                     },
                     onOpenStudyPad: { labelId in
+                        onDismiss()
                         controller?.loadStudyPadDocument(labelId: labelId)
                     },
                     bibleOrdinalResolver: { book, ordinal in

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -132,10 +132,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private(set) var renderedContentState: String = BibleReaderController.emptyRenderedContentState
     /// State machine for pending and active Android-style transient `MultiDocument` pages.
     private var transientDocumentCoordinator = BibleReaderTransientDocumentCoordinator()
-    /// Current My Documents page rendered through the local store rather than a SWORD module.
-    private var activeMyDocumentBookInitials: String?
-    /// Current My Documents page key rendered through the local store rather than a SWORD module.
-    private var activeMyDocumentPageKey: String?
+    /// Reader-local My Documents active page state and document payload assembly.
+    private var myDocumentCoordinator = BibleReaderMyDocumentCoordinator()
 
     /// Infinite scroll: tracks the range of chapters/books currently loaded in the WebView.
     private var minLoadedChapter: Int = 0
@@ -355,10 +353,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         chapter: Int? = nil,
         key: String? = nil
     ) {
-        if category != .generalBook || moduleName != activeMyDocumentBookInitials {
-            activeMyDocumentBookInitials = nil
-            activeMyDocumentPageKey = nil
-        }
+        myDocumentCoordinator.clearActivePageUnless(category: category, moduleName: moduleName)
         renderedContentState = BibleReaderRenderedContentState(
             category: category,
             moduleName: moduleName,
@@ -3841,6 +3836,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return false
         }
 
+        guard let documentJSON = myDocumentCoordinator.documentJSON(document: document, page: page) else {
+            logger.error("Failed to serialize My Documents page JSON for \(document.initials, privacy: .public)")
+            return false
+        }
+
         showingMyNotes = false
         showingStudyPad = false
         activeStudyPadLabelId = nil
@@ -3849,8 +3849,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         hasActiveSelection = false
         selectedText = ""
         currentCategory = .generalBook
-        activeMyDocumentBookInitials = bookInitials
-        activeMyDocumentPageKey = pageKey
+        myDocumentCoordinator.setActivePage(bookInitials: bookInitials, pageKey: pageKey)
         setRenderedContentState(
             category: .generalBook,
             moduleName: document.initials,
@@ -3858,7 +3857,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             key: page.pageKey
         )
 
-        let documentJSON = buildMyDocumentDocumentJSON(document: document, page: page)
         bridge.emit(event: "clear_document")
         bridge.emit(event: "add_documents", data: documentJSON)
         bridge.emit(
@@ -3868,79 +3866,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         bridge.clearSelection()
         applyNightModeBackground()
         return true
-    }
-
-    /**
-     Builds the Vue.js `OsisDocument` payload for one stored My Documents page.
-     */
-    private func buildMyDocumentDocumentJSON(document: MyDocument, page: MyDocumentPage) -> String {
-        let content = page.pageContent?.content ?? ""
-        let xml = renderedMyDocumentXML(content: content, contentType: page.contentType)
-        let promptId: Any = page.sourcePromptId?.uuidString ?? NSNull()
-
-        let osisFragment: [String: Any] = [
-            "xml": xml,
-            "key": page.pageKey,
-            "keyName": page.title,
-            "v11n": "KJVA",
-            "bookCategory": DocumentCategory.generalBook.rawValue,
-            "bookInitials": document.initials,
-            "bookAbbreviation": document.initials,
-            "osisRef": page.pageKey,
-            "isNewTestament": false,
-            "features": [String: Any](),
-            "hasStrongs": false,
-            "ordinalRange": [0, 0],
-            "language": page.languageCode ?? Locale.current.languageCode ?? "en",
-            "direction": "ltr",
-        ]
-
-        let renderedDocument: [String: Any] = [
-            "id": "my-document-\(page.id.uuidString)",
-            "type": "osis",
-            "osisFragment": osisFragment,
-            "bookInitials": document.initials,
-            "bookCategory": DocumentCategory.generalBook.rawValue,
-            "bookAbbreviation": document.initials,
-            "bookName": document.name,
-            "key": page.pageKey,
-            "v11n": "KJVA",
-            "osisRef": page.pageKey,
-            "annotateRef": page.pageKey,
-            "genericBookmarks": [Any](),
-            "ordinalRange": [0, 0],
-            "isNativeHtml": false,
-            "highlightedOrdinalRange": NSNull(),
-            "isMyDocument": true,
-            "isAiDocument": document.initials == "AIDocuments",
-            "myDocumentPageId": page.id.uuidString,
-            "sourcePromptId": promptId,
-            "sourcePromptName": NSNull(),
-            "sourceModelName": NSNull(),
-            "aiDocMarkers": [Any](),
-        ]
-
-        guard let data = try? JSONSerialization.data(withJSONObject: renderedDocument, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize My Documents page JSON for \(document.initials, privacy: .public)")
-            return "{}"
-        }
-
-        return json
-    }
-
-    /**
-     Converts stored raw My Documents content into the OSIS-template fragment consumed by Vue.js.
-     */
-    private func renderedMyDocumentXML(content: String, contentType: MyDocumentContentType) -> String {
-        switch contentType {
-        case .markdown:
-            return "<div class=\"mydoc-markdown\"><markdown>\(escapeXML(content))</markdown></div>"
-        case .html:
-            return "<div class=\"mydoc-html\"><html>\(escapeXML(content))</html></div>"
-        case .osis:
-            return content
-        }
     }
 
     /**
@@ -3967,13 +3892,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return
         }
 
-        let shareText: String
-        if payload.title.isEmpty {
-            shareText = payload.content
-        } else {
-            shareText = "\(payload.title)\n\n\(payload.content)"
-        }
-        onShareVerseText?(shareText)
+        onShareVerseText?(myDocumentCoordinator.shareText(for: payload))
     }
 
     /**
@@ -4000,8 +3919,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Reloads the currently visible My Documents page when it belongs to the supplied document.
      */
     public func bridge(_ bridge: BibleBridge, reloadMyDocumentPage bookInitials: String) {
-        guard activeMyDocumentBookInitials == bookInitials,
-              let pageKey = activeMyDocumentPageKey else {
+        guard let pageKey = myDocumentCoordinator.activePageKey(for: bookInitials) else {
             return
         }
 
@@ -4062,13 +3980,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Keeps the visible WebView in sync after an AI My Documents page deletion.
      */
     private func refreshMyDocumentAfterDeletingPage(_ context: MyDocumentAIPageActionContext) {
-        guard activeMyDocumentBookInitials == context.bookInitials else {
+        guard myDocumentCoordinator.isActiveDocument(context) else {
             return
         }
 
-        if activeMyDocumentPageKey == context.pageKey {
-            activeMyDocumentBookInitials = nil
-            activeMyDocumentPageKey = nil
+        if myDocumentCoordinator.isActivePage(context) {
+            myDocumentCoordinator.clearActivePage()
             currentCategory = .bible
             if let pageManager = activeWindow?.pageManager {
                 pageManager.currentCategoryName = DocumentCategory.bible.pageManagerKey
@@ -4078,7 +3995,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return
         }
 
-        if let pageKey = activeMyDocumentPageKey {
+        if let pageKey = myDocumentCoordinator.activePageKey(for: context.bookInitials) {
             loadMyDocumentPage(bookInitials: context.bookInitials, pageKey: pageKey)
         }
     }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderMyDocumentCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderMyDocumentCoordinator.swift
@@ -1,0 +1,230 @@
+// BibleReaderMyDocumentCoordinator.swift -- My Documents reader state and payload assembly
+
+import BibleCore
+import Foundation
+
+/**
+ Owns reader-local My Documents page identity and WebView payload assembly.
+
+ Android presents My Documents as generated general-book modules while raw editable content is
+ fetched and saved through bridge calls. This coordinator keeps the iOS reader aligned with that
+ contract without making `BibleReaderController` own the active page slots or duplicate the
+ `OsisDocument` JSON shape. The type is intentionally value-scoped to one reader pane and does not
+ perform SwiftData fetches, bridge emission, pasteboard writes, or persistence.
+
+ - Side effects: Mutates only its active document/page identity.
+ - Failure modes: Document JSON serialization returns `nil` if the assembled payload cannot be
+   encoded; callers should avoid emitting invalid placeholder JSON.
+ - Note: Content-type rendering preserves the existing iOS bridge semantics: Markdown and HTML
+   content are XML-escaped and wrapped for Vue rendering, while OSIS content is already structured
+   and passes through unchanged.
+ */
+struct BibleReaderMyDocumentCoordinator {
+    /// Active local My Documents document initials currently rendered in the pane.
+    private var activeBookInitials: String?
+
+    /// Active local My Documents page key currently rendered in the pane.
+    private var activePageKey: String?
+
+    /**
+     Records the My Documents page currently visible in the reader.
+
+     - Parameters:
+       - bookInitials: Android-compatible generated general-book initials for the document.
+       - pageKey: Page key scoped to `bookInitials`.
+     - Side effects: Replaces the active document/page identity for this coordinator.
+     - Failure modes: None; callers are responsible for resolving the page before recording it.
+     */
+    mutating func setActivePage(bookInitials: String, pageKey: String) {
+        activeBookInitials = bookInitials
+        activePageKey = pageKey
+    }
+
+    /**
+     Clears any active My Documents page identity.
+
+     - Side effects: Removes the active document/page identity for this coordinator.
+     - Failure modes: None.
+     */
+    mutating func clearActivePage() {
+        activeBookInitials = nil
+        activePageKey = nil
+    }
+
+    /**
+     Clears active My Documents state when rendered content moves away from that local document.
+
+     `BibleReaderController.setRenderedContentState` calls this for every native content emission.
+     The active My Documents page is preserved only when the rendered content remains the same
+     generated general-book module, matching the previous controller-owned reload/delete guard.
+
+     - Parameters:
+       - category: Rendered document category being sent to the reader.
+       - moduleName: Rendered module/document initials, if any.
+     - Side effects: Clears active identity when the rendered content is not the active My Document.
+     - Failure modes: None.
+     */
+    mutating func clearActivePageUnless(category: DocumentCategory, moduleName: String?) {
+        if category != .generalBook || moduleName != activeBookInitials {
+            clearActivePage()
+        }
+    }
+
+    /**
+     Returns the active page key only when it belongs to the requested My Documents collection.
+
+     - Parameter bookInitials: Android-compatible generated general-book initials to match.
+     - Returns: Active page key for the document, or `nil` when another document/category is active.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func activePageKey(for bookInitials: String) -> String? {
+        activeBookInitials == bookInitials ? activePageKey : nil
+    }
+
+    /**
+     Checks whether an AI page action belongs to the active My Documents collection.
+
+     - Parameter context: Store-validated AI page action context.
+     - Returns: `true` when the action's document initials match the active document.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func isActiveDocument(_ context: MyDocumentAIPageActionContext) -> Bool {
+        activeBookInitials == context.bookInitials
+    }
+
+    /**
+     Checks whether an AI page action targets the exact active My Documents page.
+
+     - Parameter context: Store-validated AI page action context.
+     - Returns: `true` when both document initials and page key match the active page.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func isActivePage(_ context: MyDocumentAIPageActionContext) -> Bool {
+        activeBookInitials == context.bookInitials && activePageKey == context.pageKey
+    }
+
+    /**
+     Builds the share text for a raw My Documents payload.
+
+     Android shares the page title as heading text when present and otherwise shares only the raw
+     page body. Keeping this formatting here prevents every bridge caller from re-encoding that
+     title/body rule.
+
+     - Parameter payload: Raw page payload resolved by `MyDocumentStore`.
+     - Returns: Shareable plain text for the native sharing surface.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    func shareText(for payload: MyDocumentRawContentPayload) -> String {
+        if payload.title.isEmpty {
+            return payload.content
+        }
+        return "\(payload.title)\n\n\(payload.content)"
+    }
+
+    /**
+     Builds the Vue.js `OsisDocument` payload for one stored My Documents page.
+
+     - Parameters:
+       - document: Parent My Documents collection resolved by Android-compatible initials.
+       - page: Page metadata/content to render.
+     - Returns: Sorted-key JSON string for the WebView `add_documents` event, or `nil` if encoding
+       fails.
+     - Side effects: None.
+     - Failure modes: Returns `nil` instead of an empty placeholder object so callers do not emit an
+       invalid document payload to Vue.
+     */
+    func documentJSON(document: MyDocument, page: MyDocumentPage) -> String? {
+        let content = page.pageContent?.content ?? ""
+        let xml = renderedXML(content: content, contentType: page.contentType)
+        let promptId: Any = page.sourcePromptId?.uuidString ?? NSNull()
+        let languageCode = page.languageCode ?? Locale.current.language.languageCode?.identifier ?? "en"
+
+        let osisFragment: [String: Any] = [
+            "xml": xml,
+            "key": page.pageKey,
+            "keyName": page.title,
+            "v11n": "KJVA",
+            "bookCategory": DocumentCategory.generalBook.rawValue,
+            "bookInitials": document.initials,
+            "bookAbbreviation": document.initials,
+            "osisRef": page.pageKey,
+            "isNewTestament": false,
+            "features": [String: Any](),
+            "hasStrongs": false,
+            "ordinalRange": [0, 0],
+            "language": languageCode,
+            "direction": "ltr",
+        ]
+
+        let renderedDocument: [String: Any] = [
+            "id": "my-document-\(page.id.uuidString)",
+            "type": "osis",
+            "osisFragment": osisFragment,
+            "bookInitials": document.initials,
+            "bookCategory": DocumentCategory.generalBook.rawValue,
+            "bookAbbreviation": document.initials,
+            "bookName": document.name,
+            "key": page.pageKey,
+            "v11n": "KJVA",
+            "osisRef": page.pageKey,
+            "annotateRef": page.pageKey,
+            "genericBookmarks": [Any](),
+            "ordinalRange": [0, 0],
+            "isNativeHtml": false,
+            "highlightedOrdinalRange": NSNull(),
+            "isMyDocument": true,
+            "isAiDocument": document.initials == "AIDocuments",
+            "myDocumentPageId": page.id.uuidString,
+            "sourcePromptId": promptId,
+            "sourcePromptName": NSNull(),
+            "sourceModelName": NSNull(),
+            "aiDocMarkers": [Any](),
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: renderedDocument, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /**
+     Converts stored raw My Documents content into the OSIS-template fragment consumed by Vue.js.
+
+     - Parameters:
+       - content: Raw page body stored in the local My Documents table.
+       - contentType: Stored content type matching Android's My Documents enum values.
+     - Returns: XML fragment string suitable for the rendered `osisFragment.xml` field.
+     - Side effects: None.
+     - Failure modes: None; OSIS content is trusted as caller-authored structured markup.
+     */
+    private func renderedXML(content: String, contentType: MyDocumentContentType) -> String {
+        switch contentType {
+        case .markdown:
+            return "<div class=\"mydoc-markdown\"><markdown>\(Self.escapeXML(content))</markdown></div>"
+        case .html:
+            return "<div class=\"mydoc-html\"><html>\(Self.escapeXML(content))</html></div>"
+        case .osis:
+            return content
+        }
+    }
+
+    /**
+     Escapes text content for XML wrapper fragments.
+
+     - Parameter text: Raw Markdown or HTML text from the local My Documents store.
+     - Returns: XML-safe text with the same character replacement set previously used by the
+       controller.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private static func escapeXML(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}


### PR DESCRIPTION
## Summary

Extracts My Documents active-page state and Android-compatible document payload assembly out of BibleReaderController into a focused coordinator.

## Scope

- Adds BibleReaderMyDocumentCoordinator for active local document/page identity, share text formatting, XML wrapping, and OsisDocument JSON creation.
- Updates BibleReaderController to delegate My Documents state and payload assembly while retaining bridge/store/WebView orchestration.
- Adds focused tests for active-page clearing and general-book payload shape.

## Contract references

- Android parity: My Documents continue to render as generated general-book documents with raw editable content accessed through bridge calls.
- GitNexus impact: setRenderedContentState was CRITICAL before edit; touched only to delegate the existing My Documents clearing rule. loadMyDocumentPage, helper extraction, and refreshMyDocumentAfterDeletingPage were LOW. Staged detect_changes on the worktree reported medium risk across three files.
- Issue: Refs #146.

## Change details

- Replaces controller-owned activeMyDocumentBookInitials and activeMyDocumentPageKey slots with BibleReaderMyDocumentCoordinator.
- Moves My Documents OsisDocument JSON and Markdown/HTML XML wrapper construction into the coordinator.
- Keeps SwiftData lookup, bridge responses, pasteboard writes, and WebView event emission in BibleReaderController.
- Fails closed if My Documents JSON serialization ever fails instead of emitting an empty invalid document object.

## Validation evidence

- RED: targeted coordinator tests failed before BibleReaderMyDocumentCoordinator existed.
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests/AndBibleTests/testReaderMyDocumentCoordinatorTracksActivePageUntilDifferentRenderedContent -only-testing:AndBibleTests/AndBibleTests/testReaderMyDocumentCoordinatorBuildsAndroidGeneralBookDocumentPayload
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests/AndBibleTests/testMyDocumentRawContentBridgeSendsAndroidCompatiblePayloadAndNullFallback -only-testing:AndBibleTests/AndBibleTests/testMyDocumentEditBridgePersistsContentAndReloadsVisiblePage -only-testing:AndBibleTests/AndBibleTests/testMyDocumentAIPageBridgeDeletesActivePageAndHandsOffRegeneration -only-testing:AndBibleTests/AndBibleTests/testReaderMyDocumentCoordinatorTracksActivePageUntilDifferentRenderedContent -only-testing:AndBibleTests/AndBibleTests/testReaderMyDocumentCoordinatorBuildsAndroidGeneralBookDocumentPayload
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests/AndBibleTests/testReaderConfigPayloadNormalizesInvalidPageScrollAmount -only-testing:AndBibleTests/AndBibleTests/testRestoredAndroidMultiDocumentRebuildsPayloadFromPersistedKey -only-testing:AndBibleTests/AndBibleTests/testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId -only-testing:AndBibleTests/AndBibleTests/testLoadCurrentContentEmitsBookIntroAndChapterMarkerForSecondCorinthiansOne -only-testing:AndBibleTests/AndBibleTests/testLoadCurrentContentEmitsRenderableChapterMarkerForSecondCorinthiansTwo -only-testing:AndBibleTests/AndBibleTests/testLoadCurrentContentDoesNotHighlightRestoredReadingPosition -only-testing:AndBibleTests/AndBibleTests/testLoadCurrentContentHighlightsExplicitVerseNavigationTarget -only-testing:AndBibleTests/AndBibleTests/testCommentaryMissingEntryUsesSelectedVerseKeyAndOrdinalRange
- xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" -only-testing:AndBibleTests: 592 tests, 0 failures
- python3 scripts/check_repo_standards.py docblocks
- python3 scripts/check_repo_standards.py docblocks --all-files
- git diff --check
- npx gitnexus analyze
- gitnexus detect_changes staged on the worktree path

## Risks / follow-ups

- This intentionally preserves the existing Android-style My Documents general-book payload contract.
- #146 remains open for the remaining controller ownership audit and final reassessment checklist items.

## Issue closure reference

Refs #146. Does not close #146 because the issue checklist still has remaining work.