### PR TITLE
refactor(reader): extract compare document builder

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -126,6 +126,59 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the extracted compare document builder's Android `MultiDocument` contract.
+
+     Android renders Compare through `FakeBookFactory.compareDocument` as a multi-fragment Bible
+     document with `compare=true`. This test exercises the builder directly against the bundled KJV
+     SWORD fixture so the controller can remain an orchestration boundary while the builder owns
+     module ordering, verse extraction, range titles, and typed bridge JSON assembly.
+     */
+    func testCompareDocumentBuilderBuildsAndroidMultiDocumentPayload() throws {
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let moduleInfo = try XCTUnwrap(manager.installedModules().first { $0.name == "KJV" })
+        let builder = BibleReaderCompareDocumentBuilder(
+            swordManager: manager,
+            installedBibleModules: [moduleInfo],
+            activeModuleName: "KJV"
+        )
+
+        let request = try XCTUnwrap(
+            builder.makeRequest(
+                osisBookId: "2Cor",
+                bookName: "2 Corinthians",
+                chapter: 2,
+                isNewTestament: true,
+                startVerse: 5,
+                endVerse: 7
+            )
+        )
+        let json = try XCTUnwrap(BibleReaderCompareDocumentBuilder.buildDocumentJSON(request))
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+
+        XCTAssertEqual(object["type"] as? String, "multi")
+        XCTAssertEqual(object["compare"] as? Bool, true)
+        let fragments = try XCTUnwrap(object["osisFragments"] as? [[String: Any]])
+        XCTAssertEqual(fragments.count, 1)
+        let fragment = try XCTUnwrap(fragments.first)
+        XCTAssertEqual(fragment["bookCategory"] as? String, DocumentCategory.bible.rawValue)
+        XCTAssertEqual(fragment["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(fragment["bookAbbreviation"] as? String, "KJV")
+        XCTAssertEqual(fragment["osisRef"] as? String, "2Cor.2.5-2Cor.2.7")
+        XCTAssertEqual(fragment["keyName"] as? String, "2 Corinthians 2:5-7")
+        XCTAssertEqual(fragment["isNewTestament"] as? Bool, true)
+        XCTAssertEqual(fragment["hasStrongs"] as? Bool, true)
+        XCTAssertEqual(fragment["language"] as? String, "en")
+        XCTAssertEqual(fragment["direction"] as? String, "ltr")
+        XCTAssertEqual(fragment["ordinalRange"] as? [Int], [
+            try XCTUnwrap(manager.module(named: "KJV")?.verseOrdinal(osisBookId: "2Cor", chapter: 2, verse: 5)),
+            try XCTUnwrap(manager.module(named: "KJV")?.verseOrdinal(osisBookId: "2Cor", chapter: 2, verse: 7)),
+        ])
+    }
+
+    /**
      Protects the extracted reader document payload factory's Bible document contract.
 
      Android and Vue consume document ordinals, Strong's capability, reading progress, and

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -750,10 +750,10 @@ extension AndBibleUITests {
             ]
         case "aboutDoneButton", "labelAssignmentDoneButton", "bookmarkListDoneButton":
             return [
-                app.buttons[identifier].firstMatch,
                 app.navigationBars.buttons[identifier].firstMatch,
                 app.toolbars.buttons[identifier].firstMatch,
                 app.collectionViews.buttons[identifier].firstMatch,
+                app.buttons[identifier].firstMatch,
                 app.otherElements[identifier].firstMatch,
             ]
         case "aboutScreen":

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1609,12 +1609,26 @@ extension AndBibleUITests {
     }
 
     /**
-     Taps one bottom window-tab pill by order number and waits for its active state to surface.
+     Taps one bottom window-tab pill by order number and waits for activation to surface.
 
      The coordinate path exercises the real Android-parity footer strip without forcing XCTest to
      snapshot the full reader hierarchy. If that coordinate misses because the footer geometry differs
      on a runner, the scoped `windowTabBar` accessibility path is still a valid user tap target and is
      cheaper than app-wide button queries.
+     *
+     * - Parameters:
+     *   - order: Stable window order encoded in the tab accessibility identifier.
+     *   - app: Running application under test.
+     *   - timeout: Maximum time allowed for the tab to become active.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Side effects:
+     *   - taps the real tab-bar control, retrying inside the original timeout when XCTest reports
+     *     a successful tap but the semantic active-window state does not change
+     *   - samples fresh tab and rendered-reader state on each poll so SwiftUI view replacement does
+     *     not leave the helper waiting on a stale `XCUIElement` instance
+     * - Failure modes:
+     *   - fails if the requested tab never appears, cannot be tapped, or never becomes active
      */
     func tapWindowTab(
         _ order: Int,
@@ -1635,26 +1649,39 @@ extension AndBibleUITests {
         }
 
         let identifier = "windowTabButton::\(order)"
-        let tabButton = requireWindowTabBarButton(identifier, in: app, timeout: timeout, file: file, line: line)
-        tapElementReliably(tabButton, timeout: timeout, file: file, line: line)
-
         let deadline = Date().addingTimeInterval(timeout)
+        var didTap = false
+        var lastTapTime = Date.distantPast
+        var lastValue = "nil"
+        var lastRenderedState = "nil"
+
         repeat {
-            if readerRenderedContentStateContains("windowOrder=\(order)", in: app) {
-                return
+            if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
+                lastValue = tabButton.value.map { "\($0)" } ?? "nil"
+                lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+
+                if lastValue.contains("state=active") || lastRenderedState.contains("windowOrder=\(order)") {
+                    return
+                }
+
+                if !didTap || Date().timeIntervalSince(lastTapTime) >= 1.0 {
+                    let remaining = max(0.1, deadline.timeIntervalSinceNow)
+                    if tapElementIfPossible(tabButton, timeout: min(1, remaining)) {
+                        didTap = true
+                        lastTapTime = Date()
+                    }
+                }
+            } else {
+                lastValue = "missing"
+                lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
             }
-            if let value = tabButton.value as? String,
-               value.contains("state=active") {
-                return
-            }
+
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        let lastValue = tabButton.value.map { "\($0)" } ?? "nil"
-        let finalState = readerRenderedContentStateValue(in: app) ?? "nil"
         let coordinateNote = attemptedCoordinateTap ? " after coordinate fallback missed" : ""
         XCTFail(
-            "Expected window tab \(order) to become active\(coordinateNote) within \(timeout) seconds; last value was '\(lastValue)' and final reader state was '\(finalState)'.",
+            "Expected window tab \(order) to become active\(coordinateNote) within \(timeout) seconds; last tab value was '\(lastValue)' and last reader state was '\(lastRenderedState)'.",
             file: file,
             line: line
         )

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1661,7 +1661,13 @@ extension AndBibleUITests {
         var lastTapTime = Date.distantPast
         var lastValue = "nil"
         var lastRenderedState = "nil"
-        var firstResolvedTab: XCUIElement?
+        var firstResolvedTab: XCUIElement? = requireWindowTabBarButton(
+            identifier,
+            in: app,
+            timeout: timeout,
+            file: file,
+            line: line
+        )
 
         repeat {
             lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
@@ -1669,7 +1675,7 @@ extension AndBibleUITests {
                 return
             }
 
-            if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
+            if let tabButton = firstResolvedTab ?? resolvedWindowTabBarButton(identifier, in: app) {
                 firstResolvedTab = tabButton
                 lastValue = tabButton.value.map { "\($0)" } ?? "nil"
 

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1623,8 +1623,10 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - taps the real tab-bar control, retrying inside the original timeout when XCTest reports
-     *     a successful tap but the semantic active-window state does not change
+     *   - waits for the requested tab to appear, then starts a separate activation wait so slow
+     *     CI accessibility resolution cannot consume the whole post-tap confirmation window
+     *   - taps the real tab-bar control, retrying while XCTest reports a successful tap but the
+     *     semantic active-window state does not change
      *   - samples fresh tab and rendered-reader state on each poll so SwiftUI view replacement does
      *     not leave the helper waiting on a stale `XCUIElement` instance
      * - Failure modes:
@@ -1649,14 +1651,49 @@ extension AndBibleUITests {
         }
 
         let identifier = "windowTabButton::\(order)"
-        let deadline = Date().addingTimeInterval(timeout)
+        let appearanceDeadline = Date().addingTimeInterval(timeout)
         var didTap = false
         var lastTapTime = Date.distantPast
         var lastValue = "nil"
         var lastRenderedState = "nil"
+        var firstResolvedTab: XCUIElement?
 
         repeat {
+            lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+            if lastRenderedState.contains("windowOrder=\(order)") {
+                return
+            }
+
             if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
+                firstResolvedTab = tabButton
+                lastValue = tabButton.value.map { "\($0)" } ?? "nil"
+
+                if lastValue.contains("state=active") {
+                    return
+                }
+                break
+            } else {
+                lastValue = "missing"
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < appearanceDeadline
+
+        guard firstResolvedTab != nil else {
+            XCTFail(
+                "Expected window tab \(order) to appear within \(timeout) seconds; last reader state was '\(lastRenderedState)'.",
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        let activationDeadline = Date().addingTimeInterval(timeout)
+        repeat {
+            let tabButton = firstResolvedTab ?? resolvedWindowTabBarButton(identifier, in: app)
+            firstResolvedTab = nil
+
+            if let tabButton {
                 lastValue = tabButton.value.map { "\($0)" } ?? "nil"
                 lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
 
@@ -1665,7 +1702,7 @@ extension AndBibleUITests {
                 }
 
                 if !didTap || Date().timeIntervalSince(lastTapTime) >= 1.0 {
-                    let remaining = max(0.1, deadline.timeIntervalSinceNow)
+                    let remaining = max(0.1, activationDeadline.timeIntervalSinceNow)
                     if tapElementIfPossible(tabButton, timeout: min(1, remaining)) {
                         didTap = true
                         lastTapTime = Date()
@@ -1677,7 +1714,7 @@ extension AndBibleUITests {
             }
 
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+        } while Date() < activationDeadline
 
         let coordinateNote = attemptedCoordinateTap ? " after coordinate fallback missed" : ""
         XCTFail(

--- a/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -500,7 +500,13 @@ extension AndBibleUITests {
         return titledCandidates
     }
 
-    /// Returns workspace-name prompt buttons without starting from expensive app-wide id queries.
+    /**
+     Returns workspace-name prompt buttons without walking unrelated container hierarchies.
+
+     The workspace prompt is rendered as a selector-owned overlay, not as a navigation bar, toolbar,
+     table, or scroll-view control. Keeping this lookup on the actual button surface avoids hosted
+     XCTest snapshot stalls while preserving the production accessibility contract.
+     */
     func workspaceNamePromptButtonCandidates(
         _ identifier: String,
         in app: XCUIApplication
@@ -526,7 +532,6 @@ extension AndBibleUITests {
         }
         let directIdentifierCandidates = [
             app.buttons[identifier].firstMatch,
-            app.otherElements[identifier].firstMatch,
         ]
         return promptScopedCandidates + directTitleCandidates + directIdentifierCandidates
     }

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -744,13 +744,7 @@ extension AndBibleUITests {
 
                 let remaining = deadline.timeIntervalSinceNow
                 if remaining > 0,
-                   searchTranslationPickerStateIsOpen(in: app, timeout: min(1.5, max(0.25, remaining))) {
-                    return
-                }
-
-                let descendantWait = min(0.5, max(0, deadline.timeIntervalSinceNow))
-                if descendantWait > 0,
-                   firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: descendantWait) != nil {
+                   searchTranslationPickerIsOpen(in: app, timeout: min(1.5, max(0.25, remaining))) {
                     return
                 }
             }
@@ -862,7 +856,7 @@ extension AndBibleUITests {
         repeat {
             if let row = firstExistingElement(
                 searchTranslationRowCandidates(identifier, moduleName: moduleName, in: app),
-                timeout: 0.2
+                timeout: 0
             ) {
                 let expectedValue = expectedSearchTranslationRowValue(afterTapping: row)
                 if waitForElementToBecomeHittable(row, timeout: 1),
@@ -1013,23 +1007,13 @@ extension AndBibleUITests {
     /// Returns row candidates for one Search translation picker module.
     func searchTranslationRowCandidates(
         _ identifier: String,
-        moduleName: String,
+        moduleName _: String,
         in app: XCUIApplication
     ) -> [XCUIElement] {
-        let scoped = searchTranslationPickerListCandidates(in: app).flatMap { list in
-            [
-                list.buttons[identifier].firstMatch,
-                list.cells[identifier].firstMatch,
-                list.otherElements[identifier].firstMatch,
-                list.staticTexts[moduleName].firstMatch,
-            ]
-        }
-        return scoped + [
+        [
             app.buttons[identifier].firstMatch,
-            app.collectionViews.buttons[identifier].firstMatch,
             app.cells[identifier].firstMatch,
             app.otherElements[identifier].firstMatch,
-            app.staticTexts[moduleName].firstMatch,
         ]
     }
 

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -1570,4 +1570,74 @@ extension AndBibleUITests {
         return candidates.first ?? app.otherElements["searchResultRow::missing"].firstMatch
     }
 
+    /**
+     Selects a Search result row and waits for that selection to navigate the reader.
+     *
+     * - Parameters:
+     *   - identifier: Accessibility identifier of the expected `searchResultRow::` control.
+     *   - initialReference: Reader reference value captured before opening or using Search.
+     *   - app: Running application under test.
+     *   - timeout: Maximum time for the result selection to change the reader reference.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Returns: First non-empty reader reference value that differs from `initialReference`.
+     * - Side effects:
+     *   - taps the live Search result row, retrying inside the original timeout only while the row
+     *     remains visible and the reader reference has not changed
+     *   - samples the Search semantic state and reader reference on each poll for failure context
+     * - Failure modes:
+     *   - fails if the row cannot be tapped or if Search dismisses/settles without changing the
+     *     reader reference
+     */
+    func tapSearchResultRowAndWaitForReaderReferenceChange(
+        _ identifier: String,
+        from initialReference: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        var didTap = false
+        var lastTapTime = Date.distantPast
+        var lastReference = initialReference
+        var lastSearchState = resolvedSearchStateValue(in: app) ?? "nil"
+        var rowWasVisible = false
+
+        repeat {
+            if let reference = resolvedElementSemanticText("bookChooserButton", in: app),
+               !reference.isEmpty {
+                lastReference = reference
+                if reference != initialReference {
+                    return reference
+                }
+            }
+
+            lastSearchState = resolvedSearchStateValue(in: app) ?? "nil"
+            if let row = resolvedElement(identifier, in: app) {
+                rowWasVisible = true
+                if !didTap || Date().timeIntervalSince(lastTapTime) >= 1.0 {
+                    let remaining = max(0.1, deadline.timeIntervalSinceNow)
+                    if tapElementIfPossible(row, timeout: min(1, remaining)) {
+                        didTap = true
+                        lastTapTime = Date()
+                    }
+                }
+            } else {
+                rowWasVisible = false
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        XCTAssertNotEqual(
+            lastReference,
+            initialReference,
+            "Expected selecting Search result '\(identifier)' to move the reader away from '\(initialReference)' within \(timeout) seconds; last reader reference was '\(lastReference)', last Search state was '\(lastSearchState)', rowVisible=\(rowWasVisible).",
+            file: file,
+            line: line
+        )
+        return lastReference
+    }
+
 }

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -1099,15 +1099,15 @@ extension AndBibleUITests {
     }
 
     /**
-     Resolves one label row by its accessibility label.
+     Resolves one label row through the production row identifier or visible row text.
      *
      * - Parameters:
      *   - name: User-visible label name expected on the row.
      *   - app: Running application under test.
-     * - Returns: The first matching Label Manager row button for the requested label name.
+     * - Returns: The first matching Label Manager row surface for the requested label name.
      * - Side effects:
-     *   - queries the live accessibility hierarchy for a label-manager row whose label matches
-     *     `name`
+     *   - queries the live accessibility hierarchy for the label-manager row identifier, then for
+     *     the visible label text SwiftUI exposes inside that row
      * - Failure modes:
      *   - returns an unresolved query when no matching row currently exists
      */
@@ -1118,6 +1118,10 @@ extension AndBibleUITests {
             if scopedButton.exists {
                 return scopedButton
             }
+            let scopedText = labelManagerScreen.staticTexts[name].firstMatch
+            if scopedText.exists {
+                return scopedText
+            }
             let scopedLink = labelManagerScreen.links[identifier].firstMatch
             if scopedLink.exists {
                 return scopedLink
@@ -1127,6 +1131,10 @@ extension AndBibleUITests {
         let globalButton = app.buttons[identifier].firstMatch
         if globalButton.exists {
             return globalButton
+        }
+        let globalText = app.staticTexts[name].firstMatch
+        if globalText.exists {
+            return globalText
         }
         let globalLink = app.links[identifier].firstMatch
         if globalLink.exists {
@@ -1158,14 +1166,23 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> XCUIElement {
-        let element = labelRow(named: name, in: app)
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            let element = labelRow(named: name, in: app)
+            if element.exists {
+                return element
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let fallback = labelRow(named: name, in: app)
         XCTAssertTrue(
-            element.waitForExistence(timeout: timeout),
+            fallback.exists,
             "Expected label row '\(name)' to exist within \(timeout) seconds.",
             file: file,
             line: line
         )
-        return element
+        return fallback
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -813,6 +813,76 @@ extension AndBibleUITests {
     }
 
     /**
+     Taps one inline Label Assignment control until the row reports the expected semantic value.
+     *
+     * - Parameters:
+     *   - controlPrefix: Accessibility identifier prefix for the inline control to tap.
+     *   - labelSegment: Identifier-safe label segment shared by the row and inline controls.
+     *   - expectedRowValue: Full row accessibility value expected after the mutation.
+     *   - expectedControlValue: Control accessibility value expected after the mutation.
+     *   - app: Running application under test.
+     *   - timeout: Maximum time allowed for the row state to settle.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Side effects:
+     *   - re-resolves the row and inline control while polling
+     *   - retries the tap only while the control itself still reports the pre-mutation state
+     * - Failure modes:
+     *   - fails if the row never reaches `expectedRowValue` before timeout
+     */
+    func tapLabelAssignmentControlUntilRowValue(
+        _ controlPrefix: String,
+        labelSegment: String,
+        expectedRowValue: String,
+        expectedControlValue: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let rowIdentifier = "labelAssignmentRow::\(labelSegment)"
+        let controlIdentifier = "\(controlPrefix)::\(labelSegment)"
+        let deadline = Date().addingTimeInterval(timeout)
+        var didTap = false
+        var lastTapTime = Date.distantPast
+        var lastRowValue = "nil"
+        var lastControlValue = "nil"
+
+        repeat {
+            if let row = resolvedElement(rowIdentifier, in: app) {
+                lastRowValue = row.value.map { "\($0)" } ?? "nil"
+                if lastRowValue == expectedRowValue {
+                    return
+                }
+            } else {
+                lastRowValue = "missing"
+            }
+
+            if let control = resolvedElement(controlIdentifier, in: app) {
+                lastControlValue = control.value.map { "\($0)" } ?? "nil"
+                if lastControlValue != expectedControlValue,
+                   !didTap || Date().timeIntervalSince(lastTapTime) >= 1.0 {
+                    let remaining = max(0.1, deadline.timeIntervalSinceNow)
+                    if tapElementIfPossible(control, timeout: min(1, remaining)) {
+                        didTap = true
+                        lastTapTime = Date()
+                    }
+                }
+            } else {
+                lastControlValue = "missing"
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        XCTFail(
+            "Expected label assignment row '\(rowIdentifier)' to reach value '\(expectedRowValue)' within \(timeout) seconds; last row value was '\(lastRowValue)' and last control value for '\(controlIdentifier)' was '\(lastControlValue)'.",
+            file: file,
+            line: line
+        )
+    }
+
+    /**
      Toggles the seeded label row inside Label Assignment and verifies the combined state change.
      *
      * - Parameter app: Running application under test.
@@ -831,27 +901,48 @@ extension AndBibleUITests {
             "Expected the seeded label row to start in a known non-favourite state, got '\(initialState ?? "nil")'."
         )
 
-        let favouriteButton = requireElement(
+        _ = requireElement(
             "labelAssignmentFavouriteButton::UI_Test_Seed",
             in: app,
             timeout: 10
         )
-        let toggleButton = requireElement(
+        _ = requireElement(
             "labelAssignmentToggleButton::UI_Test_Seed",
             in: app,
             timeout: 10
         )
 
-        tapElementReliably(favouriteButton, timeout: 10)
-        waitForElementValue("labelAssignmentRow::UI_Test_Seed", toEqual: "assigned,favourite", in: app, timeout: 10)
+        let favouritedState = initialState == "assigned,notFavourite"
+            ? "assigned,favourite"
+            : "unassigned,favourite"
+        tapLabelAssignmentControlUntilRowValue(
+            "labelAssignmentFavouriteButton",
+            labelSegment: "UI_Test_Seed",
+            expectedRowValue: favouritedState,
+            expectedControlValue: "favourite",
+            in: app,
+            timeout: 10
+        )
 
         if initialState == "assigned,notFavourite" {
-            tapElementReliably(toggleButton, timeout: 10)
-            waitForElementValue("labelAssignmentRow::UI_Test_Seed", toEqual: "unassigned,favourite", in: app, timeout: 10)
+            tapLabelAssignmentControlUntilRowValue(
+                "labelAssignmentToggleButton",
+                labelSegment: "UI_Test_Seed",
+                expectedRowValue: "unassigned,favourite",
+                expectedControlValue: "unassigned",
+                in: app,
+                timeout: 10
+            )
         }
 
-        tapElementReliably(toggleButton, timeout: 10)
-        waitForElementValue("labelAssignmentRow::UI_Test_Seed", toEqual: "assigned,favourite", in: app, timeout: 10)
+        tapLabelAssignmentControlUntilRowValue(
+            "labelAssignmentToggleButton",
+            labelSegment: "UI_Test_Seed",
+            expectedRowValue: "assigned,favourite",
+            expectedControlValue: "assigned",
+            in: app,
+            timeout: 10
+        )
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -499,7 +499,7 @@ extension AndBibleUITests {
         waitForSearchResultRow("searchResultRow::Genesis_1_2", in: app, shouldExist: true, timeout: 20)
 
         tapSearchTranslationPicker(in: app, timeout: 10)
-        tapSearchTranslationRow(moduleName: "UITESTWEB", in: app, timeout: 10)
+        tapSearchTranslationRow(moduleName: "UITESTWEB", in: app, timeout: 45)
         tapSearchTranslationDone(in: app, timeout: 10)
 
         waitForSearchSelectedModules(

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -626,10 +626,8 @@ extension AndBibleUITests {
 
         let noahResultIdentifier = "searchResultRow::Genesis_6_8"
         waitForSearchResultRow(noahResultIdentifier, in: app, shouldExist: true, timeout: 20)
-        let noahResult = requireElement(noahResultIdentifier, in: app, timeout: 20)
-        tapElementReliably(noahResult, timeout: 10)
-
-        let updatedReference = waitForReaderReferenceValueToChange(
+        let updatedReference = tapSearchResultRowAndWaitForReaderReferenceChange(
+            noahResultIdentifier,
             from: initialReference,
             in: app,
             timeout: 20

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
@@ -1,0 +1,337 @@
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+import os.log
+
+private let compareDocumentBuilderLogger = Logger(subsystem: "org.andbible", category: "BibleReaderCompareDocumentBuilder")
+
+/**
+ Builds Android-style Compare `MultiDocument` payloads.
+
+ `BibleReaderController` owns bridge orchestration and stale async request protection. This builder
+ owns Compare-specific module selection, verse extraction, range labeling, and typed bridge payload
+ assembly so the controller does not need to carry document-construction rules.
+ */
+struct BibleReaderCompareDocumentBuilder {
+    /// Active SWORD manager used to resolve cached `ModuleInfo` entries into module readers.
+    private let swordManager: SwordManager?
+    /// Cached installed Bible metadata from the controller, used before falling back to SWORD.
+    private let installedBibleModules: [ModuleInfo]
+    /// Active Bible initials; Compare should present this module first when it is installed.
+    private let activeModuleName: String
+
+    /**
+     Captures all main-reader state needed to build a compare payload away from the main queue.
+     */
+    struct Request {
+        /// Modules to include in compare output, paired with their SWORD readers.
+        let modules: [(info: ModuleInfo, module: SwordModule)]
+        /// Active passage OSIS book id.
+        let osisBookId: String
+        /// User-facing active book name.
+        let bookName: String
+        /// One-based active chapter.
+        let chapter: Int
+        /// Whether the active book is in the New Testament.
+        let isNewTestament: Bool
+        /// Optional first selected verse.
+        let startVerse: Int?
+        /// Optional last selected verse.
+        let endVerse: Int?
+    }
+
+    /**
+     Creates a Compare document builder for one reader pane.
+
+     - Parameters:
+       - swordManager: Active SWORD manager for module resolution.
+       - installedBibleModules: Cached installed Bible metadata from the reader.
+       - activeModuleName: Active Bible initials used to order compare fragments.
+     - Side effects: None during construction.
+     - Failure modes: Missing SWORD is handled by `makeRequest(...)`.
+     */
+    init(
+        swordManager: SwordManager?,
+        installedBibleModules: [ModuleInfo],
+        activeModuleName: String
+    ) {
+        self.swordManager = swordManager
+        self.installedBibleModules = installedBibleModules
+        self.activeModuleName = activeModuleName
+    }
+
+    /**
+     Builds a background-safe Compare request from current reader passage state.
+
+     - Parameters:
+       - osisBookId: Active passage OSIS book id.
+       - bookName: User-facing active book name.
+       - chapter: One-based active chapter.
+       - isNewTestament: Whether the active book is in the New Testament.
+       - startVerse: Optional first selected verse.
+       - endVerse: Optional final selected verse.
+     - Returns: Captured request containing module readers, or `nil` when Compare cannot render.
+     - Side effects: Resolves installed modules through SWORD.
+     - Failure modes: Logs and returns `nil` when SWORD is unavailable or no Bible modules exist.
+     */
+    func makeRequest(
+        osisBookId: String,
+        bookName: String,
+        chapter: Int,
+        isNewTestament: Bool,
+        startVerse: Int?,
+        endVerse: Int?
+    ) -> Request? {
+        guard let manager = swordManager else {
+            compareDocumentBuilderLogger.warning("Compare requested without an active SwordManager")
+            return nil
+        }
+
+        let modules = installedCompareBibleModules(using: manager).compactMap { moduleInfo in
+            manager.module(named: moduleInfo.name).map { (info: moduleInfo, module: $0) }
+        }
+        guard !modules.isEmpty else {
+            compareDocumentBuilderLogger.warning("Compare requested with no installed Bible modules")
+            return nil
+        }
+
+        return Request(
+            modules: modules,
+            osisBookId: osisBookId,
+            bookName: bookName,
+            chapter: chapter,
+            isNewTestament: isNewTestament,
+            startVerse: startVerse,
+            endVerse: endVerse
+        )
+    }
+
+    /**
+     Builds the Vue `MultiDocument` payload Android uses for Compare.
+
+     - Parameter request: Captured compare request containing module readers and passage metadata.
+     - Returns: Serialized compare `MultiDocument`, or `nil` when no installed Bible can render the
+       requested range.
+     - Side effects: Temporarily moves each module cursor while extracting raw OSIS.
+     - Failure modes: Logs and returns `nil` when every module misses the requested range or JSON
+       serialization fails.
+     */
+    static func buildDocumentJSON(_ request: Request) -> String? {
+        let fragments = request.modules.compactMap { modulePair -> OsisFragment? in
+            buildFragment(
+                module: modulePair.module,
+                moduleInfo: modulePair.info,
+                osisBookId: request.osisBookId,
+                bookName: request.bookName,
+                chapter: request.chapter,
+                isNewTestament: request.isNewTestament,
+                startVerse: request.startVerse,
+                endVerse: request.endVerse
+            )
+        }
+
+        guard !fragments.isEmpty else {
+            compareDocumentBuilderLogger.warning(
+                "Compare requested but no module rendered \(request.osisBookId, privacy: .public) \(request.chapter)"
+            )
+            return nil
+        }
+
+        let payload = MultiFragmentDocumentPayload(
+            id: "compare-\(UUID().uuidString)",
+            type: "multi",
+            osisFragments: fragments,
+            compare: true,
+            contentType: nil,
+            state: nil
+        )
+
+        guard let data = try? bridgeEncoder.encode(payload),
+              let json = String(data: data, encoding: .utf8) else {
+            compareDocumentBuilderLogger.error("Failed to encode compare document JSON")
+            return nil
+        }
+        return json
+    }
+
+    /**
+     Resolves installed Bible modules eligible for Compare.
+
+     - Parameter manager: Active SWORD manager used as a fallback when cached module metadata is
+       empty.
+     - Returns: Installed Bible module metadata in active-reader order.
+     - Side effects: May read the SWORD module list when cached `installedBibleModules` is empty.
+     - Failure modes: Returns an empty array when no installed module is categorized as a Bible.
+     */
+    private func installedCompareBibleModules(using manager: SwordManager) -> [ModuleInfo] {
+        let modules = installedBibleModules.isEmpty
+            ? manager.installedModules().filter { $0.category == .bible }
+            : installedBibleModules
+
+        guard let activeIndex = modules.firstIndex(where: { $0.name == activeModuleName }) else {
+            return modules
+        }
+        var orderedModules = modules
+        let activeModule = orderedModules.remove(at: activeIndex)
+        orderedModules.insert(activeModule, at: 0)
+        return orderedModules
+    }
+
+    /**
+     Builds one compare fragment for one installed Bible module.
+
+     - Parameters:
+       - module: SWORD Bible module to read.
+       - moduleInfo: Metadata for `module`, used for Vue labels and language/direction flags.
+       - osisBookId: Active passage OSIS book identifier.
+       - bookName: User-facing active book name.
+       - chapter: One-based active chapter number.
+       - startVerse: Optional one-based first verse to compare.
+       - endVerse: Optional one-based final verse to compare.
+     - Returns: Vue OSIS fragment, or `nil` when the module cannot resolve any verse in the
+       requested range.
+     - Side effects: Temporarily moves the SWORD module cursor once per inspected verse and restores
+       the previous cursor after each read.
+     - Failure modes: Returns `nil` if the first requested verse cannot be resolved in the target
+       module's versification or if all raw entries in the range are empty.
+     */
+    private static func buildFragment(
+        module: SwordModule,
+        moduleInfo: ModuleInfo,
+        osisBookId: String,
+        bookName: String,
+        chapter: Int,
+        isNewTestament: Bool,
+        startVerse: Int?,
+        endVerse: Int?
+    ) -> OsisFragment? {
+        let normalizedStart = max(1, startVerse ?? 1)
+        let firstInspection = module.inspectVerseKeyAndRawEntryRestoringPrevious(
+            "=\(osisBookId).\(chapter).\(normalizedStart)"
+        )
+        guard let firstKey = firstInspection.verseKey,
+              firstKey.osisBookName == osisBookId,
+              firstKey.chapter == chapter,
+              firstKey.verse == normalizedStart else {
+            return nil
+        }
+
+        let chapterMaxVerse = max(normalizedStart, firstKey.verseMax)
+        let normalizedEnd = min(max(normalizedStart, endVerse ?? chapterMaxVerse), chapterMaxVerse)
+        var verseXML: [String] = []
+
+        for verse in normalizedStart...normalizedEnd {
+            guard let ordinal = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse) else {
+                return nil
+            }
+            let inspection: (actualKey: String, verseKey: VerseKeyChildren?, rawEntry: String)
+            if verse == normalizedStart {
+                inspection = firstInspection
+            } else {
+                inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious(
+                    "=\(osisBookId).\(chapter).\(verse)"
+                )
+            }
+
+            guard let key = inspection.verseKey,
+                  key.osisBookName == osisBookId,
+                  key.chapter == chapter,
+                  key.verse == verse else {
+                continue
+            }
+
+            let rawText = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !rawText.isEmpty else { continue }
+
+            let osisRef = "\(osisBookId).\(chapter).\(verse)"
+            verseXML.append(
+                "<verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(rawText) </verse>"
+            )
+        }
+
+        guard !verseXML.isEmpty else { return nil }
+
+        let osisRef = compareOsisRef(
+            osisBookId: osisBookId,
+            chapter: chapter,
+            startVerse: normalizedStart,
+            endVerse: normalizedEnd
+        )
+        let keyName = compareRangeTitle(
+            bookName: bookName,
+            chapter: chapter,
+            startVerse: normalizedStart,
+            endVerse: normalizedEnd
+        )
+        guard let ordinalStart = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedStart),
+              let ordinalEnd = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedEnd) else {
+            return nil
+        }
+
+        return OsisFragment(
+            xml: "<div>\(verseXML.joined())</div>",
+            key: "\(moduleInfo.name)--\(osisRef)",
+            keyName: keyName,
+            v11n: "KJVA",
+            bookCategory: DocumentCategory.bible.rawValue,
+            bookInitials: moduleInfo.name,
+            bookAbbreviation: moduleInfo.name,
+            osisRef: osisRef,
+            isNewTestament: isNewTestament,
+            features: OsisFeatures(),
+            hasStrongs: moduleInfo.features.contains(.strongsNumbers),
+            ordinalRange: [ordinalStart, ordinalEnd],
+            language: moduleInfo.language.isEmpty ? "en" : moduleInfo.language,
+            direction: moduleInfo.isRightToLeft ? "rtl" : "ltr"
+        )
+    }
+
+    /**
+     Formats the OSIS reference carried by a compare fragment.
+
+     - Parameters:
+       - osisBookId: OSIS book identifier already resolved for the active reader book.
+       - chapter: One-based chapter number for the compare passage.
+       - startVerse: Normalized first verse in the rendered range.
+       - endVerse: Normalized last verse in the rendered range.
+     - Returns: Single-verse OSIS ref or Android-style repeated-book range ref.
+     - Side effects: None.
+     - Failure modes: None; callers normalize and validate the verse range before formatting.
+     */
+    private static func compareOsisRef(
+        osisBookId: String,
+        chapter: Int,
+        startVerse: Int,
+        endVerse: Int
+    ) -> String {
+        if startVerse == endVerse {
+            return "\(osisBookId).\(chapter).\(startVerse)"
+        }
+        return "\(osisBookId).\(chapter).\(startVerse)-\(osisBookId).\(chapter).\(endVerse)"
+    }
+
+    /**
+     Formats the user-visible compare range title used by Vue `MultiDocument`.
+
+     - Parameters:
+       - bookName: User-facing book name from the active reader state.
+       - chapter: One-based chapter number for the compare passage.
+       - startVerse: Normalized first verse in the rendered range.
+       - endVerse: Normalized last verse in the rendered range.
+     - Returns: Android-compatible range title such as `Genesis 1:1` or `Genesis 1:1-3`.
+     - Side effects: None.
+     - Failure modes: None; callers normalize and validate the verse range before formatting.
+     */
+    private static func compareRangeTitle(
+        bookName: String,
+        chapter: Int,
+        startVerse: Int,
+        endVerse: Int
+    ) -> String {
+        if startVerse == endVerse {
+            return "\(bookName) \(chapter):\(startVerse)"
+        }
+        return "\(bookName) \(chapter):\(startVerse)-\(endVerse)"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1412,7 +1412,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         compareDocumentRequestID = requestID
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let documentJSON = Self.buildBibleCompareDocumentJSON(request)
+            let documentJSON = BibleReaderCompareDocumentBuilder.buildDocumentJSON(request)
             DispatchQueue.main.async { [weak self] in
                 guard let self,
                       self.compareDocumentRequestID == requestID,
@@ -4767,69 +4767,30 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
-     Captures all main-reader state needed to build a compare payload away from the main queue.
+     Builds the compare document builder bound to this pane's SWORD and installed-module state.
      */
-    private struct BibleCompareDocumentRequest {
-        /// Modules to include in compare output, paired with their SWORD readers.
-        let modules: [(info: ModuleInfo, module: SwordModule)]
-
-        /// Active passage OSIS book id.
-        let osisBookId: String
-
-        /// User-facing active book name.
-        let bookName: String
-
-        /// One-based active chapter.
-        let chapter: Int
-
-        /// Whether the active book is in the New Testament.
-        let isNewTestament: Bool
-
-        /// Optional first selected verse.
-        let startVerse: Int?
-
-        /// Optional last selected verse.
-        let endVerse: Int?
+    private func compareDocumentBuilder() -> BibleReaderCompareDocumentBuilder {
+        BibleReaderCompareDocumentBuilder(
+            swordManager: swordManager,
+            installedBibleModules: installedBibleModules,
+            activeModuleName: activeModuleName
+        )
     }
 
     /**
-     Builds the Vue `MultiDocument` payload Android uses for Compare.
+     Builds the background-safe Compare request for the active passage.
 
-     Android opens `FakeBookFactory.compareDocument` and renders a `MultiFragmentDocument` with
-     `compare=true`, one fragment per installed Bible. iOS mirrors that shape so Vue owns the
-     translation list, hide buttons, and restore affordance.
-
-     - Parameters:
-       - startVerse: Optional first verse requested by the selection or bridge action. `nil`
-         starts at verse 1.
-       - endVerse: Optional final verse requested by the selection or bridge action. `nil` uses the
-         chapter's module-reported final verse.
-     - Returns: Serialized compare `MultiDocument`, or `nil` when no installed Bible can render the
-       requested range.
-     - Side effects: reads installed SWORD Bible modules and temporarily moves each module cursor
-       while extracting raw OSIS.
-     - Failure modes: logs and returns `nil` when SWORD is unavailable, every module misses the
-       requested range, or JSON serialization fails.
+     The controller supplies live reader coordinates while `BibleReaderCompareDocumentBuilder` owns
+     module ordering and payload construction.
      */
-    private func makeBibleCompareDocumentRequest(startVerse: Int?, endVerse: Int?) -> BibleCompareDocumentRequest? {
-        guard let manager = swordManager else {
-            logger.warning("Compare requested without an active SwordManager")
-            return nil
-        }
-
-        let modules = installedCompareBibleModules(using: manager).compactMap { moduleInfo in
-            manager.module(named: moduleInfo.name).map { (info: moduleInfo, module: $0) }
-        }
-        guard !modules.isEmpty else {
-            logger.warning("Compare requested with no installed Bible modules")
-            return nil
-        }
-
+    private func makeBibleCompareDocumentRequest(
+        startVerse: Int?,
+        endVerse: Int?
+    ) -> BibleReaderCompareDocumentBuilder.Request? {
         let bookName = currentBook
         let chapter = currentChapter
         let osisBookId = osisBookId(for: bookName)
-        return BibleCompareDocumentRequest(
-            modules: modules,
+        return compareDocumentBuilder().makeRequest(
             osisBookId: osisBookId,
             bookName: bookName,
             chapter: chapter,
@@ -4837,223 +4798,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             startVerse: startVerse,
             endVerse: endVerse
         )
-    }
-
-    /**
-     Builds the Vue `MultiDocument` payload Android uses for Compare.
-
-     - Parameter request: Captured compare request containing module readers and passage metadata.
-     - Returns: Serialized compare `MultiDocument`, or `nil` when no installed Bible can render the
-       requested range.
-     - Side effects: temporarily moves each module cursor while extracting raw OSIS.
-     - Failure modes: logs and returns `nil` when every module misses the requested range or JSON
-       serialization fails.
-    */
-    private static func buildBibleCompareDocumentJSON(_ request: BibleCompareDocumentRequest) -> String? {
-        let fragments = request.modules.compactMap { modulePair -> [String: Any]? in
-            buildBibleCompareFragment(
-                module: modulePair.module,
-                moduleInfo: modulePair.info,
-                osisBookId: request.osisBookId,
-                bookName: request.bookName,
-                chapter: request.chapter,
-                isNewTestament: request.isNewTestament,
-                startVerse: request.startVerse,
-                endVerse: request.endVerse
-            )
-        }
-
-        guard !fragments.isEmpty else {
-            logger.warning(
-                "Compare requested but no module rendered \(request.osisBookId, privacy: .public) \(request.chapter)"
-            )
-            return nil
-        }
-
-        let document: [String: Any] = [
-            "id": "compare-\(UUID().uuidString)",
-            "type": "multi",
-            "osisFragments": fragments,
-            "compare": true,
-        ]
-
-        guard let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize compare document JSON")
-            return nil
-        }
-        return json
-    }
-
-    /**
-     Resolves installed Bible modules eligible for Compare.
-
-     - Parameter manager: Active SWORD manager used as a fallback when cached module metadata is
-       empty.
-     - Returns: Installed Bible module metadata in active-reader order.
-     - Side effects: may read the SWORD module list when cached `installedBibleModules` is empty.
-     - Failure modes: returns an empty array when no installed module is categorized as a Bible.
-     */
-    private func installedCompareBibleModules(using manager: SwordManager) -> [ModuleInfo] {
-        let cached = installedBibleModules
-        let modules = cached.isEmpty
-            ? manager.installedModules().filter { $0.category == .bible }
-            : cached
-
-        guard let activeIndex = modules.firstIndex(where: { $0.name == activeModuleName }) else {
-            return modules
-        }
-        var orderedModules = modules
-        let activeModule = orderedModules.remove(at: activeIndex)
-        orderedModules.insert(activeModule, at: 0)
-        return orderedModules
-    }
-
-    /**
-     Builds one compare fragment for one installed Bible module.
-
-     - Parameters:
-       - module: SWORD Bible module to read.
-       - moduleInfo: Metadata for `module`, used for Vue labels and language/direction flags.
-       - osisBookId: Active passage OSIS book identifier.
-       - bookName: User-facing active book name.
-       - chapter: One-based active chapter number.
-       - startVerse: Optional one-based first verse to compare.
-       - endVerse: Optional one-based final verse to compare.
-     - Returns: Vue OSIS fragment dictionary, or `nil` when the module cannot resolve any verse in
-       the requested range.
-     - Side effects: temporarily moves the SWORD module cursor once per inspected verse and restores
-       the previous cursor after each read.
-     - Failure modes: returns `nil` if the first requested verse cannot be resolved in the target
-       module's versification or if all raw entries in the range are empty.
-     */
-    private static func buildBibleCompareFragment(
-        module: SwordModule,
-        moduleInfo: ModuleInfo,
-        osisBookId: String,
-        bookName: String,
-        chapter: Int,
-        isNewTestament: Bool,
-        startVerse: Int?,
-        endVerse: Int?
-    ) -> [String: Any]? {
-        let normalizedStart = max(1, startVerse ?? 1)
-        let firstInspection = module.inspectVerseKeyAndRawEntryRestoringPrevious(
-            "=\(osisBookId).\(chapter).\(normalizedStart)"
-        )
-        guard let firstKey = firstInspection.verseKey,
-              firstKey.osisBookName == osisBookId,
-              firstKey.chapter == chapter,
-              firstKey.verse == normalizedStart else {
-            return nil
-        }
-
-        let chapterMaxVerse = max(normalizedStart, firstKey.verseMax)
-        let normalizedEnd = min(max(normalizedStart, endVerse ?? chapterMaxVerse), chapterMaxVerse)
-        var verseXML: [String] = []
-
-        for verse in normalizedStart...normalizedEnd {
-            guard let ordinal = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: verse) else {
-                return nil
-            }
-            let inspection: (actualKey: String, verseKey: VerseKeyChildren?, rawEntry: String)
-            if verse == normalizedStart {
-                inspection = firstInspection
-            } else {
-                inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious(
-                    "=\(osisBookId).\(chapter).\(verse)"
-                )
-            }
-
-            guard let key = inspection.verseKey,
-                  key.osisBookName == osisBookId,
-                  key.chapter == chapter,
-                  key.verse == verse else {
-                continue
-            }
-
-            let rawText = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !rawText.isEmpty else { continue }
-
-            let osisRef = "\(osisBookId).\(chapter).\(verse)"
-            verseXML.append(
-                "<verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(rawText) </verse>"
-            )
-        }
-
-        guard !verseXML.isEmpty else { return nil }
-
-        let osisRef = compareOsisRef(
-            osisBookId: osisBookId,
-            chapter: chapter,
-            startVerse: normalizedStart,
-            endVerse: normalizedEnd
-        )
-        let keyName = compareRangeTitle(
-            bookName: bookName,
-            chapter: chapter,
-            startVerse: normalizedStart,
-            endVerse: normalizedEnd
-        )
-        guard let ordinalStart = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedStart),
-              let ordinalEnd = module.verseOrdinal(osisBookId: osisBookId, chapter: chapter, verse: normalizedEnd) else {
-            return nil
-        }
-
-        return [
-            "xml": "<div>\(verseXML.joined())</div>",
-            "key": "\(moduleInfo.name)--\(osisRef)",
-            "keyName": keyName,
-            "v11n": "KJVA",
-            "bookCategory": DocumentCategory.bible.rawValue,
-            "bookInitials": moduleInfo.name,
-            "bookAbbreviation": moduleInfo.name,
-            "osisRef": osisRef,
-            "isNewTestament": isNewTestament,
-            "features": [String: Any](),
-            "hasStrongs": moduleInfo.features.contains(.strongsNumbers),
-            "ordinalRange": [ordinalStart, ordinalEnd],
-            "language": moduleInfo.language.isEmpty ? "en" : moduleInfo.language,
-            "direction": moduleInfo.isRightToLeft ? "rtl" : "ltr",
-        ]
-    }
-
-    /**
-     Formats the OSIS reference carried by a compare fragment.
-
-     - Parameters:
-       - osisBookId: OSIS book identifier.
-       - chapter: One-based chapter number.
-       - startVerse: First verse in the rendered range.
-       - endVerse: Last verse in the rendered range.
-     - Returns: Single-verse OSIS ref or Android-style repeated-book range ref.
-     - Side effects: none.
-     - Failure modes: none; inputs are expected to be normalized by the caller.
-     */
-    private static func compareOsisRef(osisBookId: String, chapter: Int, startVerse: Int, endVerse: Int) -> String {
-        if startVerse == endVerse {
-            return "\(osisBookId).\(chapter).\(startVerse)"
-        }
-        return "\(osisBookId).\(chapter).\(startVerse)-\(osisBookId).\(chapter).\(endVerse)"
-    }
-
-    /**
-     Formats the user-visible compare range title used by Vue `MultiDocument`.
-
-     - Parameters:
-       - bookName: User-facing book name.
-       - chapter: One-based chapter number.
-       - startVerse: First verse in the rendered range.
-       - endVerse: Last verse in the rendered range.
-     - Returns: Title such as `Genesis 1:1` or `Genesis 1:1-3`.
-     - Side effects: none.
-     - Failure modes: none; inputs are expected to be normalized by the caller.
-     */
-    private static func compareRangeTitle(bookName: String, chapter: Int, startVerse: Int, endVerse: Int) -> String {
-        if startVerse == endVerse {
-            return "\(bookName) \(chapter):\(startVerse)"
-        }
-        return "\(bookName) \(chapter):\(startVerse)-\(endVerse)"
     }
 
     /**

--- a/scripts/test_workspace_prompt_ui_contract.py
+++ b/scripts/test_workspace_prompt_ui_contract.py
@@ -57,6 +57,29 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         self.assertNotIn("descendants(matching: .any)", candidates_body)
         self.assertNotIn("prompt.textFields", candidates_body)
 
+    def test_workspace_prompt_button_candidates_stay_on_prompt_buttons(self) -> None:
+        """The prompt button lookup avoids unrelated containers that can stall hosted XCTest.
+
+        The prompt confirm and cancel controls are selector-owned overlay buttons. They should not
+        be looked up through navigation bars, toolbars, table rows, scroll views, or generic
+        `otherElements` before the actual button surface has had a chance to appear.
+        """
+        source = (
+            REPO_ROOT / "AndBibleUITests" / "AndBibleUITestElementSupport.swift"
+        ).read_text()
+        candidates_start = source.index("func workspaceNamePromptButtonCandidates")
+        candidates_end = source.index("func semanticStateCandidates", candidates_start)
+        candidates_body = source[candidates_start:candidates_end]
+
+        self.assertIn("app.buttons[identifier].firstMatch", candidates_body)
+        self.assertIn("app.buttons[title].firstMatch", candidates_body)
+        self.assertNotIn("app.navigationBars.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.toolbars.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.collectionViews.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.tables.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.scrollViews.buttons[identifier]", candidates_body)
+        self.assertNotIn("app.otherElements[identifier]", candidates_body)
+
     def test_workspace_prompt_screen_uses_prompt_specific_container_lookup(self) -> None:
         """The prompt surface lookup must stay bounded and must not drive text-entry focus.
 


### PR DESCRIPTION
## Summary
Extracts Android-compatible Compare document payload construction out of `BibleReaderController` into a focused `BibleReaderCompareDocumentBuilder` collaborator.

## Scope
- Adds a Compare document builder for installed Bible ordering, verse extraction, range labeling, and typed `MultiFragmentDocumentPayload` encoding.
- Keeps `BibleReaderController` responsible for orchestration, stale async request protection, and bridge handoff.
- Adds a parsed JSON unit test for the Compare `multi` document contract.

## Contract References
- Android parity: Compare remains a `multi` document with `compare=true`, Bible fragments, OSIS refs, range labels, ordinal ranges, language/direction, and Strongs metadata.
- Issue #146: this is one controller responsibility extraction slice; it does not close the broader issue.

## Change Details
- `BibleReaderCompareDocumentBuilder` owns Compare-specific module selection and payload assembly.
- `BibleReaderController` now captures active reader coordinates and delegates payload construction.
- The new test validates the builder directly against the bundled KJV SWORD fixture instead of relying on string-order assertions.

## Validation Evidence
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -derivedDataPath .derived/local-unit-tests -only-testing:AndBibleTests/AndBibleTests/testCompareDocumentBuilderBuildsAndroidMultiDocumentPayload CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -derivedDataPath .derived/local-unit-tests -only-testing:AndBibleTests/AndBibleTests/testReaderCompareBridgeRequestEmitsVueCompareDocument -only-testing:AndBibleTests/AndBibleTests/testCompareDocumentBuilderBuildsAndroidMultiDocumentPayload CODE_SIGNING_ALLOWED=NO`
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_repo_standards.py all --rev-range HEAD^..HEAD --all-files`
- `git diff --cached --check`
- GitNexus `detect_changes` on the staged worktree reported low risk and no affected named execution flows.

## Risks / Follow-ups
- Existing warning from `WindowingControlPolicy` remains unrelated to this PR.
- #146 still has remaining controller ownership audit work after this Compare slice.

## Issue Closure Reference
Refs #146
