### PR TITLE
fix(ui-tests): stabilize workspace prompt focus

### DIFF
--- a/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -114,8 +114,9 @@ extension AndBibleUITests {
      - Side effects:
        - taps the resolved prompt field, verifies or clears any existing prompt value, emits
          keyboard input, and clears/retries if CI drops the input without appending duplicate text
-       - for the workspace creation prompt, verifies text entry through the prompt-owned submit
-         button because hosted XCTest can lose the SwiftUI text-field snapshot after focus
+       - for the workspace creation prompt, relies on the prompt's Android-parity autofocus and
+         verifies text entry through the prompt-owned submit button because hosted XCTest can lose
+         the SwiftUI text-field snapshot after focus
      - Failure modes:
        - records an XCTest failure when the field value or prompt-owned submit readiness never
          reflects `text`
@@ -214,12 +215,6 @@ extension AndBibleUITests {
                     for: prompt.frame,
                     normalizedOffset: CGVector(dx: 0.5, dy: 0.52)
                 )
-            case "workspaceNamePromptTextField":
-                // The workspace prompt is a centered selector-owned dialog. Hosted XCTest can
-                // wedge when re-sampling either the resolved SwiftUI field or prompt root for a
-                // frame after the field was found, so focus through the dialog's stable text-entry
-                // band without asking XCTest for another hosted snapshot.
-                return app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.46))
             default:
                 return nil
             }
