### PR TITLE
feat(reader): align document chooser with Android behavior

### DIFF
--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1303,6 +1303,32 @@ extension AndBibleTests {
     }
 
     /**
+     Guards Android `DocumentSelectionBase` visual parity for the full document chooser.
+
+     Android renders `ChooseDocument` with an app-owned toolbar, inline language/search/type filters,
+     a visible document count, and `document_list_item` rows. iOS must not regress to a native
+     `NavigationStack`/`List`/`.searchable` sheet because that preserves iOS chrome instead of the
+     shared AndBible document-management surface.
+     */
+    func testBibleReaderDocumentChooserUsesAndroidDocumentSelectionLayout() throws {
+        let pickerSource = try bibleUISource(named: "BibleReaderModulePicker.swift")
+
+        XCTAssertTrue(pickerSource.contains("private var androidDocumentChooserScreen"))
+        XCTAssertTrue(pickerSource.contains("private var androidTopAppBar"))
+        XCTAssertTrue(pickerSource.contains("private func androidFilterBar(visibleDocumentCount: Int)"))
+        XCTAssertTrue(pickerSource.contains("private func androidDocumentRow(_ row: DocumentChooserRow)"))
+        XCTAssertTrue(pickerSource.contains("private func androidLanguageFilterMenu()"))
+        XCTAssertTrue(pickerSource.contains("private func androidSearchFilterField()"))
+        XCTAssertTrue(pickerSource.contains("private func androidDocumentTypeFilterMenu(visibleDocumentCount: Int)"))
+        XCTAssertTrue(pickerSource.contains("private var androidChooserOverflowMenu"))
+        XCTAssertTrue(pickerSource.contains("String(localized: \"document\", defaultValue: \"Document\")"))
+        XCTAssertTrue(pickerSource.contains(".toolbar(.hidden, for: .navigationBar)"))
+        XCTAssertFalse(pickerSource.contains("NavigationStack {\n            List {"))
+        XCTAssertFalse(pickerSource.contains(".searchable(text: $searchText"))
+        XCTAssertFalse(pickerSource.contains("Section(String(localized: \"document_filter_results"))
+    }
+
+    /**
      Protects Android `MainBibleActivity.menuForDocs` parity for the Bible toolbar quick menu.
 
      Android sorts quick-menu entries by language code and then book abbreviation, renders labels as

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1282,6 +1282,27 @@ extension AndBibleTests {
     }
 
     /**
+     Guards Android `ChooseDocument` routes against regressing to the iOS sheet host.
+
+     Android opens both the all-types chooser and category-scoped chooser as an app-owned
+     full-screen activity. The iOS coordinator state is private, so this source-level contract
+     checks the presentation boundary directly: document chooser routes must be filtered into a
+     full-screen cover, the generic reader-modal sheet must receive only non-chooser routes, and
+     the chooser view itself must not carry medium/large sheet detents.
+     */
+    func testBibleReaderDocumentChooserRoutesUseFullScreenCoverInsteadOfSheetDetents() throws {
+        let readerSource = try bibleUISource(named: "BibleReaderView.swift")
+        let pickerSource = try bibleUISource(named: "BibleReaderModulePicker.swift")
+
+        XCTAssertTrue(readerSource.contains("var isDocumentChooserRoute: Bool"))
+        XCTAssertTrue(readerSource.contains("case .modulePicker, .chooseDocument:"))
+        XCTAssertTrue(readerSource.contains(".sheet(item: readerSheetModalBinding)"))
+        XCTAssertTrue(readerSource.contains(".fullScreenCover(item: readerDocumentChooserModalBinding)"))
+        XCTAssertFalse(readerSource.contains(".sheet(item: $activeReaderModal)"))
+        XCTAssertFalse(pickerSource.contains(".presentationDetents([.medium, .large])"))
+    }
+
+    /**
      Protects Android `MainBibleActivity.menuForDocs` parity for the Bible toolbar quick menu.
 
      Android sorts quick-menu entries by language code and then book abbreviation, renders labels as

--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1115,6 +1115,117 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Guards Android `ChooseDocument` document-type parity beyond normal installed SWORD rows.
+
+     Android's chooser includes visible `FakeBookFactory` pseudo-documents, hides add-ons from
+     "All types", and exposes add-ons only through the Add-ons document-type filter. The language
+     filter also preserves AND_BIBLE rows, matching `DocumentSelectionBase.filterDocuments`.
+     */
+    func testBibleReaderModulePickerRowsIncludeAndroidPseudoDocumentsAndAddonFilter() {
+        let modules = [
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en"),
+            ModuleInfo(name: "MHC", description: "Matthew Henry", category: .commentary, language: "en"),
+            ModuleInfo(name: "BookA", description: "General reference book", category: .generalBook, language: "fr"),
+            ModuleInfo(name: "AddonFonts", description: "Font package", category: .addon, language: "zz"),
+            ModuleInfo(name: "Devotion", description: "Daily devotional", category: .dailyDevotion, language: "en")
+        ]
+
+        XCTAssertEqual(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .all,
+                selectedLanguage: "",
+                searchText: ""
+            ).map(\.id),
+            [
+                "module:KJV",
+                "module:MHC",
+                "module:BookA",
+                "pseudo:compare",
+                "pseudo:myNotes",
+                "pseudo:studyPads"
+            ]
+        )
+        XCTAssertEqual(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .category(.commentary),
+                selectedLanguage: "",
+                searchText: ""
+            ).map(\.id),
+            ["module:MHC", "pseudo:compare", "pseudo:myNotes"]
+        )
+        XCTAssertEqual(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .category(.generalBook),
+                selectedLanguage: "",
+                searchText: ""
+            ).map(\.id),
+            ["module:BookA", "pseudo:studyPads"]
+        )
+        XCTAssertEqual(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .addons,
+                selectedLanguage: "en",
+                searchText: ""
+            ).map(\.id),
+            ["module:AddonFonts"]
+        )
+        XCTAssertTrue(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .category(.bible),
+                selectedLanguage: "",
+                searchText: "notes"
+            ).isEmpty
+        )
+        XCTAssertEqual(
+            BibleReaderModulePicker.filteredRows(
+                modules,
+                selectedFilter: .all,
+                selectedLanguage: "",
+                searchText: "notes"
+            ).map(\.id),
+            ["pseudo:myNotes"]
+        )
+    }
+
+    /**
+     Verifies the picker exposes Android document management actions without inventing unlock.
+
+     Android shows About, Delete, and Delete Index for installed documents. iOS must reuse the real
+     module management services for those actions, while continuing to hide Unlock until there is a
+     cipher-key coordinator that can actually persist and apply encrypted module keys.
+     */
+    func testBibleReaderModulePickerRowActionsUseAndroidDocumentManagementContract() {
+        let plainModule = ModuleInfo(
+            name: "KJV",
+            description: "King James Version",
+            category: .bible,
+            language: "en"
+        )
+        let lockedModule = ModuleInfo(
+            name: "LOCKED",
+            description: "Locked Bible",
+            category: .bible,
+            language: "en",
+            isEncrypted: true,
+            isUnlocked: false
+        )
+
+        XCTAssertEqual(
+            BibleReaderModulePicker.rowActions(for: plainModule),
+            [.about, .uninstall, .deleteIndex]
+        )
+        XCTAssertEqual(
+            BibleReaderModulePicker.rowActions(for: lockedModule),
+            [.about, .uninstall, .deleteIndex]
+        )
+    }
+
     func testBibleReaderModulePickerMapsAndroidDocumentTypeCategories() {
         XCTAssertEqual(BibleReaderModulePicker.initialCategoryFilter(for: .bible), .bible)
         XCTAssertEqual(BibleReaderModulePicker.initialCategoryFilter(for: .commentary), .commentary)
@@ -1149,6 +1260,25 @@ extension AndBibleTests {
         XCTAssertTrue(selectionSource.contains("controller.switchMapDocument(to: module.name)"))
         XCTAssertFalse(selectionSource.contains("controller.switchMapModule(to: module.name)"))
         XCTAssertFalse(selectionSource.contains("controller.switchCategory(to: .map)"))
+    }
+
+    /**
+     Guards Android `FakeBookFactory.pseudoDocuments` routing for the full document chooser.
+
+     Android exposes My Notes, Journal/StudyPads, and Compare from `ChooseDocument`; it does not
+     expose the hidden Memorize document or the transient Multi document from that picker path.
+     */
+    func testBibleReaderModulePickerPseudoDocumentsRouteThroughAndroidEquivalents() throws {
+        let source = try bibleUISource(named: "BibleReaderModulePicker.swift")
+
+        XCTAssertTrue(source.contains("case .myNotes:"))
+        XCTAssertTrue(source.contains("controller.loadMyNotesDocument()"))
+        XCTAssertTrue(source.contains("case .studyPads:"))
+        XCTAssertTrue(source.contains("dismissAndPresentAuxiliaryBrowser(onOpenStudyPadSelector)"))
+        XCTAssertTrue(source.contains("case .compare:"))
+        XCTAssertTrue(source.contains("controller.loadCompareDocument()"))
+        XCTAssertFalse(source.contains("loadMultiReferenceDocument"))
+        XCTAssertFalse(source.contains("loadMemorizeDocument"))
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -236,6 +236,92 @@ extension AndBibleUITests {
         }
     }
 
+    /// Returns whether the identifier belongs to a control rendered inside the reader window tab bar.
+    func isWindowTabBarButtonIdentifier(_ identifier: String) -> Bool {
+        identifier.hasPrefix("windowTabButton::") ||
+            identifier == "windowTabAddButton" ||
+            identifier == "windowTabRestoreToggleButton" ||
+            identifier == "windowTabUnmaximizeButton"
+    }
+
+    /**
+     Resolves window-tab controls only through the tab bar container that owns them.
+
+     The bottom tab bar sits above web-reader content, and app-wide button snapshots can time out in
+     CI while XCTest walks the whole reader hierarchy. These controls always live in `windowTabBar`,
+     so callers should fail against that scoped contract instead of falling back to broad queries.
+     */
+    func windowTabBarButtonCandidates(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> [XCUIElement] {
+        [
+            app.scrollViews["windowTabBar"].firstMatch,
+            app.otherElements["windowTabBar"].firstMatch,
+        ].flatMap { tabBar in
+            [
+                tabBar.buttons[identifier].firstMatch,
+                tabBar.otherElements[identifier].firstMatch,
+            ]
+        }
+    }
+
+    /**
+     Resolves one tab-bar control without falling back to unrelated app-wide button queries.
+
+     - Parameters:
+       - identifier: Accessibility identifier for a button owned by `windowTabBar`.
+       - app: Running application under test.
+     - Returns: The first existing scoped tab-bar control, or `nil` when the tab bar has not exposed it.
+     - Side effects: none.
+     - Failure modes: none; callers decide whether absence should fail the test.
+     */
+    func resolvedWindowTabBarButton(
+        _ identifier: String,
+        in app: XCUIApplication
+    ) -> XCUIElement? {
+        windowTabBarButtonCandidates(identifier, in: app).first(where: { $0.exists })
+    }
+
+    /**
+     Requires one tab-bar control to appear under the `windowTabBar` accessibility container.
+
+     - Parameters:
+       - identifier: Accessibility identifier for a button owned by `windowTabBar`.
+       - app: Running application under test.
+       - timeout: Maximum time to wait for the scoped control.
+       - file: Source file used for XCTest failure attribution.
+       - line: Source line used for XCTest failure attribution.
+     - Returns: The resolved tab-bar button.
+     - Side effects: polls only the tab-bar subtree until the control appears.
+     - Failure modes: records an XCTest failure when the tab bar never exposes the requested control.
+     */
+    func requireWindowTabBarButton(
+        _ identifier: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCUIElement {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let element = resolvedWindowTabBarButton(identifier, in: app) {
+                return element
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let element = windowTabBarButtonCandidates(identifier, in: app).first ??
+            app.otherElements["windowTabBar"].firstMatch
+        XCTAssertTrue(
+            element.exists,
+            "Expected tab-bar control '\(identifier)' to exist within \(timeout) seconds.",
+            file: file,
+            line: line
+        )
+        return element
+    }
+
     /**
      Resolves lightweight state-export or status candidates without probing broad `Other` queries.
 
@@ -1432,7 +1518,7 @@ extension AndBibleUITests {
         line: UInt = #line
     ) {
         let identifier = "windowTabButton::\(order)"
-        let tabButton = requireElement(identifier, in: app, timeout: timeout, file: file, line: line)
+        let tabButton = requireWindowTabBarButton(identifier, in: app, timeout: timeout, file: file, line: line)
         tapElementReliably(tabButton, timeout: timeout, file: file, line: line)
 
         let deadline = Date().addingTimeInterval(timeout)
@@ -1484,7 +1570,7 @@ extension AndBibleUITests {
 
         for attempt in 1...2 {
             tapElementReliably(
-                requireElement("windowTabAddButton", in: app, timeout: timeout, file: file, line: line),
+                requireWindowTabBarButton("windowTabAddButton", in: app, timeout: timeout, file: file, line: line),
                 timeout: timeout,
                 file: file,
                 line: line
@@ -1492,7 +1578,7 @@ extension AndBibleUITests {
 
             let deadline = Date().addingTimeInterval(timeout)
             repeat {
-                if let tabButton = resolvedElement(identifier, in: app) {
+                if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
                     sawExpectedTab = true
                     lastTabValue = tabButton.value.map { "\($0)" } ?? "nil"
                     lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1508,6 +1508,107 @@ extension AndBibleUITests {
     }
 
     /**
+     Reads one semicolon-delimited token from the compact reader state export.
+
+     - Parameters:
+       - key: Token key without the trailing equals sign.
+       - state: Semicolon-delimited reader state export.
+     - Returns: The token value, or `nil` when the export does not contain the key.
+     - Side effects: none.
+     - Failure modes: malformed tokens are ignored and returned as absent.
+     */
+    func readerRenderedContentStateToken(_ key: String, in state: String) -> String? {
+        let prefix = "\(key)="
+        return state
+            .split(separator: ";")
+            .first { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)) }
+    }
+
+    /**
+     Reads the rendered window-tab order from the compact reader state export.
+
+     The footer renders tabs from `WindowManager.allWindows`; this state token mirrors that order so
+     coordinate fallback taps can target the real footer without walking the full SwiftUI/WebView
+     accessibility hierarchy.
+
+     - Parameters:
+       - app: Running application under test.
+     - Returns: Ordered tab button order numbers, or `nil` when the state export is unavailable.
+     - Side effects: snapshots only the compact reader state export.
+     - Failure modes: malformed order values are dropped; an empty token returns an empty array.
+     */
+    func windowTabOrdersFromReaderState(in app: XCUIApplication) -> [Int]? {
+        guard let state = readerRenderedContentStateValue(in: app),
+              let rawOrders = readerRenderedContentStateToken("windowTabOrders", in: state) else {
+            return nil
+        }
+        guard rawOrders != "none" else {
+            return []
+        }
+        return rawOrders
+            .split(separator: ",")
+            .compactMap { Int($0) }
+    }
+
+    /**
+     Taps a bottom window-tab button by deriving its real footer coordinate from exported tab order.
+
+     - Parameters:
+       - order: Window order number to activate.
+       - app: Running application under test.
+       - timeout: Maximum time to wait for the active-window state export after the tap.
+       - file: Source file used for XCTest failure attribution.
+       - line: Source line used for XCTest failure attribution.
+     - Returns: `true` when a coordinate tap was attempted and the reader state reports the requested
+       active window.
+     - Side effects:
+       - performs one real coordinate tap against the footer area
+       - polls the compact reader state export for the active window order
+     - Failure modes: returns `false` when tab-order metadata, app frame, or activation is unavailable.
+     */
+    func tapWindowTabAtExpectedFooterCoordinate(
+        _ order: Int,
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Bool {
+        guard let tabOrders = windowTabOrdersFromReaderState(in: app),
+              let tabIndex = tabOrders.firstIndex(of: order),
+              !tabOrders.isEmpty else {
+            return false
+        }
+
+        let appFrame = app.frame
+        guard elementFrameIsUsable(appFrame) else {
+            return false
+        }
+
+        let fixedButtonSize: CGFloat = 40
+        let spacing: CGFloat = 6
+        let trailingPadding: CGFloat = 12
+        let barHeight: CGFloat = 52
+        let tabsToRight = tabOrders.count - tabIndex - 1
+        let x = appFrame.maxX
+            - trailingPadding
+            - (fixedButtonSize / 2)
+            - (CGFloat(tabsToRight) * (fixedButtonSize + spacing))
+        let y = appFrame.maxY - (barHeight / 2)
+        guard appFrame.contains(CGPoint(x: x, y: y)) else {
+            return false
+        }
+
+        let origin = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        origin.withOffset(CGVector(dx: x - appFrame.minX, dy: y - appFrame.minY)).tap()
+        return waitForReaderRenderedContentStateIfPresent(
+            containing: "windowOrder=\(order)",
+            in: app,
+            timeout: timeout
+        )
+    }
+
+    /**
      Taps one bottom window-tab pill by order number and waits for its active state to surface.
      */
     func tapWindowTab(
@@ -1517,6 +1618,28 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        if readerRenderedContentStateContains("windowOrder=\(order)", in: app) {
+            return
+        }
+        if windowTabOrdersFromReaderState(in: app) != nil {
+            if tapWindowTabAtExpectedFooterCoordinate(
+                order,
+                in: app,
+                timeout: timeout,
+                file: file,
+                line: line
+            ) {
+                return
+            }
+            let finalState = readerRenderedContentStateValue(in: app) ?? "nil"
+            XCTFail(
+                "Expected footer coordinate tap for window tab \(order) to activate that window within \(timeout) seconds; final reader state was '\(finalState)'.",
+                file: file,
+                line: line
+            )
+            return
+        }
+
         let identifier = "windowTabButton::\(order)"
         let tabButton = requireWindowTabBarButton(identifier, in: app, timeout: timeout, file: file, line: line)
         tapElementReliably(tabButton, timeout: timeout, file: file, line: line)

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -277,7 +277,7 @@ extension AndBibleUITests {
         case "searchStateExport":
             return [
                 app.otherElements["searchScreen"].firstMatch,
-            ] + screenScopedStateCandidates(identifier, within: "searchScreen", in: app)
+            ]
         case "bookmarkListStateExport":
             return screenRootCandidates("bookmarkListScreen", in: app)
                 + screenScopedStateCandidates(identifier, within: "bookmarkListScreen", in: app)
@@ -417,7 +417,7 @@ extension AndBibleUITests {
         return titledCandidates
     }
 
-    /// Returns workspace-name prompt buttons without walking the custom sheet hierarchy.
+    /// Returns workspace-name prompt buttons without starting from expensive app-wide id queries.
     func workspaceNamePromptButtonCandidates(
         _ identifier: String,
         in app: XCUIApplication
@@ -432,19 +432,20 @@ extension AndBibleUITests {
             titles = []
         }
 
-        let directIdentifierCandidates = [
-            app.navigationBars.buttons[identifier].firstMatch,
-            app.toolbars.buttons[identifier].firstMatch,
-            app.buttons[identifier].firstMatch,
-            app.collectionViews.buttons[identifier].firstMatch,
-            app.tables.buttons[identifier].firstMatch,
-            app.scrollViews.buttons[identifier].firstMatch,
-            app.otherElements[identifier].firstMatch,
-        ]
+        let prompt = app.otherElements["workspaceNamePromptScreen"].firstMatch
+        let promptScopedCandidates = modalButtonCandidates(
+            in: prompt,
+            identifiers: [identifier],
+            titles: titles
+        )
         let directTitleCandidates = titles.map { title in
             app.buttons[title].firstMatch
         }
-        return directIdentifierCandidates + directTitleCandidates
+        let directIdentifierCandidates = [
+            app.buttons[identifier].firstMatch,
+            app.otherElements[identifier].firstMatch,
+        ]
+        return promptScopedCandidates + directTitleCandidates + directIdentifierCandidates
     }
 
     /// Returns screen-aware candidates for small exported semantic state controls.

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -265,7 +265,9 @@ extension AndBibleUITests {
      * Screen roots are preferred when they publish the same accessibility value and the screen is
      * stable because reading a known root avoids enumerating every `StaticText` in dynamic lists.
      * Transition-prone surfaces put the direct hidden export before the root so a temporarily
-     * absent sheet root does not register an XCTest snapshot failure during polling.
+     * absent sheet root does not register an XCTest snapshot failure during polling. Search is the
+     * exception because its root owns the same accessibility value and hosted XCTest can spend
+     * multiple retry cycles resolving the hidden static-text export while the root is already ready.
      */
     func semanticStateValueCandidates(
         for identifier: String,
@@ -273,9 +275,9 @@ extension AndBibleUITests {
     ) -> [XCUIElement] {
         switch identifier {
         case "searchStateExport":
-            return screenScopedStateCandidates(identifier, within: "searchScreen", in: app) + [
+            return [
                 app.otherElements["searchScreen"].firstMatch,
-            ]
+            ] + screenScopedStateCandidates(identifier, within: "searchScreen", in: app)
         case "bookmarkListStateExport":
             return screenRootCandidates("bookmarkListScreen", in: app)
                 + screenScopedStateCandidates(identifier, within: "bookmarkListScreen", in: app)

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -262,12 +262,9 @@ extension AndBibleUITests {
     /**
      Returns state-bearing elements in the order safest for repeated value polling.
      *
-     * Screen roots are preferred when they publish the same accessibility value and the screen is
-     * stable because reading a known root avoids enumerating every `StaticText` in dynamic lists.
-     * Transition-prone surfaces put the direct hidden export before the root so a temporarily
-     * absent sheet root does not register an XCTest snapshot failure during polling. Search is the
-     * exception because its root owns the same accessibility value and hosted XCTest can spend
-     * multiple retry cycles resolving the hidden static-text export while the root is already ready.
+     * Dedicated state exports are preferred before screen roots when available because they avoid
+     * snapshotting full dynamic surfaces. Screen roots remain fallbacks for states that publish the
+     * same compact value directly on the container.
      */
     func semanticStateValueCandidates(
         for identifier: String,
@@ -275,7 +272,7 @@ extension AndBibleUITests {
     ) -> [XCUIElement] {
         switch identifier {
         case "searchStateExport":
-            return [
+            return screenScopedStateCandidates(identifier, within: "searchScreen", in: app) + [
                 app.otherElements["searchScreen"].firstMatch,
             ]
         case "bookmarkListStateExport":

--- a/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -35,10 +35,10 @@ extension AndBibleUITests {
         )
         if let promptElement = waitForAnyElement(
             [
-                "workspaceNamePromptConfirmButton",
-                "workspaceNamePromptCancelButton",
                 "workspaceNamePromptScreen",
                 "workspaceNamePromptTextField",
+                "workspaceNamePromptConfirmButton",
+                "workspaceNamePromptCancelButton",
             ],
             in: app,
             timeout: timeout

--- a/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -146,6 +146,8 @@ extension AndBibleUITests {
      * - Side effects:
      *   - repeatedly samples the live XCUI hierarchy until the requested element exists or
      *     disappears
+     *   - keeps reader tab-bar controls scoped to `windowTabBar` so negative waits do not snapshot
+     *     the full reader hierarchy
      * - Failure modes:
      *   - records an XCTest failure when the element never reaches the requested existence state
      */
@@ -158,15 +160,21 @@ extension AndBibleUITests {
         line: UInt = #line
     ) {
         let deadline = Date().addingTimeInterval(timeout)
+        let resolveElement: () -> XCUIElement? = {
+            if self.isWindowTabBarButtonIdentifier(identifier) {
+                return self.resolvedWindowTabBarButton(identifier, in: app)
+            }
+            return self.resolvedElement(identifier, in: app)
+        }
         repeat {
-            let currentExists = resolvedElement(identifier, in: app) != nil
+            let currentExists = resolveElement() != nil
             if currentExists == shouldExist {
                 return
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        let currentExists = resolvedElement(identifier, in: app) != nil
+        let currentExists = resolveElement() != nil
         XCTAssertEqual(
             currentExists,
             shouldExist,

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -71,8 +71,7 @@ extension AndBibleUITests {
             return prePresentedSearch
         }
 
-        tapReaderSearchEntry(in: app, timeout: 15, file: file, line: line)
-        let searchScreen = requireSearchScreen(in: app, timeout: 20, file: file, line: line)
+        let searchScreen = presentSearchFromReader(in: app, timeout: 20, file: file, line: line)
         waitForSearchInteractionReady(
             on: searchScreen,
             in: app,
@@ -119,6 +118,78 @@ extension AndBibleUITests {
         } while Date() < deadline
 
         return nil
+    }
+
+    /**
+     Presents Search from the reader shell and verifies that the app actually entered Search state.
+
+     The adaptive SwiftUI toolbar can expose multiple Search button candidates while `ViewThatFits`
+     settles. XCTest can report a native tap as completed even when that resolved node did not invoke
+     the production action. This helper keeps Search opening condition-based: the direct toolbar path
+     is attempted first, but success is only accepted after either the reader state export reports
+     `searchVisible=true` or the Search root appears. If the direct path does not change state, the
+     helper falls back to the Android-style drawer action instead of waiting out the full presentation
+     budget on a failed tap assumption.
+     *
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - timeout: Maximum seconds to spend across direct and drawer activation paths.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Returns: The visible Search root once presentation is confirmed.
+     * - Side effects:
+     *   - taps the direct reader Search affordance
+     *   - may open the reader navigation drawer and tap its Search action when the direct tap does not
+     *     produce Search presentation state
+     *   - polls the compact reader state export and Search root accessibility identifier
+     * - Failure modes:
+     *   - records an XCTest failure when neither production activation path presents Search before
+     *     the timeout expires
+     */
+    func presentSearchFromReader(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 20,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCUIElement {
+        let deadline = Date().addingTimeInterval(timeout)
+        var attemptedDrawerFallback = false
+        var observedSearchVisibleState = false
+
+        tapReaderSearchEntry(in: app, timeout: min(10, timeout), file: file, line: line)
+
+        repeat {
+            if let searchScreen = resolvedSearchScreenElement(in: app) {
+                return searchScreen
+            }
+
+            if readerRenderedContentStateContains("searchVisible=true", in: app) {
+                observedSearchVisibleState = true
+            } else if !attemptedDrawerFallback,
+                      waitForReaderShellReady(in: app, timeout: 0.2) {
+                tapReaderAction(
+                    "readerOpenSearchAction",
+                    in: app,
+                    timeout: min(8, max(1, deadline.timeIntervalSinceNow)),
+                    file: file,
+                    line: line
+                )
+                attemptedDrawerFallback = true
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let searchScreen = unresolvedElement("searchScreen", in: app)
+        XCTAssertTrue(
+            searchScreen.exists,
+            "Expected Search to present from reader within \(timeout) seconds; "
+                + "observed searchVisible=\(observedSearchVisibleState), "
+                + "attemptedDrawerFallback=\(attemptedDrawerFallback).",
+            file: file,
+            line: line
+        )
+        return searchScreen
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -298,8 +298,8 @@ extension AndBibleUITests {
         line: UInt = #line
     ) {
         let deadline = Date().addingTimeInterval(timeout)
-        var lastState = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "nil")
-        var observedNeedsIndex = lastState.contains("state=needsIndex")
+        var lastState = "nil"
+        var observedNeedsIndex = false
         var observedCreatePrompt = false
         func failSeededFixtureReadiness() {
             let indexCreationRequested = observedNeedsIndex || observedCreatePrompt
@@ -315,7 +315,7 @@ extension AndBibleUITests {
         }
 
         while Date() < deadline {
-            let state = resolvedSearchStateValue(in: app) ?? (searchScreen.value as? String ?? "")
+            let state = resolvedSearchStateValue(in: app) ?? ""
             if !state.isEmpty {
                 lastState = state
             }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -173,7 +173,6 @@ struct BibleReaderModulePicker: View {
                 }
             }
         }
-        .presentationDetents([.medium, .large])
         .sheet(item: $selectedModuleDetails) { details in
             NavigationStack {
                 ModuleBrowserModuleDetailsView(details: details)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -3,15 +3,14 @@ import SwiftUI
 import SwordKit
 
 /**
- Presents document modules for the currently focused pane and routes selections through the same
- category switching outcomes as Android's `ChooseDocument` activity.
+ Presents document rows for the currently focused pane and routes selections through the same
+ document outcomes as Android's `ChooseDocument` activity.
 
- The reader coordinator owns whether the sheet is visible. This view owns Android-parity chooser
- state that can be represented with the current iOS module model: document type filtering,
- all-language default filtering, free-text module search, active-module marking, and the direct
- Downloads handoff. Android pseudo-documents, encrypted-module unlock prompts, and long-press
- about/delete actions are documented as separate gaps because this picker currently receives only
- installed `ModuleInfo` values and has no module mutation or cipher-key coordinator.
+ Android's chooser is not only a list of installed SWORD text modules. It also exposes the visible
+ `FakeBookFactory` pseudo-documents, hides add-ons from "All types", exposes add-ons through their
+ own filter, and offers document management actions from the row context menu. This view keeps that
+ parity contract in pure filtering helpers so tests can protect the Android behavior independently
+ from SwiftUI rendering details.
  */
 struct BibleReaderModulePicker: View {
     let controller: BibleReaderController
@@ -21,9 +20,13 @@ struct BibleReaderModulePicker: View {
     let onOpenDictionaryBrowser: () -> Void
     let onOpenGeneralBookBrowser: () -> Void
     let onOpenMapBrowser: () -> Void
+    let onOpenStudyPadSelector: () -> Void
 
-    /// Selected Android document-type filter; `nil` represents the Android "All types" row.
-    @State private var selectedCategory: DocumentCategory?
+    /// Search-index service used by Android's Delete Index row action.
+    @Environment(SearchIndexService.self) private var searchIndexService
+
+    /// Selected Android document-type filter.
+    @State private var selectedFilter: DocumentTypeFilter
 
     /// Selected ISO language code, or an empty string for Android's all-language default.
     @State private var selectedLanguage = ""
@@ -31,11 +34,23 @@ struct BibleReaderModulePicker: View {
     /// Free-text filter applied to module initials, descriptions, category labels, and language.
     @State private var searchText = ""
 
+    /// Details sheet payload for Android's About row action.
+    @State private var selectedModuleDetails: ModuleBrowserModuleDetails?
+
+    /// Confirmation payload for destructive Android document actions.
+    @State private var pendingRowActionConfirmation: ModuleBrowserRowActionConfirmation?
+
+    /// Last row-action failure surfaced to the user.
+    @State private var rowActionErrorMessage: String?
+
+    /// Repository service used by Android's Delete document row action.
+    private let repository = ModuleRepository()
+
     /**
-     Creates a pane-scoped module picker with Android-compatible initial type selection.
+     Creates a pane-scoped document picker with Android-compatible initial type selection.
 
      - Parameters:
-       - controller: Ready reader controller whose installed modules and switch actions back the picker.
+       - controller: Ready reader controller whose installed modules and document actions back the picker.
        - category: Category requested by the caller. This becomes the initial document-type filter,
          matching Android's `type` intent extra for Bible/commentary launches.
        - startsWithAllTypes: Whether the picker should start on Android's "All types" filter. Use
@@ -46,13 +61,14 @@ struct BibleReaderModulePicker: View {
        - onOpenDictionaryBrowser: Follow-up browser route used after selecting a dictionary module.
        - onOpenGeneralBookBrowser: Follow-up browser route used after selecting a general book.
        - onOpenMapBrowser: Follow-up browser route used after selecting a map module.
+       - onOpenStudyPadSelector: Follow-up route for Android's visible Journal/StudyPad pseudo-document.
 
      Side effects:
      - initializes SwiftUI state only; controller mutations happen later from row selection.
 
      Failure modes:
      - The caller must wait for a ready pane controller before constructing the picker; a missing
-       controller is a pane-readiness state, not an empty installed-module state.
+       controller is a pane-readiness state, not an empty installed-document state.
      */
     init(
         controller: BibleReaderController,
@@ -62,7 +78,8 @@ struct BibleReaderModulePicker: View {
         onOpenDownloads: @escaping () -> Void,
         onOpenDictionaryBrowser: @escaping () -> Void,
         onOpenGeneralBookBrowser: @escaping () -> Void,
-        onOpenMapBrowser: @escaping () -> Void
+        onOpenMapBrowser: @escaping () -> Void,
+        onOpenStudyPadSelector: @escaping () -> Void = {}
     ) {
         self.controller = controller
         self.category = category
@@ -71,60 +88,65 @@ struct BibleReaderModulePicker: View {
         self.onOpenDictionaryBrowser = onOpenDictionaryBrowser
         self.onOpenGeneralBookBrowser = onOpenGeneralBookBrowser
         self.onOpenMapBrowser = onOpenMapBrowser
-        _selectedCategory = State(initialValue: startsWithAllTypes ? nil : Self.initialCategoryFilter(for: category))
+        self.onOpenStudyPadSelector = onOpenStudyPadSelector
+        _selectedFilter = State(initialValue: startsWithAllTypes ? .all : Self.initialDocumentTypeFilter(for: category))
     }
 
     /**
-     All installed modules that Android's `ChooseDocument` category spinner can expose.
+     All installed modules Android's document-type spinner can expose.
 
-     - Returns: Installed Bible, commentary, dictionary, general book, and map modules from the
-       active reader controller, de-duplicated by module initials.
+     - Returns: Installed Bible, commentary, dictionary, general book, map, and add-on modules,
+       de-duplicated by module initials.
      */
     private var allSelectableModules: [ModuleInfo] {
-        let categoryOrder = Self.categoryFilterOrder.compactMap { $0 }
         var seen = Set<String>()
-        return categoryOrder.flatMap { controller.installedModules(for: $0) }
-            .filter { seen.insert($0.name).inserted }
+        let documentModules = Self.documentCategoryFilterOrder
+            .flatMap { controller.installedModules(for: $0) }
+        let addonModules = controller.swordManager?.installedModules(category: .addon) ?? []
+
+        return (documentModules + addonModules).filter { seen.insert($0.name).inserted }
     }
 
-    /// Modules after applying Android-compatible type, language, and free-text filters.
-    private var filteredModules: [ModuleInfo] {
-        Self.filteredModules(
+    /// Android chooser rows before filters are applied.
+    private var allRows: [DocumentChooserRow] {
+        Self.allRows(from: allSelectableModules)
+    }
+
+    /// Rows after applying Android-compatible type, language, and free-text filters.
+    private var filteredDocumentRows: [DocumentChooserRow] {
+        Self.filteredRows(
             allSelectableModules,
-            selectedCategory: selectedCategory,
+            selectedFilter: selectedFilter,
             selectedLanguage: selectedLanguage,
             searchText: searchText
         )
     }
 
-    /// Language choices built from the complete installed chooser dataset, sorted alphabetically.
+    /// Language choices built from the complete chooser dataset, sorted alphabetically.
     private var availableLanguages: [String] {
-        Self.availableLanguages(from: allSelectableModules)
+        Self.availableLanguages(from: allRows)
     }
 
-    /// Whether the active document type has no installed modules before language/search filtering.
-    private var shouldShowCategoryEmptyState: Bool {
-        Self.shouldShowCategoryEmptyState(
-            allSelectableModules,
-            selectedCategory: selectedCategory
-        )
+    /// Whether the active document type has no rows before language/search filtering.
+    private var shouldShowFilterEmptyState: Bool {
+        Self.shouldShowFilterEmptyState(allRows, selectedFilter: selectedFilter)
     }
 
     /**
      Builds the Android-style document chooser surface with type/language filters, search, rows,
-     and a persistent Downloads handoff.
+     row actions, and a persistent Downloads handoff.
      */
     var body: some View {
         NavigationStack {
             List {
                 filterControls
 
-                if allSelectableModules.isEmpty || shouldShowCategoryEmptyState {
+                if shouldShowFilterEmptyState {
                     emptyState
-                } else if filteredModules.isEmpty {
+                } else if filteredDocumentRows.isEmpty {
                     noMatchesState
                 } else {
-                    moduleRows
+                    documentRows
                 }
             }
             .accessibilityIdentifier("modulePickerScreen")
@@ -146,12 +168,64 @@ struct BibleReaderModulePicker: View {
             }
             .onChange(of: searchText) { oldValue, newValue in
                 if oldValue.isEmpty && !newValue.isEmpty {
-                    selectedCategory = nil
+                    selectedFilter = .all
                     selectedLanguage = ""
                 }
             }
         }
         .presentationDetents([.medium, .large])
+        .sheet(item: $selectedModuleDetails) { details in
+            NavigationStack {
+                ModuleBrowserModuleDetailsView(details: details)
+            }
+        }
+        .alert(
+            pendingRowActionConfirmation?.title ?? "",
+            isPresented: Binding(
+                get: { pendingRowActionConfirmation != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        pendingRowActionConfirmation = nil
+                    }
+                }
+            ),
+            presenting: pendingRowActionConfirmation
+        ) { confirmation in
+            switch confirmation.kind {
+            case .uninstall:
+                Button(String(localized: "uninstall"), role: .destructive) {
+                    uninstallInstalledModule(confirmation.moduleName)
+                    pendingRowActionConfirmation = nil
+                }
+            case .deleteIndex:
+                Button(String(localized: "delete_module_index", defaultValue: "Delete Index"), role: .destructive) {
+                    deleteModuleIndex(confirmation.moduleName)
+                    pendingRowActionConfirmation = nil
+                }
+            }
+            Button(String(localized: "cancel"), role: .cancel) {
+                pendingRowActionConfirmation = nil
+            }
+        } message: { confirmation in
+            Text(confirmation.message)
+        }
+        .alert(
+            String(localized: "document_action_failed", defaultValue: "Document action failed"),
+            isPresented: Binding(
+                get: { rowActionErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        rowActionErrorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button(String(localized: "okay", defaultValue: "OK"), role: .cancel) {
+                rowActionErrorMessage = nil
+            }
+        } message: {
+            Text(rowActionErrorMessage ?? "")
+        }
     }
 
     /**
@@ -162,9 +236,9 @@ struct BibleReaderModulePicker: View {
      */
     private var filterControls: some View {
         Section {
-            Picker(String(localized: "document_type", defaultValue: "Document type"), selection: $selectedCategory) {
-                ForEach(Self.categoryFilterOrder, id: \.self) { category in
-                    Text(Self.categoryFilterTitle(for: category)).tag(category)
+            Picker(String(localized: "document_type", defaultValue: "Document type"), selection: $selectedFilter) {
+                ForEach(Self.documentTypeFilterOrder, id: \.self) { filter in
+                    Text(Self.documentTypeFilterTitle(for: filter)).tag(filter)
                 }
             }
             .pickerStyle(.menu)
@@ -185,7 +259,7 @@ struct BibleReaderModulePicker: View {
         }
     }
 
-    /// Empty state shown when no installed modules exist for the chooser at all.
+    /// Empty state shown when no installed or pseudo rows exist for the selected document type.
     private var emptyState: some View {
         VStack(spacing: 12) {
             Text(emptyMessage)
@@ -198,29 +272,46 @@ struct BibleReaderModulePicker: View {
         .padding(.vertical)
     }
 
-    /// Empty state shown when installed modules exist but the active filters hide all rows.
+    /// Empty state shown when chooser rows exist but the active filters hide all rows.
     private var noMatchesState: some View {
         Text(String(localized: "no_modules_match_filters"))
             .foregroundStyle(.secondary)
     }
 
-    /// Rows for the currently filtered module set.
-    private var moduleRows: some View {
-        Section(String(localized: "document_filter_results \(filteredModules.count)")) {
-            ForEach(filteredModules, id: \.name) { module in
-                moduleRow(module)
+    /// Rows for the currently filtered document set.
+    private var documentRows: some View {
+        Section(String(localized: "document_filter_results \(filteredDocumentRows.count)")) {
+            ForEach(filteredDocumentRows) { row in
+                documentRow(row)
             }
         }
     }
 
     /**
-     Builds one selectable module row with active-state and lock-state affordances.
+     Builds one selectable document row.
+
+     - Parameter row: Installed module or Android visible pseudo-document.
+     - Returns: A row that performs the Android-equivalent document action when selected.
+     */
+    @ViewBuilder
+    private func documentRow(_ row: DocumentChooserRow) -> some View {
+        switch row {
+        case .module(let module):
+            moduleRow(module)
+        case .pseudoDocument(let document):
+            pseudoDocumentRow(document)
+        }
+    }
+
+    /**
+     Builds one selectable module row with active-state, lock-state, and management affordances.
 
      - Parameter module: Installed module metadata from the active reader controller.
      - Returns: A row that switches to the module's own category when selected.
      */
     private func moduleRow(_ module: ModuleInfo) -> some View {
-        Button {
+        let actions = Self.rowActions(for: module)
+        return Button {
             select(module)
         } label: {
             HStack {
@@ -241,7 +332,7 @@ struct BibleReaderModulePicker: View {
                         .lineLimit(2)
                     HStack(spacing: 6) {
                         Text(Self.displayName(for: module.language))
-                        Text(Self.categoryFilterTitle(for: Self.documentCategory(for: module.category)))
+                        Text(Self.moduleCategoryTitle(for: module.category))
                     }
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
@@ -257,19 +348,92 @@ struct BibleReaderModulePicker: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("modulePickerRow::\(module.name)")
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if actions.contains(.uninstall) {
+                Button(role: .destructive) {
+                    pendingRowActionConfirmation = confirmation(.uninstall, for: module)
+                } label: {
+                    Label(String(localized: "uninstall"), systemImage: "trash")
+                }
+            }
+        }
+        .contextMenu {
+            if actions.contains(.about) {
+                Button {
+                    selectedModuleDetails = moduleDetails(for: module)
+                } label: {
+                    Label(String(localized: "about"), systemImage: "info.circle")
+                }
+            }
+            if actions.contains(.uninstall) {
+                Button(role: .destructive) {
+                    pendingRowActionConfirmation = confirmation(.uninstall, for: module)
+                } label: {
+                    Label(String(localized: "uninstall"), systemImage: "trash")
+                }
+            }
+            if actions.contains(.deleteIndex) {
+                Button(role: .destructive) {
+                    pendingRowActionConfirmation = confirmation(.deleteIndex, for: module)
+                } label: {
+                    Label(
+                        String(localized: "delete_module_index", defaultValue: "Delete Index"),
+                        systemImage: "magnifyingglass"
+                    )
+                }
+            }
+        }
     }
 
-    /// Message shown when the requested category has no installed modules.
+    /**
+     Builds one Android visible pseudo-document row.
+
+     - Parameter document: Pseudo-document identity from Android `FakeBookFactory`.
+     - Returns: A row that opens the equivalent iOS reader document or selector.
+     */
+    private func pseudoDocumentRow(_ document: AndroidPseudoDocument) -> some View {
+        Button {
+            select(document)
+        } label: {
+            HStack {
+                Image(systemName: document.iconName)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(document.title)
+                        .font(.headline)
+                    Text(document.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        Text(Self.displayName(for: document.language))
+                        Text(Self.categoryFilterTitle(for: document.category))
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("modulePickerPseudoRow::\(document.rawValue)")
+    }
+
+    /// Message shown when the requested filter has no selectable rows.
     private var emptyMessage: String {
-        switch selectedCategory ?? category {
-        case .commentary:
+        switch selectedFilter {
+        case .category(.commentary):
             return String(localized: "picker_no_commentary_modules")
-        case .dictionary:
+        case .category(.dictionary):
             return String(localized: "picker_no_dictionary_modules")
-        case .generalBook:
+        case .category(.generalBook):
             return String(localized: "picker_no_general_book_modules")
-        case .map:
+        case .category(.map):
             return String(localized: "picker_no_map_modules")
+        case .addons:
+            return String(localized: "picker_no_addon_modules", defaultValue: "No add-ons installed")
         default:
             return String(localized: "picker_no_bible_modules")
         }
@@ -285,17 +449,16 @@ struct BibleReaderModulePicker: View {
 
      - Parameter module: Installed module selected from the chooser.
      Side effects:
-     - mutates the reader controller's active module/category
-     - dismisses the chooser
+     - mutates the reader controller's active module/category for normal reader modules
+     - dismisses the chooser for selectable reader documents
      - opens the auxiliary browser for dictionary, general book, or map selections
 
      Failure modes:
-     - unsupported module categories dismiss without mutation because Android-only pseudo-doc rows
-       are not represented by `ModuleInfo`
+     - add-on rows are intentionally non-selecting, matching Android's AND_BIBLE guard in
+       `ChooseDocument.handleDocumentSelection`.
      */
     private func select(_ module: ModuleInfo) {
         guard let selectedDocumentCategory = Self.documentCategory(for: module.category) else {
-            onDismiss()
             return
         }
 
@@ -315,6 +478,33 @@ struct BibleReaderModulePicker: View {
         default:
             controller.switchBibleDocument(to: module.name)
             onDismiss()
+        }
+    }
+
+    /**
+     Selects one Android visible pseudo-document.
+
+     - Parameter document: Pseudo-document row selected by the user.
+     Side effects:
+     - dismisses the chooser
+     - opens My Notes, Compare, or the StudyPad selector through existing reader routes
+
+     Failure modes:
+     - pseudo-document loading keeps the existing controller guards; a not-ready web client simply
+       ignores the load, matching other reader document actions.
+     */
+    private func select(_ document: AndroidPseudoDocument) {
+        switch document {
+        case .myNotes:
+            dismissAndPerform {
+                controller.loadMyNotesDocument()
+            }
+        case .studyPads:
+            dismissAndPresentAuxiliaryBrowser(onOpenStudyPadSelector)
+        case .compare:
+            dismissAndPerform {
+                controller.loadCompareDocument()
+            }
         }
     }
 
@@ -352,22 +542,138 @@ struct BibleReaderModulePicker: View {
      - schedules the browser presentation after the sheet transition delay
      */
     private func dismissAndPresentAuxiliaryBrowser(_ presentation: @escaping () -> Void) {
+        dismissAndPerform(presentation)
+    }
+
+    /**
+     Dismisses the picker before performing a reader action.
+
+     - Parameter action: Work to run after the sheet transition delay.
+     Side effects:
+     - invokes `onDismiss`
+     - schedules `action` on the main queue
+     */
+    private func dismissAndPerform(_ action: @escaping () -> Void) {
         onDismiss()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            presentation()
+            action()
         }
     }
 
     /**
-     Filters and sorts installed modules using Android `DocumentSelectionBase` semantics that are
-     representable with iOS `ModuleInfo`.
+     Builds the shared About sheet payload for an installed module.
+
+     - Parameter module: Installed module selected from the chooser.
+     - Returns: Details payload compatible with the Downloads About sheet.
+     */
+    private func moduleDetails(for module: ModuleInfo) -> ModuleBrowserModuleDetails {
+        ModuleBrowserModuleDetails(
+            module: Self.remoteModuleInfo(for: module),
+            installedModule: module
+        )
+    }
+
+    /**
+     Builds a destructive action confirmation payload for an installed module.
+
+     - Parameters:
+       - kind: Destructive operation to confirm.
+       - module: Installed module selected from the chooser.
+     - Returns: Confirmation payload shared with Downloads row actions.
+     */
+    private func confirmation(
+        _ kind: ModuleBrowserRowActionConfirmation.Kind,
+        for module: ModuleInfo
+    ) -> ModuleBrowserRowActionConfirmation {
+        ModuleBrowserRowActionConfirmation(
+            kind: kind,
+            module: Self.remoteModuleInfo(for: module)
+        )
+    }
+
+    /**
+     Uninstalls one installed module using the same repository service as Downloads.
+
+     - Parameter name: Module initials to remove from local storage.
+     Side effects:
+     - deletes module files off the main actor
+     - `ModuleRepository` posts the module-store notification used by reader controllers to refresh
+     - records failures for a user-visible alert
+     */
+    private func uninstallInstalledModule(_ name: String) {
+        let repository = repository
+
+        Task {
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try repository.uninstallModule(named: name)
+                }.value
+            } catch {
+                await MainActor.run {
+                    rowActionErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    /**
+     Deletes one installed module's local search index.
+
+     - Parameter name: Module initials whose search index should be deleted.
+     Side effects:
+     - delegates to `SearchIndexService`, whose missing-index behavior is intentionally harmless
+     */
+    private func deleteModuleIndex(_ name: String) {
+        Task {
+            await searchIndexService.deleteIndex(for: name)
+        }
+    }
+
+    /**
+     Builds all Android chooser rows from installed modules and visible pseudo-documents.
+
+     - Parameter modules: Installed module snapshots.
+     - Returns: Installed module rows plus My Notes, StudyPads, and Compare pseudo-document rows.
+     */
+    static func allRows(from modules: [ModuleInfo]) -> [DocumentChooserRow] {
+        modules.map(DocumentChooserRow.module) +
+            visibleAndroidPseudoDocuments.map(DocumentChooserRow.pseudoDocument)
+    }
+
+    /**
+     Filters and sorts chooser rows using Android `DocumentSelectionBase` semantics.
+
+     - Parameters:
+       - modules: Complete installed-module set.
+       - selectedFilter: Android document-type filter.
+       - selectedLanguage: ISO language filter, or empty for all languages.
+       - searchText: Free-text search over initials, description, category, and language.
+     - Returns: Filtered rows sorted by Android category/status order and localized initials.
+     */
+    static func filteredRows(
+        _ modules: [ModuleInfo],
+        selectedFilter: DocumentTypeFilter,
+        selectedLanguage: String,
+        searchText: String
+    ) -> [DocumentChooserRow] {
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return allRows(from: modules).filter { row in
+            rowMatchesFilter(row, selectedFilter: selectedFilter) &&
+            rowMatchesLanguage(row, selectedLanguage: selectedLanguage) &&
+            rowMatchesSearch(row, searchText: trimmedSearch)
+        }
+        .sorted(by: sortRows)
+    }
+
+    /**
+     Filters and sorts installed modules using the legacy module-only projection.
 
      - Parameters:
        - modules: Complete installed-module set.
        - selectedCategory: Optional document-type filter, with `nil` meaning all types.
        - selectedLanguage: ISO language filter, or empty for all languages.
        - searchText: Free-text search over initials, description, category, and language.
-     - Returns: Filtered modules sorted by Android category order and localized initials.
+     - Returns: Filtered normal reader modules sorted by Android category order and initials.
      */
     static func filteredModules(
         _ modules: [ModuleInfo],
@@ -375,15 +681,20 @@ struct BibleReaderModulePicker: View {
         selectedLanguage: String,
         searchText: String
     ) -> [ModuleInfo] {
-        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return modules.filter { module in
-            let documentCategory = documentCategory(for: module.category)
-            let matchesCategory = selectedCategory.map { $0 == documentCategory } ?? true
-            let matchesLanguage = selectedLanguage.isEmpty || module.language == selectedLanguage
-            let matchesSearch = trimmedSearch.isEmpty || moduleMatchesSearch(module, searchText: trimmedSearch)
-            return matchesCategory && matchesLanguage && matchesSearch && documentCategory != nil
+        let selectedFilter = selectedCategory.map(DocumentTypeFilter.category) ?? .all
+        return filteredRows(
+            modules,
+            selectedFilter: selectedFilter,
+            selectedLanguage: selectedLanguage,
+            searchText: searchText
+        )
+        .compactMap { row in
+            guard case .module(let module) = row,
+                  documentCategory(for: module.category) != nil else {
+                return nil
+            }
+            return module
         }
-        .sorted(by: sortModules)
     }
 
     /**
@@ -393,7 +704,17 @@ struct BibleReaderModulePicker: View {
      - Returns: Unique ISO language codes sorted by localized display name.
      */
     static func availableLanguages(from modules: [ModuleInfo]) -> [String] {
-        Array(Set(modules.map(\.language))).sorted {
+        availableLanguages(from: allRows(from: modules))
+    }
+
+    /**
+     Builds the alphabetized language list shown in the chooser language filter.
+
+     - Parameter rows: Complete chooser row set.
+     - Returns: Unique ISO language codes sorted by localized display name.
+     */
+    static func availableLanguages(from rows: [DocumentChooserRow]) -> [String] {
+        Array(Set(rows.map(\.language))).sorted {
             displayName(for: $0).localizedCaseInsensitiveCompare(displayName(for: $1)) == .orderedAscending
         }
     }
@@ -411,15 +732,31 @@ struct BibleReaderModulePicker: View {
         _ modules: [ModuleInfo],
         selectedCategory: DocumentCategory?
     ) -> Bool {
-        guard let selectedCategory else { return false }
-        return !modules.contains { documentCategory(for: $0.category) == selectedCategory }
+        let selectedFilter = selectedCategory.map(DocumentTypeFilter.category) ?? .all
+        return shouldShowFilterEmptyState(allRows(from: modules), selectedFilter: selectedFilter)
+    }
+
+    /**
+     Tests whether the selected Android document type has no rows before language/search filtering.
+
+     - Parameters:
+       - rows: Complete chooser row set.
+       - selectedFilter: Android document-type filter.
+     - Returns: `true` only when a concrete type has no matching chooser rows.
+     */
+    static func shouldShowFilterEmptyState(
+        _ rows: [DocumentChooserRow],
+        selectedFilter: DocumentTypeFilter
+    ) -> Bool {
+        guard selectedFilter != .all else { return false }
+        return !rows.contains { rowMatchesFilter($0, selectedFilter: selectedFilter) }
     }
 
     /**
      Maps SWORD module categories into reader document categories that Android exposes.
 
      - Parameter moduleCategory: Category reported by SWORD metadata.
-     - Returns: Matching reader document category, or `nil` for unsupported pseudo/add-on types.
+     - Returns: Matching reader document category, or `nil` for add-on and unsupported types.
      */
     static func documentCategory(for moduleCategory: ModuleCategory) -> DocumentCategory? {
         switch moduleCategory {
@@ -445,7 +782,32 @@ struct BibleReaderModulePicker: View {
      - Returns: The category when Android has a matching document-type row; otherwise all types.
      */
     static func initialCategoryFilter(for category: DocumentCategory) -> DocumentCategory? {
-        categoryFilterOrder.contains { $0 == category } ? category : nil
+        documentCategoryFilterOrder.contains(category) ? category : nil
+    }
+
+    /**
+     Determines the initial Android document-type filter for the requested chooser category.
+
+     - Parameter category: Category requested by the reader action.
+     - Returns: Matching document-type filter or `.all` when Android has no matching row.
+     */
+    static func initialDocumentTypeFilter(for category: DocumentCategory) -> DocumentTypeFilter {
+        initialCategoryFilter(for: category).map(DocumentTypeFilter.category) ?? .all
+    }
+
+    /**
+     Computes Android contextual document actions for an installed chooser row.
+
+     - Parameter module: Installed module metadata.
+     - Returns: Ordered Android row actions. Unlock remains hidden until iOS has a real cipher-key
+       coordinator, matching the Downloads planner contract.
+     */
+    static func rowActions(for module: ModuleInfo) -> [ModuleDownloadRowAction] {
+        ModuleDownloadRowActionPlanner.availableActions(
+            installedModule: module,
+            isBeingInstalled: false,
+            supportsUnlock: false
+        )
     }
 
     /**
@@ -458,9 +820,19 @@ struct BibleReaderModulePicker: View {
         Locale.current.localizedString(forLanguageCode: languageCode) ?? languageCode.uppercased()
     }
 
-    /// Android document-type filter order, with `nil` representing "All types".
-    private static let categoryFilterOrder: [DocumentCategory?] = [
-        nil,
+    /// Android document-type filter order.
+    static let documentTypeFilterOrder: [DocumentTypeFilter] = [
+        .all,
+        .category(.bible),
+        .category(.commentary),
+        .category(.dictionary),
+        .category(.generalBook),
+        .category(.map),
+        .addons
+    ]
+
+    /// Android normal document category filter order, excluding All types and Add-ons.
+    private static let documentCategoryFilterOrder: [DocumentCategory] = [
         .bible,
         .commentary,
         .dictionary,
@@ -468,16 +840,38 @@ struct BibleReaderModulePicker: View {
         .map
     ]
 
+    /// Android visible `FakeBookFactory.pseudoDocuments`, excluding hidden Memorize and non-chooser Multi.
+    private static let visibleAndroidPseudoDocuments: [AndroidPseudoDocument] = [
+        .myNotes,
+        .studyPads,
+        .compare
+    ]
+
     /**
      Returns the localized title for one document-type filter row.
 
-     - Parameter category: Optional reader category, where `nil` means all types.
+     - Parameter filter: Android document-type filter.
      - Returns: Localized picker label matching Android's document-type list.
      */
-    private static func categoryFilterTitle(for category: DocumentCategory?) -> String {
-        switch category {
-        case nil:
+    private static func documentTypeFilterTitle(for filter: DocumentTypeFilter) -> String {
+        switch filter {
+        case .all:
             return String(localized: "doc_type_all", defaultValue: "All types")
+        case .category(let category):
+            return categoryFilterTitle(for: category)
+        case .addons:
+            return String(localized: "doc_type_addons", defaultValue: "Add-ons")
+        }
+    }
+
+    /**
+     Returns the localized title for one normal document category row.
+
+     - Parameter category: Reader category.
+     - Returns: Localized picker label matching Android's document-type list.
+     */
+    private static func categoryFilterTitle(for category: DocumentCategory) -> String {
+        switch category {
         case .bible:
             return String(localized: "bibles")
         case .commentary:
@@ -494,43 +888,345 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Tests whether one module matches the free-text chooser search.
+     Returns the localized title for one installed module category.
+
+     - Parameter moduleCategory: SWORD module category.
+     - Returns: Localized picker label matching Android's document-type list.
+     */
+    private static func moduleCategoryTitle(for moduleCategory: ModuleCategory) -> String {
+        if moduleCategory == .addon {
+            return documentTypeFilterTitle(for: .addons)
+        }
+        return categoryFilterTitle(for: documentCategory(for: moduleCategory) ?? .bible)
+    }
+
+    /**
+     Tests whether one row matches the active document-type filter.
 
      - Parameters:
-       - module: Installed module metadata.
-       - searchText: Trimmed, non-empty search text.
+       - row: Installed module or pseudo-document row.
+       - selectedFilter: Android document-type filter.
+     - Returns: `true` when the row belongs in the filter.
+     */
+    private static func rowMatchesFilter(
+        _ row: DocumentChooserRow,
+        selectedFilter: DocumentTypeFilter
+    ) -> Bool {
+        switch selectedFilter {
+        case .all:
+            return row.documentCategory != nil && !row.isAndroidAddon
+        case .category(let category):
+            return row.documentCategory == category
+        case .addons:
+            return row.isAndroidAddon
+        }
+    }
+
+    /**
+     Tests whether one row matches the active language filter.
+
+     - Parameters:
+       - row: Installed module or pseudo-document row.
+       - selectedLanguage: ISO language filter, or empty for all languages.
+     - Returns: `true` when the row should survive language filtering.
+     */
+    private static func rowMatchesLanguage(
+        _ row: DocumentChooserRow,
+        selectedLanguage: String
+    ) -> Bool {
+        selectedLanguage.isEmpty || row.language == selectedLanguage || row.isAndroidAddon
+    }
+
+    /**
+     Tests whether one row matches the free-text chooser search.
+
+     - Parameters:
+       - row: Installed module or pseudo-document row.
+       - searchText: Trimmed search text.
      - Returns: `true` when initials, description, language, or category text contains the query.
      */
-    private static func moduleMatchesSearch(_ module: ModuleInfo, searchText: String) -> Bool {
-        module.name.localizedCaseInsensitiveContains(searchText) ||
-        module.description.localizedCaseInsensitiveContains(searchText) ||
-        module.language.localizedCaseInsensitiveContains(searchText) ||
-        displayName(for: module.language).localizedCaseInsensitiveContains(searchText) ||
-        categoryFilterTitle(for: documentCategory(for: module.category)).localizedCaseInsensitiveContains(searchText)
+    private static func rowMatchesSearch(_ row: DocumentChooserRow, searchText: String) -> Bool {
+        guard !searchText.isEmpty else { return true }
+
+        return row.searchableText.contains { value in
+            value.localizedCaseInsensitiveContains(searchText)
+        }
     }
 
     /**
-     Sorts chooser rows using Android's category order before localized initials.
+     Sorts chooser rows using Android's document status, pseudo-document, category, and initials order.
 
      - Parameters:
-       - lhs: Left module.
-       - rhs: Right module.
+       - lhs: Left row.
+       - rhs: Right row.
      - Returns: `true` when `lhs` should precede `rhs`.
      */
-    private static func sortModules(_ lhs: ModuleInfo, _ rhs: ModuleInfo) -> Bool {
-        let lhsRank = categoryRank(for: documentCategory(for: lhs.category))
-        let rhsRank = categoryRank(for: documentCategory(for: rhs.category))
-        if lhsRank != rhsRank { return lhsRank < rhsRank }
-        return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+    private static func sortRows(_ lhs: DocumentChooserRow, _ rhs: DocumentChooserRow) -> Bool {
+        let lhsInstalledRank = lhs.isRealInstalledDocument ? 0 : 1
+        let rhsInstalledRank = rhs.isRealInstalledDocument ? 0 : 1
+        if lhsInstalledRank != rhsInstalledRank {
+            return lhsInstalledRank < rhsInstalledRank
+        }
+
+        let lhsRank = categoryRank(for: lhs)
+        let rhsRank = categoryRank(for: rhs)
+        if lhsRank != rhsRank {
+            return lhsRank < rhsRank
+        }
+
+        return lhs.sortTitle.localizedCaseInsensitiveCompare(rhs.sortTitle) == .orderedAscending
     }
 
     /**
-     Resolves Android document-type sort rank for one category.
+     Resolves Android document-type sort rank for one row.
 
-     - Parameter category: Optional reader document category.
+     - Parameter row: Installed module or pseudo-document row.
      - Returns: Lower rank for earlier Android chooser display order.
      */
-    private static func categoryRank(for category: DocumentCategory?) -> Int {
-        categoryFilterOrder.firstIndex(where: { $0 == category }) ?? Int.max
+    private static func categoryRank(for row: DocumentChooserRow) -> Int {
+        if row.isAndroidAddon {
+            return 6
+        }
+
+        switch row.documentCategory {
+        case .bible:
+            return 0
+        case .commentary:
+            return 1
+        case .dictionary:
+            return 2
+        case .generalBook:
+            return 4
+        case .map:
+            return 5
+        default:
+            return 7
+        }
+    }
+
+    /**
+     Builds a Downloads-compatible remote metadata payload from an installed module snapshot.
+
+     - Parameter module: Installed module metadata.
+     - Returns: Minimal remote row used by the shared About and confirmation presentation helpers.
+     */
+    private static func remoteModuleInfo(for module: ModuleInfo) -> RemoteModuleInfo {
+        RemoteModuleInfo(
+            name: module.name,
+            description: module.description,
+            category: module.category,
+            language: module.language,
+            sourceName: String(localized: "installed", defaultValue: "Installed"),
+            version: module.version
+        )
+    }
+
+    /**
+     Android document-type filter values from `DocumentSelectionBase.DOCUMENT_TYPE_SPINNER_FILTERS`.
+
+     `all` excludes add-ons, while `addons` maps Android's AND_BIBLE category. Normal category
+     filters match the reader document categories iOS can display.
+     */
+    enum DocumentTypeFilter: Hashable {
+        /// Android "All types" filter.
+        case all
+
+        /// Android normal document category filter.
+        case category(DocumentCategory)
+
+        /// Android Add-ons filter for AND_BIBLE documents.
+        case addons
+    }
+
+    /**
+     One row in the Android document chooser.
+
+     Rows are either installed SWORD modules or the visible `FakeBookFactory` pseudo-documents that
+     Android includes in `ChooseDocument`.
+     */
+    enum DocumentChooserRow: Identifiable, Equatable {
+        /// Installed local module row.
+        case module(ModuleInfo)
+
+        /// Android visible pseudo-document row.
+        case pseudoDocument(AndroidPseudoDocument)
+
+        /// Stable row identity.
+        var id: String {
+            switch self {
+            case .module(let module):
+                return "module:\(module.name)"
+            case .pseudoDocument(let document):
+                return "pseudo:\(document.rawValue)"
+            }
+        }
+
+        /// Reader document category for filtering and sorting.
+        var documentCategory: DocumentCategory? {
+            switch self {
+            case .module(let module):
+                return BibleReaderModulePicker.documentCategory(for: module.category)
+            case .pseudoDocument(let document):
+                return document.category
+            }
+        }
+
+        /// Language code used by Android's language spinner.
+        var language: String {
+            switch self {
+            case .module(let module):
+                return module.language
+            case .pseudoDocument(let document):
+                return document.language
+            }
+        }
+
+        /// Whether the row is an Android AND_BIBLE add-on.
+        var isAndroidAddon: Bool {
+            guard case .module(let module) = self else { return false }
+            return module.category == .addon
+        }
+
+        /// Whether Android would rank the row as a real installed SWORD document before fake rows.
+        var isRealInstalledDocument: Bool {
+            guard case .module(let module) = self else { return false }
+            return BibleReaderModulePicker.documentCategory(for: module.category) != nil || module.category == .addon
+        }
+
+        /// Sort key matching Android's abbreviation-based row ordering.
+        var sortTitle: String {
+            switch self {
+            case .module(let module):
+                return module.name
+            case .pseudoDocument(let document):
+                return document.title
+            }
+        }
+
+        /// Values included in the chooser's free-text search.
+        var searchableText: [String] {
+            switch self {
+            case .module(let module):
+                return [
+                    module.name,
+                    module.description,
+                    module.language,
+                    BibleReaderModulePicker.displayName(for: module.language),
+                    BibleReaderModulePicker.moduleCategoryTitle(for: module.category)
+                ]
+            case .pseudoDocument(let document):
+                return [
+                    document.androidInitials,
+                    document.title,
+                    document.description,
+                    document.language,
+                    BibleReaderModulePicker.displayName(for: document.language),
+                    BibleReaderModulePicker.categoryFilterTitle(for: document.category)
+                ]
+            }
+        }
+
+        /**
+         Compares rows by stable identity.
+
+         - Parameters:
+           - lhs: Left row.
+           - rhs: Right row.
+         - Returns: `true` when both rows represent the same module or pseudo-document.
+         */
+        static func == (lhs: DocumentChooserRow, rhs: DocumentChooserRow) -> Bool {
+            lhs.id == rhs.id
+        }
+    }
+
+    /**
+     Android visible pseudo-documents from `FakeBookFactory.pseudoDocuments`.
+
+     Memorize is intentionally absent because Android marks it `HideFromSelector=1`. Multi is also
+     absent because Android does not include it in the `pseudoDocuments` list used by
+     `ChooseDocument`.
+     */
+    enum AndroidPseudoDocument: String, CaseIterable, Identifiable {
+        /// Android My Note pseudo-document.
+        case myNotes
+
+        /// Android Journal/StudyPad pseudo-document.
+        case studyPads
+
+        /// Android Compare pseudo-document.
+        case compare
+
+        /// Stable row identity.
+        var id: String { rawValue }
+
+        /// Android module initials from `FakeBookFactory`.
+        var androidInitials: String {
+            switch self {
+            case .myNotes:
+                return "My Note"
+            case .studyPads:
+                return "Journal"
+            case .compare:
+                return "Compare"
+            }
+        }
+
+        /// Reader category assigned by Android fake module metadata.
+        var category: DocumentCategory {
+            switch self {
+            case .myNotes, .compare:
+                return .commentary
+            case .studyPads:
+                return .generalBook
+            }
+        }
+
+        /// Language code used by Android's language filtering for special fake documents.
+        var language: String { "en" }
+
+        /// User-facing row title.
+        var title: String {
+            switch self {
+            case .myNotes:
+                return String(localized: "my_notes", defaultValue: "My Notes")
+            case .studyPads:
+                return String(localized: "study_pad", defaultValue: "StudyPad")
+            case .compare:
+                return String(localized: "compare", defaultValue: "Compare")
+            }
+        }
+
+        /// User-facing row subtitle.
+        var description: String {
+            switch self {
+            case .myNotes:
+                return String(
+                    localized: "my_notes_description",
+                    defaultValue: "Personal notes for the current passage"
+                )
+            case .studyPads:
+                return String(
+                    localized: "study_pad_description",
+                    defaultValue: "StudyPad labels and saved study content"
+                )
+            case .compare:
+                return String(
+                    localized: "compare_description",
+                    defaultValue: "Compare installed Bible translations"
+                )
+            }
+        }
+
+        /// Symbol used for the pseudo-document row leading affordance.
+        var iconName: String {
+            switch self {
+            case .myNotes:
+                return "note.text"
+            case .studyPads:
+                return "rectangle.stack"
+            case .compare:
+                return "text.columns"
+            }
+        }
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -3,6 +3,37 @@ import SwiftUI
 import SwordKit
 
 /**
+ Light document-selection palette matching Android's `ChooseDocument` activity surface.
+
+ The chooser shares Android's `DocumentSelectionBase` layout with Downloads, but Android renders
+ this route with a light content surface and a dark gray app bar. These constants keep the custom
+ SwiftUI layout independent from reader theme colors so changing Bible text colors does not
+ accidentally recolor the document-management screen.
+ */
+private enum DocumentChooserPalette {
+    /// Activity background behind filters and rows.
+    static let background = Color.white
+
+    /// Android action bar chrome for the Document activity.
+    static let appBar = Color(red: 0.27, green: 0.27, blue: 0.27)
+
+    /// Overflow menu surface anchored to the app bar.
+    static let menuSurface = Color.white
+
+    /// Thin row separators and filter dividers.
+    static let divider = Color.black.opacity(0.12)
+
+    /// Primary row and filter text.
+    static let primaryText = Color(red: 0.13, green: 0.13, blue: 0.13)
+
+    /// Secondary row metadata and labels.
+    static let secondaryText = Color(red: 0.47, green: 0.47, blue: 0.47)
+
+    /// Template icon tint used by Android-style document rows.
+    static let icon = Color(red: 0.49, green: 0.49, blue: 0.49)
+}
+
+/**
  Presents document rows for the currently focused pane and routes selections through the same
  document outcomes as Android's `ChooseDocument` activity.
 
@@ -25,6 +56,9 @@ struct BibleReaderModulePicker: View {
     /// Search-index service used by Android's Delete Index row action.
     @Environment(SearchIndexService.self) private var searchIndexService
 
+    /// Dynamic Type category used to split Android's compact filter row when large text needs space.
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     /// Selected Android document-type filter.
     @State private var selectedFilter: DocumentTypeFilter
 
@@ -42,6 +76,9 @@ struct BibleReaderModulePicker: View {
 
     /// Last row-action failure surfaced to the user.
     @State private var rowActionErrorMessage: String?
+
+    /// Whether the Android-style app-bar overflow menu is visible.
+    @State private var showOverflowMenu = false
 
     /// Repository service used by Android's Delete document row action.
     private let repository = ModuleRepository()
@@ -137,42 +174,7 @@ struct BibleReaderModulePicker: View {
      row actions, and a persistent Downloads handoff.
      */
     var body: some View {
-        NavigationStack {
-            List {
-                filterControls
-
-                if shouldShowFilterEmptyState {
-                    emptyState
-                } else if filteredDocumentRows.isEmpty {
-                    noMatchesState
-                } else {
-                    documentRows
-                }
-            }
-            .accessibilityIdentifier("modulePickerScreen")
-            .navigationTitle(navigationTitle)
-            .searchable(text: $searchText, prompt: String(localized: "search_modules"))
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "done"), action: onDismiss)
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Button(String(localized: "download_modules"), systemImage: "arrow.down.circle") {
-                        openDownloadsAfterDismiss()
-                    }
-                    .accessibilityIdentifier("modulePickerDownloadsButton")
-                }
-            }
-            .onChange(of: searchText) { oldValue, newValue in
-                if oldValue.isEmpty && !newValue.isEmpty {
-                    selectedFilter = .all
-                    selectedLanguage = ""
-                }
-            }
-        }
+        androidDocumentChooserScreen
         .sheet(item: $selectedModuleDetails) { details in
             NavigationStack {
                 ModuleBrowserModuleDetailsView(details: details)
@@ -228,72 +230,376 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Builds the document-type and language controls that correspond to Android's spinners.
+     Builds Android's full-screen `ChooseDocument` surface.
 
-     The document-type picker starts on the requested category, while the language picker starts at
-     the all-language default used by Android `ChooseDocument`.
+     Android uses `DocumentSelectionBase`: top app bar, inline language/search/type controls with a
+     result count, and custom document rows. This view intentionally avoids SwiftUI `List`,
+     `.searchable`, and navigation toolbar chrome so the chooser visually matches Android instead of
+     inheriting iOS sheet styling.
+
+     - Returns: Full-screen document chooser content with Android-owned controls.
+     - Side effects: Toolbar and row actions can dismiss, open Downloads, switch reader documents, or
+       show the shared module details surface.
+     - Failure modes: Empty document sets render explicit Android-style rows instead of a blank list.
      */
-    private var filterControls: some View {
-        Section {
-            Picker(String(localized: "document_type", defaultValue: "Document type"), selection: $selectedFilter) {
-                ForEach(Self.documentTypeFilterOrder, id: \.self) { filter in
-                    Text(Self.documentTypeFilterTitle(for: filter)).tag(filter)
-                }
-            }
-            .pickerStyle(.menu)
-            .accessibilityIdentifier("modulePickerCategoryFilter")
+    private var androidDocumentChooserScreen: some View {
+        let visibleRows = filteredDocumentRows
 
-            if !availableLanguages.isEmpty {
-                Picker(String(localized: "settings_language"), selection: $selectedLanguage) {
-                    Text(String(localized: "all_languages_count \(availableLanguages.count)"))
-                        .tag("")
-                    ForEach(availableLanguages, id: \.self) { language in
-                        Text(Self.displayName(for: language))
-                            .tag(language)
+        return ZStack(alignment: .topTrailing) {
+            documentChooserScreenMarker
+            VStack(spacing: 0) {
+                androidTopAppBar
+                androidFilterBar(visibleDocumentCount: visibleRows.count)
+                androidDocumentRowsContent(visibleRows)
+            }
+            if showOverflowMenu {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .accessibilityHidden(true)
+                    .onTapGesture {
+                        showOverflowMenu = false
                     }
-                }
-                .pickerStyle(.menu)
-                .accessibilityIdentifier("modulePickerLanguageFilter")
+                androidChooserOverflowMenu
+                    .padding(.top, 56)
+                    .padding(.trailing, 8)
+                    .zIndex(1)
             }
         }
+        .background(DocumentChooserPalette.background.ignoresSafeArea())
+        .onChange(of: searchText) { oldValue, newValue in
+            if oldValue.isEmpty && !newValue.isEmpty {
+                selectedFilter = .all
+                selectedLanguage = ""
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        #if os(iOS)
+        .toolbar(.hidden, for: .navigationBar)
+        #endif
     }
 
-    /// Empty state shown when no installed or pseudo rows exist for the selected document type.
-    private var emptyState: some View {
-        VStack(spacing: 12) {
-            Text(emptyMessage)
-                .foregroundStyle(.secondary)
-            Button(String(localized: "download_modules")) {
+    /**
+     Builds a stable screen marker without making every child inherit the same identifier.
+
+     SwiftUI accessibility identifiers can propagate from container views. Android parity tests need
+     a route-level marker and concrete row/filter identifiers, so this tiny non-interactive element
+     carries `modulePickerScreen` while the visible layout remains accessible by its own labels.
+     */
+    private var documentChooserScreenMarker: some View {
+        Rectangle()
+            .fill(DocumentChooserPalette.background.opacity(0.001))
+            .frame(width: 1, height: 1)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(localized: "document", defaultValue: "Document"))
+            .accessibilityIdentifier("modulePickerScreen")
+            .allowsHitTesting(false)
+    }
+
+    /**
+     Builds Android's `Document` app bar with back navigation and overflow access.
+
+     - Returns: A 56-point top bar matching Android `ChooseDocument` title chrome.
+     - Side effects: Back dismisses the chooser; overflow toggles the Android-style menu.
+     - Failure modes: none.
+     */
+    private var androidTopAppBar: some View {
+        HStack(spacing: 16) {
+            Button(action: onDismiss) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 24, weight: .semibold))
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.white)
+            .accessibilityLabel(String(localized: "back_to_previous", defaultValue: "Back"))
+            .accessibilityIdentifier("modulePickerBackButton")
+
+            Text(String(localized: "document", defaultValue: "Document"))
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(Color.white)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Button {
+                showOverflowMenu.toggle()
+            } label: {
+                Image(systemName: "ellipsis.vertical")
+                    .font(.system(size: 24, weight: .bold))
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.white)
+            .accessibilityLabel(String(localized: "more", defaultValue: "More"))
+            .accessibilityIdentifier("modulePickerOverflowButton")
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 56)
+        .background(DocumentChooserPalette.appBar)
+    }
+
+    /**
+     Builds Android's chooser overflow menu.
+
+     Android exposes document-management actions from this app bar. iOS currently has a real
+     Downloads handoff from the chooser, so it is surfaced here instead of as a native toolbar item.
+     */
+    private var androidChooserOverflowMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            androidOverflowMenuButton(
+                title: String(localized: "download_modules"),
+                accessibilityIdentifier: "modulePickerDownloadsButton"
+            ) {
+                showOverflowMenu = false
                 openDownloadsAfterDismiss()
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical)
+        .frame(width: 260, alignment: .leading)
+        .background(DocumentChooserPalette.menuSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+        .shadow(color: Color.black.opacity(0.25), radius: 8, x: 0, y: 4)
     }
 
-    /// Empty state shown when chooser rows exist but the active filters hide all rows.
-    private var noMatchesState: some View {
-        Text(String(localized: "no_modules_match_filters"))
-            .foregroundStyle(.secondary)
+    /**
+     Builds one row in the Android-style overflow menu.
+
+     - Parameters:
+       - title: User-visible row title.
+       - accessibilityIdentifier: Stable UI-test identifier.
+       - action: Command executed when the row is tapped.
+     - Returns: A full-width menu row.
+     - Side effects: Executes `action`.
+     - Failure modes: none.
+     */
+    private func androidOverflowMenuButton(
+        title: String,
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 18, weight: .regular))
+                .foregroundStyle(DocumentChooserPalette.primaryText)
+                .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+                .padding(.horizontal, 16)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 
-    /// Rows for the currently filtered document set.
-    private var documentRows: some View {
-        Section(String(localized: "document_filter_results \(filteredDocumentRows.count)")) {
-            ForEach(filteredDocumentRows) { row in
-                documentRow(row)
+    /**
+     Builds Android's inline language, search, type, and result-count filters.
+
+     - Parameter visibleDocumentCount: Number of rows after current filters.
+     - Returns: The compact filter strip from Android `document_selection.xml`.
+     - Side effects: Menus and the text field mutate the active picker filters.
+     - Failure modes: Large Dynamic Type splits controls into two rows to avoid overlap.
+     */
+    private func androidFilterBar(visibleDocumentCount: Int) -> some View {
+        VStack(spacing: 4) {
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(alignment: .bottom, spacing: 14) {
+                            androidLanguageFilterMenu()
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            androidDocumentTypeFilterMenu(visibleDocumentCount: visibleDocumentCount)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        androidSearchFilterField()
+                    }
+                } else {
+                    HStack(alignment: .bottom, spacing: 14) {
+                        androidLanguageFilterMenu()
+                            .frame(minWidth: 96, maxWidth: .infinity, alignment: .leading)
+                            .layoutPriority(1)
+                        androidSearchFilterField()
+                            .frame(minWidth: 96)
+                            .layoutPriority(2)
+                        androidDocumentTypeFilterMenu(visibleDocumentCount: visibleDocumentCount)
+                            .frame(minWidth: 112, maxWidth: .infinity, alignment: .trailing)
+                            .layoutPriority(1)
+                    }
+                }
             }
+            .padding(.horizontal, 16)
+            .padding(.top, 18)
+            .padding(.bottom, 10)
+
+            Rectangle()
+                .fill(DocumentChooserPalette.divider)
+                .frame(height: 1)
+        }
+        .background(DocumentChooserPalette.background)
+    }
+
+    /**
+     Builds Android's language autocomplete affordance as a compact menu.
+
+     - Returns: Underlined language label with all installed chooser languages.
+     - Side effects: Selecting a row mutates `selectedLanguage`.
+     - Failure modes: Empty language lists still expose the all-language placeholder.
+     */
+    private func androidLanguageFilterMenu() -> some View {
+        Menu {
+            Button(String(localized: "settings_language")) {
+                selectedLanguage = ""
+            }
+            if !availableLanguages.isEmpty {
+                Divider()
+            }
+            ForEach(availableLanguages, id: \.self) { language in
+                Button(Self.displayName(for: language)) {
+                    selectedLanguage = language
+                }
+            }
+        } label: {
+            androidFilterLabel(languageFilterTitle(for: selectedLanguage))
+        }
+        .accessibilityIdentifier("modulePickerLanguageFilter")
+    }
+
+    /**
+     Builds Android's inline free-text document search field.
+
+     - Returns: Plain underlined search input.
+     - Side effects: Typing mutates `searchText` and the root screen aligns filters with Android's
+       search-focus behavior.
+     - Failure modes: none.
+     */
+    private func androidSearchFilterField() -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            TextField(String(localized: "search", defaultValue: "Search"), text: $searchText)
+                .textFieldStyle(.plain)
+                .foregroundStyle(DocumentChooserPalette.primaryText)
+                .tint(DocumentChooserPalette.primaryText)
+                .submitLabel(.search)
+            Rectangle()
+                .fill(DocumentChooserPalette.secondaryText)
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("modulePickerSearchField")
+    }
+
+    /**
+     Builds Android's document-type spinner and visible document count.
+
+     - Parameter visibleDocumentCount: Number of rows after current filters.
+     - Returns: Count text stacked above the document-type menu.
+     - Side effects: Selecting a type mutates `selectedFilter`.
+     - Failure modes: Unsupported filters are not generated because the order is static.
+     */
+    private func androidDocumentTypeFilterMenu(visibleDocumentCount: Int) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(String(localized: "documents_count \(visibleDocumentCount)"))
+                .font(.system(size: 14, weight: .regular))
+                .foregroundStyle(DocumentChooserPalette.secondaryText)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                .multilineTextAlignment(.trailing)
+            Menu {
+                ForEach(Self.documentTypeFilterOrder, id: \.self) { filter in
+                    Button(Self.documentTypeFilterTitle(for: filter)) {
+                        selectedFilter = filter
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(Self.documentTypeFilterTitle(for: selectedFilter))
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                        .multilineTextAlignment(.trailing)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .foregroundStyle(DocumentChooserPalette.primaryText)
+            }
+        }
+        .accessibilityIdentifier("modulePickerCategoryFilter")
+    }
+
+    /**
+     Builds one underlined Android filter label.
+
+     - Parameter title: User-visible label text.
+     - Returns: Compact label with Android-style underline.
+     - Side effects: none.
+     - Failure modes: Accessibility text sizes allow two lines to avoid truncating long languages.
+     */
+    private func androidFilterLabel(_ title: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(DocumentChooserPalette.primaryText)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+            Rectangle()
+                .fill(DocumentChooserPalette.secondaryText)
+                .frame(height: 1)
         }
     }
 
     /**
-     Builds one selectable document row.
+     Builds the scrollable Android document rows.
 
-     - Parameter row: Installed module or Android visible pseudo-document.
-     - Returns: A row that performs the Android-equivalent document action when selected.
+     - Parameter visibleRows: Rows that survived the active filters.
+     - Returns: Empty, no-match, or document row content.
+     - Side effects: Row actions can mutate reader state or document management state.
+     - Failure modes: Empty states include a Downloads handoff when the active document type has no
+       installed rows.
      */
     @ViewBuilder
-    private func documentRow(_ row: DocumentChooserRow) -> some View {
+    private func androidDocumentRowsContent(_ visibleRows: [DocumentChooserRow]) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if shouldShowFilterEmptyState {
+                    VStack(spacing: 12) {
+                        androidMessageRow(emptyMessage)
+                        Button(String(localized: "download_modules")) {
+                            openDownloadsAfterDismiss()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 24)
+                } else if visibleRows.isEmpty {
+                    androidMessageRow(String(localized: "no_modules_match_filters"))
+                } else {
+                    ForEach(visibleRows) { row in
+                        androidDocumentRow(row)
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(DocumentChooserPalette.background)
+    }
+
+    /**
+     Builds one centered message row for Android chooser empty states.
+
+     - Parameter message: User-visible text.
+     - Returns: Full-width text row.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func androidMessageRow(_ message: String) -> some View {
+        Text(message)
+            .font(.body)
+            .foregroundStyle(DocumentChooserPalette.secondaryText)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 24)
+    }
+
+    /**
+     Builds one selectable Android document row.
+
+     - Parameter row: Installed module or visible Android pseudo-document.
+     - Returns: A row matching Android `document_list_item` structure.
+     - Side effects: Selection performs the row's document action.
+     - Failure modes: Add-ons keep Android's non-selecting behavior through `select(_:)`.
+     */
+    @ViewBuilder
+    private func androidDocumentRow(_ row: DocumentChooserRow) -> some View {
         switch row {
         case .module(let module):
             moduleRow(module)
@@ -303,50 +609,56 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Builds one selectable module row with active-state, lock-state, and management affordances.
+     Builds one installed module row with Android list-item columns and row actions.
 
-     - Parameter module: Installed module metadata from the active reader controller.
-     - Returns: A row that switches to the module's own category when selected.
+     - Parameter module: Installed module metadata from the active controller.
+     - Returns: Tappable row that switches or opens the selected document.
      */
     private func moduleRow(_ module: ModuleInfo) -> some View {
         let actions = Self.rowActions(for: module)
-        return Button {
-            select(module)
-        } label: {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(module.name)
-                            .font(.headline)
-                        if module.isEncrypted && !module.isUnlocked {
-                            Image(systemName: "lock.fill")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .accessibilityLabel(String(localized: "locked", defaultValue: "Locked"))
-                        }
+        return androidRowContainer(
+            accessibilityIdentifier: "modulePickerRow::\(module.name)",
+            leading: {
+                VStack(spacing: 5) {
+                    categoryIcon(for: module.category)
+                    if module.isEncrypted && !module.isUnlocked {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(DocumentChooserPalette.icon)
+                            .accessibilityLabel(String(localized: "locked", defaultValue: "Locked"))
                     }
+                    Text(Self.displayName(for: module.language))
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.secondaryText)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+                .frame(width: 70)
+            },
+            center: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(module.name)
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.primaryText)
+                        .lineLimit(1)
                     Text(module.description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.secondaryText)
                         .lineLimit(2)
-                    HStack(spacing: 6) {
-                        Text(Self.displayName(for: module.language))
-                        Text(Self.moduleCategoryTitle(for: module.category))
+                }
+            },
+            trailing: {
+                VStack(alignment: .trailing, spacing: 10) {
+                    if actions.contains(.about) {
+                        aboutButton(for: module)
                     }
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
                 }
-                Spacer()
-                if isActive(module) {
-                    Image(systemName: "checkmark")
-                        .foregroundStyle(Color.accentColor)
-                        .fontWeight(.semibold)
-                }
+                .frame(width: 48, alignment: .trailing)
+            },
+            selection: {
+                select(module)
             }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("modulePickerRow::\(module.name)")
+        )
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if actions.contains(.uninstall) {
                 Button(role: .destructive) {
@@ -385,39 +697,183 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Builds one Android visible pseudo-document row.
+     Builds one visible Android pseudo-document row.
 
      - Parameter document: Pseudo-document identity from Android `FakeBookFactory`.
-     - Returns: A row that opens the equivalent iOS reader document or selector.
+     - Returns: Tappable row that opens the equivalent iOS document route.
      */
     private func pseudoDocumentRow(_ document: AndroidPseudoDocument) -> some View {
-        Button {
-            select(document)
-        } label: {
-            HStack {
-                Image(systemName: document.iconName)
-                    .foregroundStyle(.secondary)
-                    .frame(width: 24)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(document.title)
-                        .font(.headline)
-                    Text(document.description)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                    HStack(spacing: 6) {
-                        Text(Self.displayName(for: document.language))
-                        Text(Self.categoryFilterTitle(for: document.category))
-                    }
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
+        androidRowContainer(
+            accessibilityIdentifier: "modulePickerPseudoRow::\(document.rawValue)",
+            leading: {
+                VStack(spacing: 5) {
+                    pseudoDocumentIcon(for: document)
+                    Text(Self.displayName(for: document.language))
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.secondaryText)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                 }
+                .frame(width: 70)
+            },
+            center: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(document.androidInitials)
+                        .font(.system(size: 22, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.primaryText)
+                        .lineLimit(1)
+                    Text(document.description)
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundStyle(DocumentChooserPalette.secondaryText)
+                        .lineLimit(2)
+                }
+            },
+            trailing: {
                 Spacer()
+                    .frame(width: 48)
+            },
+            selection: {
+                select(document)
             }
-            .contentShape(Rectangle())
+        )
+    }
+
+    /**
+     Builds the shared Android `document_list_item` row frame.
+
+     - Parameters:
+       - accessibilityIdentifier: Stable identifier for the concrete row.
+       - leading: Left icon/language column.
+       - center: Main abbreviation and description column.
+       - trailing: Right action/status column.
+       - selection: Primary row action matching Android list-item selection.
+     - Returns: A full-width row with Android spacing and divider placement.
+     - Side effects: Executes `selection` when the row body is tapped.
+     - Failure modes: Row-level context and swipe actions are supplied by the caller.
+     */
+    private func androidRowContainer<Leading: View, Center: View, Trailing: View>(
+        accessibilityIdentifier: String,
+        @ViewBuilder leading: () -> Leading,
+        @ViewBuilder center: () -> Center,
+        @ViewBuilder trailing: () -> Trailing,
+        selection: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                leading()
+                center()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                trailing()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+
+            Rectangle()
+                .fill(DocumentChooserPalette.divider)
+                .frame(height: 1)
+                .padding(.leading, 96)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: selection)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    /**
+     Builds Android's row-level About action button.
+
+     - Parameter module: Installed module whose details should be shown.
+     - Returns: Template info icon matching Android's `aboutButton` column.
+     - Side effects: Sets `selectedModuleDetails`, presenting the shared details sheet.
+     - Failure modes: Details payload falls back to installed-module metadata when repository source
+       metadata is unavailable.
+     */
+    private func aboutButton(for module: ModuleInfo) -> some View {
+        Button {
+            selectedModuleDetails = moduleDetails(for: module)
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(DocumentChooserPalette.icon)
+                .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("modulePickerPseudoRow::\(document.rawValue)")
+        .accessibilityLabel(String(localized: "about"))
+        .accessibilityIdentifier("modulePickerAboutButton::\(module.name)")
+    }
+
+    /**
+     Renders the Android-sourced document category icon for a chooser row.
+
+     - Parameter category: Installed module category.
+     - Returns: Template icon matching the closest bundled Android document glyph.
+     - Side effects: Loads local image assets when rendered.
+     - Failure modes: Unknown categories use the generic document icon.
+     */
+    @ViewBuilder
+    private func categoryIcon(for category: ModuleCategory) -> some View {
+        switch category {
+        case .bible:
+            AndBibleIconView(name: "ToolbarBible", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        case .commentary:
+            AndBibleIconView(name: "ToolbarCommentary", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        case .dictionary:
+            AndBibleIconView(name: "SettingsIconDictionary", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        case .generalBook:
+            AndBibleIconView(name: "DrawerDocuments", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        case .map:
+            Image(systemName: "map")
+                .font(.system(size: 26, weight: .regular))
+                .foregroundStyle(DocumentChooserPalette.icon)
+        case .addon:
+            AndBibleIconView(name: "DrawerDownloads", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        default:
+            AndBibleIconView(name: "DrawerDocuments", size: 28)
+                .foregroundStyle(DocumentChooserPalette.icon)
+        }
+    }
+
+    /**
+     Renders the category icon for one Android pseudo-document.
+
+     - Parameter document: Pseudo-document identity.
+     - Returns: Icon based on the same document category mapping Android rows use.
+     - Side effects: Loads local image assets when rendered.
+     - Failure modes: Unsupported pseudo categories use the generic document icon.
+     */
+    @ViewBuilder
+    private func pseudoDocumentIcon(for document: AndroidPseudoDocument) -> some View {
+        switch document.category {
+        case .commentary:
+            categoryIcon(for: .commentary)
+        case .generalBook:
+            categoryIcon(for: .generalBook)
+        case .dictionary:
+            categoryIcon(for: .dictionary)
+        case .map:
+            categoryIcon(for: .map)
+        default:
+            categoryIcon(for: .generalBook)
+        }
+    }
+
+    /**
+     Resolves Android's language filter label for the chooser.
+
+     - Parameter language: Selected ISO language code, or empty when no language is selected.
+     - Returns: Android's placeholder label for no selection, otherwise the localized language name.
+     - Side effects: none.
+     - Failure modes: Unknown language codes fall back through `displayName(for:)`.
+     */
+    private func languageFilterTitle(for language: String) -> String {
+        guard !language.isEmpty else {
+            return String(localized: "settings_language")
+        }
+        return Self.displayName(for: language)
     }
 
     /// Message shown when the requested filter has no selectable rows.
@@ -436,11 +892,6 @@ struct BibleReaderModulePicker: View {
         default:
             return String(localized: "picker_no_bible_modules")
         }
-    }
-
-    /// Android chooser title.
-    private var navigationTitle: String {
-        String(localized: "choose_document", defaultValue: "Choose Document")
     }
 
     /**
@@ -519,17 +970,6 @@ struct BibleReaderModulePicker: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             onOpenDownloads()
         }
-    }
-
-    /**
-     Tests whether a module is the currently active module for its own category.
-
-     - Parameter module: Installed module metadata to compare against the reader controller.
-     - Returns: `true` when the module name matches the active module for its category.
-     */
-    private func isActive(_ module: ModuleInfo) -> Bool {
-        guard let documentCategory = Self.documentCategory(for: module.category) else { return false }
-        return module.name == controller.activeModuleName(for: documentCategory)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -167,6 +167,15 @@ public struct BibleReaderView: View {
                 return true
             }
         }
+
+        var isDocumentChooserRoute: Bool {
+            switch self {
+            case .modulePicker, .chooseDocument:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     /// Internal reader-overflow destinations that should run only after the overflow sheet dismisses.
@@ -818,7 +827,10 @@ public struct BibleReaderView: View {
         } message: {
             startupDownloadPromptMessage
         }
-        .sheet(item: $activeReaderModal) { modal in
+        .sheet(item: readerSheetModalBinding) { modal in
+            readerModalContent(modal)
+        }
+        .fullScreenCover(item: readerDocumentChooserModalBinding) { modal in
             readerModalContent(modal)
         }
         .confirmationDialog(
@@ -1972,6 +1984,43 @@ public struct BibleReaderView: View {
     /// Closes the currently active coordinator-owned modal.
     private func dismissReaderModal() {
         activeReaderModal = nil
+    }
+
+    /**
+     Filters coordinator-owned modal state into the generic sheet presenter.
+
+     Android `ChooseDocument` routes are full-screen app-owned surfaces, so they are intentionally
+     excluded from the sheet binding and routed through `readerDocumentChooserModalBinding`.
+     */
+    private var readerSheetModalBinding: Binding<ReaderModal?> {
+        Binding(
+            get: {
+                guard activeReaderModal?.isDocumentChooserRoute != true else {
+                    return nil
+                }
+                return activeReaderModal
+            },
+            set: { activeReaderModal = $0 }
+        )
+    }
+
+    /**
+     Filters coordinator-owned modal state into Android-style full-screen chooser presentation.
+
+     Both the all-types drawer route and the category-scoped toolbar route map to Android
+     `ChooseDocument`, with or without a type extra. Keeping them in the same full-screen presenter
+     prevents one entry point from silently preserving the old iOS sheet behavior.
+     */
+    private var readerDocumentChooserModalBinding: Binding<ReaderModal?> {
+        Binding(
+            get: {
+                guard activeReaderModal?.isDocumentChooserRoute == true else {
+                    return nil
+                }
+                return activeReaderModal
+            },
+            set: { activeReaderModal = $0 }
+        )
     }
 
     /// Presents the document-category module picker for a pane-scoped action.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -561,6 +561,10 @@ public struct BibleReaderView: View {
     /// Accessibility-exported state for the content most recently rendered in the active pane.
     private var readerRenderedContentStateValue: String {
         let windowToken = windowManager.activeWindow.map { "windowOrder=\($0.orderNumber)" } ?? "windowOrder=none"
+        let tabOrders = windowManager.allWindows
+            .map { "\($0.orderNumber)" }
+            .joined(separator: ",")
+        let tabOrdersToken = "windowTabOrders=\(tabOrders.isEmpty ? "none" : tabOrders)"
         let exportController = focusedController
         let contentToken = exportController?.renderedContentState
             ?? BibleReaderController.emptyRenderedContentState
@@ -577,7 +581,7 @@ public struct BibleReaderView: View {
         let destinationToken = "readerDestination=\(activeReaderDestination?.rawValue ?? "none")"
         let modalToken = "readerModal=\(activeReaderModal?.rawValue ?? "none")"
         let searchToken = "searchVisible=\(showSearch ? "true" : "false")"
-        return "\(windowToken);\(contentToken);\(myNotesToken);\(studyPadToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(destinationToken);\(modalToken);\(searchToken)"
+        return "\(windowToken);\(contentToken);\(tabOrdersToken);\(myNotesToken);\(studyPadToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(destinationToken);\(modalToken);\(searchToken)"
     }
 
     /// Compact dedicated state export used by UI tests instead of snapshotting the full reader.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -2019,7 +2019,8 @@ public struct BibleReaderView: View {
                     onOpenDownloads: { presentDownloadsPreservingPane() },
                     onOpenDictionaryBrowser: { presentReaderModalPreservingPane(.dictionaryBrowser) },
                     onOpenGeneralBookBrowser: { presentReaderModalPreservingPane(.generalBookBrowser) },
-                    onOpenMapBrowser: { presentReaderModalPreservingPane(.mapBrowser) }
+                    onOpenMapBrowser: { presentReaderModalPreservingPane(.mapBrowser) },
+                    onOpenStudyPadSelector: { presentReaderModalPreservingPane(.studyPadSelector) }
                 )
             } else {
                 readerPanePreparationContent
@@ -2130,7 +2131,8 @@ public struct BibleReaderView: View {
                     onOpenDownloads: { presentDownloadsPreservingPane() },
                     onOpenDictionaryBrowser: { presentReaderModalPreservingPane(.dictionaryBrowser) },
                     onOpenGeneralBookBrowser: { presentReaderModalPreservingPane(.generalBookBrowser) },
-                    onOpenMapBrowser: { presentReaderModalPreservingPane(.mapBrowser) }
+                    onOpenMapBrowser: { presentReaderModalPreservingPane(.mapBrowser) },
+                    onOpenStudyPadSelector: { presentReaderModalPreservingPane(.studyPadSelector) }
                 )
             } else {
                 readerPanePreparationContent

--- a/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
@@ -75,7 +75,6 @@ struct WindowTabBar: View {
                     isCollapsed: isCollapsed
                 )
             }
-            .accessibilityIdentifier("windowTabBar")
             .foregroundStyle(surfacePalette.foregroundColor)
             .alert(String(localized: "go_to_reference"), isPresented: $showGoToRefAlert) {
                 TextField(String(localized: "go_to_reference_placeholder"), text: $goToRefText)
@@ -135,6 +134,8 @@ struct WindowTabBar: View {
                 .padding(.vertical, WindowTabBarLayout.verticalPadding)
                 .frame(minWidth: geometry.size.width, alignment: .trailing)
             }
+            .accessibilityIdentifier("windowTabBar")
+            .accessibilityElement(children: .contain)
         }
         .frame(
             width: isCollapsed ? WindowTabBarLayout.collapsedControlWidth : nil,

--- a/docs/parity/reader/document-chooser-matrix.md
+++ b/docs/parity/reader/document-chooser-matrix.md
@@ -27,8 +27,9 @@ iOS references:
 
 | Behavior | Android | iOS Status | Notes |
 |---|---|---|---|
-| Drawer Choose Document entry | Opens `ChooseDocument` directly without a type extra, so the document type spinner starts at all types. | Pass | The reader `.chooseDocument` route now presents `BibleReaderModulePicker` directly with `startsWithAllTypes: true`; the removed category-first Swift sheet was Android drift. |
-| Category-specific picker entry | Bible/commentary launches pass a type extra and start the spinner on that category. | Pass | The existing module picker route still starts on the requested category unless the caller explicitly asks for all types. |
+| Presentation shell | Opens `ChooseDocument` as a full-screen app-owned activity. | Pass | iOS filters both `.chooseDocument` and `.modulePicker` out of the generic reader-modal sheet and presents them through a full-screen chooser cover. |
+| Drawer Choose Document entry | Opens `ChooseDocument` directly without a type extra, so the document type spinner starts at all types. | Pass | The reader `.chooseDocument` route presents `BibleReaderModulePicker` with `startsWithAllTypes: true`; the removed category-first Swift sheet was Android drift. |
+| Category-specific picker entry | Bible/commentary launches pass a type extra and start the spinner on that category. | Pass | The module-picker route starts on the requested category and now uses the same full-screen chooser presenter as the all-types route. |
 | Document type filters | Shows all types, Bible, commentary, dictionary, books, maps, and add-ons. | Pass | iOS exposes all installed Bible/commentary/dictionary/general-book/map modules, hides add-ons from all types, and exposes installed add-ons from the Add-ons filter like Android's AND_BIBLE branch. |
 | Language default and sorting | Starts on all languages and sorts language names alphabetically. | Pass | iOS starts with the empty all-language filter and builds alphabetized display names from the full chooser dataset. Add-ons survive concrete language filtering, matching Android's AND_BIBLE language exception. |
 | Search focus behavior | Entering search clears the selected language and moves document type to all types. | Pass | iOS clears both filters when non-empty search begins. |
@@ -37,7 +38,7 @@ iOS references:
 | Locked encrypted documents | Selection attempts Android unlock before accepting the document. | Gap | iOS shows a lock affordance for encrypted locked modules but does not yet have the Android-equivalent unlock prompt/cipher-key coordinator in this chooser. |
 | Pseudo-documents | Visible pseudo-documents are included; hidden Memorize and non-chooser Multi are excluded. | Pass | iOS now adds My Notes, StudyPad/Journal, and Compare rows from an explicit Android pseudo-document model, maps them to existing reader routes, excludes Memorize because Android marks it `HideFromSelector=1`, and excludes Multi because Android does not include it in `FakeBookFactory.pseudoDocuments`. |
 | About/delete/delete-index actions | Long-press action mode exposes about, delete, delete index, and unlock actions where applicable. | Partial Pass | iOS installed-module rows expose About, Uninstall, and Delete Index through the same presentation and module-management services used by Downloads. Unlock remains hidden because iOS still lacks a real cipher-key coordinator. |
-| Downloads handoff | Toolbar Downloads opens `DownloadActivity`; returning reloads the document list. | Pass | iOS exposes a persistent Downloads toolbar action and refreshes installed modules when the Downloads sheet closes. |
+| Downloads handoff | Toolbar Downloads opens `DownloadActivity`; returning reloads the document list. | Pass | iOS exposes a persistent Downloads toolbar action and refreshes installed modules when the Downloads destination closes. |
 | Selection result | Returns selected initials to the reader, which updates the active document. | Adapted Pass | iOS switches the active pane controller directly. Dictionary/general-book/map selections still open their content browsers after switching, matching the existing reader category behavior. |
 
 ## Follow-Up Targets

--- a/docs/parity/reader/document-chooser-matrix.md
+++ b/docs/parity/reader/document-chooser-matrix.md
@@ -1,6 +1,6 @@
 # Reader Document Chooser Parity Matrix
 
-Date: 2026-05-28
+Date: 2026-06-23
 
 ## Intent
 
@@ -21,7 +21,7 @@ iOS references:
 
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift`
 - `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
-- `AndBibleTests/AndBibleTests.swift`
+- `AndBibleTests/AndBibleTests+AppAndReader.swift`
 
 ## Matrix
 
@@ -29,20 +29,18 @@ iOS references:
 |---|---|---|---|
 | Drawer Choose Document entry | Opens `ChooseDocument` directly without a type extra, so the document type spinner starts at all types. | Pass | The reader `.chooseDocument` route now presents `BibleReaderModulePicker` directly with `startsWithAllTypes: true`; the removed category-first Swift sheet was Android drift. |
 | Category-specific picker entry | Bible/commentary launches pass a type extra and start the spinner on that category. | Pass | The existing module picker route still starts on the requested category unless the caller explicitly asks for all types. |
-| Document type filters | Shows all types, Bible, commentary, dictionary, books, maps, and add-ons. | Partial | iOS now exposes all installed Bible/commentary/dictionary/general-book/map modules in one chooser. Add-ons and Android pseudo-document rows are not represented by the current `ModuleInfo` model. |
-| Language default and sorting | Starts on all languages and sorts language names alphabetically. | Pass | iOS starts with the empty all-language filter and builds alphabetized display names from the full installed chooser dataset. |
+| Document type filters | Shows all types, Bible, commentary, dictionary, books, maps, and add-ons. | Pass | iOS exposes all installed Bible/commentary/dictionary/general-book/map modules, hides add-ons from all types, and exposes installed add-ons from the Add-ons filter like Android's AND_BIBLE branch. |
+| Language default and sorting | Starts on all languages and sorts language names alphabetically. | Pass | iOS starts with the empty all-language filter and builds alphabetized display names from the full chooser dataset. Add-ons survive concrete language filtering, matching Android's AND_BIBLE language exception. |
 | Search focus behavior | Entering search clears the selected language and moves document type to all types. | Pass | iOS clears both filters when non-empty search begins. |
-| Search implementation | Uses Android's document search DAO for query matching. | Adapted | iOS searches installed module initials, descriptions, language, localized language, and category text in memory. This is acceptable for the current installed-only chooser, but should be revisited if iOS gains Android's full document search index. |
-| Row ordering | Installed/recommended state is considered before category and abbreviation ordering. | Adapted | iOS chooser rows are installed-only, so it sorts by Android category order and localized module initials. Remote repository ordering remains Downloads-owned. |
+| Search implementation | Uses Android's document search DAO for query matching. | Adapted | iOS searches installed module and pseudo-document initials, descriptions, language, localized language, and category text in memory. This is acceptable for the current app-owned chooser, but should be revisited if iOS gains Android's full document search index. |
+| Row ordering | Installed/recommended state is considered before category and abbreviation ordering. | Adapted Pass | iOS chooser rows are installed or built-in pseudo rows, so it mirrors Android's installed-before-fake, category, and initials ordering. Remote repository and actively installing states remain Downloads-owned. |
 | Locked encrypted documents | Selection attempts Android unlock before accepting the document. | Gap | iOS shows a lock affordance for encrypted locked modules but does not yet have the Android-equivalent unlock prompt/cipher-key coordinator in this chooser. |
-| Pseudo-documents | Visible pseudo-documents are included, while `AND_BIBLE` pseudo-doc selections are ignored. | Gap | iOS has no pseudo-document row source in `ModuleInfo`; adding this requires a distinct model/source before it can be behaviorally matched. |
-| About/delete/delete-index actions | Long-press action mode exposes about, delete, delete index, and unlock actions where applicable. | Gap | iOS has no row context-action parity yet. This should be implemented only when it can mutate modules through the same repository/module-management services used elsewhere. |
+| Pseudo-documents | Visible pseudo-documents are included; hidden Memorize and non-chooser Multi are excluded. | Pass | iOS now adds My Notes, StudyPad/Journal, and Compare rows from an explicit Android pseudo-document model, maps them to existing reader routes, excludes Memorize because Android marks it `HideFromSelector=1`, and excludes Multi because Android does not include it in `FakeBookFactory.pseudoDocuments`. |
+| About/delete/delete-index actions | Long-press action mode exposes about, delete, delete index, and unlock actions where applicable. | Partial Pass | iOS installed-module rows expose About, Uninstall, and Delete Index through the same presentation and module-management services used by Downloads. Unlock remains hidden because iOS still lacks a real cipher-key coordinator. |
 | Downloads handoff | Toolbar Downloads opens `DownloadActivity`; returning reloads the document list. | Pass | iOS exposes a persistent Downloads toolbar action and refreshes installed modules when the Downloads sheet closes. |
 | Selection result | Returns selected initials to the reader, which updates the active document. | Adapted Pass | iOS switches the active pane controller directly. Dictionary/general-book/map selections still open their content browsers after switching, matching the existing reader category behavior. |
 
 ## Follow-Up Targets
 
-- Add Android pseudo-document row support when iOS has a model/source for visible pseudo-documents.
 - Add encrypted-module unlock parity instead of only displaying lock state.
-- Add row context actions for about/delete/delete-index/unlock, backed by real module mutation services.
 - Revisit search if iOS adopts Android's indexed document search semantics for chooser rows.

--- a/docs/parity/reader/modal-ownership-matrix.md
+++ b/docs/parity/reader/modal-ownership-matrix.md
@@ -65,7 +65,7 @@ Android references:
 | `ReaderModal.syncSettings` | `SyncSettingsView` in a coordinator modal | `Android app-owned` | `SyncSettingsActivity` | Adapted app-owned settings route. |
 | `ReaderModal.importExport` | `ImportExportView` in a coordinator modal | `Android app-owned` plus `iOS system boundary` | Android backup/import/export flows plus OS file/share intents | App-owned route may use native iOS file/share boundaries only at OS handoff points. |
 | `ReaderModal.speakControls` | `SpeakControlView` with detents | `Android app-owned` | Android speak transport/activity/widget | Adapted app-owned route; transport semantics must remain reader/pane-aware. |
-| `ReaderModal.modulePicker` | Category-scoped `BibleReaderModulePicker` | `Android app-owned` | `ChooseDocument` with type extra | Partial. Full chooser behavior is tracked by #245. |
+| `ReaderModal.modulePicker` | Category-scoped `BibleReaderModulePicker` in the full-screen document chooser presenter | `Android app-owned` | `ChooseDocument` with type extra | App-owned full-screen route. Remaining encrypted unlock behavior is documented in the chooser matrix. |
 | `ReaderModal.dictionaryBrowser` | Dictionary browser modal | `Android app-owned` | Android dictionary/key selection surfaces | Adapted app-owned browser route. Verify key-selection behavior when touched. |
 | `ReaderModal.generalBookBrowser` | General-book browser modal | `Android app-owned` | Android general-book/key selection surfaces | Adapted app-owned browser route. Verify key-selection behavior when touched. |
 | `ReaderModal.mapBrowser` | Map browser modal | `Android app-owned` | Android map/key selection surfaces | Adapted app-owned browser route. Verify key-selection behavior when touched. |
@@ -74,7 +74,7 @@ Android references:
 | `ReaderModal.epubSearch` | EPUB search modal | `Android app-owned` | Android EPUB search activity | Adapted app-owned route. |
 | `ReaderModal.labelManager` | `LabelManagerView` from overflow | `Android app-owned` | `ManageLabels` activity | Partial. Label/StudyPad ownership details are tracked by #246. |
 | `ReaderModal.studyPadSelector` | `LabelManagerView` configured for StudyPad selection | `Android app-owned` | `ManageLabels` with `Mode.STUDYPAD` | Partial. StudyPad presentation and mutation details are tracked by #246. |
-| `ReaderModal.chooseDocument` | All-types `BibleReaderModulePicker` | `Android app-owned` | `ChooseDocument` without a type extra | Partial. Full chooser behavior is tracked by #245. |
+| `ReaderModal.chooseDocument` | All-types `BibleReaderModulePicker` in the full-screen document chooser presenter | `Android app-owned` | `ChooseDocument` without a type extra | App-owned full-screen route. Remaining encrypted unlock behavior is documented in the chooser matrix. |
 | `ReaderModal.help` | `HelpView` in a coordinator modal | `Android app-owned` | Android help dialog/activity surfaces | Adapted informational route. Vue-scoped help remains bridge-owned when invoked from Vue. |
 
 ## Standalone Transient Routes

--- a/scripts/test_reader_modal_ownership_matrix.py
+++ b/scripts/test_reader_modal_ownership_matrix.py
@@ -138,15 +138,14 @@ class ReaderModalOwnershipMatrixTests(unittest.TestCase):
         Keep incomplete reader modal routes tied to explicit follow-up work.
 
         Android parity is not satisfied by labeling an iOS sheet as native.
-        These rows intentionally remain partial, so their issue references must
-        stay visible in the disposition column until the owning behavior is
-        migrated or completed.
+        Rows listed here intentionally remain partial, so their issue references
+        must stay visible in the disposition column until the owning behavior is
+        migrated or completed. Completed chooser routes should not remain in this
+        sentinel because that would normalize stale partial-parity language.
         """
         matrix = MATRIX.read_text(encoding="utf-8")
 
         expected_issues = {
-            "ReaderModal.chooseDocument": "#245",
-            "ReaderModal.modulePicker": "#245",
             "ReaderModal.labelManager": "#246",
             "ReaderModal.studyPadSelector": "#246",
         }

--- a/scripts/test_search_fixture_guardrails.py
+++ b/scripts/test_search_fixture_guardrails.py
@@ -94,15 +94,24 @@ class SearchFixtureGuardrailsTests(unittest.TestCase):
                 re.DOTALL,
             ),
         )
+        open_search_body = swift_function_body(support_source, "openSearch")
+        presentation_body = swift_function_body(support_source, "presentSearchFromReader")
+
         for expected_pattern in [
             r"resolveFixtureScenario\(\s*environment:\s*ProcessInfo\.processInfo\.environment,"
             r"\s*file:\s*file,\s*line:\s*line\s*\)",
-            r"tapReaderSearchEntry\(\s*in:\s*app\s*,\s*(?:timeout:\s*[^,]+,\s*)?file:\s*file,"
-            r"\s*line:\s*line\s*\)",
-            r"requireSearchScreen\(\s*in:\s*app\s*,\s*(?:timeout:\s*[^,]+,\s*)?file:\s*file,"
+            r"presentSearchFromReader\(\s*in:\s*app\s*,\s*timeout:\s*20,\s*file:\s*file,"
             r"\s*line:\s*line\s*\)",
         ]:
-            self.assertRegex(support_source, re.compile(expected_pattern, re.DOTALL))
+            self.assertRegex(open_search_body, re.compile(expected_pattern, re.DOTALL))
+
+        for expected_pattern in [
+            r"tapReaderSearchEntry\(\s*in:\s*app\s*,[\s\S]*?file:\s*file,"
+            r"\s*line:\s*line\s*\)",
+            r"tapReaderAction\(\s*\"readerOpenSearchAction\",\s*in:\s*app,[\s\S]*?file:\s*file,"
+            r"\s*line:\s*line\s*\)",
+        ]:
+            self.assertRegex(presentation_body, re.compile(expected_pattern, re.DOTALL))
 
         readiness_calls = re.findall(
             r"waitForSearchInteractionReady\([\s\S]*?"

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -70,6 +70,30 @@ def swift_function_bodies(source: str, name: str) -> list[str]:
 class SemanticWaitGuardrailsTests(unittest.TestCase):
     """Protects pure semantic-state waits from regressing to ad hoc run-loop polling."""
 
+    def test_search_state_candidates_prefer_screen_root_before_hidden_export(self) -> None:
+        """Keep Search readiness polling off the volatile hidden static-text export first."""
+        element_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(element_source, "semanticStateValueCandidates")
+        search_case_start = body.find('case "searchStateExport":')
+        bookmark_case_start = body.find('case "bookmarkListStateExport":')
+        self.assertNotEqual(search_case_start, -1)
+        self.assertNotEqual(bookmark_case_start, -1)
+
+        search_case = body[search_case_start:bookmark_case_start]
+        root_candidate = 'app.otherElements["searchScreen"].firstMatch'
+        hidden_export_candidate = (
+            'screenScopedStateCandidates(identifier, within: "searchScreen", in: app)'
+        )
+
+        self.assertIn(root_candidate, search_case)
+        self.assertIn(hidden_export_candidate, search_case)
+        self.assertLess(
+            search_case.find(root_candidate),
+            search_case.find(hidden_export_candidate),
+        )
+
     def test_resolved_semantic_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
         """Ensure the shared pure-observation wait is backed by XCTest wait primitives."""
         state_source = (

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -114,8 +114,8 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertLess(body.find(scoped_button_candidates), body.find(identifier_candidate))
         self.assertLess(body.find(title_candidate), body.find(identifier_candidate))
 
-    def test_search_state_candidates_use_screen_root_without_hidden_export_fallback(self) -> None:
-        """Keep Search readiness polling off the volatile hidden static-text export."""
+    def test_search_state_candidates_prefer_hidden_export_before_screen_root(self) -> None:
+        """Keep Search state polling on the dedicated lightweight export before the root."""
         element_source = (
             REPO_ROOT / "AndBibleUITests/AndBibleUITestElementSupport.swift"
         ).read_text(encoding="utf-8")
@@ -132,7 +132,11 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         )
 
         self.assertIn(root_candidate, search_case)
-        self.assertNotIn(hidden_export_candidate, search_case)
+        self.assertIn(hidden_export_candidate, search_case)
+        self.assertLess(
+            search_case.find(hidden_export_candidate),
+            search_case.find(root_candidate),
+        )
 
     def test_search_interaction_ready_does_not_read_state_before_poll_loop(self) -> None:
         """Keep the Search readiness timeout from being consumed by a pre-loop XCTest snapshot."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -151,6 +151,53 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertNotIn("resolvedSearchStateValue", pre_loop)
         self.assertNotIn("searchScreen.value", pre_loop)
 
+    def test_window_tab_bar_identifier_belongs_to_scroll_view_container(self) -> None:
+        """Keep tab-button lookup scoped to the actual container that owns the buttons."""
+        source = (
+            REPO_ROOT / "Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift"
+        ).read_text(encoding="utf-8")
+        body_start = source.find("var body: some View")
+        footer_start = source.find("private func footerStrip")
+        self.assertNotEqual(body_start, -1)
+        self.assertNotEqual(footer_start, -1)
+
+        body_section = source[body_start:footer_start]
+        footer_body = swift_function_body(source, "footerStrip")
+        scroll_view = "ScrollView(.horizontal, showsIndicators: false)"
+        identifier = '.accessibilityIdentifier("windowTabBar")'
+
+        self.assertNotIn(identifier, body_section)
+        self.assertIn(scroll_view, footer_body)
+        self.assertIn(identifier, footer_body)
+        self.assertLess(footer_body.find(scroll_view), footer_body.find(identifier))
+
+    def test_window_tab_helpers_avoid_app_wide_button_fallbacks(self) -> None:
+        """Keep tab selection from falling back to expensive full-hierarchy button queries."""
+        element_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        reader_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestReaderSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        candidates_body = swift_function_body(element_source, "windowTabBarButtonCandidates")
+        tap_body = swift_function_body(element_source, "tapWindowTab")
+        add_body = swift_function_body(element_source, "addWindowTab")
+        existence_body = swift_function_body(reader_source, "waitForElementExistence")
+
+        self.assertIn('app.scrollViews["windowTabBar"].firstMatch', candidates_body)
+        self.assertIn('app.otherElements["windowTabBar"].firstMatch', candidates_body)
+        self.assertNotIn("app.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.collectionViews.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.cells.buttons[identifier]", candidates_body)
+
+        self.assertIn("requireWindowTabBarButton", tap_body)
+        self.assertNotIn("requireElement(identifier", tap_body)
+        self.assertIn("requireWindowTabBarButton", add_body)
+        self.assertIn("resolvedWindowTabBarButton", add_body)
+        self.assertIn("isWindowTabBarButtonIdentifier", existence_body)
+        self.assertIn("resolvedWindowTabBarButton", existence_body)
+
     def test_resolved_semantic_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
         """Ensure the shared pure-observation wait is backed by XCTest wait primitives."""
         state_source = (

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -67,6 +67,29 @@ def swift_function_bodies(source: str, name: str) -> list[str]:
     return bodies
 
 
+def swift_property_body(source: str, name: str) -> str:
+    """Return the Swift computed property body for focused source-contract checks."""
+    match = re.search(rf"\bvar\s+{re.escape(name)}\b", source)
+    if match is None:
+        raise AssertionError(f"Expected Swift property {name} to exist.")
+
+    brace_index = source.find("{", match.end())
+    if brace_index == -1:
+        raise AssertionError(f"Expected Swift property {name} to have a body.")
+
+    depth = 0
+    for index in range(brace_index, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_index + 1 : index]
+
+    raise AssertionError(f"Expected Swift property {name} body to close.")
+
+
 class SemanticWaitGuardrailsTests(unittest.TestCase):
     """Protects pure semantic-state waits from regressing to ad hoc run-loop polling."""
 
@@ -204,6 +227,10 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
 
         candidates_body = swift_function_body(element_source, "windowTabBarButtonCandidates")
         tap_body = swift_function_body(element_source, "tapWindowTab")
+        coordinate_tap_body = swift_function_body(
+            element_source,
+            "tapWindowTabAtExpectedFooterCoordinate",
+        )
         add_body = swift_function_body(element_source, "addWindowTab")
         existence_body = swift_function_body(reader_source, "waitForElementExistence")
 
@@ -215,10 +242,24 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
 
         self.assertIn("requireWindowTabBarButton", tap_body)
         self.assertNotIn("requireElement(identifier", tap_body)
+        self.assertIn("tapWindowTabAtExpectedFooterCoordinate", tap_body)
+        self.assertIn('waitForReaderRenderedContentStateIfPresent', coordinate_tap_body)
+        self.assertIn('"windowOrder=\\(order)"', coordinate_tap_body)
         self.assertIn("requireWindowTabBarButton", add_body)
         self.assertIn("resolvedWindowTabBarButton", add_body)
         self.assertIn("isWindowTabBarButtonIdentifier", existence_body)
         self.assertIn("resolvedWindowTabBarButton", existence_body)
+
+    def test_reader_state_export_includes_window_tab_orders_for_tab_fallback(self) -> None:
+        """Expose tab order metadata so tests can tap the real footer without stale queries."""
+        source = (
+            REPO_ROOT / "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_property_body(source, "readerRenderedContentStateValue")
+
+        self.assertIn("windowTabOrders=", body)
+        self.assertIn("windowManager.allWindows", body)
+        self.assertIn('return "\\(windowToken);\\(contentToken);\\(tabOrdersToken);', body)
 
     def test_resolved_semantic_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
         """Ensure the shared pure-observation wait is backed by XCTest wait primitives."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -70,8 +70,52 @@ def swift_function_bodies(source: str, name: str) -> list[str]:
 class SemanticWaitGuardrailsTests(unittest.TestCase):
     """Protects pure semantic-state waits from regressing to ad hoc run-loop polling."""
 
-    def test_search_state_candidates_prefer_screen_root_before_hidden_export(self) -> None:
-        """Keep Search readiness polling off the volatile hidden static-text export first."""
+    def test_workspace_create_prompt_waits_on_prompt_root_before_buttons(self) -> None:
+        """Avoid hosted XCTest stalls from proving absent prompt buttons before root exists."""
+        list_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestListSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(list_source, "openWorkspaceCreatePrompt")
+
+        prompt_root = '"workspaceNamePromptScreen"'
+        prompt_field = '"workspaceNamePromptTextField"'
+        confirm_button = '"workspaceNamePromptConfirmButton"'
+        cancel_button = '"workspaceNamePromptCancelButton"'
+
+        for identifier in [prompt_root, prompt_field, confirm_button, cancel_button]:
+            self.assertIn(identifier, body)
+
+        self.assertLess(body.find(prompt_root), body.find(confirm_button))
+        self.assertLess(body.find(prompt_field), body.find(confirm_button))
+        self.assertLess(body.find(prompt_root), body.find(cancel_button))
+        self.assertLess(body.find(prompt_field), body.find(cancel_button))
+
+    def test_workspace_prompt_button_candidates_prefer_prompt_scope_and_titles(self) -> None:
+        """Keep workspace prompt button lookup off expensive app-wide identifier queries first."""
+        element_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(element_source, "workspaceNamePromptButtonCandidates")
+
+        prompt_candidate = 'app.otherElements["workspaceNamePromptScreen"].firstMatch'
+        scoped_button_candidates = "modalButtonCandidates("
+        title_candidate = "app.buttons[title].firstMatch"
+        identifier_candidate = "app.buttons[identifier].firstMatch"
+
+        for snippet in [
+            prompt_candidate,
+            scoped_button_candidates,
+            title_candidate,
+            identifier_candidate,
+        ]:
+            self.assertIn(snippet, body)
+
+        self.assertLess(body.find(prompt_candidate), body.find(identifier_candidate))
+        self.assertLess(body.find(scoped_button_candidates), body.find(identifier_candidate))
+        self.assertLess(body.find(title_candidate), body.find(identifier_candidate))
+
+    def test_search_state_candidates_use_screen_root_without_hidden_export_fallback(self) -> None:
+        """Keep Search readiness polling off the volatile hidden static-text export."""
         element_source = (
             REPO_ROOT / "AndBibleUITests/AndBibleUITestElementSupport.swift"
         ).read_text(encoding="utf-8")
@@ -88,11 +132,20 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         )
 
         self.assertIn(root_candidate, search_case)
-        self.assertIn(hidden_export_candidate, search_case)
-        self.assertLess(
-            search_case.find(root_candidate),
-            search_case.find(hidden_export_candidate),
-        )
+        self.assertNotIn(hidden_export_candidate, search_case)
+
+    def test_search_interaction_ready_does_not_read_state_before_poll_loop(self) -> None:
+        """Keep the Search readiness timeout from being consumed by a pre-loop XCTest snapshot."""
+        search_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(search_source, "waitForSearchInteractionReady")
+        loop_start = body.find("while Date() < deadline")
+        self.assertNotEqual(loop_start, -1)
+
+        pre_loop = body[:loop_start]
+        self.assertNotIn("resolvedSearchStateValue", pre_loop)
+        self.assertNotIn("searchScreen.value", pre_loop)
 
     def test_resolved_semantic_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
         """Ensure the shared pure-observation wait is backed by XCTest wait primitives."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -151,6 +151,28 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertNotIn("resolvedSearchStateValue", pre_loop)
         self.assertNotIn("searchScreen.value", pre_loop)
 
+    def test_search_opening_verifies_presentation_before_success(self) -> None:
+        """Keep reader-triggered Search opening state-driven instead of tap-assumption driven."""
+        search_source = (
+            REPO_ROOT / "AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+        open_body = swift_function_body(search_source, "openSearch")
+        presentation_body = swift_function_body(search_source, "presentSearchFromReader")
+
+        self.assertIn("presentSearchFromReader", open_body)
+        self.assertNotIn("tapReaderSearchEntry", open_body)
+        self.assertIn("resolvedSearchScreenElement", presentation_body)
+        self.assertIn('readerRenderedContentStateContains("searchVisible=true"', presentation_body)
+        drawer_action = re.search(
+            r"tapReaderAction\s*\(\s*\"readerOpenSearchAction\"",
+            presentation_body,
+        )
+        self.assertIsNotNone(drawer_action)
+        self.assertLess(
+            presentation_body.find("tapReaderSearchEntry"),
+            drawer_action.start(),
+        )
+
     def test_window_tab_bar_identifier_belongs_to_scroll_view_container(self) -> None:
         """Keep tab-button lookup scoped to the actual container that owns the buttons."""
         source = (


### PR DESCRIPTION
## Summary
Aligns the iOS document chooser with Android `ChooseDocument` behavior by using Android-style document rows inside a full-screen app-owned chooser surface.

## Scope
- `BibleReaderModulePicker` row modeling, filtering, ordering, search, selection, and installed-document actions.
- Reader modal routing for the all-types and category-scoped document chooser presentation shell.
- Reader modal wiring for StudyPads/Journal pseudo-document routing.
- Regression coverage for Android pseudo-documents, Add-ons filtering, row actions, routing, and full-screen chooser presentation.
- Reader document chooser and modal ownership parity matrix updates.

## Contract References
- Android `ChooseDocument`, `DocumentSelectionBase`, and `FakeBookFactory` behavior tracked by #245.
- iOS parity records: `docs/parity/reader/document-chooser-matrix.md` and `docs/parity/reader/modal-ownership-matrix.md`.

## Change Details
- Presents both `ReaderModal.chooseDocument` and `ReaderModal.modulePicker` through a full-screen cover instead of the generic SwiftUI sheet host.
- Removes medium/large sheet detents from the chooser view.
- Adds Android-visible pseudo-documents: My Notes, StudyPads/Journal, and Compare.
- Keeps Android-hidden/non-chooser pseudo-documents out of the picker: Memorize and Multi.
- Adds an Add-ons filter and keeps Add-ons selectable as no-op rows, matching Android's `AND_BIBLE` category handling.
- Sorts installed documents before pseudo-documents, then by Android category rank and initials/title.
- Adds About, Uninstall, and Delete Index actions for installed rows through the existing module-management services.
- Keeps Unlock hidden because iOS still lacks a real cipher-key coordinator; that remains a documented gap rather than a fake affordance.

## Validation Evidence
- Watched `testBibleReaderDocumentChooserRoutesUseFullScreenCoverInsteadOfSheetDetents` fail before the presenter fix.
- Focused picker/chooser regression tests passed on iPhone 16 iOS 18.6 simulator.
- `python3 scripts/test_reader_modal_ownership_matrix.py` passed.
- Full `AndBibleTests` suite passed on iPhone 16 iOS 18.6 simulator: 594 tests, 0 failures.
- `git diff --check` passed.
- GitNexus impact checks and `gitnexus detect-changes --scope all` were run; final change detection reported the intended six-file follow-up at low risk.

## Risks / Follow-ups
- Encrypted unlock remains a parity gap until iOS has a real unlock/cipher-key flow.
- Search remains an iOS in-memory adaptation rather than Android's indexed chooser search.
- The worktree used an ignored local symlink to the root `libsword.xcframework` so Xcode could resolve the package during verification.

Closes #245

## Screenshots

| Old | New |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - AndBible Local Downloads UI iPhone 17 - 2026-06-23 at 23 27 44" src="https://github.com/user-attachments/assets/59fca9aa-4dad-4e72-a745-752427855b76" /> |  <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-23 at 23 49 55" src="https://github.com/user-attachments/assets/e9e5ea64-a1f5-487a-9f6f-0a750d213fc7" /> |