### PR TITLE
refactor(reader): extract infinite scroll range state

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2208,6 +2208,39 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the controller's pre-render infinite-scroll sentinel behavior during extraction.
+
+     The legacy controller kept its loaded range at Genesis chapter 0 until the first reader render.
+     Vue can still request append/prepend during that window: prepend has no valid chapter, while
+     append resolves to Genesis 1. A failure here means the extracted coordinator changed startup
+     bridge behavior instead of only moving the range ownership out of `BibleReaderController`.
+     */
+    func testReaderInfiniteScrollCoordinatorPreservesPreRenderAppendSentinel() {
+        let coordinator = BibleReaderInfiniteScrollCoordinator()
+
+        XCTAssertNil(
+            coordinator.previousCandidate(
+                previousBook: { $0 == "Genesis" ? nil : "Genesis" },
+                chapterCount: { book in
+                    XCTFail("Genesis sentinel prepend should not query chapter count, got \(book)")
+                    return 0
+                }
+            )
+        )
+
+        XCTAssertEqual(
+            coordinator.nextCandidate(
+                nextBook: { book in
+                    XCTFail("Genesis sentinel append should not query a next book, got \(book)")
+                    return nil
+                },
+                chapterCount: { $0 == "Genesis" ? 50 : 0 }
+            ),
+            BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 1)
+        )
+    }
+
+    /**
      Protects infinite-scroll append range state as a coordinator-owned reader concern.
 
      Android appends within the current book until the active versification reaches the final
@@ -2266,6 +2299,48 @@ extension AndBibleTests {
         XCTAssertTrue(
             responseScript.contains(#""key":"Gen.1""#),
             "Expected the previous chapter document to be returned. Script: \(responseScript)"
+        )
+        XCTAssertTrue(
+            responseScript.contains(#""osisFragment""#),
+            "Expected the response payload to preserve the Bible document shape. Script: \(responseScript)"
+        )
+    }
+
+    /**
+     Protects append infinite-scroll bridge responses after the reader content is rendered.
+
+     The setup loads Genesis 1 through the real controller path, records the existing bridge output,
+     then requests more content at the end and verifies the original call id receives a full Genesis 2
+     document payload. A failure means the coordinator extraction broke the controller delegate path,
+     stale call id handling, or the Android-compatible document shape used by Vue infinite scroll.
+     */
+    @MainActor
+    func testRequestMoreToEndSendsDocumentResponseWithOriginalCallId() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+
+        controller.navigateTo(book: "Genesis", chapter: 1, verse: 1)
+        controller.loadCurrentContent()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        let baselineCount = recordedScripts().count
+        controller.bridge(bridge, requestMoreToEnd: 3703)
+
+        let responseScript = try XCTUnwrap(
+            recordedScripts().dropFirst(baselineCount).first {
+                $0.contains("bibleView.response(3703")
+            }
+        )
+
+        XCTAssertTrue(
+            responseScript.hasPrefix("bibleView.response(3703, {"),
+            "Expected a document JSON response for the original callId. Script: \(responseScript)"
+        )
+        XCTAssertTrue(
+            responseScript.contains(#""key":"Gen.2""#),
+            "Expected the next chapter document to be returned. Script: \(responseScript)"
         )
         XCTAssertTrue(
             responseScript.contains(#""osisFragment""#),

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2167,6 +2167,78 @@ extension AndBibleTests {
         )
     }
 
+    /**
+     Protects infinite-scroll loaded-range state as a coordinator-owned reader concern.
+
+     Android advances the loaded Bible range only after an adjacent chapter document is available.
+     The setup asks for a previous chapter, deliberately does not commit it, and then asks again to
+     prove failed document loading cannot advance the lower bound. It then commits the candidate and
+     verifies the next request crosses into the previous book. A failure means the controller has
+     regained mutate-and-revert loaded-range state that can drift after failed prepend loads.
+     */
+    func testReaderInfiniteScrollCoordinatorKeepsPreviousCandidateUncommittedUntilLoadSucceeds() {
+        var coordinator = BibleReaderInfiniteScrollCoordinator()
+        coordinator.reset(book: "Exodus", chapter: 2)
+
+        let firstCandidate = coordinator.previousCandidate(
+            previousBook: { $0 == "Exodus" ? "Genesis" : nil },
+            chapterCount: { $0 == "Genesis" ? 50 : 40 }
+        )
+        XCTAssertEqual(firstCandidate, BibleReaderInfiniteScrollChapter(book: "Exodus", chapter: 1))
+
+        XCTAssertEqual(
+            coordinator.previousCandidate(
+                previousBook: { $0 == "Exodus" ? "Genesis" : nil },
+                chapterCount: { $0 == "Genesis" ? 50 : 40 }
+            ),
+            BibleReaderInfiniteScrollChapter(book: "Exodus", chapter: 1)
+        )
+
+        if let firstCandidate {
+            coordinator.commitPrevious(firstCandidate)
+        }
+
+        XCTAssertEqual(
+            coordinator.previousCandidate(
+                previousBook: { $0 == "Exodus" ? "Genesis" : nil },
+                chapterCount: { $0 == "Genesis" ? 50 : 40 }
+            ),
+            BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 50)
+        )
+    }
+
+    /**
+     Protects infinite-scroll append range state as a coordinator-owned reader concern.
+
+     Android appends within the current book until the active versification reaches the final
+     chapter, then crosses to the next book. The setup starts at the final Genesis chapter, verifies
+     that the next candidate is Exodus 1, commits it, and then verifies normal same-book append
+     resumes at Exodus 2. A failure means the extraction changed cross-book append behavior instead
+     of only moving loaded-range ownership out of `BibleReaderController`.
+     */
+    func testReaderInfiniteScrollCoordinatorCrossesToNextBookAfterFinalChapter() {
+        var coordinator = BibleReaderInfiniteScrollCoordinator()
+        coordinator.reset(book: "Genesis", chapter: 50)
+
+        let nextBookCandidate = coordinator.nextCandidate(
+            nextBook: { $0 == "Genesis" ? "Exodus" : nil },
+            chapterCount: { $0 == "Genesis" ? 50 : 40 }
+        )
+        XCTAssertEqual(nextBookCandidate, BibleReaderInfiniteScrollChapter(book: "Exodus", chapter: 1))
+
+        if let nextBookCandidate {
+            coordinator.commitNext(nextBookCandidate)
+        }
+
+        XCTAssertEqual(
+            coordinator.nextCandidate(
+                nextBook: { $0 == "Genesis" ? "Exodus" : nil },
+                chapterCount: { $0 == "Genesis" ? 50 : 40 }
+            ),
+            BibleReaderInfiniteScrollChapter(book: "Exodus", chapter: 2)
+        )
+    }
+
     @MainActor
     func testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId() throws {
         let (bridge, recordedScripts) = makeRecordingBridge()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -135,11 +135,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Reader-local My Documents active page state and document payload assembly.
     private var myDocumentCoordinator = BibleReaderMyDocumentCoordinator()
 
-    /// Infinite scroll: tracks the range of chapters/books currently loaded in the WebView.
-    private var minLoadedChapter: Int = 0
-    private var maxLoadedChapter: Int = 0
-    private var minLoadedBook: String = "Genesis"
-    private var maxLoadedBook: String = "Genesis"
+    /// Reader-local loaded-range state for Vue infinite-scroll prepend/append requests.
+    private var infiniteScrollCoordinator = BibleReaderInfiniteScrollCoordinator()
 
     /**
      Serialized payload rebuilt from Android's durable `Multi` PageManager key.
@@ -2860,28 +2857,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.sendResponse(callId: callId, value: "null")
             return
         }
-        let newChapter = minLoadedChapter - 1
-        if newChapter < 1 {
-            // Cross-book: try loading the last chapter of the previous book
-            if let prevBook = previousBook(before: minLoadedBook) {
-                let lastChap = chapterCount(for: prevBook)
-                if let document = loadChapterJSON(book: prevBook, chapter: lastChap) {
-                    minLoadedBook = prevBook
-                    minLoadedChapter = lastChap
-                    bridge.sendResponse(callId: callId, value: document)
-                } else {
-                    bridge.sendResponse(callId: callId, value: "null")
-                }
-            } else {
-                bridge.sendResponse(callId: callId, value: "null")
-            }
+        guard let candidate = infiniteScrollCoordinator.previousCandidate(
+            previousBook: { [self] in previousBook(before: $0) },
+            chapterCount: { [self] in chapterCount(for: $0) }
+        ) else {
+            bridge.sendResponse(callId: callId, value: "null")
             return
         }
-        minLoadedChapter = newChapter
-        if let document = loadChapterJSON(book: minLoadedBook, chapter: newChapter) {
+        if let document = loadChapterJSON(book: candidate.book, chapter: candidate.chapter) {
+            infiniteScrollCoordinator.commitPrevious(candidate)
             bridge.sendResponse(callId: callId, value: document)
         } else {
-            minLoadedChapter = newChapter + 1 // revert
             bridge.sendResponse(callId: callId, value: "null")
         }
     }
@@ -2904,28 +2890,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bridge.sendResponse(callId: callId, value: "null")
             return
         }
-        let lastChapter = chapterCount(for: maxLoadedBook)
-        let newChapter = maxLoadedChapter + 1
-        if newChapter > lastChapter {
-            // Cross-book: try loading chapter 1 of the next book
-            if let nextBk = nextBook(after: maxLoadedBook) {
-                if let document = loadChapterJSON(book: nextBk, chapter: 1) {
-                    maxLoadedBook = nextBk
-                    maxLoadedChapter = 1
-                    bridge.sendResponse(callId: callId, value: document)
-                } else {
-                    bridge.sendResponse(callId: callId, value: "null")
-                }
-            } else {
-                bridge.sendResponse(callId: callId, value: "null")
-            }
+        guard let candidate = infiniteScrollCoordinator.nextCandidate(
+            nextBook: { [self] in nextBook(after: $0) },
+            chapterCount: { [self] in chapterCount(for: $0) }
+        ) else {
+            bridge.sendResponse(callId: callId, value: "null")
             return
         }
-        maxLoadedChapter = newChapter
-        if let document = loadChapterJSON(book: maxLoadedBook, chapter: newChapter) {
+        if let document = loadChapterJSON(book: candidate.book, chapter: candidate.chapter) {
+            infiniteScrollCoordinator.commitNext(candidate)
             bridge.sendResponse(callId: callId, value: document)
         } else {
-            maxLoadedChapter = newChapter - 1 // revert
             bridge.sendResponse(callId: callId, value: "null")
         }
     }
@@ -6260,11 +6235,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         ) else { return }
         bridge.emit(event: "add_documents", data: document)
 
-        // Track loaded chapter/book range for infinite scroll
-        minLoadedChapter = currentChapter
-        maxLoadedChapter = currentChapter
-        minLoadedBook = currentBook
-        maxLoadedBook = currentBook
+        infiniteScrollCoordinator.reset(book: currentBook, chapter: currentChapter)
 
         // Restore either the exact verse anchor or the chapter-top reading context.
         let restoreTarget = navigationCoordinator.consumeContentRestoreTarget(

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInfiniteScrollCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInfiniteScrollCoordinator.swift
@@ -1,0 +1,119 @@
+/**
+ Chapter identity used by the reader's infinite-scroll range coordinator.
+
+ - Side effects: None; this is a value payload.
+ - Failure modes: None; callers provide only already-normalized book/chapter values.
+ */
+struct BibleReaderInfiniteScrollChapter: Equatable {
+    /// Display book name from the active reader versification.
+    let book: String
+
+    /// One-based chapter number within `book`.
+    let chapter: Int
+}
+
+/**
+ Owns the reader-local loaded chapter range used by Vue infinite scroll.
+
+ Android keeps the currently loaded Bible window range separate from current-page navigation state:
+ prepend/append requests ask for the adjacent chapter, and the range advances only when the
+ adjacent document was actually loaded. This coordinator keeps that state rule out of
+ `BibleReaderController` while leaving document construction and bridge responses with the
+ controller.
+
+ - Side effects: Mutates only the in-memory lower/upper loaded range.
+ - Failure modes: Returns `nil` when there is no adjacent book or chapter. Failed document loading is
+   reported by simply not committing the candidate, so the range remains unchanged.
+ */
+struct BibleReaderInfiniteScrollCoordinator {
+    /// Earliest chapter currently loaded in the WebView.
+    private var lowerBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 1)
+
+    /// Latest chapter currently loaded in the WebView.
+    private var upperBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 1)
+
+    /**
+     Resets the loaded range to the currently rendered Bible chapter.
+
+     - Parameters:
+       - book: Display book name from the active module versification.
+       - chapter: One-based chapter number.
+     - Side effects: Replaces both range bounds.
+     - Failure modes: None; invalid values remain caller responsibility, matching the previous
+       controller-owned state.
+     */
+    mutating func reset(book: String, chapter: Int) {
+        let chapter = BibleReaderInfiniteScrollChapter(book: book, chapter: chapter)
+        lowerBound = chapter
+        upperBound = chapter
+    }
+
+    /**
+     Resolves the chapter immediately before the current lower loaded bound.
+
+     - Parameters:
+       - previousBook: Lookup for the previous book in the active module versification.
+       - chapterCount: Lookup for the final chapter number of a book.
+     - Returns: Adjacent previous chapter, or `nil` when the current lower bound is the first
+       selectable chapter.
+     - Side effects: None; callers must commit the returned candidate after loading succeeds.
+     - Failure modes: Returns `nil` when no previous book exists.
+     */
+    func previousCandidate(
+        previousBook: (String) -> String?,
+        chapterCount: (String) -> Int
+    ) -> BibleReaderInfiniteScrollChapter? {
+        let chapter = lowerBound.chapter - 1
+        guard chapter >= 1 else {
+            guard let book = previousBook(lowerBound.book) else { return nil }
+            return BibleReaderInfiniteScrollChapter(book: book, chapter: chapterCount(book))
+        }
+        return BibleReaderInfiniteScrollChapter(book: lowerBound.book, chapter: chapter)
+    }
+
+    /**
+     Resolves the chapter immediately after the current upper loaded bound.
+
+     - Parameters:
+       - nextBook: Lookup for the next book in the active module versification.
+       - chapterCount: Lookup for the final chapter number of a book.
+     - Returns: Adjacent next chapter, or `nil` when the current upper bound is the final selectable
+       chapter.
+     - Side effects: None; callers must commit the returned candidate after loading succeeds.
+     - Failure modes: Returns `nil` when no next book exists.
+     */
+    func nextCandidate(
+        nextBook: (String) -> String?,
+        chapterCount: (String) -> Int
+    ) -> BibleReaderInfiniteScrollChapter? {
+        let chapter = upperBound.chapter + 1
+        let lastChapter = chapterCount(upperBound.book)
+        guard chapter <= lastChapter else {
+            guard let book = nextBook(upperBound.book) else { return nil }
+            return BibleReaderInfiniteScrollChapter(book: book, chapter: 1)
+        }
+        return BibleReaderInfiniteScrollChapter(book: upperBound.book, chapter: chapter)
+    }
+
+    /**
+     Commits a successfully loaded previous candidate as the new lower bound.
+
+     - Parameter chapter: Candidate returned from `previousCandidate`.
+     - Side effects: Replaces the lower loaded bound.
+     - Failure modes: None; callers only commit after document loading succeeds.
+     */
+    mutating func commitPrevious(_ chapter: BibleReaderInfiniteScrollChapter) {
+        lowerBound = chapter
+    }
+
+    /**
+     Commits a successfully loaded next candidate as the new upper bound.
+
+     - Parameter chapter: Candidate returned from `nextCandidate`.
+     - Side effects: Replaces the upper loaded bound.
+     - Failure modes: None; callers only commit after document loading succeeds.
+     */
+    mutating func commitNext(_ chapter: BibleReaderInfiniteScrollChapter) {
+        upperBound = chapter
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInfiniteScrollCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInfiniteScrollCoordinator.swift
@@ -19,18 +19,20 @@ struct BibleReaderInfiniteScrollChapter: Equatable {
  prepend/append requests ask for the adjacent chapter, and the range advances only when the
  adjacent document was actually loaded. This coordinator keeps that state rule out of
  `BibleReaderController` while leaving document construction and bridge responses with the
- controller.
+ controller. The initial Genesis 0 sentinel mirrors the controller's pre-render bridge behavior:
+ prepend has no chapter to load, while append starts at Genesis 1 until the first rendered chapter
+ resets the range.
 
  - Side effects: Mutates only the in-memory lower/upper loaded range.
  - Failure modes: Returns `nil` when there is no adjacent book or chapter. Failed document loading is
    reported by simply not committing the candidate, so the range remains unchanged.
  */
 struct BibleReaderInfiniteScrollCoordinator {
-    /// Earliest chapter currently loaded in the WebView.
-    private var lowerBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 1)
+    /// Earliest chapter currently loaded in the WebView, or Genesis 0 before the first render.
+    private var lowerBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 0)
 
-    /// Latest chapter currently loaded in the WebView.
-    private var upperBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 1)
+    /// Latest chapter currently loaded in the WebView, or Genesis 0 before the first render.
+    private var upperBound = BibleReaderInfiniteScrollChapter(book: "Genesis", chapter: 0)
 
     /**
      Resets the loaded range to the currently rendered Bible chapter.


### PR DESCRIPTION
## Summary
Extracts reader-local infinite-scroll loaded-range state out of `BibleReaderController` into `BibleReaderInfiniteScrollCoordinator`.

## Scope
- Adds a focused coordinator for lower/upper loaded chapter range state.
- Updates prepend/append bridge requests to ask for adjacent candidates and commit them only after document loading succeeds.
- Keeps document construction, bridge response emission, and current navigation state in `BibleReaderController`.
- Preserves the controller's pre-render Genesis 0 sentinel contract so append starts at Genesis 1 before the first rendered chapter resets the range.

## Contract References
- Android parity: infinite scroll advances the loaded Bible range only when the adjacent chapter document is available.
- Issue #146: continues the remaining reader/window/workspace state ownership audit.

## Change Details
- Replaces `minLoadedChapter`, `maxLoadedChapter`, `minLoadedBook`, and `maxLoadedBook` with `BibleReaderInfiniteScrollCoordinator`.
- Resets loaded range when a Bible chapter is loaded.
- Avoids mutate-then-revert range handling by leaving candidates uncommitted until load success.
- Adds focused unit tests for failed previous-candidate safety, cross-book next-candidate behavior, the pre-render sentinel, and controller append bridge responses.

## Validation Evidence
- RED check: `testReaderInfiniteScrollCoordinatorPreservesPreRenderAppendSentinel` failed before restoring the Genesis 0 sentinel because append returned Genesis 2 and prepend queried beyond the sentinel contract.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F' -derivedDataPath .derived/local-unit-tests -only-testing:AndBibleTests/AndBibleTests/testReaderInfiniteScrollCoordinatorPreservesPreRenderAppendSentinel -only-testing:AndBibleTests/AndBibleTests/testReaderInfiniteScrollCoordinatorKeepsPreviousCandidateUncommittedUntilLoadSucceeds -only-testing:AndBibleTests/AndBibleTests/testReaderInfiniteScrollCoordinatorCrossesToNextBookAfterFinalChapter -only-testing:AndBibleTests/AndBibleTests/testRequestMoreToBeginningSendsDocumentResponseWithOriginalCallId -only-testing:AndBibleTests/AndBibleTests/testRequestMoreToEndSendsDocumentResponseWithOriginalCallId CODE_SIGNING_ALLOWED=NO`
- `python3 scripts/check_repo_standards.py all`
- `git diff --check`
- GitNexus impact on `loadCurrentChapter` previously reported CRITICAL reader-loading blast radius; GitNexus `detect_changes` could not inspect this active worktree because only the main checkout is indexed, so local git scope was verified before commit.

## Risks / Follow-ups
- No intended user-visible behavior change.
- #146 still needs final controller size/orchestration reassessment after this remaining-state slice.

## Issue Closure Reference
Refs #146