### PR TITLE
refactor(reader): extract native selection coordinator

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -1136,6 +1136,55 @@ extension AndBibleTests {
 
     #if os(iOS)
     /**
+     Protects native selection state and payload decisions as a focused reader responsibility.
+
+     Android action mode tracks selection state separately from page navigation, and `Multi`/generic
+     pages must not fabricate Bible references from the pane that opened them. The setup exercises the
+     coordinator directly with a normal Bible page and an Android-style non-Bible page. The expected
+     result is a Bible copy/share payload only for Bible-capable pages, text-only copy for non-Bible
+     pages, and cleared state after deselection. A failure means the selection extraction either lost
+     state transitions or reintroduced stale Bible-reference behavior outside controller orchestration.
+     The test performs no simulator, pasteboard, or persistence side effects and is deterministic.
+     */
+    func testReaderSelectionCoordinatorOwnsSelectionStateAndReferencePayloads() {
+        var coordinator = BibleReaderSelectionCoordinator()
+        let bibleContext = BibleReaderSelectionPageContext(
+            canUseBibleReferenceActions: true,
+            currentBook: "Genesis",
+            currentChapter: 1,
+            activeModuleName: "KJV"
+        )
+        let multiContext = BibleReaderSelectionPageContext(
+            canUseBibleReferenceActions: false,
+            currentBook: "Genesis",
+            currentChapter: 1,
+            activeModuleName: "KJV"
+        )
+
+        coordinator.selectionChanged("In the beginning")
+
+        XCTAssertTrue(coordinator.hasActiveSelection)
+        XCTAssertEqual(coordinator.selectedText, "In the beginning")
+        XCTAssertEqual(
+            coordinator.copyText(context: bibleContext),
+            "In the beginning\n\u{2014} Genesis 1 (KJV)"
+        )
+        XCTAssertEqual(
+            coordinator.shareText(context: bibleContext),
+            "In the beginning\n\u{2014} Genesis 1 (KJV)"
+        )
+        XCTAssertEqual(coordinator.copyText(context: multiContext), "In the beginning")
+        XCTAssertNil(coordinator.shareText(context: multiContext))
+
+        coordinator.clearSelection()
+
+        XCTAssertFalse(coordinator.hasActiveSelection)
+        XCTAssertEqual(coordinator.selectedText, "")
+        XCTAssertNil(coordinator.copyText(context: bibleContext))
+        XCTAssertNil(coordinator.shareText(context: bibleContext))
+    }
+
+    /**
      Protects native selection actions from falling back to the stale Bible page behind `Multi`.
 
      Android treats `FakeBookFactory.multiDocument` as a special general-book page. Bible-only

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -474,6 +474,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private let swordCoordinator = BibleReaderSwordCoordinator()
     /// Reader config/window-state collaborator that owns bridge payload projection and compare visibility state.
     private var configurationCoordinator = BibleReaderConfigurationCoordinator()
+    /// Reader-local native selection state and pure action-payload decisions.
+    private var selectionCoordinator = BibleReaderSelectionCoordinator()
     /// Workspace store for history recording
     var workspaceStore: WorkspaceStore?
     /// The current window (for history recording)
@@ -1481,8 +1483,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
         applyTransientPageIdentity(request)
 
         bridge.emit(event: "clear_document")
@@ -1574,8 +1575,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
 
         let osisBookId = osisBookId(for: currentBook)
         let chapter = currentChapter
@@ -1776,8 +1776,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
     }
 
     /**
@@ -1922,8 +1921,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
 
         guard let reader = activeEpubReader else {
             bridge.emit(event: "clear_document")
@@ -3394,8 +3392,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Records the latest text selection reported by the web client and enables native action mode UI.
      */
     public func bridge(_ bridge: BibleBridge, selectionChanged text: String) {
-        hasActiveSelection = true
-        selectedText = text
+        selectionCoordinator.selectionChanged(text)
         bridge.emit(event: "set_action_mode", data: "true")
     }
 
@@ -3403,12 +3400,41 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Clears native selection state when the web client deselects text.
      */
     public func bridgeSelectionCleared(_ bridge: BibleBridge) {
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
         bridge.emit(event: "set_action_mode", data: "false")
     }
 
     // MARK: - Selection Actions
+
+    /**
+     Builds the current page context used by pure native-selection payload decisions.
+
+     - Returns: A snapshot of the page identity and Bible-reference eligibility at action time.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private func selectionPageContext() -> BibleReaderSelectionPageContext {
+        BibleReaderSelectionPageContext(
+            canUseBibleReferenceActions: canUseBibleReferenceActions,
+            currentBook: currentBook,
+            currentChapter: currentChapter,
+            activeModuleName: activeModuleName
+        )
+    }
+
+    /**
+     Clears native selection bookkeeping without emitting bridge action-mode events.
+
+     Document replacement paths already clear the WebView selection separately when needed. This
+     helper centralizes the native state reset so those paths do not mutate selection fields owned by
+     the coordinator.
+
+     - Side effects: Mutates only native selection state.
+     - Failure modes: None.
+     */
+    private func clearNativeSelectionState() {
+        selectionCoordinator.clearSelection()
+    }
 
     /**
      Queries the active web selection using Android-compatible selection metadata.
@@ -3592,12 +3618,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Failure modes: Returns `nil` for an empty native selection.
      */
     func selectionCopyTextForCurrentPage() -> String? {
-        guard !selectedText.isEmpty else { return nil }
-        if canUseBibleReferenceActions {
-            let reference = "\(currentBook) \(currentChapter)"
-            return "\(selectedText)\n\u{2014} \(reference) (\(activeModuleName))"
-        }
-        return selectedText
+        selectionCoordinator.copyText(context: selectionPageContext())
     }
 
     /**
@@ -3621,10 +3642,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Share the selected text.
     func shareSelection() {
-        guard canUseBibleReferenceActions else { return }
-        guard !selectedText.isEmpty else { return }
-        let reference = "\(currentBook) \(currentChapter)"
-        let shareText = "\(selectedText)\n\u{2014} \(reference) (\(activeModuleName))"
+        guard let shareText = selectionCoordinator.shareText(context: selectionPageContext()) else { return }
         onShareVerseText?(shareText)
         bridge.clearSelection()
     }
@@ -3668,9 +3686,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Open a web search for the currently selected text.
     func webSearchSelection() {
-        guard !selectedText.isEmpty else { return }
-        guard let encoded = selectedText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: "https://www.google.com/search?q=\(encoded)") else { return }
+        guard let url = selectionCoordinator.webSearchURL() else { return }
         #if os(iOS)
         UIApplication.shared.open(url)
         #elseif os(macOS)
@@ -3685,7 +3701,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      enabled unless they are explicitly disabled, and successful lookups render as transient
      document content instead of an iOS-only sheet.
 
-     - Parameters: None; the method reads the controller's current `selectedText`.
+     - Parameters: None; the method reads the current selection from the selection coordinator.
      - Returns: No direct return value; a successful lookup emits a Vue document payload through
        the current pane or configured links-window target.
      - Side effects: May show a localized "not found" toast, route a dictionary document payload,
@@ -3695,8 +3711,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        required.
      */
     func lookupSelectionInDictionaries() {
-        guard !selectedText.isEmpty else { return }
-        let query = BibleReaderWordLookupDocumentBuilder.normalizeQuery(selectedText)
+        guard let query = selectionCoordinator.normalizedDictionaryQuery() else { return }
         guard !query.isEmpty else {
             onShowToast?(String(
                 localized: "word_not_found_in_dictionaries",
@@ -3735,9 +3750,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     var onOpenExternalURL: ((URL) -> Void)?
 
     /// Whether there's an active text selection in the WebView.
-    private(set) var hasActiveSelection = false
+    var hasActiveSelection: Bool { selectionCoordinator.hasActiveSelection }
     /// The currently selected text.
-    private(set) var selectedText: String = ""
+    var selectedText: String { selectionCoordinator.selectedText }
     /// Whether any plain word-lookup dictionaries are currently available.
     var hasWordLookupDictionaries: Bool { wordLookupDocumentBuilder().hasWordLookupDictionaries }
 
@@ -3821,8 +3836,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
         currentCategory = .generalBook
         myDocumentCoordinator.setActivePage(bookInitials: bookInitials, pageKey: pageKey)
         setRenderedContentState(
@@ -4191,8 +4205,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
 
         let osisBookId = osisBookId(for: currentBook)
         guard let range = currentChapterOrdinalRange() else {
@@ -4258,8 +4271,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
 
         bridge.emit(event: "clear_document")
         bridge.emit(event: "add_documents", data: document)
@@ -4301,8 +4313,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = labelId
         activeStudyPadLabelName = label.name
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
 
         // Fetch all data for this StudyPad
         let bibleBookmarks = service.bibleBookmarks(withLabel: labelId)
@@ -5590,8 +5601,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         activeStudyPadLabelId = nil
         activeStudyPadLabelName = nil
         editingInWebView = false
-        hasActiveSelection = false
-        selectedText = ""
+        clearNativeSelectionState()
         let osisBookId = osisBookId(for: currentBook)
         let isNT = isNewTestament(currentBook)
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSelectionCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSelectionCoordinator.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/**
+ Page identity needed to decide which native selection actions may include Bible references.
+
+ Android treats normal Bible pages differently from `Multi`/generic result documents: Bible pages
+ may copy or share the selected text with the active passage and module, while generic pages must
+ keep their own document identity and must not fabricate a stale Bible reference. This value carries
+ only the immutable page facts needed for that decision.
+
+ - Important: The type is intentionally side-effect free and may be built repeatedly from controller
+   state whenever an action executes.
+ */
+struct BibleReaderSelectionPageContext {
+    /// Whether the current page is eligible for Bible-reference copy/share actions.
+    let canUseBibleReferenceActions: Bool
+
+    /// Display book name for Bible-reference payloads.
+    let currentBook: String
+
+    /// One-based chapter number for Bible-reference payloads.
+    let currentChapter: Int
+
+    /// Active module initials displayed with Bible-reference payloads.
+    let activeModuleName: String
+}
+
+/**
+ Owns native text-selection state and deterministic payload decisions for reader actions.
+
+ The controller receives selection events from the Vue bridge and performs platform side effects
+ such as pasteboard writes, share presentation, and opening URLs. This coordinator keeps the
+ Android-compatible state and pure payload rules in one place so controller orchestration no longer
+ needs to mutate `hasActiveSelection` and `selectedText` directly.
+ */
+struct BibleReaderSelectionCoordinator {
+    /// Whether the web client currently reports an active text selection.
+    private(set) var hasActiveSelection = false
+
+    /// Latest selected text reported by the web client.
+    private(set) var selectedText = ""
+
+    /**
+     Records the latest web-client text selection.
+
+     - Parameter text: Selection text reported by Vue; empty text still represents an active bridge
+       selection until the client emits a clear event.
+     - Side effects: Mutates coordinator state only.
+     - Failure modes: None.
+     */
+    mutating func selectionChanged(_ text: String) {
+        hasActiveSelection = true
+        selectedText = text
+    }
+
+    /**
+     Clears native selection state after deselection or document replacement.
+
+     - Side effects: Mutates coordinator state only.
+     - Failure modes: None.
+     */
+    mutating func clearSelection() {
+        hasActiveSelection = false
+        selectedText = ""
+    }
+
+    /**
+     Builds the text payload used by the native copy action.
+
+     - Parameter context: Current page identity and Bible-reference eligibility.
+     - Returns: Bible pages return selected text plus `Book Chapter (Module)`; generic pages return
+       text only; empty selections return `nil`.
+     - Side effects: None.
+     - Failure modes: Returns `nil` when no usable selection text exists.
+     */
+    func copyText(context: BibleReaderSelectionPageContext) -> String? {
+        guard !selectedText.isEmpty else { return nil }
+        guard context.canUseBibleReferenceActions else { return selectedText }
+        return "\(selectedText)\n\u{2014} \(referenceText(context: context))"
+    }
+
+    /**
+     Builds the text payload used by native share UI.
+
+     - Parameter context: Current page identity and Bible-reference eligibility.
+     - Returns: Bible-reference payload for eligible pages; `nil` for generic pages or empty text.
+     - Side effects: None.
+     - Failure modes: Returns `nil` when sharing should not be offered for the current selection.
+     */
+    func shareText(context: BibleReaderSelectionPageContext) -> String? {
+        guard context.canUseBibleReferenceActions else { return nil }
+        return copyText(context: context)
+    }
+
+    /**
+     Builds the external Google search URL for the selected text.
+
+     - Returns: Encoded Google search URL, or `nil` when the selection is empty or cannot form a URL.
+     - Side effects: None; callers open the URL on the appropriate platform.
+     - Failure modes: Returns `nil` if URL encoding or URL construction fails.
+     */
+    func webSearchURL() -> URL? {
+        guard !selectedText.isEmpty,
+              let encoded = selectedText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return nil
+        }
+        return URL(string: "https://www.google.com/search?q=\(encoded)")
+    }
+
+    /**
+     Normalizes the selected text into a dictionary lookup key.
+
+     - Returns: Normalized lookup query, or `nil` when there is no selected text.
+     - Side effects: None.
+     - Failure modes: Empty normalized results are returned as an empty string so callers can
+       preserve existing user-facing "not found" behavior.
+     */
+    func normalizedDictionaryQuery() -> String? {
+        guard !selectedText.isEmpty else { return nil }
+        return BibleReaderWordLookupDocumentBuilder.normalizeQuery(selectedText)
+    }
+
+    /**
+     Formats the Android-compatible Bible reference suffix for copy/share payloads.
+
+     - Parameter context: Current Bible page identity.
+     - Returns: `Book Chapter (Module)` display text.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private func referenceText(context: BibleReaderSelectionPageContext) -> String {
+        "\(context.currentBook) \(context.currentChapter) (\(context.activeModuleName))"
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/LabelAssignmentView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/LabelAssignmentView.swift
@@ -83,6 +83,8 @@ struct LabelAssignmentView: View {
                                 .font(.body)
                         }
                         .buttonStyle(.plain)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                         .accessibilityIdentifier(labelInlineActionIdentifier("labelAssignmentFavouriteButton", for: label))
                         .accessibilityValue(label.favourite ? "favourite" : "notFavourite")
 
@@ -94,6 +96,8 @@ struct LabelAssignmentView: View {
                                 .font(.body)
                         }
                         .buttonStyle(.plain)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                         .accessibilityIdentifier(labelInlineActionIdentifier("labelAssignmentToggleButton", for: label))
                         .accessibilityValue(assignedLabelIds.contains(label.id) ? "assigned" : "unassigned")
                     }


### PR DESCRIPTION
Summary
- Extracts native reader selection state and pure payload decisions into BibleReaderSelectionCoordinator.
- Keeps BibleReaderController as the orchestration point for bridge events, pasteboard/share/open side effects, and WebView selection clearing.

Scope
- Native selection state and selected-text payload decisions only.
- Does not change Android-compatible behavior for Bible pages versus Multi/generic pages.
- Does not close #146; this is one remaining responsibility slice.

Contract references
- Refs #146.
- Android parity: Bible selections may copy/share with reference and module; Multi/generic selections must not fabricate stale Bible references.

Change details
- Added BibleReaderSelectionCoordinator and BibleReaderSelectionPageContext.
- Routed selectionChanged, selection clearing, copy/share/web-search/dictionary lookup, and document replacement resets through the coordinator.
- Added a focused unit contract covering Bible payloads, generic text-only copy/share behavior, and cleared selection state.

Validation evidence
- git diff --check.
- python3 scripts/check_repo_standards.py all.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F' -derivedDataPath .derived/local-unit-tests -only-testing:AndBibleTests/AndBibleTests/testReaderSelectionCoordinatorOwnsSelectionStateAndReferencePayloads -only-testing:AndBibleTests/AndBibleTests/testMultiDocumentNativeSelectionActionsDoNotUseStaleBibleReference -only-testing:AndBibleTests/AndBibleTests/testMyDocumentEditBridgePersistsContentAndReloadsVisiblePage CODE_SIGNING_ALLOWED=NO.\n- npx gitnexus detect-changes --scope all --repo and-bible-ios returned low risk but reported unrelated CLAUDE.md symbols rather than this worktree diff, so direct diff/tests are the authoritative evidence.\n\nRisks/follow-ups\n- Controller line count is not meaningfully reduced by this slice because helper docs remain local; the selection responsibility is now isolated for a later action-surface split.\n- Remaining #146 checklist work should continue after this merges.\n\nIssue closure reference\n- Refs #146