### PR TITLE
refactor(reader): extract external link routing

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -1583,6 +1583,131 @@ extension AndBibleTests {
     }
 
     /**
+     Protects Android-style external-link classification outside controller orchestration.
+
+     Android splits responsibilities between `BibleJavascriptInterface.openExternalLink`,
+     `BibleView.openLink`, and `LinkControl`: pseudo-links become typed app routes while unknown
+     web links remain platform URLs. The setup exercises the new pure router with Strong's,
+     morphology, MyBible, MySword, multi-reference, EPUB, Downloads, My Notes, and StudyPad inputs.
+     The expected result is typed route data with no bridge, SWORD, pasteboard, or simulator side
+     effects. A failure means the extraction preserved the controller code shape without preserving
+     Android's routing contract.
+     */
+    func testExternalLinkRouterClassifiesAndroidPseudoSchemes() {
+        let router = BibleReaderExternalLinkRouter()
+
+        XCTAssertEqual(
+            router.route(for: "ab-w://?strong=H0430&robinson=N-NSM"),
+            .definition(strongs: ["H0430"], robinson: ["N-NSM"])
+        )
+        XCTAssertEqual(
+            router.route(for: "strongs://G2316"),
+            .definition(strongs: ["G2316"], robinson: [])
+        )
+        XCTAssertEqual(
+            router.route(for: "morphology://robinson/V-PAI-3S"),
+            .definition(strongs: [], robinson: ["V-PAI-3S"])
+        )
+        XCTAssertEqual(
+            router.route(for: "ab-find-all://?type=hebrew&name=5775"),
+            .findAllOccurrences("H5775")
+        )
+        XCTAssertEqual(
+            router.route(for: "download://?initials=KJV"),
+            .downloads(searchText: "KJV")
+        )
+        XCTAssertEqual(
+            router.route(for: "epub-ref://?book=Pilgrim&toKey=chapter1.xhtml&toId=anchor"),
+            .epubReference(book: "Pilgrim", toKey: "chapter1.xhtml", toId: "anchor")
+        )
+        XCTAssertEqual(
+            router.route(for: "my-notes://?osis=Gen.1.1&ordinal=1"),
+            .myNotes(osisRef: "Gen.1.1", ordinal: 1)
+        )
+        XCTAssertEqual(
+            router.route(for: "journal://?id=00000000-0000-0000-0000-000000000001&bookmarkId=00000000-0000-0000-0000-000000000002"),
+            .studyPad(
+                labelId: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+                bookmarkId: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+            )
+        )
+        XCTAssertEqual(
+            router.route(for: "osis://?osis=Gen.1.1,Exod.2.1&v11n=KJVA"),
+            .osisReferences(["Gen.1.1,Exod.2.1"])
+        )
+        XCTAssertEqual(
+            router.route(for: "multi://?osis=Gen.1.1&osis=Exod.2.1&v11n=KJVA"),
+            .multiReferences(["Gen.1.1", "Exod.2.1"])
+        )
+        XCTAssertEqual(
+            router.route(for: "sword://Bible/John.3.16"),
+            .swordReference("John.3.16")
+        )
+        XCTAssertEqual(
+            router.route(for: "B:470 1:1"),
+            .osisNavigation("Matt.1.1")
+        )
+        XCTAssertEqual(
+            router.route(for: "#b40.1.1"),
+            .osisNavigation("Matt.1.1")
+        )
+        XCTAssertEqual(
+            router.route(for: "S:G2424"),
+            .definition(strongs: ["G2424"], robinson: [])
+        )
+        XCTAssertEqual(
+            router.route(for: "#dH0430"),
+            .definition(strongs: ["H0430"], robinson: [])
+        )
+        XCTAssertEqual(
+            router.route(for: "https://andbible.org"),
+            .platformURL(URL(string: "https://andbible.org")!)
+        )
+    }
+
+    /**
+     Protects multi-reference document construction as its own Android `Multi` responsibility.
+
+     Android stores cross-reference results as `FakeBookFactory.multiDocument` backed by a
+     `BookAndKeyList`, not as a controller-local sheet. The setup feeds parsed references into the
+     builder without an active SWORD module so fallback XML is deterministic. The expected JSON has
+     the Vue `type: "multi"` shape, one OSIS fragment per reference, stable module/key metadata, and
+     escaped fallback text. A failure means the extraction left document construction coupled to the
+     controller or changed the persisted/rendered document contract.
+     */
+    func testMultiReferenceDocumentBuilderCreatesAndroidMultiPayload() throws {
+        let refs = [
+            OsisRef(book: "Genesis", chapter: 1, verse: 1, osisId: "Gen"),
+            OsisRef(book: "Exodus", chapter: 2, verse: 1, osisId: "Exod"),
+        ]
+        let builder = BibleReaderMultiReferenceDocumentBuilder(
+            activeModule: nil,
+            activeModuleName: "KJV",
+            compatibilityOrdinal: { chapter, verse in chapter * 1_000 + verse },
+            isNewTestament: { $0 == "Matthew" }
+        )
+
+        let json = try XCTUnwrap(builder.buildDocumentJSON(refs: refs))
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let fragments = try XCTUnwrap(payload["osisFragments"] as? [[String: Any]])
+
+        XCTAssertEqual(payload["type"] as? String, "multi")
+        XCTAssertEqual(payload["compare"] as? Bool, false)
+        XCTAssertEqual(fragments.count, 2)
+        XCTAssertEqual(fragments[0]["key"] as? String, "KJV--Gen.1.1")
+        XCTAssertEqual(fragments[0]["osisRef"] as? String, "Gen.1.1")
+        XCTAssertEqual(fragments[0]["bookCategory"] as? String, "BIBLE")
+        XCTAssertEqual(fragments[0]["ordinalRange"] as? [Int], [1001, 1001])
+        XCTAssertTrue(
+            (fragments[0]["xml"] as? String)?.contains("Genesis 1:1") == true,
+            "Expected fallback XML to include the display reference when no module is available."
+        )
+        XCTAssertEqual(fragments[1]["key"] as? String, "KJV--Exod.2.1")
+        XCTAssertEqual(fragments[1]["ordinalRange"] as? [Int], [2001, 2001])
+    }
+
+    /**
      Validates the native-to-WebView reader configuration contract for Android parity fields.
 
      The setup writes pane text-display settings, app settings, workspace state, and reading

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -1583,6 +1583,28 @@ extension AndBibleTests {
     }
 
     /**
+     Protects Android's boundary between `osis://` navigation and `multi://` MultiDocument links.
+
+     Android's `SCHEME_REFERENCE` handler reads only `getQueryParameter("osis")`; repeated `osis`
+     query values are not a MultiDocument signal. Setup sends a deliberately duplicated `osis://`
+     link through the native bridge with no SWORD module so the route is deterministic. The expected
+     result is navigation to the first reference only and no transient multi-document payload. A
+     failure means iOS widened single-reference links into invented multi-reference behavior instead
+     of requiring Android's `multi://` route.
+     */
+    @MainActor
+    func testOsisReferenceUsesFirstQueryValueLikeAndroidReferenceScheme() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let controller = BibleReaderController(bridge: bridge)
+
+        controller.bridge(bridge, openExternalLink: "osis://?osis=Exod.2.1&osis=Gen.1.1&v11n=KJVA")
+
+        XCTAssertEqual(controller.currentBook, "Exodus")
+        XCTAssertEqual(controller.currentChapter, 2)
+        XCTAssertFalse(recordedScripts().contains { $0.contains(#""type":"multi""#) })
+    }
+
+    /**
      Protects Android-style external-link classification outside controller orchestration.
 
      Android splits responsibilities between `BibleJavascriptInterface.openExternalLink`,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -67,6 +67,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Router for bridge events whose behavior is limited to pane-local modal and host callbacks.
     @ObservationIgnored
     private lazy var bridgeEventRouter = makeBridgeEventRouter()
+    /// Pure classifier for Android-compatible external link and pseudo-link strings.
+    private let externalLinkRouter = BibleReaderExternalLinkRouter()
 
     /// SWORD module manager and active Bible module
     private(set) var swordManager: SwordManager?
@@ -4362,90 +4364,65 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - unrecognized schemes fall through to the platform URL-opening path
      */
     public func bridge(_ bridge: BibleBridge, openExternalLink link: String) {
-        // Handle Strong's/morphology links: ab-w://?strong=H1234&robinson=...
-        if link.hasPrefix("ab-w://") {
-            handleStrongsLink(link)
-            return
-        }
-        // Handle document-independent Strong's links: strongs://G2316, strongs://H430.
-        if link.hasPrefix("strongs://") {
-            handleStandaloneStrongsLink(link)
-            return
-        }
-        // Handle document-independent morphology links: morphology://robinson/V-PAI-3S.
-        if link.hasPrefix("morphology://") {
-            handleStandaloneMorphologyLink(link)
-            return
-        }
-        // Handle "Find all occurrences" links from FeaturesLink.vue
-        if link.hasPrefix("ab-find-all://") {
-            handleFindAllLink(link)
-            return
-        }
-        // Handle error-report links surfaced in web-rendered error overlays.
-        if link.hasPrefix("ab-error://") {
+        guard let route = externalLinkRouter.route(for: link) else { return }
+        handleExternalLinkRoute(route)
+    }
+
+    /**
+     Executes a typed Android-compatible external link route for this reader pane.
+
+     `BibleReaderExternalLinkRouter` owns pure parsing and classification. This method owns the
+     side effects Android performs through `LinkControl`: navigation, transient `MultiDocument`
+     emission, downloads presentation, EPUB jumps, My Notes, StudyPad, and platform URL opening.
+
+     - Parameter route: Classified route generated from a bridge link.
+     - Side effects: May navigate the active pane, emit transient documents, invoke owner callbacks,
+       or open platform URLs.
+     - Failure modes: Invalid references or payload-build failures are ignored, matching Android's
+       no-op behavior for unresolved links.
+     */
+    private func handleExternalLinkRoute(_ route: BibleReaderExternalLinkRouter.Route) {
+        switch route {
+        case let .definition(strongs, robinson):
+            logger.info("handleExternalLinkRoute.definition: strongs=\(strongs), robinson=\(robinson)")
+            guard let multiDocJSON = buildStrongsMultiDocJSON(
+                strongs: strongs,
+                robinson: robinson,
+                stateJSON: currentStrongsDocumentStateJSON()
+            ) else {
+                return
+            }
+            openDefinitionDocument(
+                multiDocJSON,
+                renderedBook: "Strongs",
+                renderedKey: "strongs"
+            )
+        case let .findAllOccurrences(name):
+            onShowStrongsSearch?(name)
+        case .errorReport:
             handleErrorReportLink()
-            return
+        case let .epubReference(book, toKey, toId):
+            bridge(self.bridge, openEpubLink: book, toKey: toKey, toId: toId)
+        case let .downloads(searchText):
+            bridgeEventRouter.requestOpenDownloads(searchText: searchText)
+        case let .myNotes(osisRef, ordinal):
+            if let osisRef, let ref = parseOsisReferences(osisRef).first {
+                navigateTo(book: ref.book, chapter: ref.chapter, verse: ref.verse)
+                loadMyNotesDocument(jumpToOrdinal: ordinal)
+            } else {
+                loadMyNotesDocument(jumpToOrdinal: ordinal)
+            }
+        case let .studyPad(labelId, bookmarkId):
+            loadStudyPadDocument(labelId: labelId, bookmarkId: bookmarkId)
+        case let .osisReferences(values):
+            handleOsisReferenceValues(values)
+        case let .multiReferences(values):
+            handleMultiReferenceValues(values)
+        case let .swordReference(ref), let .osisNavigation(ref):
+            _ = navigateToOsisRef(ref)
+        case let .platformURL(url):
+            openPlatformURL(url)
         }
-        // Handle EPUB internal reference links when surfaced as raw anchors.
-        if link.hasPrefix("epub-ref://") {
-            handleEpubRefLink(link)
-            return
-        }
-        // Handle Downloads links surfaced in web-rendered help/error content.
-        if link.hasPrefix("download://") {
-            bridgeEventRouter.requestOpenDownloads(searchText: Self.downloadSearchText(from: link))
-            return
-        }
-        // Handle My Notes links surfaced in bookmark metadata.
-        if link.hasPrefix("my-notes://") {
-            handleMyNotesLink(link)
-            return
-        }
-        // Handle StudyPad links surfaced in bookmark metadata.
-        if link.hasPrefix("journal://") {
-            handleJournalLink(link)
-            return
-        }
-        // Handle cross-reference links: osis://?osis=Matt.1.1&v11n=KJV
-        if link.hasPrefix("osis://") {
-            handleOsisLink(link)
-            return
-        }
-        // Handle multi cross-reference links: multi://?osis=Matt.1.1&osis=Mark.2.3
-        if link.hasPrefix("multi://") {
-            handleMultiLink(link)
-            return
-        }
-        // Handle sword:// links (e.g. sword://Bible/John.17.11 from Calvin's commentary)
-        if link.hasPrefix("sword://") {
-            handleSwordLink(link)
-            return
-        }
-        // Handle MyBible cross-reference links: "B:bookInt chapter:verse"
-        if link.hasPrefix("B:") {
-            handleMyBibleLink(link)
-            return
-        }
-        // Handle MyBible Strong's links: "S:G2424" or "S:H1234"
-        if link.hasPrefix("S:") {
-            let strongRef = String(link.dropFirst(2))
-            handleStrongsLink("ab-w://?strong=\(strongRef)")
-            return
-        }
-        // Handle MySword Bible links: "#bBookInt.Chapter.Verse"
-        if link.hasPrefix("#b") {
-            handleMySwordBibleLink(link)
-            return
-        }
-        // Handle MySword Strong's links: "#sG2424" or "#dH1234"
-        if link.hasPrefix("#s") || link.hasPrefix("#d") {
-            let strongRef = String(link.dropFirst(2))
-            handleStrongsLink("ab-w://?strong=\(strongRef)")
-            return
-        }
-        guard let url = URL(string: link) else { return }
-        openPlatformURL(url)
     }
 
     /**
@@ -4477,61 +4454,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         #elseif os(macOS)
         NSWorkspace.shared.open(url)
         #endif
-    }
-
-    /**
-     Parses Strong's and morphology link payloads from `ab-w://` URLs.
-
-     Android routes these links through normal document/window handling. iOS follows that route by
-     building the shared Vue `MultiDocument` payload with `contentType: "strongs"` and then handing
-     it to the pane-owned definition document router.
-
-     - Parameter link: `ab-w://` URL containing one or more `strong` or `robinson` query items.
-     - Returns: No direct return value; valid links route a transient Strong's document payload.
-     - Side effects: May emit an `add_documents` event in the current pane or configured links
-       target window. Preserves saved Strong's tab state when recursive Strong's links are opened
-       from an existing Strong's document.
-     - Failure modes: Malformed URLs, links without recognized query items, or payload-build
-       failures are ignored, matching the existing bridge-link behavior.
-     */
-    private func handleStrongsLink(_ link: String) {
-        logger.info("handleStrongsLink: \(link)")
-        guard let components = URLComponents(string: link) else {
-            logger.warning("handleStrongsLink: failed to parse URL")
-            return
-        }
-        let items = components.queryItems ?? []
-
-        var strongs: [String] = []
-        var robinson: [String] = []
-
-        for item in items {
-            guard let value = item.value, !value.isEmpty else { continue }
-            switch item.name {
-            case "strong":
-                strongs.append(value)
-            case "robinson":
-                robinson.append(value)
-            default:
-                break
-            }
-        }
-
-        logger.info("handleStrongsLink: strongs=\(strongs), robinson=\(robinson)")
-        if strongs.isEmpty && robinson.isEmpty { return }
-
-        let multiDocJSON = buildStrongsMultiDocJSON(
-            strongs: strongs,
-            robinson: robinson,
-            stateJSON: currentStrongsDocumentStateJSON()
-        )
-        guard let multiDocJSON else { return }
-
-        openDefinitionDocument(
-            multiDocJSON,
-            renderedBook: "Strongs",
-            renderedKey: "strongs"
-        )
     }
 
     /**
@@ -4617,30 +4539,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         return activeWindow?.pageManager?.jsState
     }
 
-    private func handleStandaloneStrongsLink(_ link: String) {
-        guard let components = URLComponents(string: link) else { return }
-        let ref = components.host ?? components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard !ref.isEmpty else { return }
-        handleStrongsLink("ab-w://?strong=\(ref)")
-    }
-
-    private func handleStandaloneMorphologyLink(_ link: String) {
-        guard let components = URLComponents(string: link) else { return }
-        let code = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard !code.isEmpty else { return }
-        handleStrongsLink("ab-w://?robinson=\(code)")
-    }
-
-    private func handleEpubRefLink(_ link: String) {
-        guard let components = URLComponents(string: link),
-              let items = components.queryItems,
-              let book = items.first(where: { $0.name == "book" })?.value,
-              let toKey = items.first(where: { $0.name == "toKey" })?.value,
-              let toId = items.first(where: { $0.name == "toId" })?.value else { return }
-
-        bridge(self.bridge, openEpubLink: book, toKey: toKey, toId: toId)
-    }
-
     /**
      Builds the Android-style Strong's `MultiDocument` payload for bridge routing.
 
@@ -4684,61 +4582,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                 Set(self?.settingsStore?.getStringSet(.disabledWordLookupDictionaries) ?? [])
             }
         )
-    }
-
-    /// Handle "Find all occurrences" links: ab-find-all://?type=hebrew&name=H05775
-    private func handleFindAllLink(_ link: String) {
-        logger.info("handleFindAllLink: \(link)")
-        guard let components = URLComponents(string: link) else { return }
-        let items = components.queryItems ?? []
-        let type = items.first(where: { $0.name == "type" })?.value
-        var name = items.first(where: { $0.name == "name" })?.value ?? ""
-
-        // Ensure name has H/G prefix
-        if !name.isEmpty && name.first?.isLetter != true {
-            if type == "hebrew" {
-                name = "H\(name)"
-            } else if type == "greek" {
-                name = "G\(name)"
-            }
-        }
-
-        if !name.isEmpty {
-            onShowStrongsSearch?(name)
-        }
-    }
-
-    private func handleMyNotesLink(_ link: String) {
-        logger.info("handleMyNotesLink: \(link)")
-        guard let components = URLComponents(string: link) else {
-            loadMyNotesDocument()
-            return
-        }
-
-        let items = components.queryItems ?? []
-        let ordinal = items.first(where: { $0.name == "ordinal" })?.value.flatMap(Int.init)
-
-        if let osisRef = items.first(where: { $0.name == "osis" })?.value,
-           let ref = parseOsisReferences(osisRef).first {
-            navigateTo(book: ref.book, chapter: ref.chapter, verse: ref.verse)
-            loadMyNotesDocument(jumpToOrdinal: ordinal)
-            return
-        }
-
-        loadMyNotesDocument(jumpToOrdinal: ordinal)
-    }
-
-    private func handleJournalLink(_ link: String) {
-        logger.info("handleJournalLink: \(link)")
-        guard let components = URLComponents(string: link),
-              let items = components.queryItems,
-              let labelId = items.first(where: { $0.name == "id" })?.value,
-              let labelUUID = UUID(uuidString: labelId) else { return }
-
-        let entryId = items.first(where: { $0.name == "bookmarkId" })?.value
-            ?? items.first(where: { $0.name == "entryId" })?.value
-        let bookmarkUUID = entryId.flatMap(UUID.init(uuidString:))
-        loadStudyPadDocument(labelId: labelUUID, bookmarkId: bookmarkUUID)
     }
 
     /**
@@ -4789,56 +4632,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        documents to `MultiDocument`, matching Android's `FakeBookFactory.multiDocument` path.
      */
     private func buildBibleMultiReferenceDocumentJSON(refs: [OsisRef]) -> String? {
-        guard !refs.isEmpty else { return nil }
-
-        let moduleName = activeModuleName
-        let fragments: [[String: Any]] = refs.compactMap { ref in
-            let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
-            let ordinal: Int
-            if let activeModule {
-                guard let moduleOrdinal = activeModule.verseOrdinal(
-                    osisBookId: ref.osisId,
-                    chapter: ref.chapter,
-                    verse: ref.verse
-                ) else {
-                    return nil
-                }
-                ordinal = moduleOrdinal
-            } else {
-                ordinal = compatibilityOrdinal(chapter: ref.chapter, verse: ref.verse)
+        BibleReaderMultiReferenceDocumentBuilder(
+            activeModule: activeModule,
+            activeModuleName: activeModuleName,
+            compatibilityOrdinal: { [weak self] chapter, verse in
+                self?.compatibilityOrdinal(chapter: chapter, verse: verse)
+                    ?? BibleChapterDocumentBuilder.ordinal(chapter: chapter, verse: verse)
+            },
+            isNewTestament: { [weak self] bookName in
+                self?.isNewTestament(bookName) ?? Self.isNewTestament(bookName)
             }
-            return [
-                "xml": buildBibleMultiReferenceXML(ref: ref, module: activeModule, ordinal: ordinal),
-                "key": "\(moduleName)--\(osisRef)",
-                "keyName": ref.displayName,
-                "v11n": "KJVA",
-                "bookCategory": DocumentCategory.bible.rawValue,
-                "bookInitials": moduleName,
-                "bookAbbreviation": ref.osisId,
-                "osisRef": osisRef,
-                "isNewTestament": isNewTestament(ref.book),
-                "features": [String: Any](),
-                "hasStrongs": activeModule?.info.features.contains(.strongsNumbers) ?? false,
-                "ordinalRange": [ordinal, ordinal],
-                "language": "en",
-                "direction": "ltr",
-            ]
-        }
-        guard fragments.count == refs.count else { return nil }
-
-        let document: [String: Any] = [
-            "id": "multi-\(UUID().uuidString)",
-            "type": "multi",
-            "osisFragments": fragments,
-            "compare": false,
-        ]
-
-        guard let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize multi-reference document JSON")
-            return nil
-        }
-        return json
+        ).buildDocumentJSON(refs: refs)
     }
 
     /**
@@ -4855,33 +4659,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        fragment contains an escaped display label rather than throwing.
      */
     private func buildBibleMultiReferenceXML(ref: OsisRef, module: SwordModule?, ordinal: Int) -> String {
-        let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
-        let rawText: String
-
-        if let module {
-            let inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious("=\(osisRef)")
-            if let key = inspection.verseKey,
-               key.osisBookName == ref.osisId,
-               key.chapter == ref.chapter,
-               key.verse == ref.verse {
-                rawText = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
-            } else {
-                rawText = ""
-            }
-        } else {
-            rawText = ""
-        }
-
-        let body = rawText.isEmpty ? escapeXML(ref.displayName) : rawText
-        return "<div><verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(body) </verse></div>"
-    }
-
-    /// Escape special XML characters in text content.
-    private func escapeXML(_ text: String) -> String {
-        text.replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
+        BibleReaderMultiReferenceDocumentBuilder.buildBibleMultiReferenceXML(
+            ref: ref,
+            module: module,
+            ordinal: ordinal
+        )
     }
 
     /**
@@ -4894,16 +4676,17 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         BibleReaderStrongsDocumentBuilder.lookupInModule(module, keyOptions: keyOptions)
     }
 
-    /// Handle a single cross-reference link: osis://?osis=Matt.1.1&v11n=KJV
-    private func handleOsisLink(_ link: String) {
-        logger.info("handleOsisLink: \(link)")
-        guard let components = URLComponents(string: link) else { return }
-        let items = components.queryItems ?? []
-        guard let osisRef = items.first(where: { $0.name == "osis" })?.value else { return }
+    /**
+     Handles already-classified `osis://` query values from Android-compatible links.
 
-        let refs = parseOsisReferences(osisRef)
+     - Parameter values: Raw OSIS query values preserved in link order.
+     - Side effects: Navigates a single reference or opens Android's transient `Multi` document for
+       range/list references.
+     - Failure modes: Invalid values are ignored; no side effects occur when nothing parses.
+     */
+    private func handleOsisReferenceValues(_ values: [String]) {
+        let refs = values.flatMap(parseOsisReferences)
         if refs.count == 1, let ref = refs.first {
-            // Single reference: if links window callback is available, use it
             if let openInLinks = onOpenInLinksWindow {
                 openInLinks(ref.book, ref.chapter)
             } else {
@@ -4915,18 +4698,16 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     }
 
-    /// Handle multi cross-reference links: multi://?osis=Matt.1.1&osis=Mark.2.3&...
-    private func handleMultiLink(_ link: String) {
-        logger.info("handleMultiLink: \(link)")
-        guard let components = URLComponents(string: link) else { return }
-        let items = components.queryItems ?? []
-        let osisValues = items.filter { $0.name == "osis" }.compactMap(\.value)
+    /**
+     Handles already-classified `multi://` OSIS query values from Android-compatible links.
 
-        var allRefs: [OsisRef] = []
-        for value in osisValues {
-            allRefs.append(contentsOf: parseOsisReferences(value))
-        }
-
+     - Parameter values: OSIS query values from the pseudo-link.
+     - Side effects: Navigates a single parsed reference or opens a transient `Multi` document for
+       multiple parsed references.
+     - Failure modes: Invalid values are ignored; no side effects occur when nothing parses.
+     */
+    private func handleMultiReferenceValues(_ values: [String]) {
+        let allRefs = values.flatMap(parseOsisReferences)
         guard !allRefs.isEmpty else { return }
 
         if allRefs.count == 1, let ref = allRefs.first {
@@ -4955,148 +4736,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             loadMultiReferenceDocument(documentJSON)
         }
     }
-
-    /**
-     Handle sword:// links (e.g. sword://Bible/John.17.11 from Calvin's commentary).
-     Format: sword://moduleName/OsisRef or sword://Bible/OsisRef
-     */
-    private func handleSwordLink(_ link: String) {
-        logger.info("handleSwordLink: \(link)")
-        // Strip "sword://" prefix
-        var ref = String(link.dropFirst("sword://".count))
-        // Strip leading/trailing slashes
-        while ref.hasPrefix("/") { ref = String(ref.dropFirst()) }
-        while ref.hasSuffix("/") { ref = String(ref.dropLast()) }
-
-        guard !ref.isEmpty else { return }
-
-        if let slashIdx = ref.firstIndex(of: "/") {
-            let modulePart = String(ref[ref.startIndex..<slashIdx]).lowercased()
-            let osisRef = String(ref[ref.index(after: slashIdx)...])
-            // If module is "Bible" (generic), just navigate to the OSIS ref
-            if modulePart == "bible" {
-                _ = navigateToOsisRef(osisRef)
-            } else {
-                // Try to navigate with the OSIS ref regardless of module name
-                // (we don't switch modules for now, just navigate to the reference)
-                _ = navigateToOsisRef(osisRef)
-            }
-        } else {
-            // No slash — treat the whole thing as an OSIS reference
-            _ = navigateToOsisRef(ref)
-        }
-    }
-
-    /**
-     Handle MyBible cross-reference links: "B:bookInt chapter:verse"
-     Example: "B:470 1:1" → Matthew 1:1
-     */
-    private func handleMyBibleLink(_ link: String) {
-        logger.info("handleMyBibleLink: \(link)")
-        // Format: "B:bookInt chapter:verse" (e.g. "B:470 1:1")
-        let parts = link.split(separator: " ", maxSplits: 1)
-        guard parts.count >= 2 else { return }
-
-        // Extract book number from "B:470"
-        let bookPart = String(parts[0])
-        guard bookPart.hasPrefix("B:"),
-              let bookInt = Int(bookPart.dropFirst(2)) else { return }
-
-        // Look up OSIS ID from MyBible book number
-        guard let osisId = Self.myBibleIntToOsisId[bookInt] else {
-            logger.warning("Unknown MyBible book number: \(bookInt)")
-            return
-        }
-
-        // Parse "chapter:verse"
-        let chapVerse = String(parts[1]).components(separatedBy: ":")
-        guard let chapter = Int(chapVerse[0]) else { return }
-        let verse = chapVerse.count >= 2 ? Int(chapVerse[1]) : nil
-
-        let osisRef = verse != nil ? "\(osisId).\(chapter).\(verse!)" : "\(osisId).\(chapter)"
-        _ = navigateToOsisRef(osisRef)
-    }
-
-    /**
-     Handle MySword Bible links: "#bBookInt.Chapter.Verse"
-     Example: "#b40.1.1" → Matthew 1:1 (MySword uses sequential 1-66 numbering)
-     */
-    private func handleMySwordBibleLink(_ link: String) {
-        logger.info("handleMySwordBibleLink: \(link)")
-        // Format: "#bBookInt.Chapter.Verse" (e.g. "#b40.1.1")
-        let rest = String(link.dropFirst(2)) // strip "#b"
-        let parts = rest.split(separator: ".").compactMap { Int($0) }
-        guard parts.count >= 2 else { return }
-
-        let bookInt = parts[0]
-        let chapter = parts[1]
-        let verse = parts.count >= 3 ? parts[2] : nil
-
-        // MySword uses sequential 1-66 numbering (1=Gen, 40=Matt, 66=Rev)
-        guard let osisId = Self.mySwordIntToOsisId[bookInt] else {
-            logger.warning("Unknown MySword book number: \(bookInt)")
-            return
-        }
-
-        let osisRef = verse != nil ? "\(osisId).\(chapter).\(verse!)" : "\(osisId).\(chapter)"
-        _ = navigateToOsisRef(osisRef)
-    }
-
-    // MARK: - MySword/MyBible Book Number Mappings
-
-    /**
-     MySword sequential book numbering (1-66, Protestant canon).
-     Matches Android's mySwordIntToBibleBook in MySwordBookMap.kt.
-     */
-    private static let mySwordIntToOsisId: [Int: String] = [
-        1: "Gen", 2: "Exod", 3: "Lev", 4: "Num", 5: "Deut",
-        6: "Josh", 7: "Judg", 8: "Ruth", 9: "1Sam", 10: "2Sam",
-        11: "1Kgs", 12: "2Kgs", 13: "1Chr", 14: "2Chr",
-        15: "Ezra", 16: "Neh", 17: "Esth", 18: "Job",
-        19: "Ps", 20: "Prov", 21: "Eccl", 22: "Song",
-        23: "Isa", 24: "Jer", 25: "Lam", 26: "Ezek", 27: "Dan",
-        28: "Hos", 29: "Joel", 30: "Amos", 31: "Obad", 32: "Jonah",
-        33: "Mic", 34: "Nah", 35: "Hab", 36: "Zeph",
-        37: "Hag", 38: "Zech", 39: "Mal",
-        40: "Matt", 41: "Mark", 42: "Luke", 43: "John",
-        44: "Acts", 45: "Rom", 46: "1Cor", 47: "2Cor",
-        48: "Gal", 49: "Eph", 50: "Phil", 51: "Col",
-        52: "1Thess", 53: "2Thess", 54: "1Tim", 55: "2Tim",
-        56: "Titus", 57: "Phlm", 58: "Heb",
-        59: "Jas", 60: "1Pet", 61: "2Pet",
-        62: "1John", 63: "2John", 64: "3John",
-        65: "Jude", 66: "Rev",
-    ]
-
-    /**
-     MyBible non-sequential book numbering.
-     Matches Android's myBibleIntToBibleBook in MyBibleBookMap.kt.
-     */
-    private static let myBibleIntToOsisId: [Int: String] = [
-        10: "Gen", 20: "Exod", 30: "Lev", 40: "Num", 50: "Deut",
-        60: "Josh", 70: "Judg", 80: "Ruth",
-        90: "1Sam", 100: "2Sam", 110: "1Kgs", 120: "2Kgs",
-        130: "1Chr", 140: "2Chr",
-        150: "Ezra", 160: "Neh", 190: "Esth",
-        220: "Job", 230: "Ps", 240: "Prov", 250: "Eccl", 260: "Song",
-        290: "Isa", 300: "Jer", 310: "Lam", 320: "Bar",
-        330: "Ezek", 340: "Dan",
-        350: "Hos", 360: "Joel", 370: "Amos", 380: "Obad",
-        390: "Jonah", 400: "Mic", 410: "Nah", 420: "Hab",
-        430: "Zeph", 440: "Hag", 450: "Zech", 460: "Mal",
-        470: "Matt", 480: "Mark", 490: "Luke", 500: "John",
-        510: "Acts", 520: "Rom", 530: "1Cor", 540: "2Cor",
-        550: "Gal", 560: "Eph", 570: "Phil", 580: "Col",
-        590: "1Thess", 600: "2Thess", 610: "1Tim", 620: "2Tim",
-        630: "Titus", 640: "Phlm", 650: "Heb",
-        660: "Jas", 670: "1Pet", 680: "2Pet",
-        690: "1John", 700: "2John", 710: "3John",
-        720: "Jude", 730: "Rev",
-        // Deuterocanonical / Apocrypha (MyBible includes these)
-        170: "Tob", 180: "Jdt", 270: "Wis", 280: "Sir",
-        462: "1Macc", 464: "2Macc", 466: "3Macc", 467: "4Macc",
-        468: "2Esd",
-    ]
 
     /**
      Parses an OSIS reference string into structured verse references.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -4685,7 +4685,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Failure modes: Invalid values are ignored; no side effects occur when nothing parses.
      */
     private func handleOsisReferenceValues(_ values: [String]) {
-        let refs = values.flatMap(parseOsisReferences)
+        guard let value = values.first else { return }
+        let refs = parseOsisReferences(value)
         if refs.count == 1, let ref = refs.first {
             if let openInLinks = onOpenInLinksWindow {
                 openInLinks(ref.book, ref.chapter)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderExternalLinkRouter.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderExternalLinkRouter.swift
@@ -1,0 +1,330 @@
+import Foundation
+
+/**
+ Classifies Android-compatible reader links into typed native reader routes.
+
+ Android separates pseudo-link classification from execution: `BibleJavascriptInterface` and
+ `BibleView` convert `ab-w`, `osis`, `multi`, MyBible, MySword, Strong's, morphology, EPUB,
+ Downloads, My Notes, and StudyPad links into application routes, and `LinkControl` performs the
+ document/window work. This type owns the same pure classification step for iOS so
+ `BibleReaderController` only performs pane-specific side effects.
+ */
+struct BibleReaderExternalLinkRouter {
+    /**
+     Typed destination for an external-style reader link.
+
+     Associated values carry only already-decoded routing data. The enum performs no SWORD access,
+     bridge emission, navigation, persistence, or platform URL opening.
+     */
+    enum Route: Equatable {
+        /// Open a Strong's/morphology multi-document with collected Strong's and Robinson keys.
+        case definition(strongs: [String], robinson: [String])
+        /// Show all occurrences for a normalized Strong's key.
+        case findAllOccurrences(String)
+        /// Open the native error-report target.
+        case errorReport
+        /// Navigate inside an EPUB module.
+        case epubReference(book: String, toKey: String, toId: String)
+        /// Open Downloads, optionally filtered by module initials.
+        case downloads(searchText: String?)
+        /// Open My Notes, optionally jumping to an OSIS reference and ordinal.
+        case myNotes(osisRef: String?, ordinal: Int?)
+        /// Open StudyPad for a label and optional bookmark entry.
+        case studyPad(labelId: UUID, bookmarkId: UUID?)
+        /// Resolve one or more OSIS query values from an `osis://` link.
+        case osisReferences([String])
+        /// Resolve one or more OSIS query values from a `multi://` link.
+        case multiReferences([String])
+        /// Navigate a SWORD reference stripped from a `sword://` pseudo-link.
+        case swordReference(String)
+        /// Navigate an OSIS-style reference produced by MyBible/MySword links.
+        case osisNavigation(String)
+        /// Open an ordinary platform URL.
+        case platformURL(URL)
+    }
+
+    /**
+     Converts a raw bridge link string into a typed route.
+
+     - Parameter link: Raw link emitted by Vue or module HTML.
+     - Returns: A route when the link is recognized or a valid platform URL, otherwise `nil`.
+     - Side effects: None.
+     - Failure modes: Malformed pseudo-links return `nil`, matching Android's "do nothing" path for
+       incomplete app links. Unknown but valid URLs route to platform URL handling.
+     */
+    func route(for link: String) -> Route? {
+        if link.hasPrefix("ab-w://") {
+            return definitionRoute(fromAbWordLink: link)
+        }
+        if link.hasPrefix("strongs://") {
+            return standaloneStrongsRoute(from: link)
+        }
+        if link.hasPrefix("morphology://") {
+            return standaloneMorphologyRoute(from: link)
+        }
+        if link.hasPrefix("ab-find-all://") {
+            return findAllRoute(from: link)
+        }
+        if link.hasPrefix("ab-error://") {
+            return .errorReport
+        }
+        if link.hasPrefix("epub-ref://") {
+            return epubRoute(from: link)
+        }
+        if link.hasPrefix("download://") {
+            return .downloads(searchText: BibleReaderBridgeEventRouter.downloadSearchText(from: link))
+        }
+        if link.hasPrefix("my-notes://") {
+            return myNotesRoute(from: link)
+        }
+        if link.hasPrefix("journal://") {
+            return studyPadRoute(from: link)
+        }
+        if link.hasPrefix("osis://") {
+            return osisRoute(from: link)
+        }
+        if link.hasPrefix("multi://") {
+            return multiRoute(from: link)
+        }
+        if link.hasPrefix("sword://") {
+            return swordRoute(from: link)
+        }
+        if link.hasPrefix("B:") {
+            return myBibleRoute(from: link)
+        }
+        if link.hasPrefix("S:") {
+            let strongRef = String(link.dropFirst(2))
+            return strongRef.isEmpty ? nil : .definition(strongs: [strongRef], robinson: [])
+        }
+        if link.hasPrefix("#b") {
+            return mySwordBibleRoute(from: link)
+        }
+        if link.hasPrefix("#s") || link.hasPrefix("#d") {
+            let strongRef = String(link.dropFirst(2))
+            return strongRef.isEmpty ? nil : .definition(strongs: [strongRef], robinson: [])
+        }
+        return URL(string: link).map(Route.platformURL)
+    }
+
+    /**
+     Parses `ab-w://` Strong's and morphology query values into a definition route.
+     */
+    private func definitionRoute(fromAbWordLink link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        var strongs: [String] = []
+        var robinson: [String] = []
+        for item in components.queryItems ?? [] {
+            guard let value = item.value, !value.isEmpty else { continue }
+            switch item.name {
+            case "strong":
+                strongs.append(value)
+            case "robinson":
+                robinson.append(value)
+            default:
+                break
+            }
+        }
+        guard !strongs.isEmpty || !robinson.isEmpty else { return nil }
+        return .definition(strongs: strongs, robinson: robinson)
+    }
+
+    /**
+     Parses document-independent `strongs://` links into Android's Strong's definition route.
+     */
+    private func standaloneStrongsRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        let ref = components.host ?? components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return ref.isEmpty ? nil : .definition(strongs: [ref], robinson: [])
+    }
+
+    /**
+     Parses document-independent morphology links into the Robinson morphology route iOS renders.
+     */
+    private func standaloneMorphologyRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        let code = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return code.isEmpty ? nil : .definition(strongs: [], robinson: [code])
+    }
+
+    /**
+     Parses Android's "find all occurrences" pseudo-link and normalizes bare H/G numbers.
+     */
+    private func findAllRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        let items = components.queryItems ?? []
+        let type = items.first(where: { $0.name == "type" })?.value
+        var name = items.first(where: { $0.name == "name" })?.value ?? ""
+        if !name.isEmpty && name.first?.isLetter != true {
+            if type == "hebrew" {
+                name = "H\(name)"
+            } else if type == "greek" {
+                name = "G\(name)"
+            }
+        }
+        return name.isEmpty ? nil : .findAllOccurrences(name)
+    }
+
+    /**
+     Parses EPUB reference query parameters emitted by rendered EPUB/module links.
+     */
+    private func epubRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link),
+              let items = components.queryItems,
+              let book = items.first(where: { $0.name == "book" })?.value,
+              let toKey = items.first(where: { $0.name == "toKey" })?.value,
+              let toId = items.first(where: { $0.name == "toId" })?.value else {
+            return nil
+        }
+        return .epubReference(book: book, toKey: toKey, toId: toId)
+    }
+
+    /**
+     Parses My Notes links into optional jump metadata.
+     */
+    private func myNotesRoute(from link: String) -> Route {
+        guard let components = URLComponents(string: link) else {
+            return .myNotes(osisRef: nil, ordinal: nil)
+        }
+        let items = components.queryItems ?? []
+        let osisRef = items.first(where: { $0.name == "osis" })?.value
+        let ordinal = items.first(where: { $0.name == "ordinal" })?.value.flatMap(Int.init)
+        return .myNotes(osisRef: osisRef, ordinal: ordinal)
+    }
+
+    /**
+     Parses StudyPad journal links into label and optional bookmark identifiers.
+     */
+    private func studyPadRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link),
+              let items = components.queryItems,
+              let labelId = items.first(where: { $0.name == "id" })?.value,
+              let labelUUID = UUID(uuidString: labelId) else {
+            return nil
+        }
+        let entryId = items.first(where: { $0.name == "bookmarkId" })?.value
+            ?? items.first(where: { $0.name == "entryId" })?.value
+        return .studyPad(labelId: labelUUID, bookmarkId: entryId.flatMap(UUID.init(uuidString:)))
+    }
+
+    /**
+     Parses Android `osis://` links and preserves each query value for controller-side resolution.
+     */
+    private func osisRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        let values = (components.queryItems ?? [])
+            .filter { $0.name == "osis" }
+            .compactMap(\.value)
+        return values.isEmpty ? nil : .osisReferences(values)
+    }
+
+    /**
+     Parses Android `multi://` links and preserves all OSIS query values in emitted order.
+     */
+    private func multiRoute(from link: String) -> Route? {
+        guard let components = URLComponents(string: link) else { return nil }
+        let values = (components.queryItems ?? [])
+            .filter { $0.name == "osis" }
+            .compactMap(\.value)
+        return values.isEmpty ? nil : .multiReferences(values)
+    }
+
+    /**
+     Strips the module component from `sword://module/ref` links and returns the target reference.
+     */
+    private func swordRoute(from link: String) -> Route? {
+        var ref = String(link.dropFirst("sword://".count))
+        while ref.hasPrefix("/") { ref = String(ref.dropFirst()) }
+        while ref.hasSuffix("/") { ref = String(ref.dropLast()) }
+        guard !ref.isEmpty else { return nil }
+        if let slashIndex = ref.firstIndex(of: "/") {
+            ref = String(ref[ref.index(after: slashIndex)...])
+        }
+        return ref.isEmpty ? nil : .swordReference(ref)
+    }
+
+    /**
+     Converts a MyBible `B:` Bible link into an OSIS reference using Android's book-number map.
+     */
+    private func myBibleRoute(from link: String) -> Route? {
+        let parts = link.split(separator: " ", maxSplits: 1)
+        guard parts.count >= 2 else { return nil }
+        let bookPart = String(parts[0])
+        guard bookPart.hasPrefix("B:"),
+              let bookInt = Int(bookPart.dropFirst(2)),
+              let osisId = Self.myBibleIntToOsisId[bookInt] else {
+            return nil
+        }
+        let chapterVerse = String(parts[1]).components(separatedBy: ":")
+        guard let chapterText = chapterVerse.first, let chapter = Int(chapterText) else { return nil }
+        let verse = chapterVerse.count >= 2 ? Int(chapterVerse[1]) : nil
+        return .osisNavigation(verse.map { "\(osisId).\(chapter).\($0)" } ?? "\(osisId).\(chapter)")
+    }
+
+    /**
+     Converts a MySword `#b` Bible link into an OSIS reference using Android's book-number map.
+     */
+    private func mySwordBibleRoute(from link: String) -> Route? {
+        let rest = String(link.dropFirst(2))
+        let parts = rest.split(separator: ".").compactMap { Int($0) }
+        guard parts.count >= 2,
+              let osisId = Self.mySwordIntToOsisId[parts[0]] else {
+            return nil
+        }
+        let chapter = parts[1]
+        let verse = parts.count >= 3 ? parts[2] : nil
+        return .osisNavigation(verse.map { "\(osisId).\(chapter).\($0)" } ?? "\(osisId).\(chapter)")
+    }
+
+    /**
+     MySword sequential book numbering (1-66, Protestant canon).
+     Matches Android's `mySwordIntToBibleBook` map.
+     */
+    private static let mySwordIntToOsisId: [Int: String] = [
+        1: "Gen", 2: "Exod", 3: "Lev", 4: "Num", 5: "Deut",
+        6: "Josh", 7: "Judg", 8: "Ruth", 9: "1Sam", 10: "2Sam",
+        11: "1Kgs", 12: "2Kgs", 13: "1Chr", 14: "2Chr",
+        15: "Ezra", 16: "Neh", 17: "Esth", 18: "Job",
+        19: "Ps", 20: "Prov", 21: "Eccl", 22: "Song",
+        23: "Isa", 24: "Jer", 25: "Lam", 26: "Ezek", 27: "Dan",
+        28: "Hos", 29: "Joel", 30: "Amos", 31: "Obad", 32: "Jonah",
+        33: "Mic", 34: "Nah", 35: "Hab", 36: "Zeph",
+        37: "Hag", 38: "Zech", 39: "Mal",
+        40: "Matt", 41: "Mark", 42: "Luke", 43: "John",
+        44: "Acts", 45: "Rom", 46: "1Cor", 47: "2Cor",
+        48: "Gal", 49: "Eph", 50: "Phil", 51: "Col",
+        52: "1Thess", 53: "2Thess", 54: "1Tim", 55: "2Tim",
+        56: "Titus", 57: "Phlm", 58: "Heb",
+        59: "Jas", 60: "1Pet", 61: "2Pet",
+        62: "1John", 63: "2John", 64: "3John",
+        65: "Jude", 66: "Rev",
+    ]
+
+    /**
+     MyBible non-sequential book numbering, including the deuterocanonical IDs Android recognizes.
+     Matches Android's `myBibleIntToBibleBook` map.
+     */
+    private static let myBibleIntToOsisId: [Int: String] = [
+        10: "Gen", 20: "Exod", 30: "Lev", 40: "Num", 50: "Deut",
+        60: "Josh", 70: "Judg", 80: "Ruth",
+        90: "1Sam", 100: "2Sam", 110: "1Kgs", 120: "2Kgs",
+        130: "1Chr", 140: "2Chr",
+        150: "Ezra", 160: "Neh", 190: "Esth",
+        220: "Job", 230: "Ps", 240: "Prov", 250: "Eccl", 260: "Song",
+        290: "Isa", 300: "Jer", 310: "Lam", 320: "Bar",
+        330: "Ezek", 340: "Dan",
+        350: "Hos", 360: "Joel", 370: "Amos", 380: "Obad",
+        390: "Jonah", 400: "Mic", 410: "Nah", 420: "Hab",
+        430: "Zeph", 440: "Hag", 450: "Zech", 460: "Mal",
+        470: "Matt", 480: "Mark", 490: "Luke", 500: "John",
+        510: "Acts", 520: "Rom", 530: "1Cor", 540: "2Cor",
+        550: "Gal", 560: "Eph", 570: "Phil", 580: "Col",
+        590: "1Thess", 600: "2Thess", 610: "1Tim", 620: "2Tim",
+        630: "Titus", 640: "Phlm", 650: "Heb",
+        660: "Jas", 670: "1Pet", 680: "2Pet",
+        690: "1John", 700: "2John", 710: "3John",
+        720: "Jude", 730: "Rev",
+        170: "Tob", 180: "Jdt", 270: "Wis", 280: "Sir",
+        462: "1Macc", 464: "2Macc", 466: "3Macc", 467: "4Macc",
+        468: "2Esd",
+    ]
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderMultiReferenceDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderMultiReferenceDocumentBuilder.swift
@@ -1,0 +1,163 @@
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+import os.log
+
+private let multiReferenceDocumentBuilderLogger = Logger(
+    subsystem: "org.andbible",
+    category: "BibleReaderMultiReferenceDocumentBuilder"
+)
+
+/**
+ Builds Android-style Bible `MultiDocument` payloads for OSIS and multi-reference links.
+
+ Android resolves cross-reference lists through `LinkControl.openMulti(...)` into
+ `FakeBookFactory.multiDocument`. This builder owns the equivalent iOS payload construction so the
+ reader controller supplies only active-module state and window orchestration.
+ */
+struct BibleReaderMultiReferenceDocumentBuilder {
+    /// Active Bible module used to resolve ordinals and extract raw OSIS fragments.
+    private let activeModule: SwordModule?
+    /// Active Bible module initials used in fragment identity when no source module override exists.
+    private let activeModuleName: String
+    /// Legacy ordinal fallback used only when no module can resolve a verse.
+    private let compatibilityOrdinal: (_ chapter: Int, _ verse: Int) -> Int
+    /// Book-test helper supplied by the controller's current book catalog.
+    private let isNewTestament: (_ bookName: String) -> Bool
+
+    /**
+     Creates a multi-reference document builder for one reader pane.
+
+     - Parameters:
+       - activeModule: Active Bible module, if one is loaded.
+       - activeModuleName: Active Bible initials to attach to generated fragments.
+       - compatibilityOrdinal: Fallback ordinal projection for no-module startup states.
+       - isNewTestament: Book classification closure from the controller's active catalog.
+     - Side effects: None during construction.
+     - Failure modes: Missing active module is handled by fallback fragment generation.
+     */
+    init(
+        activeModule: SwordModule?,
+        activeModuleName: String,
+        compatibilityOrdinal: @escaping (_ chapter: Int, _ verse: Int) -> Int,
+        isNewTestament: @escaping (_ bookName: String) -> Bool
+    ) {
+        self.activeModule = activeModule
+        self.activeModuleName = activeModuleName
+        self.compatibilityOrdinal = compatibilityOrdinal
+        self.isNewTestament = isNewTestament
+    }
+
+    /**
+     Builds the Vue `MultiDocument` payload Android uses for multi-reference Bible links.
+
+     - Parameter refs: Parsed OSIS references in the order supplied by an Android-compatible link.
+     - Returns: Serialized JSON for a transient multi-document, or `nil` if no complete fragment
+       set can be produced.
+     - Side effects: Reads the active SWORD Bible module and may temporarily move its key cursor
+       while extracting verse OSIS.
+     - Failure modes: Returns `nil` when any requested reference cannot be resolved by the active
+       module, preserving the pre-existing all-or-nothing document contract.
+     */
+    func buildDocumentJSON(refs: [OsisRef]) -> String? {
+        guard !refs.isEmpty else { return nil }
+
+        let fragments: [[String: Any]] = refs.compactMap { ref in
+            let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+            let ordinal: Int
+            if let activeModule {
+                guard let moduleOrdinal = activeModule.verseOrdinal(
+                    osisBookId: ref.osisId,
+                    chapter: ref.chapter,
+                    verse: ref.verse
+                ) else {
+                    return nil
+                }
+                ordinal = moduleOrdinal
+            } else {
+                ordinal = compatibilityOrdinal(ref.chapter, ref.verse)
+            }
+            return [
+                "xml": Self.buildBibleMultiReferenceXML(ref: ref, module: activeModule, ordinal: ordinal),
+                "key": "\(activeModuleName)--\(osisRef)",
+                "keyName": ref.displayName,
+                "v11n": "KJVA",
+                "bookCategory": DocumentCategory.bible.rawValue,
+                "bookInitials": activeModuleName,
+                "bookAbbreviation": ref.osisId,
+                "osisRef": osisRef,
+                "isNewTestament": isNewTestament(ref.book),
+                "features": [String: Any](),
+                "hasStrongs": activeModule?.info.features.contains(.strongsNumbers) ?? false,
+                "ordinalRange": [ordinal, ordinal],
+                "language": "en",
+                "direction": "ltr",
+            ]
+        }
+        guard fragments.count == refs.count else { return nil }
+
+        let document: [String: Any] = [
+            "id": "multi-\(UUID().uuidString)",
+            "type": "multi",
+            "osisFragments": fragments,
+            "compare": false,
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            multiReferenceDocumentBuilderLogger.error("Failed to serialize multi-reference document JSON")
+            return nil
+        }
+        return json
+    }
+
+    /**
+     Reads one Bible verse as an OSIS fragment suitable for Vue `MultiDocument`.
+
+     - Parameters:
+       - ref: Parsed Bible reference to render.
+       - module: Bible module to read from. A missing module yields a fallback fragment.
+       - ordinal: Verse ordinal to write into the fragment.
+     - Returns: A `<div>` containing one `<verse>` element.
+     - Side effects: When `module` is present, temporarily moves its SWORD key cursor inside a
+       serialized inspection call and restores the previous cursor before returning.
+     - Failure modes: Missing or mismatched module content falls back to the escaped display label.
+     */
+    static func buildBibleMultiReferenceXML(ref: OsisRef, module: SwordModule?, ordinal: Int) -> String {
+        let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+        let rawText: String
+
+        if let module {
+            let inspection = module.inspectVerseKeyAndRawEntryRestoringPrevious("=\(osisRef)")
+            if let key = inspection.verseKey,
+               key.osisBookName == ref.osisId,
+               key.chapter == ref.chapter,
+               key.verse == ref.verse {
+                rawText = inspection.rawEntry.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                rawText = ""
+            }
+        } else {
+            rawText = ""
+        }
+
+        let body = rawText.isEmpty ? escapeXML(ref.displayName) : rawText
+        return "<div><verse osisID=\"\(osisRef)\" verseOrdinal=\"\(ordinal)\">\(body) </verse></div>"
+    }
+
+    /**
+     Escapes text inserted into synthetic XML fallback fragments.
+
+     - Parameter text: Plain text fallback label.
+     - Returns: Text with XML-sensitive characters escaped.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private static func escapeXML(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the external/link routing and multi-reference document construction slice from `BibleReaderController` for #146.

## Scope

- Adds `BibleReaderExternalLinkRouter` as the pure Android-compatible pseudo-link classifier.
- Adds `BibleReaderMultiReferenceDocumentBuilder` for Bible `MultiDocument` payload construction.
- Leaves pane-specific side effects in `BibleReaderController`: navigation, downloads presentation, EPUB jumps, My Notes, StudyPad, definition document opening, links-window routing, and platform URL opening.
- Adds parity-focused tests for route classification and multi-reference payload construction.

## Contract References

- #146 controller decomposition work stream.
- Android parity sources checked locally:
  - `BibleJavascriptInterface.openExternalLink`
  - `BibleView.openLink`
  - `LinkControl.openMulti/loadApplicationUrl`
- Existing iOS tests for Android `MultiDocument` behavior remain part of the validation surface.

## Change Details

- External link parsing for `ab-w://`, `strongs://`, `morphology://`, `ab-find-all://`, `epub-ref://`, `download://`, `my-notes://`, `journal://`, `osis://`, `multi://`, `sword://`, MyBible, and MySword now lives in a typed router.
- Multi-reference Bible document JSON/XML generation now lives in a focused builder shared by fresh multi-reference openings and restored `Multi` fragment XML construction.
- `BibleReaderController.swift` drops from 6,925 lines on `main` to 6,472 lines on this branch.

## Validation Evidence

- `git diff --check`
- `python3 scripts/check_repo_standards.py docblocks`
- Focused reader link-routing tests: 7 tests, 0 failures.
- Broader `AndBibleTests` suite: 562 tests, 0 failures.
- GitNexus impact checks before editing showed LOW risk for the directly indexed multi-reference/link helpers. The overloaded bridge delegate method was ambiguous in GitNexus, so I treated it as a parity-sensitive controller entry point and validated by direct source reads plus tests.
- `npx gitnexus detect-changes --scope all --repo and-bible-ios` was run, but after `npx gitnexus analyze` it repeatedly reported a regenerated `CLAUDE.md` artifact even with a clean working tree for that file. The staged git diff was verified manually as the four intended files.

## Risks / Follow-ups

- This does not complete #146. Remaining controller ownership slices should continue under the issue checklist.
- The router preserves current iOS side-effect execution while aligning the classification boundary with Android; additional link-resolution parity work should build on this shared route surface rather than reintroducing controller-local parsing.

Refs #146