### PR TITLE
fix(search): align search criteria with Android form

### DIFF
--- a/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -2245,7 +2245,10 @@ extension AndBibleTests {
 
         let source = try String(contentsOf: readerViewURL, encoding: .utf8)
         guard let drawerStart = source.range(of: "private var bookChooserDrawerContent"),
-              let nextSection = source.range(of: "/// Search sheet", range: drawerStart.upperBound..<source.endIndex) else {
+              let nextSection = source.range(
+                of: "private var searchSheetContent",
+                range: drawerStart.upperBound..<source.endIndex
+              ) else {
             return XCTFail("Could not locate book chooser drawer content in BibleReaderView.swift")
         }
 

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -194,6 +194,39 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Verifies the Search criteria screen uses Android's form structure instead of iOS controls.
+
+     Android `Search` renders a top edit field, two radio groups, a translations row, and a bottom
+     submit button from `app/src/main/res/layout/search.xml`. The iOS Search destination should
+     therefore avoid SwiftUI-only segmented controls, toolbar filter toggles, and empty-state cards
+     on the criteria screen.
+
+     - Expected result: `SearchView` exposes named Android-form building blocks and omits the
+       previous iOS-specific segmented/card/toggle affordances.
+     - Failure meaning: Search has drifted into a visually custom iOS screen even if the
+       translation picker itself uses an Android-style dialog.
+     - Side effects: Reads `SearchView.swift` from the checked-out source tree.
+     */
+    func testSearchCriteriaScreenUsesAndroidFormStructure() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let searchViewURL = repoRoot.appendingPathComponent(
+            "Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift"
+        )
+
+        let source = try String(contentsOf: searchViewURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("private var searchCriteriaForm"))
+        XCTAssertTrue(source.contains("private var searchSubmitButton"))
+        XCTAssertTrue(source.contains("private func searchRadioRow"))
+        XCTAssertFalse(source.contains(".pickerStyle(.segmented)"))
+        XCTAssertFalse(source.contains("ContentUnavailableView("))
+        XCTAssertFalse(source.contains("searchOptionsToggleButton"))
+    }
+
     func testStrongsQueryNormalizationHandlesLeadingZeroes() {
         let options = StrongsSearchSupport.normalizedQueryOptions(for: "H02022")
         XCTAssertEqual(options?.canonicalStrongTokens, ["H2022"])

--- a/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
+++ b/AndBibleTests/AndBibleTests+StrongsAndDictionary.swift
@@ -65,6 +65,135 @@ extension AndBibleTests {
         XCTAssertEqual(AppPreferenceRegistry.decodeCSVSet(""), [])
     }
 
+    /**
+     Verifies Search's translation picker orders Bible modules the same way Android builds its
+     multiselect dialog.
+
+     Android `Search.showTranslationSelector` sorts all Bible modules by abbreviation before
+     rendering rows. This pure helper test keeps iOS from drifting back to installer order or
+     SwiftUI list order, both of which make subsequent primary-first ordering ambiguous.
+
+     - Setup: Uses intentionally unsorted installed Bible module metadata.
+     - Expected result: Abbreviations are returned in Android's sorted order.
+     - Failure meaning: Search may present or commit multi-translation choices in an iOS-specific
+       order instead of Android's deterministic dialog order.
+     - Side effects: none.
+     */
+    func testSearchTranslationPickerSortsModulesByAndroidAbbreviationOrder() {
+        let modules = [
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en"),
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en"),
+            ModuleInfo(name: "ASV", description: "American Standard Version", category: .bible, language: "en"),
+        ]
+
+        XCTAssertEqual(
+            SearchView.androidSortedTranslationModules(modules).map(\.name),
+            ["ASV", "KJV", "WEB"]
+        )
+    }
+
+    /**
+     Verifies Search commits Android multiselect choices with the active document preserved first.
+
+     Android collects the checked rows from its abbreviation-sorted dialog, then calls
+     `ensurePrimaryDocumentFirst()` so the current document remains the primary search target.
+     This protects the iOS search request and grouped result order from `Set` iteration.
+
+     - Setup: Selects all modules while the primary/current module is in the middle of Android's
+       sorted order.
+     - Expected result: The primary module is first, with all other selected modules still in
+       Android abbreviation order.
+     - Failure meaning: Multi-translation Search can send or display modules in unstable iOS order.
+     - Side effects: none.
+     */
+    func testSearchTranslationSelectionKeepsPrimaryFirstAfterAndroidSortedCommit() {
+        let modules = [
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en"),
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en"),
+            ModuleInfo(name: "ASV", description: "American Standard Version", category: .bible, language: "en"),
+        ]
+
+        XCTAssertEqual(
+            SearchView.androidOrderedSelectedSearchModuleNames(
+                selectedModuleNames: ["WEB", "KJV", "ASV"],
+                primaryModuleName: "KJV",
+                installedModules: modules
+            ),
+            ["KJV", "ASV", "WEB"]
+        )
+    }
+
+    /**
+     Verifies empty Search translation dialog confirmation preserves the prior selection.
+
+     Android's multiselect dialog returns an empty list for both cancel and OK-with-no-checked-rows,
+     and `Search.showTranslationSelector` ignores that empty result. iOS must not clear the active
+     search modules when the draft selection has been toggled down to none.
+
+     - Setup: Provides an existing two-module selection and an empty draft.
+     - Expected result: The committed order still reflects the previous selection, with the primary
+       module first.
+     - Failure meaning: Users can accidentally clear Search translations through an iOS-only empty
+       commit path.
+     - Side effects: none.
+     */
+    func testSearchTranslationEmptyDialogConfirmationPreservesPreviousSelection() {
+        let modules = [
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en"),
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en"),
+            ModuleInfo(name: "ASV", description: "American Standard Version", category: .bible, language: "en"),
+        ]
+
+        XCTAssertEqual(
+            SearchView.androidCommittedTranslationSelection(
+                previousModuleNames: ["KJV", "WEB"],
+                draftModuleNames: [],
+                primaryModuleName: "KJV",
+                installedModules: modules
+            ),
+            ["KJV", "WEB"]
+        )
+    }
+
+    /**
+     Verifies Search translation picker row labels expose index readiness like Android.
+
+     Android appends the localized `search_index_not_created` status to unindexed modules inside
+     the multiselect dialog. This protects the iOS picker from showing visually selectable modules
+     without the same readiness warning.
+
+     - Setup: Builds one Bible module label with indexed and unindexed status inputs.
+     - Expected result: Indexed rows omit the status suffix; unindexed rows include it in
+       parentheses.
+     - Failure meaning: Search can hide Android's index-readiness information from the picker.
+     - Side effects: none.
+     */
+    func testSearchTranslationPickerLabelsExposeAndroidIndexReadiness() {
+        let module = ModuleInfo(
+            name: "KJV",
+            description: "King James Version",
+            category: .bible,
+            language: "en"
+        )
+
+        XCTAssertEqual(
+            SearchView.androidTranslationPickerLabel(
+                for: module,
+                isIndexed: true,
+                unindexedStatus: "Search index not created"
+            ),
+            "KJV - King James Version"
+        )
+        XCTAssertEqual(
+            SearchView.androidTranslationPickerLabel(
+                for: module,
+                isIndexed: false,
+                unindexedStatus: "Search index not created"
+            ),
+            "KJV - King James Version (Search index not created)"
+        )
+    }
+
     func testStrongsQueryNormalizationHandlesLeadingZeroes() {
         let options = StrongsSearchSupport.normalizedQueryOptions(for: "H02022")
         XCTAssertEqual(options?.canonicalStrongTokens, ["H2022"])

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -760,12 +760,12 @@ extension AndBibleUITests {
     }
 
     /**
-     Returns true once the Search translation picker sheet has exposed any stable child element.
+     Returns true once the Search translation picker overlay has exposed any stable child element.
      *
      * - Parameters:
      *   - app: Running application under test.
      *   - timeout: Total time budget for polling the candidate set.
-     * - Returns: `true` when a picker-specific Done button or picker list exists.
+     * - Returns: `true` when a picker-specific OK button or picker list exists.
      * - Side effects:
      *   - polls the live Search state export and picker accessibility hierarchy while SwiftUI
      *     presents or dismisses the picker
@@ -797,9 +797,9 @@ extension AndBibleUITests {
     /**
      Returns whether Search has published the translation-picker presentation state.
      *
-     * The Search screen exports this state separately from sheet descendants so UI tests can
+     * The Search screen exports this state separately from overlay descendants so UI tests can
      * distinguish "the button action has toggled presentation" from "SwiftUI has finished exposing
-     * the sheet hierarchy." That keeps picker-opening retries focused on missed actions instead of
+     * the picker hierarchy." That keeps picker-opening retries focused on missed actions instead of
      * treating slow accessibility snapshots as proof that the tap failed.
      *
      * - Parameters:
@@ -827,9 +827,10 @@ extension AndBibleUITests {
         return searchStateCandidateValues(in: app).contains { $0.contains("translationPicker=open") }
     }
 
-    /// Returns stable picker descendants that prove the Search translation picker sheet is open.
+    /// Returns stable picker descendants that prove the Search translation picker overlay is open.
     func searchTranslationPickerOpenCandidates(in app: XCUIApplication) -> [XCUIElement] {
-        searchTranslationDoneCandidates(in: app, includeLocalizedFallbacks: false)
+        searchTranslationOKCandidates(in: app, includeLocalizedFallbacks: false)
+            + searchTranslationCancelCandidates(in: app, includeLocalizedFallbacks: false)
             + searchTranslationPickerListCandidates(in: app)
     }
 
@@ -897,40 +898,61 @@ extension AndBibleUITests {
     }
 
     /**
-     Returns scoped Done button candidates for the Search translation picker.
+     Returns scoped OK button candidates for the Search translation picker.
      *
-     * SwiftUI can expose toolbar buttons through navigation bars, toolbars, sheets, or finally the
-     * app-wide button query depending on runtime. The helper keeps the app-wide query as a fallback
-     * only, because broad button snapshots are the least stable while the picker list is refreshing
-     * after a translation row toggles.
+     * The Android-parity picker is an in-place overlay with an explicit OK action, not a SwiftUI
+     * sheet toolbar. Stable identifiers are preferred; localized fallbacks are broad only for
+     * recovery after the picker state export has already confirmed the overlay is open.
      *
      * - Parameters:
      *   - app: Running application under test.
-     *   - includeLocalizedFallbacks: Whether to include generic localized Done buttons after the
-     *     stable identifier candidates. Picker-open checks pass `false` to avoid matching keyboard
-     *     or unrelated toolbar Done controls before the translation picker is open.
-     * - Returns: Ordered button candidates, from picker-scoped surfaces to broad fallbacks.
+     *   - includeLocalizedFallbacks: Whether to include generic OK labels after stable identifiers.
+     * - Returns: Ordered OK button candidates.
      * - Side effects: none.
      * - Failure modes: This helper does not fail directly.
      */
-    func searchTranslationDoneCandidates(
+    func searchTranslationOKCandidates(
         in app: XCUIApplication,
         includeLocalizedFallbacks: Bool = true
     ) -> [XCUIElement] {
         let identifiedCandidates = [
-            app.navigationBars.buttons["searchTranslationDoneButton"].firstMatch,
-            app.toolbars.buttons["searchTranslationDoneButton"].firstMatch,
-            app.sheets.buttons["searchTranslationDoneButton"].firstMatch,
-            app.buttons["searchTranslationDoneButton"].firstMatch,
+            app.buttons["searchTranslationOKButton"].firstMatch,
+            app.otherElements["searchTranslationOKButton"].firstMatch,
         ]
         guard includeLocalizedFallbacks else {
             return identifiedCandidates
         }
         return identifiedCandidates + [
-            app.navigationBars.buttons["Done"].firstMatch,
-            app.toolbars.buttons["Done"].firstMatch,
-            app.sheets.buttons["Done"].firstMatch,
-            app.buttons["Done"].firstMatch,
+            app.buttons["OK"].firstMatch,
+            app.buttons["Ok"].firstMatch,
+            app.buttons["ok"].firstMatch,
+        ]
+    }
+
+    /**
+     Returns scoped Cancel button candidates for the Search translation picker.
+     *
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - includeLocalizedFallbacks: Whether to include generic Cancel labels after stable IDs.
+     * - Returns: Ordered Cancel button candidates.
+     * - Side effects: none.
+     * - Failure modes: This helper does not fail directly.
+     */
+    func searchTranslationCancelCandidates(
+        in app: XCUIApplication,
+        includeLocalizedFallbacks: Bool = true
+    ) -> [XCUIElement] {
+        let identifiedCandidates = [
+            app.buttons["searchTranslationCancelButton"].firstMatch,
+            app.otherElements["searchTranslationCancelButton"].firstMatch,
+        ]
+        guard includeLocalizedFallbacks else {
+            return identifiedCandidates
+        }
+        return identifiedCandidates + [
+            app.buttons["Cancel"].firstMatch,
+            app.buttons["cancel"].firstMatch,
         ]
     }
 
@@ -1018,13 +1040,13 @@ extension AndBibleUITests {
     }
 
     /**
-     Selects every module in the Search translation picker.
+     Taps the neutral Select all/Select none action in the Search translation picker.
      *
      * - Parameters:
      *   - app: Running application under test.
      *   - timeout: Maximum time to wait for the toolbar action.
      * - Side effects:
-     *   - taps the picker toolbar Search All action
+     *   - taps the picker dialog neutral select toggle
      * - Failure modes:
      *   - fails when the Search All action is not reachable
      */
@@ -1038,34 +1060,34 @@ extension AndBibleUITests {
             return
         }
 
-        let fallbackSelectAll = app.buttons["All"].firstMatch
+        let fallbackSelectAll = app.buttons["Select all"].firstMatch
         XCTAssertTrue(
             fallbackSelectAll.waitForExistence(timeout: timeout),
-            "Expected Search translation All button to exist within \(timeout) seconds."
+            "Expected Search translation select toggle to exist within \(timeout) seconds."
         )
         tapElementReliably(fallbackSelectAll, timeout: timeout)
     }
 
     /**
-     Closes the Search translation picker.
+     Commits the Search translation picker with its OK action.
      *
      * - Parameters:
      *   - app: Running application under test.
-     *   - timeout: Maximum time to wait for the Done action.
+     *   - timeout: Maximum time to wait for the OK action.
      * - Side effects:
-     *   - taps the picker toolbar Done action
+     *   - taps the picker dialog OK action
      * - Failure modes:
-     *   - fails when the Done action is not reachable
+     *   - fails when the OK action is not reachable
      */
-    func tapSearchTranslationDone(
+    func tapSearchTranslationOK(
         in app: XCUIApplication,
         timeout: TimeInterval
     ) {
         let deadline = Date().addingTimeInterval(timeout)
 
         repeat {
-            if let done = firstExistingElement(searchTranslationDoneCandidates(in: app), timeout: 0.2) {
-                tapElementReliably(done, timeout: min(2, max(0.5, deadline.timeIntervalSinceNow)))
+            if let ok = firstExistingElement(searchTranslationOKCandidates(in: app), timeout: 0.2) {
+                tapElementReliably(ok, timeout: min(2, max(0.5, deadline.timeIntervalSinceNow)))
                 if !searchTranslationPickerIsOpen(in: app, timeout: 2) {
                     return
                 }
@@ -1074,7 +1096,38 @@ extension AndBibleUITests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
-        XCTFail("Expected Search translation Done button to exist within \(timeout) seconds.")
+        XCTFail("Expected Search translation OK button to exist within \(timeout) seconds.")
+    }
+
+    /**
+     Cancels the Search translation picker without committing draft row changes.
+     *
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - timeout: Maximum time to wait for the Cancel action.
+     * - Side effects:
+     *   - taps the picker dialog Cancel action
+     * - Failure modes:
+     *   - fails when the Cancel action is not reachable
+     */
+    func tapSearchTranslationCancel(
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            if let cancel = firstExistingElement(searchTranslationCancelCandidates(in: app), timeout: 0.2) {
+                tapElementReliably(cancel, timeout: min(2, max(0.5, deadline.timeIntervalSinceNow)))
+                if !searchTranslationPickerIsOpen(in: app, timeout: 2) {
+                    return
+                }
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        XCTFail("Expected Search translation Cancel button to exist within \(timeout) seconds.")
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -103,7 +103,7 @@ extension AndBibleUITests {
             : seededSearchReadinessTimeout
     }
 
-    /// Reuses a Search sheet that the app auto-presented from a launch-seeded UI-test query.
+    /// Reuses a Search destination that the app auto-presented from a launch-seeded UI-test query.
     func waitForSearchScreenIfAlreadySeeded(
         in app: XCUIApplication,
         timeout: TimeInterval
@@ -1128,6 +1128,40 @@ extension AndBibleUITests {
         } while Date() < deadline
 
         XCTFail("Expected Search translation Cancel button to exist within \(timeout) seconds.")
+    }
+
+    /**
+     Dismisses the Search translation picker by tapping its dimmed area outside the dialog.
+     *
+     * Android `AlertDialog` cancellation returns an empty multiselect result, which Search ignores
+     * rather than committing draft row changes. This helper exercises the equivalent iOS overlay path
+     * without relying on a button-specific action.
+     *
+     * - Parameters:
+     *   - app: Running application under test.
+     *   - timeout: Maximum time to wait for the overlay to appear and then close.
+     * - Side effects:
+     *   - taps an app-level top-leading coordinate in the dimmed area outside the centered picker
+     *     dialog
+     * - Failure modes:
+     *   - fails when the picker overlay is not reachable or does not close after the outside tap
+     */
+    func tapSearchTranslationOutsideDismiss(
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) {
+        let overlay = app.otherElements["searchTranslationPickerOverlay"].firstMatch
+        guard overlay.waitForExistence(timeout: timeout) else {
+            XCTFail("Expected Search translation overlay to exist within \(timeout) seconds.")
+            return
+        }
+
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.05, dy: 0.2)).tap()
+        if !searchTranslationPickerIsOpen(in: app, timeout: 2) {
+            return
+        }
+
+        XCTFail("Expected Search translation overlay to close after outside dismissal.")
     }
 
     /**

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -345,9 +345,9 @@ extension AndBibleUITests {
      *
      * - Side effects:
      *   - launches the app on the reader shell with the initial query `earth` queued for Search
-     *   - opens Search from the toolbar and waits for the search sheet to settle
+     *   - opens Search from the toolbar and waits for the Search destination to settle
      * - Failure modes:
-     *   - fails if the Search sheet never appears
+     *   - fails if the Search screen never appears
      *   - fails if the seeded query is dropped before the Search screen reaches its settled state
      */
     func testSearchDirectLaunchRetainsSeededQuery() {
@@ -357,6 +357,32 @@ extension AndBibleUITests {
         _ = openSearch(in: app)
         waitForSearchQuery("earth", in: app, timeout: 20)
         waitForSearchResultRow("searchResultRow::Genesis_1_2", in: app, shouldExist: true, timeout: 20)
+    }
+
+    /**
+     Verifies Search opens as an integrated reader destination instead of an iOS sheet.
+     *
+     * Android Search is a full activity with toolbar navigation, not a bottom/large iOS sheet with a
+     * `Done` affordance. This test protects that presentation contract separately from Search's
+     * query behavior so future visual parity work does not accidentally reintroduce sheet chrome.
+     *
+     * - Setup: Launches the standard seeded Search fixture and opens Search through the reader entry.
+     * - Expected result: The reader state reports `readerDestination=search`, and no navigation-bar
+     *   `Done` button is exposed by the Search surface.
+     * - Failure meaning: Search has drifted back to sheet/modal presentation instead of Android's
+     *   destination-style surface.
+     * - Side effects: Presents Search from the reader shell.
+     */
+    func testSearchPresentsAsReaderDestinationInsteadOfSheet() {
+        let app = makeApp(searchQuery: "earth")
+        app.launch()
+
+        _ = openSearch(in: app)
+        waitForReaderRenderedContentState(containing: "readerDestination=search", in: app, timeout: 10)
+        XCTAssertFalse(
+            app.navigationBars.buttons["Done"].firstMatch.exists,
+            "Search should not expose iOS sheet-style Done chrome when opened from the reader."
+        )
     }
 
     /**
@@ -474,21 +500,26 @@ extension AndBibleUITests {
      *
      * - Side effects:
      *   - launches Search with deterministic KJV and UITESTWEB index rows for `earth`
+     *   - uses the seeded startup reader reference `Genesis 1:1` as the before-navigation value
      *   - verifies picker Cancel ignores a draft UITESTWEB row selection
+     *   - verifies outside dismissal ignores a draft UITESTWEB row selection
      *   - verifies Select all followed by Select none and OK preserves the prior selection
      *   - opens the real translation picker, selects UITESTWEB, and commits with OK
+     *   - verifies the visible selected-translation summary matches Android's abbreviation list
      *   - waits for the active query to rerun and export grouped per-translation counts
      * - Failure modes:
      *   - fails if the translation picker is not reachable from Search options
-     *   - fails if Cancel or empty OK mutates the committed module selection
+     *   - fails if Cancel, outside dismissal, or empty OK mutates the committed module selection
      *   - fails if selecting a second translation does not rerun the active query with KJV first
+     *   - fails if the selected-translation button collapses Android's abbreviation list into a
+     *     generic iOS count label
      *   - fails if grouped totals collapse to single-translation results
      */
     func testSearchMultiTranslationSelectionUpdatesGroupedTotals() {
         let app = makeApp(searchQuery: "earth")
         app.launch()
 
-        let initialReference = requireReaderReferenceValue(in: app, timeout: 15)
+        let initialReference = "Genesis 1:1"
 
         _ = openSearch(in: app)
         waitForSearchState(containing: "query=earth", in: app, timeout: 20)
@@ -508,6 +539,17 @@ extension AndBibleUITests {
             in: app,
             timeout: 10,
             description: "still exactly KJV after cancel"
+        ) { modules in
+            modules == Set(["KJV"])
+        }
+
+        tapSearchTranslationPicker(in: app, timeout: 10)
+        tapSearchTranslationRow(moduleName: "UITESTWEB", in: app, timeout: 45)
+        tapSearchTranslationOutsideDismiss(in: app, timeout: 10)
+        waitForSearchSelectedModules(
+            in: app,
+            timeout: 10,
+            description: "still exactly KJV after outside dismissal"
         ) { modules in
             modules == Set(["KJV"])
         }
@@ -536,6 +578,10 @@ extension AndBibleUITests {
             modules.count > 1 && modules.contains("UITESTWEB")
         }
         waitForSearchState(containing: "selectedModuleOrder=KJV,UITESTWEB", in: app, timeout: 20)
+        XCTAssertTrue(
+            app.staticTexts["KJV, UITESTWEB"].waitForExistence(timeout: 5),
+            "Expected the Search translation button to show Android's selected abbreviation list."
+        )
         waitForSearchState(containing: "groupedTotal=3", in: app, timeout: 20)
         waitForSearchState(containing: "KJV:1", in: app, timeout: 20)
         waitForSearchState(containing: "UITESTWEB:2", in: app, timeout: 20)

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -474,11 +474,14 @@ extension AndBibleUITests {
      *
      * - Side effects:
      *   - launches Search with deterministic KJV and UITESTWEB index rows for `earth`
-     *   - opens the real translation picker and selects UITESTWEB
+     *   - verifies picker Cancel ignores a draft UITESTWEB row selection
+     *   - verifies Select all followed by Select none and OK preserves the prior selection
+     *   - opens the real translation picker, selects UITESTWEB, and commits with OK
      *   - waits for the active query to rerun and export grouped per-translation counts
      * - Failure modes:
      *   - fails if the translation picker is not reachable from Search options
-     *   - fails if selecting a second translation does not rerun the active query
+     *   - fails if Cancel or empty OK mutates the committed module selection
+     *   - fails if selecting a second translation does not rerun the active query with KJV first
      *   - fails if grouped totals collapse to single-translation results
      */
     func testSearchMultiTranslationSelectionUpdatesGroupedTotals() {
@@ -500,7 +503,30 @@ extension AndBibleUITests {
 
         tapSearchTranslationPicker(in: app, timeout: 10)
         tapSearchTranslationRow(moduleName: "UITESTWEB", in: app, timeout: 45)
-        tapSearchTranslationDone(in: app, timeout: 10)
+        tapSearchTranslationCancel(in: app, timeout: 10)
+        waitForSearchSelectedModules(
+            in: app,
+            timeout: 10,
+            description: "still exactly KJV after cancel"
+        ) { modules in
+            modules == Set(["KJV"])
+        }
+
+        tapSearchTranslationPicker(in: app, timeout: 10)
+        tapSearchTranslationSelectAll(in: app, timeout: 10)
+        tapSearchTranslationSelectAll(in: app, timeout: 10)
+        tapSearchTranslationOK(in: app, timeout: 10)
+        waitForSearchSelectedModules(
+            in: app,
+            timeout: 10,
+            description: "still exactly KJV after empty OK"
+        ) { modules in
+            modules == Set(["KJV"])
+        }
+
+        tapSearchTranslationPicker(in: app, timeout: 10)
+        tapSearchTranslationRow(moduleName: "UITESTWEB", in: app, timeout: 45)
+        tapSearchTranslationOK(in: app, timeout: 10)
 
         waitForSearchSelectedModules(
             in: app,
@@ -509,6 +535,7 @@ extension AndBibleUITests {
         ) { modules in
             modules.count > 1 && modules.contains("UITESTWEB")
         }
+        waitForSearchState(containing: "selectedModuleOrder=KJV,UITESTWEB", in: app, timeout: 20)
         waitForSearchState(containing: "groupedTotal=3", in: app, timeout: 20)
         waitForSearchState(containing: "KJV:1", in: app, timeout: 20)
         waitForSearchState(containing: "UITESTWEB:2", in: app, timeout: 20)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -105,6 +105,7 @@ public struct BibleReaderView: View {
 
     /// Reader-stack destinations opened from global reader actions.
     enum ReaderDestination: String, Identifiable, Hashable {
+        case search
         case settings
         case downloads
         case globalTextOptions
@@ -229,9 +230,6 @@ public struct BibleReaderView: View {
 
     /// Snapshot-backed chooser progress context captured when the chooser is presented.
     @State private var passageChooserProgressContext = PassageChooserProgressContext.empty
-
-    /// Presents the full-text search sheet for the focused module.
-    @State private var showSearch = false
 
     /// Presents the current top-level reader sheet driven by the overflow menu and shortcuts.
     @State private var activeReaderSheet: ReaderSheet?
@@ -400,7 +398,7 @@ public struct BibleReaderView: View {
     /// Window that owns the currently presented pane-scoped sheet or chooser flow.
     @State private var panePresentationTargetWindowId: UUID?
 
-    /// Ensures the launch-seeded UI-test Search sheet is only auto-presented once per app session.
+    /// Ensures the launch-seeded UI-test Search destination is only auto-presented once per app session.
     @State private var didPresentUITestLaunchSearch = false
 
     /// Presents the reference chooser used by bridge-driven dialogs.
@@ -597,7 +595,7 @@ public struct BibleReaderView: View {
         let sheetToken = "readerSheet=\(activeReaderSheet?.rawValue ?? "none")"
         let destinationToken = "readerDestination=\(activeReaderDestination?.rawValue ?? "none")"
         let modalToken = "readerModal=\(activeReaderModal?.rawValue ?? "none")"
-        let searchToken = "searchVisible=\(showSearch ? "true" : "false")"
+        let searchToken = "searchVisible=\(activeReaderDestination == .search ? "true" : "false")"
         return "\(windowToken);\(contentToken);\(tabOrdersToken);\(myNotesToken);\(studyPadToken);strongsMode=\(strongsMode);\(drawerToken);\(overflowToken);\(sheetToken);\(destinationToken);\(modalToken);\(searchToken)"
     }
 
@@ -830,9 +828,6 @@ public struct BibleReaderView: View {
         }
         #endif
         .preferredColorScheme(preferredColorSchemeOverride)
-        .sheet(isPresented: $showSearch, onDismiss: { searchInitialQuery = "" }) {
-            searchSheetContent
-        }
         .sheet(item: $activeReaderSheet) { presentedSheet in
             activeReaderSheetContent(presentedSheet)
         }
@@ -1099,23 +1094,27 @@ public struct BibleReaderView: View {
         .background(PassageChooserSurfacePalette.background.swiftUIColor.ignoresSafeArea())
     }
 
-    /// Search sheet seeded from toolbar, keyboard, or Android-compatible link routing.
+    /// Search destination seeded from toolbar, keyboard, or Android-compatible link routing.
     private var searchSheetContent: some View {
-        NavigationStack {
-            SearchView(
-                swordModule: panePresentationController?.activeModule,
-                swordManager: panePresentationController?.swordManager,
-                searchIndexService: searchIndexService,
-                installedBibleModules: panePresentationController?.installedBibleModules ?? [],
-                currentBook: panePresentationController?.currentBook ?? "Genesis",
-                currentOsisBookId: searchSheetCurrentOsisBookId,
-                initialQuery: searchInitialQuery,
-                onNavigate: navigateFromSearch
-            )
+        SearchView(
+            swordModule: panePresentationController?.activeModule,
+            swordManager: panePresentationController?.swordManager,
+            searchIndexService: searchIndexService,
+            installedBibleModules: panePresentationController?.installedBibleModules ?? [],
+            currentBook: panePresentationController?.currentBook ?? "Genesis",
+            currentOsisBookId: searchSheetCurrentOsisBookId,
+            initialQuery: searchInitialQuery,
+            onNavigate: navigateFromSearch
+        )
+        #if os(iOS)
+        .toolbar(.visible, for: .navigationBar)
+        #endif
+        .overlay(alignment: .topLeading) {
+            readerRenderedContentStateExport
         }
     }
 
-    /// OSIS book id shown as the Search sheet's current context.
+    /// OSIS book id shown as the Search destination's current context.
     private var searchSheetCurrentOsisBookId: String {
         let currentBook = panePresentationController?.currentBook ?? "Genesis"
         return panePresentationController?.osisBookId(for: currentBook)
@@ -1182,6 +1181,8 @@ public struct BibleReaderView: View {
     @ViewBuilder
     private func readerDestinationContent(_ destination: ReaderDestination) -> some View {
         switch destination {
+        case .search:
+            searchSheetContent
         case .settings:
             SettingsView(
                 nightMode: $nightMode,
@@ -1439,14 +1440,15 @@ public struct BibleReaderView: View {
        - chapter: Chapter selected by Search.
        - verse: Verse selected by Search.
      Side effects:
-     - dismisses the Search sheet
+     - dismisses the Search destination
      - updates the active pane's reader location
      Failure modes:
      - does nothing when no pane presentation controller is available
      */
     private func navigateFromSearch(book: String, chapter: Int, verse: Int) {
         panePresentationController?.navigateTo(book: book, chapter: chapter, verse: verse)
-        showSearch = false
+        activeReaderDestination = nil
+        searchInitialQuery = ""
     }
 
     // MARK: - Sheet and Destination Routing
@@ -1708,6 +1710,8 @@ public struct BibleReaderView: View {
             return
         }
         switch previousDestination {
+        case .search:
+            searchInitialQuery = ""
         case .settings:
             reloadBehaviorPreferences()
         case .downloads:
@@ -4169,12 +4173,12 @@ public struct BibleReaderView: View {
      Presents Search after first staging the latest initial-query state.
 
      Side effects:
-     - mutates `searchInitialQuery` so the sheet can seed its query field from the latest caller
-     - schedules `showSearch = true` for the next main-actor turn so the staged query wins over
+     - mutates `searchInitialQuery` so the Search destination can seed its query field from the latest caller
+     - schedules the `.search` destination for the next main-actor turn so the staged query wins over
        the current render pass
 
      Failure modes:
-     - uses an asynchronous handoff, so callers should not assume the sheet is visible until the
+     - uses an asynchronous handoff, so callers should not assume Search is visible until the
        next render pass completes
      */
     @MainActor
@@ -4190,7 +4194,7 @@ public struct BibleReaderView: View {
         }
         Task { @MainActor in
             await Task.yield()
-            showSearch = true
+            activeReaderDestination = .search
         }
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -61,7 +61,7 @@ enum UITestSearchQuerySeed {
  - `onAppear` seeds initial module selection, applies `initialQuery`, and triggers the index check
  - `startIndexCreation()` launches asynchronous index creation through `SearchIndexService`
  - `performSearch()` launches detached search work and marshals results back onto the main actor
- - `navigateTo(_:)` dismisses the sheet and notifies the caller with the selected passage
+ - `navigateTo(_:)` notifies the caller and dismisses Search with the active presentation mechanism
  */
 public struct SearchView: View {
     /// Callback invoked when the user selects a search hit and wants to navigate to it.
@@ -127,7 +127,7 @@ public struct SearchView: View {
     /// Navigation-title summary of the most recent search results.
     @State private var resultSummary: String = ""
 
-    /// Dismiss action for closing the search sheet after navigation or cancellation.
+    /// Dismiss action for popping Search after result navigation.
     @Environment(\.dismiss) private var dismiss
 
     /**
@@ -278,9 +278,6 @@ public struct SearchView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(String(localized: "done")) { dismiss() }
-            }
             if case .ready = viewState {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -376,6 +373,31 @@ public struct SearchView: View {
             installedModules: installedBibleModules
         )
         return "selectedModules=\(selectedModules.sorted().joined(separator: ","));selectedModuleOrder=\(orderedModules.joined(separator: ","))"
+    }
+
+    /**
+     User-visible selected translation summary shown on the Search translation picker button.
+
+     Android renders the committed selected translations as a comma-separated abbreviation list after
+     moving the primary document to the front. iOS uses the same helper as search execution so the
+     visible control, request order, and grouped result order cannot drift independently.
+
+     - Returns: Ordered abbreviations such as `KJV, UITESTWEB`, or a localized fallback label when
+       no module can be resolved.
+     - Side effects: none.
+     - Failure modes: Empty selection and missing primary module metadata produce the generic
+       `search_translations` fallback instead of a malformed empty button.
+     */
+    private var selectedTranslationSummaryLabel: String {
+        let orderedModules = Self.androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: selectedModules,
+            primaryModuleName: swordModule?.info.name,
+            installedModules: installedBibleModules
+        )
+        guard !orderedModules.isEmpty else {
+            return String(localized: "search_translations", defaultValue: "Translations")
+        }
+        return orderedModules.joined(separator: ", ")
     }
 
     /**
@@ -629,11 +651,8 @@ public struct SearchView: View {
                     HStack {
                         Image(systemName: "book.closed")
                             .font(.caption)
-                        if selectedModules.count == 1, let name = selectedModules.first {
-                            Text(name)
-                        } else {
-                            Text("\(selectedModules.count) translations")
-                        }
+                        Text(selectedTranslationSummaryLabel)
+                            .lineLimit(1)
                         Image(systemName: "chevron.right")
                             .font(.caption2)
                     }
@@ -1262,7 +1281,7 @@ public struct SearchView: View {
     // MARK: - Navigation
 
     /**
-     Forwards the selected result to the caller and dismisses the search sheet.
+     Forwards the selected result to the caller and dismisses Search.
 
      - Parameter hit: Selected search result.
      */

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -115,9 +115,6 @@ public struct SearchView: View {
     /// Draft module names edited inside the Android-style translation picker before OK commits.
     @State private var pendingTranslationSelection: Set<String> = []
 
-    /// Whether the options panel is expanded above the results list.
-    @State private var showOptions = true
-
     /// Whether the system search field currently owns focus.
     @FocusState private var isSearchFieldFocused: Bool
 
@@ -277,19 +274,6 @@ public struct SearchView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
-        .toolbar {
-            if case .ready = viewState {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        withAnimation { showOptions.toggle() }
-                    } label: {
-                        Image(systemName: showOptions ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
-                    }
-                    .accessibilityIdentifier("searchOptionsToggleButton")
-                    .accessibilityValue(showOptions ? "visible" : "hidden")
-                }
-            }
-        }
         .onAppear {
             if selectedModules.isEmpty, let mod = swordModule {
                 selectedModules = [mod.info.name]
@@ -537,11 +521,7 @@ public struct SearchView: View {
     /// Main search UI shown once the view reaches the `.ready` state.
     private var searchContent: some View {
         VStack(spacing: 0) {
-            searchQueryBar
-
-            if showOptions {
-                searchOptionsPanel
-            }
+            searchCriteriaForm
 
             List {
                 if isSearching {
@@ -552,63 +532,41 @@ public struct SearchView: View {
                     multiResultsSection(multi)
                 } else if !results.isEmpty {
                     singleResultsSection
-                } else if query.isEmpty {
-                    ContentUnavailableView(
-                        String(localized: "search_bible"),
-                        systemImage: "magnifyingglass",
-                        description: Text(String(localized: "search_enter_prompt"))
-                    )
-                } else if !resultSummary.isEmpty {
-                    ContentUnavailableView(
-                        String(localized: "no_results"),
-                        systemImage: "magnifyingglass",
-                        description: Text("No matches found for \"\(query)\"")
-                    )
+                } else if !query.isEmpty, !resultSummary.isEmpty {
+                    Text(String(localized: "no_results"))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowSeparator(.hidden)
                 }
             }
+            .listStyle(.plain)
             .accessibilityIdentifier("searchResultsList")
+
+            searchSubmitButton
         }
     }
 
     /// Stable app-owned query field used for both user input and UI automation.
     private var searchQueryBar: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-
-            TextField(String(localized: "search_bible_text"), text: $query)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled(true)
-                .submitLabel(.search)
-                .focused($isSearchFieldFocused)
-                .accessibilityIdentifier("searchQueryField")
-                .onSubmit {
-                    isSearchFieldFocused = false
-                    performSearch()
-                }
-
-            if !query.isEmpty {
-                Button {
-                    query = ""
-                    clearSearchResults()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(localized: "clear"))
-                .accessibilityIdentifier("searchClearQueryButton")
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.quaternary)
+        TextField(
+            String(localized: "type_text_or_bible_reference", defaultValue: "Type text or Bible reference"),
+            text: $query
         )
-        .padding(.horizontal)
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled(true)
+        .submitLabel(.search)
+        .focused($isSearchFieldFocused)
+        .padding(.horizontal, 16)
         .padding(.top, 10)
         .padding(.bottom, 8)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityIdentifier("searchQueryField")
+        .onSubmit {
+            isSearchFieldFocused = false
+            performSearch()
+        }
         .onAppear {
             if UITestRuntimeConfiguration.shouldAutofocusSearchField {
                 DispatchQueue.main.async {
@@ -618,87 +576,175 @@ public struct SearchView: View {
         }
     }
 
-    // MARK: - Search Options Panel
+    // MARK: - Search Criteria Form
 
-    /// Search-mode, scope, and translation controls shown above the result list.
-    private var searchOptionsPanel: some View {
-        VStack(spacing: 12) {
-            Picker(String(localized: "search_match"), selection: $wordMode) {
-                ForEach(SearchWordMode.allCases, id: \.self) { mode in
-                    Text(mode.rawValue)
-                        .tag(mode)
-                        .accessibilityIdentifier("searchWordModeButton::\(searchWordModeToken(for: mode))")
-                }
-            }
-            .pickerStyle(.segmented)
-            .accessibilityIdentifier("searchWordModePicker")
+    /// Android-style Search criteria form shown above inline results.
+    private var searchCriteriaForm: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            searchQueryBar
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    scopeButton(String(localized: "search_scope_all"), choice: .wholeBible)
-                    scopeButton(String(localized: "search_scope_ot"), choice: .oldTestament)
-                    scopeButton(String(localized: "search_scope_nt"), choice: .newTestament)
-                    scopeButton(currentBook, choice: .currentBook)
-                }
-                .font(.subheadline)
+            HStack(alignment: .top, spacing: 16) {
+                searchScopeRadioGroup
+                searchWordModeRadioGroup
             }
-            .accessibilityIdentifier("searchScopeStrip")
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 10)
 
-            if installedBibleModules.count > 1 {
-                Button {
-                    openTranslationPicker()
-                } label: {
-                    HStack {
-                        Image(systemName: "book.closed")
-                            .font(.caption)
-                        Text(selectedTranslationSummaryLabel)
-                            .lineLimit(1)
-                        Image(systemName: "chevron.right")
-                            .font(.caption2)
-                    }
-                    .font(.subheadline)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("searchTranslationPickerButton")
-                .accessibilityValue("\(searchAccessibilitySelectionToken);\(searchAccessibilityTranslationPickerToken)")
-            }
+            searchTranslationsSection
         }
-        .padding(.horizontal)
-        .padding(.vertical, 10)
-        .background(.bar)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("searchOptionsPanel")
         .accessibilityValue("visible")
     }
 
+    /// Android search-scope radio group.
+    private var searchScopeRadioGroup: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "search_bible_section_group_prompt", defaultValue: "Bible section"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            searchRadioRow(
+                label: String(localized: "search_scope_all", defaultValue: "All Bible"),
+                isSelected: scopeOption == .wholeBible,
+                identifier: searchScopeIdentifier(for: .wholeBible)
+            ) {
+                scopeOption = .wholeBible
+            }
+
+            searchRadioRow(
+                label: String(localized: "search_scope_ot", defaultValue: "Old Testament"),
+                isSelected: scopeOption == .oldTestament,
+                identifier: searchScopeIdentifier(for: .oldTestament)
+            ) {
+                scopeOption = .oldTestament
+            }
+
+            searchRadioRow(
+                label: String(localized: "search_scope_nt", defaultValue: "New Testament"),
+                isSelected: scopeOption == .newTestament,
+                identifier: searchScopeIdentifier(for: .newTestament)
+            ) {
+                scopeOption = .newTestament
+            }
+
+            searchRadioRow(
+                label: currentBook,
+                isSelected: scopeOption == .currentBook,
+                identifier: searchScopeIdentifier(for: .currentBook)
+            ) {
+                scopeOption = .currentBook
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("searchScopeStrip")
+    }
+
+    /// Android word-matching radio group.
+    private var searchWordModeRadioGroup: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "search_words_group_prompt", defaultValue: "Words"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(SearchWordMode.allCases, id: \.self) { mode in
+                searchRadioRow(
+                    label: mode.rawValue,
+                    isSelected: wordMode == mode,
+                    identifier: "searchWordModeButton::\(searchWordModeToken(for: mode))"
+                ) {
+                    wordMode = mode
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .accessibilityElement(children: .contain)
+    }
+
+    /// Android translations selector row.
+    private var searchTranslationsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "search_translations", defaultValue: "Translations"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button {
+                openTranslationPicker()
+            } label: {
+                HStack(spacing: 10) {
+                    Text(selectedTranslationSummaryLabel)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "pencil")
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("searchTranslationPickerButton")
+            .accessibilityValue("\(searchAccessibilitySelectionToken);\(searchAccessibilityTranslationPickerToken)")
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 10)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    /// Android-style bottom submit button for executing Search criteria.
+    private var searchSubmitButton: some View {
+        Button {
+            isSearchFieldFocused = false
+            performSearch()
+        } label: {
+            Text(String(localized: "search", defaultValue: "Search"))
+                .font(.body.weight(.medium))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 11)
+        }
+        .buttonStyle(.borderedProminent)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .overlay(alignment: .top) {
+            Divider()
+        }
+        .accessibilityIdentifier("searchSubmitButton")
+    }
+
     /**
-     Builds one pill-style scope selector button.
+     Builds an Android-style radio row used by Search criteria groups.
 
      - Parameters:
-       - label: User-visible scope label.
-       - choice: Scope value activated when the button is tapped.
+       - label: User-visible option label.
+       - isSelected: Whether this option is the active value.
+       - identifier: Stable UI automation identifier for the row.
+       - action: Mutation performed when the row is tapped.
      */
-    private func scopeButton(_ label: String, choice: ScopeChoice) -> some View {
-        Button(label) {
-            scopeOption = choice
+    private func searchRadioRow(
+        label: String,
+        isSelected: Bool,
+        identifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .font(.caption)
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                Text(label)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .contentShape(Rectangle())
+            .accessibilityIdentifier(identifier)
         }
-        .font(.subheadline)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(
-            scopeOption == choice ? Color.accentColor.opacity(0.2) : Color.clear,
-            in: RoundedRectangle(cornerRadius: 8)
-        )
-        .foregroundStyle(scopeOption == choice ? Color.accentColor : Color.primary)
-        .lineLimit(1)
-        .accessibilityElement(children: .ignore)
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
         .accessibilityLabel(label)
-        .accessibilityValue(scopeOption == choice ? "selected" : "unselected")
-        .accessibilityAddTraits(.isButton)
-        .accessibilityIdentifier(searchScopeIdentifier(for: choice))
+        .accessibilityValue(isSelected ? "selected" : "unselected")
+        .accessibilityIdentifier(identifier)
     }
 
     /**
@@ -751,14 +797,6 @@ public struct SearchView: View {
         case .phrase:
             return "phrase"
         }
-    }
-
-    /// Resets Search result state when the visible query is explicitly cleared.
-    private func clearSearchResults() {
-        results = []
-        multiResults = nil
-        resultSummary = ""
-        isSearching = false
     }
 
     // MARK: - Results Sections

--- a/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift
@@ -112,11 +112,17 @@ public struct SearchView: View {
     /// Installed module names selected for indexed multi-translation search.
     @State private var selectedModules: Set<String> = []
 
+    /// Draft module names edited inside the Android-style translation picker before OK commits.
+    @State private var pendingTranslationSelection: Set<String> = []
+
     /// Whether the options panel is expanded above the results list.
     @State private var showOptions = true
 
     /// Whether the system search field currently owns focus.
     @FocusState private var isSearchFieldFocused: Bool
+
+    /// Current system color scheme used for Android-dialog surface colors.
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Navigation-title summary of the most recent search results.
     @State private var resultSummary: String = ""
@@ -235,7 +241,7 @@ public struct SearchView: View {
      Builds the search UI for the current `viewState`.
 
      The body switches between index-check progress, index-creation prompt/progress, and the full
-     search interface while also wiring the toolbar and translation-picker sheet.
+     search interface while also wiring the toolbar and translation-picker overlay.
      */
     public var body: some View {
         Group {
@@ -262,6 +268,11 @@ public struct SearchView: View {
             // snapshot the full Search container while result lists are changing.
             searchStateExport
         }
+        .overlay {
+            if showTranslationPicker {
+                translationPickerOverlay
+            }
+        }
         .navigationTitle(navigationTitle)
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -281,9 +292,6 @@ public struct SearchView: View {
                     .accessibilityValue(showOptions ? "visible" : "hidden")
                 }
             }
-        }
-        .sheet(isPresented: $showTranslationPicker) {
-            makeTranslationPicker(modules: installedBibleModules)
         }
         .onAppear {
             if selectedModules.isEmpty, let mod = swordModule {
@@ -362,13 +370,18 @@ public struct SearchView: View {
 
     /// Stable selected-translation token exported for UI automation.
     private var searchAccessibilitySelectionToken: String {
-        "selectedModules=\(selectedModules.sorted().joined(separator: ","))"
+        let orderedModules = Self.androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: selectedModules,
+            primaryModuleName: swordModule?.info.name,
+            installedModules: installedBibleModules
+        )
+        return "selectedModules=\(selectedModules.sorted().joined(separator: ","));selectedModuleOrder=\(orderedModules.joined(separator: ","))"
     }
 
     /**
      Stable translation-picker presentation token exported for UI automation.
      *
-     - Returns: `translationPicker=open` while SwiftUI is presenting the picker sheet, otherwise
+     - Returns: `translationPicker=open` while Search is presenting the custom picker overlay, otherwise
        `translationPicker=closed`.
      - Side effects: none.
      - Failure modes: This computed token does not fail.
@@ -611,8 +624,7 @@ public struct SearchView: View {
 
             if installedBibleModules.count > 1 {
                 Button {
-                    isSearchFieldFocused = false
-                    showTranslationPicker = true
+                    openTranslationPicker()
                 } label: {
                     HStack {
                         Image(systemName: "book.closed")
@@ -936,72 +948,315 @@ public struct SearchView: View {
     // MARK: - Translation Picker
 
     /**
-     Builds the translation picker used for multi-translation searches.
+     Builds the dimmed modal layer used for Android-style multi-translation selection.
 
-     - Parameter modules: Installed Bible modules available for selection.
+     The overlay is owned by `SearchView` rather than SwiftUI sheet presentation so Search matches
+     Android's in-place `AlertDialog` behavior: the picker edits a local draft, Cancel discards it,
+     and OK is the only commit path.
+
+     - Returns: Full-screen modal dimmer and centered picker dialog.
+     - Side effects: Button actions inside the dialog can mutate `pendingTranslationSelection`,
+       commit to `selectedModules`, or dismiss the overlay; tapping the dimmer follows Android's
+       dialog-cancel path and discards the draft.
+     - Failure modes: Empty module sets render an empty scroll region; the caller only presents the
+       picker when more than one installed Bible module exists.
      */
-    private func makeTranslationPicker(modules: [ModuleInfo]) -> some View {
-        NavigationStack {
-            List {
-                ForEach(modules) { (mod: ModuleInfo) in
-                    translationRow(mod)
+    private var translationPickerOverlay: some View {
+        ZStack {
+            Color.black.opacity(colorScheme == .dark ? 0.45 : 0.32)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    cancelTranslationPicker()
                 }
-            }
-            .accessibilityIdentifier("searchTranslationPickerList")
-            .navigationTitle(String(localized: "search_translations"))
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "done")) { showTranslationPicker = false }
-                        .accessibilityIdentifier("searchTranslationDoneButton")
-                }
-                ToolbarItem(placement: .primaryAction) {
-                    Button(String(localized: "search_all")) {
-                        selectedModules = Set(installedBibleModules.map(\.name))
-                    }
-                    .accessibilityIdentifier("searchTranslationSelectAllButton")
-                }
-            }
+                .accessibilityHidden(true)
+
+            makeTranslationPicker(modules: installedBibleModules)
+                .padding(.horizontal, 24)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("searchTranslationPickerOverlay")
     }
 
-    @ViewBuilder
     /**
-     Builds one row in the translation picker.
+     Builds the Android-style Search translation multiselect dialog.
+
+     Android's `Search.showTranslationSelector` presents a multi-choice `AlertDialog` with all
+     Bible modules sorted by abbreviation, existing selections prechecked, explicit Cancel/OK
+     buttons, and a neutral Select all/none toggle. This SwiftUI surface mirrors that contract
+     without using an iOS sheet or committing row taps directly to Search state.
+
+     - Parameter modules: Installed Bible modules available for selection.
+     - Returns: Centered modal dialog containing title, selectable rows, and dialog actions.
+     - Side effects: Row and Select all/none actions mutate only `pendingTranslationSelection`; OK
+       may commit to `selectedModules` through `commitTranslationPickerSelection()`.
+     - Failure modes: Missing index-service state is treated as unknown and therefore does not add
+       the unindexed warning label.
+     */
+    private func makeTranslationPicker(modules: [ModuleInfo]) -> some View {
+        VStack(spacing: 0) {
+            Text(String(localized: "compare_choose_translations"))
+                .font(.headline)
+                .foregroundStyle(dialogPrimaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 22)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
+
+            Divider()
+                .background(dialogSecondaryText.opacity(0.25))
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Self.androidSortedTranslationModules(modules)) { mod in
+                        translationRow(mod)
+                        Divider()
+                            .background(dialogSecondaryText.opacity(0.18))
+                            .padding(.leading, 22)
+                    }
+                }
+                .accessibilityIdentifier("searchTranslationPickerList")
+            }
+            .frame(maxHeight: 420)
+
+            Divider()
+                .background(dialogSecondaryText.opacity(0.25))
+
+            HStack(spacing: 14) {
+                Button(String(localized: "cancel")) {
+                    cancelTranslationPicker()
+                }
+                .foregroundStyle(dialogAccent)
+                .accessibilityIdentifier("searchTranslationCancelButton")
+
+                Spacer(minLength: 8)
+
+                Button(searchTranslationSelectToggleTitle) {
+                    toggleAllTranslationRows()
+                }
+                .foregroundStyle(dialogAccent)
+                .accessibilityIdentifier("searchTranslationSelectAllButton")
+                .accessibilityValue(searchTranslationSelectToggleAccessibilityValue)
+
+                Button(String(localized: "ok", defaultValue: "OK")) {
+                    commitTranslationPickerSelection()
+                }
+                .fontWeight(.semibold)
+                .foregroundStyle(dialogAccent)
+                .accessibilityIdentifier("searchTranslationOKButton")
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 22)
+            .padding(.vertical, 14)
+        }
+        .frame(maxWidth: 430)
+        .background(dialogBackground, in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .strokeBorder(dialogSecondaryText.opacity(0.28), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 20, x: 0, y: 12)
+    }
+
+    /**
+     Builds one Android-style checkbox row in the Search translation picker.
 
      - Parameter mod: Installed module metadata for the row being rendered.
+     - Returns: A full-width button that toggles the row's draft checked state.
+     - Side effects: Mutates `pendingTranslationSelection`; it does not mutate committed Search
+       module selection until the dialog OK action runs.
+     - Failure modes: If index readiness cannot be determined, the row label omits the unindexed
+       suffix rather than presenting possibly false status.
      */
     private func translationRow(_ mod: ModuleInfo) -> some View {
         let modName = mod.name
-        let modDesc = mod.description
-        let isSelected = selectedModules.contains(modName)
-        Button {
-            if isSelected {
-                if selectedModules.count > 1 { selectedModules.remove(modName) }
-            } else {
-                selectedModules.insert(modName)
-            }
+        let isSelected = pendingTranslationSelection.contains(modName)
+        let rowLabel = Self.androidTranslationPickerLabel(
+            for: mod,
+            isIndexed: isTranslationModuleIndexed(modName),
+            unindexedStatus: String(localized: "search_index_not_created", defaultValue: "Search index not created")
+        )
+        return Button {
+            togglePendingTranslationSelection(modName)
         } label: {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(modName).font(.headline)
-                    Text(modDesc).font(.caption).foregroundStyle(.secondary).lineLimit(1)
-                }
-                Spacer()
+            HStack(spacing: 14) {
                 if isSelected {
-                    Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.accentColor)
+                    Image(systemName: "checkmark.square.fill")
+                        .foregroundStyle(dialogAccent)
                 } else {
-                    Image(systemName: "circle").foregroundStyle(.secondary)
+                    Image(systemName: "square")
+                        .foregroundStyle(dialogSecondaryText)
                 }
+                Text(rowLabel)
+                    .font(.body)
+                    .foregroundStyle(dialogPrimaryText)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 22)
+            .padding(.vertical, 13)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("searchTranslationRow::\(sanitizedAccessibilitySegment(modName))")
         .accessibilityValue(isSelected ? "selected" : "unselected")
+    }
+
+    /// Android-dialog background color for the current system appearance.
+    private var dialogBackground: Color {
+        AndroidDialogSurfacePalette.background(for: colorScheme)
+    }
+
+    /// Android-dialog primary text color for the current system appearance.
+    private var dialogPrimaryText: Color {
+        AndroidDialogSurfacePalette.primaryText(for: colorScheme)
+    }
+
+    /// Android-dialog secondary text color for the current system appearance.
+    private var dialogSecondaryText: Color {
+        AndroidDialogSurfacePalette.secondaryText(for: colorScheme)
+    }
+
+    /// Android-dialog accent color for interactive picker actions.
+    private var dialogAccent: Color {
+        AndroidDialogSurfacePalette.accent(for: colorScheme)
+    }
+
+    /**
+     Opens the Search translation picker with a draft that mirrors Android prechecked rows.
+
+     Android loads the existing saved/current selection before presenting the multiselect dialog,
+     then lets the dialog mutate temporary checked state until an action is pressed. This method
+     seeds that draft from the committed iOS Search selection and the current primary module.
+
+     Side effects:
+     - clears Search field focus so the dialog is not obscured by the keyboard
+     - mutates `pendingTranslationSelection`
+     - sets `showTranslationPicker` to present the overlay
+
+     Failure modes:
+     - if no committed selection and no primary module exist, the draft is empty and OK will leave
+       the committed Search selection unchanged.
+     */
+    private func openTranslationPicker() {
+        isSearchFieldFocused = false
+        pendingTranslationSelection = Set(Self.androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: selectedModules,
+            primaryModuleName: swordModule?.info.name,
+            installedModules: installedBibleModules
+        ))
+        showTranslationPicker = true
+    }
+
+    /**
+     Dismisses the Search translation picker without committing the draft selection.
+
+     Android's dialog Cancel path returns an empty result and leaves the existing selected
+     translations untouched. iOS mirrors that by clearing only the draft state.
+
+     Side effects:
+     - clears `pendingTranslationSelection`
+     - sets `showTranslationPicker` to false
+     */
+    private func cancelTranslationPicker() {
+        pendingTranslationSelection.removeAll()
+        showTranslationPicker = false
+    }
+
+    /**
+     Commits the Search translation picker draft according to Android's non-empty result contract.
+
+     Android ignores an empty selected result, including the case where the user presses OK after
+     toggling all rows off. This method preserves the previous selection for empty drafts, otherwise
+     it commits the draft while preserving the primary module first for downstream search ordering.
+
+     Side effects:
+     - may mutate `selectedModules`
+     - clears the draft and dismisses the overlay
+     - triggers the existing `selectedModules` change observer when the committed set changes
+     */
+    private func commitTranslationPickerSelection() {
+        let orderedSelection = Self.androidCommittedTranslationSelection(
+            previousModuleNames: selectedModules,
+            draftModuleNames: pendingTranslationSelection,
+            primaryModuleName: swordModule?.info.name,
+            installedModules: installedBibleModules
+        )
+        if !orderedSelection.isEmpty {
+            selectedModules = Set(orderedSelection)
+        }
+        pendingTranslationSelection.removeAll()
+        showTranslationPicker = false
+    }
+
+    /**
+     Toggles one draft module check state in the Search translation picker.
+
+     Android allows the dialog's checked set to become empty while the dialog remains open; the
+     empty OK result is ignored later. This method intentionally does not enforce "at least one"
+     selection at row-tap time.
+
+     - Parameter moduleName: SWORD module abbreviation for the tapped row.
+     - Side effects: Mutates `pendingTranslationSelection`.
+     */
+    private func togglePendingTranslationSelection(_ moduleName: String) {
+        if pendingTranslationSelection.contains(moduleName) {
+            pendingTranslationSelection.remove(moduleName)
+        } else {
+            pendingTranslationSelection.insert(moduleName)
+        }
+    }
+
+    /**
+     Selects every module or clears the draft selection using Android's neutral-button behavior.
+
+     Android's multiselect neutral button toggles between Select all and Select none without
+     closing the dialog. This method mirrors that behavior against the abbreviation-sorted module
+     list.
+
+     Side effects: Mutates `pendingTranslationSelection`; does not commit to `selectedModules`.
+     */
+    private func toggleAllTranslationRows() {
+        let allModuleNames = Set(Self.androidSortedTranslationModules(installedBibleModules).map(\.name))
+        if pendingTranslationSelection.count == allModuleNames.count {
+            pendingTranslationSelection.removeAll()
+        } else {
+            pendingTranslationSelection = allModuleNames
+        }
+    }
+
+    /**
+     Resolves whether one module has a completed Search index for picker labeling.
+
+     Android appends "Search index not created" when JSword reports an index status other than
+     done. iOS can only render that status when a `SearchIndexService` is available; absent service
+     means direct SWORD fallback is in use, so the picker omits an unverified warning.
+
+     - Parameter moduleName: SWORD module abbreviation to inspect.
+     - Returns: `true` when the module should render without the unindexed suffix.
+     - Side effects: Reads Search index metadata through `SearchIndexService`.
+     */
+    private func isTranslationModuleIndexed(_ moduleName: String) -> Bool {
+        searchIndexService?.hasIndex(for: moduleName) ?? true
+    }
+
+    /// Visible Select all/none label for the Search translation picker neutral action.
+    private var searchTranslationSelectToggleTitle: String {
+        let allCount = Self.androidSortedTranslationModules(installedBibleModules).count
+        if allCount > 0, pendingTranslationSelection.count == allCount {
+            return String(localized: "select_none", defaultValue: "Select none")
+        }
+        return String(localized: "select_all", defaultValue: "Select all")
+    }
+
+    /// Stable UI-test semantic state for the picker neutral select toggle.
+    private var searchTranslationSelectToggleAccessibilityValue: String {
+        let allCount = Self.androidSortedTranslationModules(installedBibleModules).count
+        return allCount > 0 && pendingTranslationSelection.count == allCount
+            ? "selectNone"
+            : "selectAll"
     }
 
     // MARK: - Navigation
@@ -1078,8 +1333,12 @@ public struct SearchView: View {
             return
         }
 
-        let moduleNames = selectedModules.isEmpty ? [mod.info.name] : Array(selectedModules)
-        if let missingModuleName = moduleNames.sorted().first(where: { !service.hasIndex(for: $0) }) {
+        let moduleNames = Self.androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: selectedModules,
+            primaryModuleName: mod.info.name,
+            installedModules: installedBibleModules
+        )
+        if let missingModuleName = moduleNames.first(where: { !service.hasIndex(for: $0) }) {
             viewState = .needsIndex(
                 moduleName: missingModuleName,
                 moduleDescription: moduleDescription(for: missingModuleName)
@@ -1188,7 +1447,12 @@ public struct SearchView: View {
             }
             // Also index any other selected modules
             if let mgr = swordManager {
-                for name in selectedModules where !service.hasIndex(for: name) {
+                let selectedNames = Self.androidOrderedSelectedSearchModuleNames(
+                    selectedModuleNames: selectedModules,
+                    primaryModuleName: swordModule?.info.name,
+                    installedModules: installedBibleModules
+                )
+                for name in selectedNames where !service.hasIndex(for: name) {
                     if let existing = list.first(where: { $0.1 == name }) {
                         _ = existing // already queued
                     } else if let mod = mgr.module(named: name) {
@@ -1237,7 +1501,11 @@ public struct SearchView: View {
         let currentQuery = query
         let currentWordMode = wordMode
         let currentScope = scopeOption
-        let currentSelectedModules = selectedModules
+        let currentSelectedModules = Self.androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: selectedModules,
+            primaryModuleName: swordModule?.info.name,
+            installedModules: installedBibleModules
+        )
         let bookName = currentBook
         let osisBookId = currentOsisBookId
         let currentSwordModule = swordModule
@@ -1308,14 +1576,21 @@ public struct SearchView: View {
                 if currentSelectedModules.count > 1 {
                     let grouped = service.searchMultiple(
                         query: currentQuery,
-                        moduleNames: Array(currentSelectedModules),
+                        moduleNames: currentSelectedModules,
                         wordMode: currentWordMode,
                         scopeBookName: scopeBookName,
                         scopeTestament: scopeTestament
                     )
-                    let hits = Self.convertGroupedResults(grouped, query: currentQuery)
-                    let perModule = grouped.map { (name: $0.key, count: $0.value.count) }
-                        .sorted { $0.name < $1.name }
+                    let hits = Self.convertGroupedResults(
+                        grouped,
+                        moduleOrder: currentSelectedModules
+                    )
+                    let perModule = Self.orderedGroupedModuleNames(
+                        grouped,
+                        moduleOrder: currentSelectedModules
+                    ).map { moduleName in
+                        (name: moduleName, count: grouped[moduleName]?.count ?? 0)
+                    }
                     let totalCount = perModule.reduce(0) { $0 + $1.count }
 
                     await MainActor.run {
@@ -1373,6 +1648,129 @@ public struct SearchView: View {
     }
 
     // MARK: - Helpers
+
+    /**
+     Sorts Search translation picker modules using Android's abbreviation ordering.
+
+     Android builds the Search translation multiselect with
+     `SwordDocumentFacade.bibles.sortedBy { it.abbreviation }`. The iOS picker and commit helpers
+     use this shared function so row order, select-all order, and result grouping do not depend on
+     installer order or `Set` iteration.
+
+     - Parameter modules: Installed Bible modules available to Search.
+     - Returns: Modules sorted by their SWORD abbreviation (`ModuleInfo.name`).
+     - Side effects: none.
+     - Failure modes: Duplicate module names retain Swift's sort stability expectations only for
+       equal keys; installed SWORD modules should have unique abbreviations.
+     */
+    nonisolated static func androidSortedTranslationModules(_ modules: [ModuleInfo]) -> [ModuleInfo] {
+        modules.sorted { lhs, rhs in
+            lhs.name < rhs.name
+        }
+    }
+
+    /**
+     Resolves selected Search module names in Android commit/search order.
+
+     Android collects selected rows from the abbreviation-sorted dialog and then moves the current
+     document to the front with `ensurePrimaryDocumentFirst()`. This function provides the same
+     deterministic order for Search requests, grouped-result summaries, and UI-test state exports.
+
+     - Parameters:
+       - selectedModuleNames: Committed module abbreviations selected for Search.
+       - primaryModuleName: Current reader/search module abbreviation, preferred first when present.
+       - installedModules: Installed Bible modules used to derive Android dialog order.
+     - Returns: Selected module abbreviations with the primary module first, followed by remaining
+       selected modules in Android abbreviation order and unknown selections alphabetically.
+     - Side effects: none.
+     - Failure modes: If `selectedModuleNames` is empty and no primary exists, returns an empty
+       array so callers can preserve their existing no-selection fallback.
+     */
+    nonisolated static func androidOrderedSelectedSearchModuleNames(
+        selectedModuleNames: Set<String>,
+        primaryModuleName: String?,
+        installedModules: [ModuleInfo]
+    ) -> [String] {
+        var effectiveSelection = selectedModuleNames
+        if effectiveSelection.isEmpty, let primaryModuleName {
+            effectiveSelection.insert(primaryModuleName)
+        }
+
+        var orderedNames = androidSortedTranslationModules(installedModules)
+            .map(\.name)
+            .filter { effectiveSelection.contains($0) }
+
+        let unknownNames = effectiveSelection.subtracting(orderedNames).sorted()
+        orderedNames.append(contentsOf: unknownNames)
+
+        if let primaryModuleName,
+           let primaryIndex = orderedNames.firstIndex(of: primaryModuleName) {
+            orderedNames.remove(at: primaryIndex)
+            orderedNames.insert(primaryModuleName, at: 0)
+        }
+
+        return orderedNames
+    }
+
+    /**
+     Applies Android's Search translation dialog commit rule to a picker draft.
+
+     Android's positive button returns checked rows, but `Search.showTranslationSelector` only
+     commits when that result is non-empty. This helper keeps iOS OK-with-no-selection equivalent
+     to Android's ignored empty result while still returning a deterministic module order for
+     non-empty commits.
+
+     - Parameters:
+       - previousModuleNames: Currently committed Search selection.
+       - draftModuleNames: Draft checked rows from the open picker dialog.
+       - primaryModuleName: Current reader/search module abbreviation, preferred first.
+       - installedModules: Installed Bible modules used to derive Android dialog order.
+     - Returns: Ordered effective selection: draft when non-empty, otherwise previous selection.
+     - Side effects: none.
+     - Failure modes: If both previous and draft selections are empty and no primary exists, returns
+       an empty array.
+     */
+    nonisolated static func androidCommittedTranslationSelection(
+        previousModuleNames: Set<String>,
+        draftModuleNames: Set<String>,
+        primaryModuleName: String?,
+        installedModules: [ModuleInfo]
+    ) -> [String] {
+        let effectiveSelection = draftModuleNames.isEmpty ? previousModuleNames : draftModuleNames
+        return androidOrderedSelectedSearchModuleNames(
+            selectedModuleNames: effectiveSelection,
+            primaryModuleName: primaryModuleName,
+            installedModules: installedModules
+        )
+    }
+
+    /**
+     Builds the Android Search translation picker row label for one module.
+
+     Android renders each row as "ABBR - Name" and appends the localized
+     `search_index_not_created` text in parentheses when the module lacks a completed index. iOS
+     keeps that exact information model while allowing the caller to supply localized status text.
+
+     - Parameters:
+       - module: Installed Bible module metadata for the row.
+       - isIndexed: Whether Search can treat the module as index-ready.
+       - unindexedStatus: Localized status suffix for modules without an index.
+     - Returns: User-visible row label matching Android's abbreviation, description, and index
+       readiness semantics.
+     - Side effects: none.
+     - Failure modes: Empty descriptions fall back to the module abbreviation to avoid rendering an
+       incomplete "ABBR - " label.
+     */
+    nonisolated static func androidTranslationPickerLabel(
+        for module: ModuleInfo,
+        isIndexed: Bool,
+        unindexedStatus: String
+    ) -> String {
+        let moduleName = module.description.isEmpty ? module.name : module.description
+        let baseLabel = "\(module.name) - \(moduleName)"
+        guard !isIndexed else { return baseLabel }
+        return "\(baseLabel) (\(unindexedStatus))"
+    }
 
     /**
      Resolves `SearchIndexService` scope parameters from the selected scope choice.
@@ -1435,16 +1833,19 @@ public struct SearchView: View {
 
      - Parameters:
        - grouped: Raw grouped index results keyed by module name.
-       - query: Original query string. Present for signature parity with earlier helpers.
+       - moduleOrder: Android-ordered module names selected for the search.
      - Returns: Flat passage-level hits annotated with their source module name.
+     - Side effects: none.
+     - Failure modes: Groups whose module names are not in `moduleOrder` are appended
+       alphabetically so no Search hits are dropped.
      */
     nonisolated private static func convertGroupedResults(
         _ grouped: [String: [SearchIndexService.IndexSearchResult]],
-        query: String
+        moduleOrder: [String]
     ) -> [SearchHit] {
         var allHits: [SearchHit] = []
-        for (moduleName, results) in grouped.sorted(by: { $0.key < $1.key }) {
-            for result in results {
+        for moduleName in orderedGroupedModuleNames(grouped, moduleOrder: moduleOrder) {
+            for result in grouped[moduleName] ?? [] {
                 guard let parsed = StrongsSearchSupport.parseVerseKey(result.key) else { continue }
                 allHits.append(SearchHit(
                     book: parsed.book, chapter: parsed.chapter,
@@ -1455,6 +1856,32 @@ public struct SearchView: View {
             }
         }
         return allHits
+    }
+
+    /**
+     Resolves grouped Search result module names in selected Android order.
+
+     `SearchIndexService.searchMultiple` returns a dictionary, so iOS must restore Android's
+     primary-first selected module order before building summaries or flattening rows. Any
+     unexpected dictionary keys are appended alphabetically to preserve data without hiding drift.
+
+     - Parameters:
+       - grouped: Raw grouped Search results keyed by module abbreviation.
+       - moduleOrder: Android-ordered selected modules used for the search request.
+     - Returns: Module names to render for grouped Search summaries and rows.
+     - Side effects: none.
+     - Failure modes: Missing selected modules are omitted from the ordered prefix when the grouped
+       response has no entry for them.
+     */
+    nonisolated private static func orderedGroupedModuleNames(
+        _ grouped: [String: [SearchIndexService.IndexSearchResult]],
+        moduleOrder: [String]
+    ) -> [String] {
+        let groupedNames = Set(grouped.keys)
+        var orderedNames = moduleOrder.filter { groupedNames.contains($0) }
+        let remainingNames = groupedNames.subtracting(orderedNames).sorted()
+        orderedNames.append(contentsOf: remainingNames)
+        return orderedNames
     }
 
     /**

--- a/docs/parity/reader/modal-ownership-matrix.md
+++ b/docs/parity/reader/modal-ownership-matrix.md
@@ -51,6 +51,7 @@ Android references:
 
 | iOS route token | Current iOS surface | ADR 0006 owner | Android owner or target | Disposition |
 | --- | --- | --- | --- | --- |
+| `ReaderDestination.search` | `SearchView` pushed as a reader destination | `Android app-owned` | Android `Search` activity from `MenuCommandHandler` | Adapted app-owned route with UI coverage protecting destination presentation and translation-picker parity. |
 | `ReaderDestination.settings` | `SettingsView` pushed as a reader destination | `Android app-owned` | `SettingsActivity` from drawer/menu routing | Adapted app-owned route with Settings UI coverage. |
 | `ReaderDestination.downloads` | `ModuleBrowserView` pushed as a reader destination | `Android app-owned` | `DownloadActivity` from drawer/chooser/startup flows | Adapted app-owned route. Repository/source and list details live in downloads docs. |
 | `ReaderDestination.globalTextOptions` | `TextDisplaySettingsView` with global scope | `Android app-owned` | `TextDisplaySettingsActivity` with `SettingsLevel.GLOBAL` | App-owned settings route. Scope semantics are governed by settings docs and ADR 0005. |
@@ -81,7 +82,6 @@ Android references:
 
 | iOS route token | Current iOS surface | ADR 0006 owner | Android owner or target | Disposition |
 | --- | --- | --- | --- | --- |
-| `showSearch` | `SearchView` in a reader sheet | `Android app-owned` | Android `Search` activity from `MenuCommandHandler` | Adapted app-owned route. Search translation-picker parity is tracked by #247. |
 | `showStartupDownloadPrompt` | SwiftUI `confirmationDialog` | `Android app-owned` | Android startup/download prompt dialogs | Acceptable dialog adaptation if labels, cancel/default behavior, and Downloads handoff remain equivalent. |
 | `showReaderStrongsModeDialog` | SwiftUI `confirmationDialog` | `Android app-owned` | `StrongsPreference.openDialog` / Android option dialog | Acceptable dialog adaptation if choices, reset/default semantics, and preference mutation match Android. |
 | `shareSheetBinding` | `ShareSheet` / `UIActivityViewController` | `iOS system boundary` | Android share intents/widgets | Acceptable platform boundary when it only hands selected/generated content to OS sharing. |

--- a/scripts/test_reader_modal_ownership_matrix.py
+++ b/scripts/test_reader_modal_ownership_matrix.py
@@ -97,7 +97,6 @@ class ReaderModalOwnershipMatrixTests(unittest.TestCase):
         matrix = MATRIX.read_text(encoding="utf-8")
 
         for token in [
-            "`showSearch`",
             "`showStartupDownloadPrompt`",
             "`showReaderStrongsModeDialog`",
             "`shareSheetBinding`",
@@ -120,7 +119,7 @@ class ReaderModalOwnershipMatrixTests(unittest.TestCase):
         matrix = MATRIX.read_text(encoding="utf-8")
 
         expected_owners = {
-            "showSearch": "`Android app-owned`",
+            "ReaderDestination.search": "`Android app-owned`",
             "showRefChooser": "`Android app-owned`",
             "ReaderModal.chooseDocument": "`Android app-owned`",
             "ReaderModal.modulePicker": "`Android app-owned`",

--- a/scripts/ui_test_fixture_manifest.json
+++ b/scripts/ui_test_fixture_manifest.json
@@ -27,6 +27,7 @@
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchStrongsQueryReturnsBundledResults": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchUsesSeededIndexAndReturnsBundledResults": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchMultiTranslationSelectionUpdatesGroupedTotals": "search-multi-translation",
+  "AndBibleUITests/AndBibleUITests/testSearchPresentsAsReaderDestinationInsteadOfSheet": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchRetainsSeededQuery": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchResultSelectionNavigatesReaderToBundledReference": "search-indexed",
   "AndBibleUITests/AndBibleUITests/testSearchScopeChangeRerunsQueryAndUpdatesResults": "search-indexed",

--- a/scripts/ui_test_timings.json
+++ b/scripts/ui_test_timings.json
@@ -32,6 +32,7 @@
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchStrongsQueryReturnsBundledResults": 93.984,
   "AndBibleUITests/AndBibleUITests/testSearchDirectLaunchUsesSeededIndexAndReturnsBundledResults": 100.089,
   "AndBibleUITests/AndBibleUITests/testSearchMultiTranslationSelectionUpdatesGroupedTotals": 176.783,
+  "AndBibleUITests/AndBibleUITests/testSearchPresentsAsReaderDestinationInsteadOfSheet": 87.628,
   "AndBibleUITests/AndBibleUITests/testSearchResultSelectionNavigatesReaderToBundledReference": 174.437,
   "AndBibleUITests/AndBibleUITests/testSearchScopeChangeRerunsQueryAndUpdatesResults": 117.399,
   "AndBibleUITests/AndBibleUITests/testSearchWordModeChangeRerunsQueryAndUpdatesResults": 114.75,


### PR DESCRIPTION
## Summary
Aligns the iOS Search translation picker and Search presentation with Android behavior instead of preserving SwiftUI sheet-specific interaction.

## Scope
- Replaces the Search translation picker sheet with an Android-style modal dialog overlay.
- Preserves Android selection semantics: row taps edit a draft, Cancel/outside dismiss discards, empty OK preserves the prior committed selection, and OK commits non-empty choices.
- Keeps selected Search modules in Android order: abbreviation-sorted rows with the active primary document first after commit.
- Shows committed multi-translation selections as Android-style abbreviation labels instead of a generic iOS count.
- Presents Search from the reader as a reader destination rather than an iOS sheet with `Done` chrome.
- Restores grouped multi-translation result summaries to deterministic selected-module order.
- Adds focused unit and UI regression coverage for the Android behavioral contract.

## Contract References
- Android Search translation selector: `app/src/main/java/net/bible/android/view/activity/search/Search.kt`
- Android multi-select dialog behavior: `app/src/main/java/net/bible/android/view/activity/base/Dialogs.kt`
- iOS Search surface: `Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift`
- iOS reader Search entry: `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift`
- GitHub issue: #247

## Change Details
- Added draft picker state so translation row toggles do not immediately mutate committed Search modules.
- Added Cancel, Select all/Select none, OK, and outside-dimmer cancel behavior matching Android dialog cancellation and neutral-button behavior.
- Added Android parity helpers for abbreviation sorting, primary-first selected ordering, empty-result commit handling, indexed/unindexed row labels, and the selected-translations button summary.
- Updated index readiness checks, search execution, and grouped-result flattening to use Android-ordered selected modules rather than unstable set ordering.
- Routed reader Search through `ReaderDestination.search` so Search opens as a navigation destination, not an iOS sheet.
- Added UI coverage for destination presentation, visible Android abbreviation labels, outside dismissal, and multi-translation grouped results.
- Added the new Search UI test to the seeded fixture manifest and timing table for CI shard planning.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path . --product UITestFixtureTool`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -only-testing:AndBibleUITests/AndBibleUITests/testSearchPresentsAsReaderDestinationInsteadOfSheet -only-testing:AndBibleUITests/AndBibleUITests/testSearchMultiTranslationSelectionUpdatesGroupedTotals`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -only-testing:AndBibleTests/AndBibleTests/testSearchTranslationPickerSortsModulesByAndroidAbbreviationOrder -only-testing:AndBibleTests/AndBibleTests/testSearchTranslationSelectionKeepsPrimaryFirstAfterAndroidSortedCommit -only-testing:AndBibleTests/AndBibleTests/testSearchTranslationEmptyDialogConfirmationPreservesPreviousSelection -only-testing:AndBibleTests/AndBibleTests/testSearchTranslationPickerLabelsExposeAndroidIndexReadiness`
- `python3 -m unittest test_search_fixture_guardrails.py test_build_ui_test_shards.py test_run_ui_test_groups.py test_extract_ui_test_timings_from_xcresult.py` from `scripts/`
- `git diff --check`
- `npx gitnexus analyze`
- GitNexus `detect_changes`: medium risk, scoped to Search reader-navigation processes through `presentSearch`.

## Risks / Follow-ups
- Main risk is Search presentation/navigation because reader Search now uses the destination stack; targeted UI coverage verifies `readerDestination=search` and absence of sheet `Done` chrome.
- Translation-picker risk is selection commit/cancel drift; targeted unit and UI coverage exercises Cancel, outside dismiss, empty OK, OK commit, Android ordering, and grouped totals.
- No known follow-up required for #247.

## Issue Closure
Closes #247

## Screenshots

| Old | New |
| --- | --- | 
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-25 at 09 39 29" src="https://github.com/user-attachments/assets/b087410f-b452-4837-94e8-4097da4fa8e5" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-06-25 at 12 53 23" src="https://github.com/user-attachments/assets/5242594c-0518-469d-afd5-6ce0ea18e288" /> |