@@ -372,16 +367,8 @@ extension AndBibleUITests {
         repeat {
             let promptTextField = resolvedPromptTextField()
             let preferredPromptCandidates = [promptTextField]
-            focusResolvedPromptTextEntryElement(
-                promptTextField,
-                in: app,
-                promptTapCoordinate: promptOwnedTextEntryTapCoordinate,
-                timeout: min(5, max(1, deadline.timeIntervalSinceNow)),
-                file: file,
-                line: line
-            )
             if skipsPromptValueObservation {
-                app.typeText(text)
+                promptTextField.typeText(text)
                 if waitForWorkspacePromptSubmitButtonToEnable(
                     timeout: min(5, max(0.5, deadline.timeIntervalSinceNow))
                 ) {
@@ -390,6 +377,14 @@ extension AndBibleUITests {
                 RunLoop.current.run(until: Date().addingTimeInterval(0.2))
                 continue
             }
+            focusResolvedPromptTextEntryElement(
+                promptTextField,
+                in: app,
+                promptTapCoordinate: promptOwnedTextEntryTapCoordinate,
+                timeout: min(5, max(1, deadline.timeIntervalSinceNow)),
+                file: file,
+                line: line
+            )
             let existingValue = observedPromptTextValue(preferred: preferredPromptCandidates)
             if existingValue == text {
                 return true
@@ -443,6 +438,16 @@ extension AndBibleUITests {
             _ = clearObservedPromptTextValue(preferred: preferredPromptCandidates, forceKeyboardDelete: true)
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
+
+        if skipsPromptValueObservation {
+            XCTAssertTrue(
+                waitForWorkspacePromptSubmitButtonToEnable(timeout: 0),
+                "Expected workspace prompt submit button to become enabled after typing '\(text)'.",
+                file: file,
+                line: line
+            )
+            return false
+        }
 
         XCTAssertEqual(
             observedPromptTextValue(),

--- a/Sources/BibleUI/Sources/BibleUI/Workspace/WorkspaceSelectorView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Workspace/WorkspaceSelectorView.swift
@@ -601,10 +601,23 @@ private struct WorkspaceNamePromptView: View {
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("workspaceNamePromptScreen")
         .tint(dialogAccent)
-        .task {
-            await MainActor.run {
-                isNameFieldFocused = true
-            }
+        .onAppear {
+            requestNameFieldFocus()
         }
+        .task(id: prompt.id) {
+            await requestNameFieldFocusAfterAttachment()
+        }
+    }
+
+    @MainActor
+    private func requestNameFieldFocus() {
+        isNameFieldFocused = true
+    }
+
+    @MainActor
+    private func requestNameFieldFocusAfterAttachment() async {
+        requestNameFieldFocus()
+        await Task.yield()
+        requestNameFieldFocus()
     }
 }

--- a/scripts/test_workspace_prompt_ui_contract.py
+++ b/scripts/test_workspace_prompt_ui_contract.py
@@ -105,8 +105,8 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         element_candidates_start = source.index("func elementCandidates(")
         element_candidates_end = source.index("func resolvedElement(", element_candidates_start)
         element_candidates_body = source[element_candidates_start:element_candidates_end]
-        coordinate_start = state_source.index('case "workspaceNamePromptTextField":')
-        coordinate_end = state_source.index("default:", coordinate_start)
+        coordinate_start = state_source.index("func promptOwnedTextEntryTapCoordinate")
+        coordinate_end = state_source.index("func observedPromptTextValue", coordinate_start)
         coordinate_body = state_source[coordinate_start:coordinate_end]
 
         self.assertIn("app.otherElements[identifier].firstMatch", prompt_candidates_body)
@@ -115,9 +115,8 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         self.assertNotIn("workspaceNamePromptScreenCandidates(in: app)", coordinate_body)
         self.assertNotIn('app.collectionViews["workspaceNamePromptScreen"]', coordinate_body)
         self.assertNotIn('app.scrollViews["workspaceNamePromptScreen"]', coordinate_body)
-        self.assertIn("app.coordinate(withNormalizedOffset:", coordinate_body)
-        self.assertIn("CGVector(dx: 0.5, dy: 0.46)", coordinate_body)
-        self.assertNotIn("return nil", coordinate_body)
+        self.assertNotIn('case "workspaceNamePromptTextField"', coordinate_body)
+        self.assertNotIn("CGVector(dx: 0.5, dy: 0.46)", coordinate_body)
         self.assertIn(
             'case "workspaceNamePromptScreen":\n'
             "            return workspaceNamePromptScreenCandidates(in: app)",
@@ -147,18 +146,42 @@ class WorkspacePromptUITestContractTests(unittest.TestCase):
         submit_helper_end = typing_body.index("func clearObservedPromptTextValue", submit_helper_start)
         submit_helper_body = typing_body[submit_helper_start:submit_helper_end]
         workspace_branch_start = typing_body.index("if skipsPromptValueObservation")
-        workspace_branch_end = typing_body.index(
-            "let existingValue = observedPromptTextValue",
-            workspace_branch_start,
-        )
+        workspace_branch_end = typing_body.index("focusResolvedPromptTextEntryElement", workspace_branch_start)
         workspace_branch = typing_body[workspace_branch_start:workspace_branch_end]
 
         self.assertIn('resolvedIdentifier == "workspaceNamePromptTextField"', typing_body)
         self.assertIn("waitForWorkspacePromptSubmitButtonToEnable", typing_body)
         self.assertIn('"workspaceNamePromptConfirmButton"', submit_helper_body)
-        self.assertIn("app.typeText(text)", workspace_branch)
+        self.assertIn("promptTextField.typeText(text)", workspace_branch)
+        self.assertNotIn("app.typeText(text)", workspace_branch)
+        self.assertNotIn("focusResolvedPromptTextEntryElement", workspace_branch)
         self.assertNotIn("observedPromptTextValue", workspace_branch)
         self.assertNotIn("currentTextEntryValue", workspace_branch)
+
+    def test_workspace_prompt_requests_focus_after_attachment(self) -> None:
+        """The workspace name prompt owns focus like Android's `EditText` dialog.
+
+        Android calls `requestFocus()` and shows the soft input when creating, renaming, or cloning a
+        workspace. The iOS prompt must keep that behavior in product code so tests do not focus the
+        field by tapping an approximate screen coordinate that can dismiss the dialog.
+        """
+        source = (
+            REPO_ROOT
+            / "Sources"
+            / "BibleUI"
+            / "Sources"
+            / "BibleUI"
+            / "Workspace"
+            / "WorkspaceSelectorView.swift"
+        ).read_text()
+        prompt_start = source.index("private struct WorkspaceNamePromptView")
+        prompt_source = source[prompt_start:]
+
+        self.assertIn(".focused($isNameFieldFocused)", prompt_source)
+        self.assertIn(".onAppear", prompt_source)
+        self.assertIn("requestNameFieldFocus()", prompt_source)
+        self.assertIn(".task(id: prompt.id)", prompt_source)
+        self.assertIn("await Task.yield()", prompt_source)
 
     def test_workspace_prompt_is_selector_owned_instead_of_nested_sheet(self) -> None:
         """The create/rename/clone prompt is owned by the selector, matching Android dialog scope.


### PR DESCRIPTION
Summary
- Fixes the workspace selector create-flow CI failure that remained after PR #262 merged.
- Moves workspace prompt focus ownership into the product prompt, matching Android dialog behavior, instead of relying on a UI-test coordinate tap.

Scope
- Workspace name prompt autofocus behavior.
- UI test prompt typing helper for the workspace prompt path.
- Workspace prompt contract guardrail tests.

Contract references
- Android workspace dialogs focus the name EditText and show the soft input when creating or renaming workspaces.
- PR #262 merged the issue #248 parity work before this CI correction could attach to that PR.

Change details
- WorkspaceNamePromptView requests focus on appear and again after overlay attachment.
- Workspace prompt UI tests type through the resolved Name text field and verify the prompt submit button, avoiding hard-coded screen coordinates and transient field value reads.
- Guardrails now prevent reintroducing the coordinate-based focus path and assert the prompt focus contract.

Validation evidence
- python3 scripts/test_workspace_prompt_ui_contract.py
- git diff --cached --check
- npx gitnexus detect-changes --repo and-bible-ios-issue-248 --scope staged
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination platform=iOS Simulator,name=iPhone 16,OS=18.6 -only-testing:AndBibleUITests/AndBibleUITests/testWorkspaceSelectorCreateAndSwitchFlow -only-testing:AndBibleUITests/AndBibleUITests/testLabelManagerCreateRenameDeleteFlow

Risks/follow-ups
- Low risk: changes are limited to the workspace prompt focus contract and its UI test helper path.
- Follow-up parity question remains outside this fix: iOS create workspace starts with an empty field while Android preselects a suggested Workspace N name.

Issue closure reference
- Closes: none. Issue #248 is already closed by merged PR #262; this is a CI/root-cause follow-up for that merged work.
- Refs #248
- Refs #262