### PR TITLE
refactor(reader): extract annotation bridge coordination

### DIFF
--- a/AndBibleTests/AndBibleTests+Bookmarks.swift
+++ b/AndBibleTests/AndBibleTests+Bookmarks.swift
@@ -248,6 +248,49 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies native reader label assignment refreshes generic bookmarks as well as Bible
+     bookmarks.
+
+     Android's bookmark bridge event model emits both Bible and generic bookmark payloads through
+     the same `add_or_update_bookmarks` event. iOS label assignment supports `GenericBookmark`
+     records too, so the reader refresh path must not silently drop generic bookmark updates after
+     the native label editor dismisses.
+
+     Failure meaning:
+     - the reader label-assignment refresh path only supports Bible bookmarks and leaves generic
+       bookmark rows stale in Vue after native label edits.
+     */
+    @MainActor
+    func testReaderBookmarkBridgeRefreshEmitsGenericBookmarkPayload() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkStore = BookmarkStore(modelContext: modelContext)
+        let bookmarkService = BookmarkService(store: bookmarkStore)
+        let controller = BibleReaderController(bridge: bridge)
+        controller.bookmarkService = bookmarkService
+
+        let bookmark = bookmarkService.addGenericBookmark(
+            bookInitials: "MHC",
+            key: "Gen.1.1",
+            startOrdinal: 1,
+            endOrdinal: 1
+        )
+        bookmarkService.saveBibleBookmarkNote(bookmarkId: bookmark.id, note: "Generic note")
+
+        controller.refreshBookmarkInVueJS(bookmarkId: bookmark.id)
+
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: recordedScripts(), event: "add_or_update_bookmarks") as? [[String: Any]]
+        )
+        let bookmarkObject = try XCTUnwrap(payload.first)
+        XCTAssertEqual(bookmarkObject["type"] as? String, "generic-bookmark")
+        XCTAssertEqual(bookmarkObject["bookInitials"] as? String, "MHC")
+        XCTAssertEqual(bookmarkObject["key"] as? String, "Gen.1.1")
+        XCTAssertEqual(bookmarkObject["notes"] as? String, "Generic note")
+    }
+
+    /**
      Verifies bookmark bridge payloads derive range fields from the same ordinal-backed
      JSword-style verse range Android serializes through `ClientBibleBookmark`.
      *

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
@@ -1,0 +1,388 @@
+import Foundation
+import BibleCore
+import BibleView
+
+/**
+ Owns bookmark and StudyPad bridge event application for one reader pane.
+
+ `BibleReaderBookmarkActionCoordinator` and `BibleReaderStudyPadActionCoordinator` own the
+ Android-aligned persistence rules. This coordinator owns the remaining bridge boundary: creating
+ those action coordinators, applying their native state effects, and emitting the shared BibleView
+ event names/payload shapes. Keeping that boundary outside `BibleReaderController` prevents the
+ controller from mixing bookmark persistence, StudyPad ordering, workspace cursor persistence, and
+ JavaScript event emission.
+
+ Inputs:
+ - bridge callbacks and payload strings from the shared BibleView runtime
+ - controller state closures for mutation revisions, workspace settings, recent labels, labels,
+   config, and state persistence
+ - bookmark persistence through `BookmarkService`
+ - annotation payload projection through `BibleReaderAnnotationPayloadFactory`
+
+ Outputs:
+ - JavaScript bridge events consumed by Vue/BibleView
+ - controller-owned revision and workspace mutations applied through closures
+
+ Side effects:
+ - mutates bookmark and StudyPad persistence through the composed action coordinators
+ - mutates controller-owned revision counters and workspace settings through injected closures
+ - emits bridge events and optional label/config refresh events
+
+ Failure modes:
+ - returns `false` for note persistence when no bookmark service exists or a stale identifier
+   produces no native/bridge effect
+ - stale or malformed action inputs are delegated to the action coordinators, which return
+   no-change results instead of throwing
+ */
+struct BibleReaderAnnotationBridgeCoordinator {
+    /// Active bridge instance for the pane callback being handled.
+    private let bridge: BibleBridge
+    /// Persistence facade for bookmark and StudyPad mutations.
+    private let bookmarkService: BookmarkService
+    /// Payload projector shared with document rendering.
+    private let payloadFactory: BibleReaderAnnotationPayloadFactory
+    /// Current reader book name used by bookmark creation.
+    private let currentBook: String
+    /// Active notes content type supplier for note and StudyPad journal creation.
+    private let currentNotesContentType: () -> String
+    /// Current workspace settings supplier for auto-label and cursor mutations.
+    private let workspaceSettings: () -> WorkspaceSettings?
+    /// Applies updated workspace settings back to the active workspace.
+    private let setWorkspaceSettings: (WorkspaceSettings) -> Void
+    /// Persists reader/window state after workspace-affecting bridge actions.
+    private let persistState: () -> Void
+    /// Advances My Notes mutation revision for UI-test exports and document refresh tracking.
+    private let incrementMyNotesRevision: () -> Void
+    /// Advances StudyPad mutation revision for UI-test exports and document refresh tracking.
+    private let incrementStudyPadRevision: () -> Void
+    /// Tracks recently used labels in the app settings model.
+    private let trackRecentLabel: (String) -> Void
+    /// Emits the latest label list to Vue.
+    private let sendLabels: () -> Void
+    /// Builds the current config payload to refresh Vue app settings.
+    private let buildConfigJSON: () -> String
+
+    /**
+     Creates an annotation bridge coordinator for one controller callback.
+
+     - Parameters:
+       - bridge: Active BibleView bridge for event emission.
+       - bookmarkService: Bookmark persistence facade.
+       - payloadFactory: Projection factory for typed bridge DTOs.
+       - currentBook: Current book name for new Bible bookmark rows.
+       - currentNotesContentType: Closure returning the active notes content type.
+       - workspaceSettings: Closure returning the active workspace settings.
+       - setWorkspaceSettings: Closure applying updated workspace settings.
+       - persistState: Closure persisting reader/window state.
+       - incrementMyNotesRevision: Closure advancing My Notes mutation revision.
+       - incrementStudyPadRevision: Closure advancing StudyPad mutation revision.
+       - trackRecentLabel: Closure recording recent label usage.
+       - sendLabels: Closure emitting current labels to Vue.
+       - buildConfigJSON: Closure building the current `set_config` payload.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        bridge: BibleBridge,
+        bookmarkService: BookmarkService,
+        payloadFactory: BibleReaderAnnotationPayloadFactory,
+        currentBook: String,
+        currentNotesContentType: @escaping () -> String,
+        workspaceSettings: @escaping () -> WorkspaceSettings?,
+        setWorkspaceSettings: @escaping (WorkspaceSettings) -> Void,
+        persistState: @escaping () -> Void,
+        incrementMyNotesRevision: @escaping () -> Void,
+        incrementStudyPadRevision: @escaping () -> Void,
+        trackRecentLabel: @escaping (String) -> Void,
+        sendLabels: @escaping () -> Void,
+        buildConfigJSON: @escaping () -> String
+    ) {
+        self.bridge = bridge
+        self.bookmarkService = bookmarkService
+        self.payloadFactory = payloadFactory
+        self.currentBook = currentBook
+        self.currentNotesContentType = currentNotesContentType
+        self.workspaceSettings = workspaceSettings
+        self.setWorkspaceSettings = setWorkspaceSettings
+        self.persistState = persistState
+        self.incrementMyNotesRevision = incrementMyNotesRevision
+        self.incrementStudyPadRevision = incrementStudyPadRevision
+        self.trackRecentLabel = trackRecentLabel
+        self.sendLabels = sendLabels
+        self.buildConfigJSON = buildConfigJSON
+    }
+
+    /**
+     Creates or updates a Bible bookmark and applies all bridge/state effects.
+     */
+    func addOrUpdateBibleBookmark(
+        bookInitials: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool,
+        wholeVerse: Bool,
+        startOffset: Int? = nil,
+        endOffset: Int? = nil
+    ) {
+        apply(
+            bookmarkCoordinator.addOrUpdateBibleBookmark(
+                bookInitials: bookInitials,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal,
+                addNote: addNote,
+                wholeVerse: wholeVerse,
+                startOffset: startOffset,
+                endOffset: endOffset,
+                workspaceSettings: workspaceSettings()
+            )
+        )
+    }
+
+    /**
+     Creates a generic bookmark and applies all bridge/state effects.
+     */
+    func addGenericBookmark(
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool
+    ) {
+        apply(
+            bookmarkCoordinator.addGenericBookmark(
+                bookInitials: bookInitials,
+                osisRef: osisRef,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal,
+                addNote: addNote,
+                workspaceSettings: workspaceSettings()
+            )
+        )
+    }
+
+    /// Creates a Bible paragraph-break bookmark and emits the resulting update.
+    func addParagraphBreakBibleBookmark(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        apply(
+            bookmarkCoordinator.addParagraphBreakBibleBookmark(
+                bookInitials: bookInitials,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal
+            )
+        )
+    }
+
+    /// Creates a generic paragraph-break bookmark and emits the resulting update.
+    func addGenericParagraphBreakBookmark(
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) {
+        apply(
+            bookmarkCoordinator.addGenericParagraphBreakBookmark(
+                bookInitials: bookInitials,
+                osisRef: osisRef,
+                startOrdinal: startOrdinal,
+                endOrdinal: endOrdinal
+            )
+        )
+    }
+
+    /// Deletes a Bible bookmark and emits Android's delete event.
+    func removeBookmark(_ bookmarkId: String) {
+        apply(bookmarkCoordinator.removeBookmark(bookmarkId))
+    }
+
+    /// Deletes a generic bookmark.
+    func removeGenericBookmark(_ bookmarkId: String) {
+        apply(bookmarkCoordinator.removeGenericBookmark(bookmarkId))
+    }
+
+    /**
+     Saves bookmark note text and emits the resulting note-modified event.
+
+     - Returns: `true` when the action produced a native revision increment or bridge event.
+     */
+    @discardableResult
+    func saveBookmarkNote(bookmarkId: String, note: String?) -> Bool {
+        let result = bookmarkCoordinator.saveBookmarkNote(bookmarkId: bookmarkId, note: note)
+        apply(result)
+        return result.incrementsMyNotesRevision || !result.events.isEmpty
+    }
+
+    /// Refreshes one bookmark payload after native label assignment dismisses.
+    func refreshBookmark(bookmarkId: UUID) {
+        guard let bookmark = bookmarkService.bibleBookmark(id: bookmarkId) else { return }
+        bridge.emit(event: "add_or_update_bookmarks", data: [payloadFactory.bookmarkJSONForStudyPad(bookmark)])
+        sendLabels()
+        emitConfig()
+    }
+
+    /// Toggles one label assignment on a bookmark and emits the resulting update.
+    func toggleBookmarkLabel(bookmarkId: String, labelId: String) {
+        apply(bookmarkCoordinator.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId))
+    }
+
+    /// Removes one label assignment from a bookmark and emits the resulting update.
+    func removeBookmarkLabel(bookmarkId: String, labelId: String) {
+        apply(bookmarkCoordinator.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId))
+    }
+
+    /// Sets the primary label for a bookmark and emits the resulting update.
+    func setPrimaryLabel(bookmarkId: String, labelId: String) {
+        apply(bookmarkCoordinator.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId))
+    }
+
+    /// Updates whole-verse highlighting state for a bookmark and emits the resulting update.
+    func setBookmarkWholeVerse(bookmarkId: String, value: Bool) {
+        apply(bookmarkCoordinator.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value))
+    }
+
+    /// Updates a bookmark custom icon and emits the resulting update.
+    func setBookmarkCustomIcon(bookmarkId: String, value: String?) {
+        apply(bookmarkCoordinator.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value))
+    }
+
+    /// Persists a bookmark edit action and emits the resulting update.
+    func setBookmarkEditAction(bookmarkId: String, value: String) {
+        apply(bookmarkCoordinator.setBookmarkEditAction(bookmarkId: bookmarkId, value: value))
+    }
+
+    /// Creates a StudyPad journal row and emits the resulting reorder/update event sequence.
+    func createNewStudyPadEntry(labelId: String, entryType: String, afterEntryId: String) {
+        apply(
+            studyPadCoordinator.createNewStudyPadEntry(
+                labelId: labelId,
+                entryType: entryType,
+                afterEntryId: afterEntryId
+            )
+        )
+    }
+
+    /// Deletes a StudyPad journal row and emits the resulting delete/reorder events.
+    func deleteStudyPadEntry(_ studyPadId: String) {
+        apply(studyPadCoordinator.deleteStudyPadEntry(studyPadId))
+    }
+
+    /// Updates StudyPad journal row metadata from a shared-client payload.
+    func updateStudyPadTextEntry(data: String) {
+        apply(studyPadCoordinator.updateStudyPadTextEntry(data: data))
+    }
+
+    /// Updates StudyPad journal text and emits the resulting row payload.
+    func updateStudyPadTextEntryText(id: String, text: String) {
+        apply(studyPadCoordinator.updateStudyPadTextEntryText(id: id, text: text))
+    }
+
+    /// Updates StudyPad row ordering from Android/shared-client payload keys.
+    func updateOrderNumber(labelId: String, data: String) {
+        apply(studyPadCoordinator.updateOrderNumber(labelId: labelId, data: data))
+    }
+
+    /// Updates one Bible bookmark-to-label relation from a StudyPad payload.
+    func updateBookmarkToLabel(data: String) {
+        apply(studyPadCoordinator.updateBookmarkToLabel(data: data))
+    }
+
+    /// Updates one generic bookmark-to-label relation from a StudyPad payload.
+    func updateGenericBookmarkToLabel(data: String) {
+        apply(studyPadCoordinator.updateGenericBookmarkToLabel(data: data))
+    }
+
+    /**
+     Persists the current StudyPad insertion cursor and re-emits config for Vue.
+     */
+    func setStudyPadCursor(labelId: String, orderNumber: Int) {
+        guard let uuid = UUID(uuidString: labelId) else { return }
+        var settings = workspaceSettings() ?? WorkspaceSettings()
+        settings.studyPadCursors[uuid] = orderNumber
+        settings.normalizeAutoAssignPrimaryLabel()
+        setWorkspaceSettings(settings)
+        persistState()
+        emitConfig()
+    }
+
+    private var bookmarkCoordinator: BibleReaderBookmarkActionCoordinator {
+        BibleReaderBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: payloadFactory,
+            currentBook: currentBook,
+            currentNotesContentType: currentNotesContentType
+        )
+    }
+
+    private var studyPadCoordinator: BibleReaderStudyPadActionCoordinator {
+        BibleReaderStudyPadActionCoordinator(
+            bookmarkService: bookmarkService,
+            payloadFactory: payloadFactory,
+            currentNotesContentType: currentNotesContentType
+        )
+    }
+
+    private func apply(_ result: BibleReaderBookmarkActionResult) {
+        if result.incrementsMyNotesRevision {
+            incrementMyNotesRevision()
+        }
+        if var updatedWorkspaceSettings = result.updatedWorkspaceSettings {
+            updatedWorkspaceSettings.normalizeAutoAssignPrimaryLabel()
+            setWorkspaceSettings(updatedWorkspaceSettings)
+        }
+        if result.requiresPersistState {
+            persistState()
+        }
+        if let recentLabelId = result.recentLabelId {
+            trackRecentLabel(recentLabelId)
+        }
+        for event in result.events {
+            emit(event)
+        }
+        if result.refreshesLabels {
+            sendLabels()
+        }
+        if result.refreshesConfig {
+            emitConfig()
+        }
+    }
+
+    private func emit(_ event: BibleReaderBookmarkActionEvent) {
+        switch event {
+        case .bookmarksUpdated(let payloads):
+            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
+        case .genericBookmarksUpdated(let payloads):
+            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
+        case .bookmarksDeleted(let ids):
+            bridge.emitEncoded(event: "delete_bookmarks", data: ids)
+        case .bookmarkClicked(let id, let openLabels, let openNotes):
+            bridge.emit(
+                event: "bookmark_clicked",
+                data: "\"\(id)\", {\"openLabels\":\(openLabels),\"openNotes\":\(openNotes)}"
+            )
+        case .bookmarkNoteModified(let payload):
+            bridge.emit(event: "bookmark_note_modified", data: payload)
+        }
+    }
+
+    private func apply(_ result: BibleReaderStudyPadActionResult) {
+        if result.incrementsStudyPadRevision {
+            incrementStudyPadRevision()
+        }
+        for event in result.events {
+            emit(event)
+        }
+    }
+
+    private func emit(_ event: BibleReaderStudyPadActionEvent) {
+        switch event {
+        case .studyPadUpdated(let payload):
+            bridge.emit(event: "add_or_update_study_pad", data: payload)
+        case .studyPadTextEntryDeleted(let id):
+            bridge.emitEncoded(event: "delete_study_pad_text_entry", data: id.uuidString)
+        case .bookmarkToLabelUpdated(let payload):
+            bridge.emit(event: "add_or_update_bookmark_to_label", data: payload)
+        }
+    }
+
+    private func emitConfig() {
+        bridge.emit(event: "set_config", data: buildConfigJSON())
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
@@ -212,8 +212,13 @@ struct BibleReaderAnnotationBridgeCoordinator {
 
     /// Refreshes one bookmark payload after native label assignment dismisses.
     func refreshBookmark(bookmarkId: UUID) {
-        guard let bookmark = bookmarkService.bibleBookmark(id: bookmarkId) else { return }
-        bridge.emit(event: "add_or_update_bookmarks", data: [payloadFactory.bookmarkJSONForStudyPad(bookmark)])
+        if let bookmark = bookmarkService.bibleBookmark(id: bookmarkId) {
+            bridge.emit(event: "add_or_update_bookmarks", data: [payloadFactory.bookmarkJSONForStudyPad(bookmark)])
+        } else if let bookmark = bookmarkService.genericBookmark(id: bookmarkId) {
+            bridge.emit(event: "add_or_update_bookmarks", data: [payloadFactory.genericBookmarkJSONForStudyPad(bookmark)])
+        } else {
+            return
+        }
         sendLabels()
         emitConfig()
     }
@@ -269,9 +274,16 @@ struct BibleReaderAnnotationBridgeCoordinator {
         apply(studyPadCoordinator.updateStudyPadTextEntry(data: data))
     }
 
-    /// Updates StudyPad journal text and emits the resulting row payload.
-    func updateStudyPadTextEntryText(id: String, text: String) {
-        apply(studyPadCoordinator.updateStudyPadTextEntryText(id: id, text: text))
+    /**
+     Updates StudyPad journal text and emits the resulting row payload.
+
+     - Returns: `true` when the action produced a native revision increment or bridge event.
+     */
+    @discardableResult
+    func updateStudyPadTextEntryText(id: String, text: String) -> Bool {
+        let result = studyPadCoordinator.updateStudyPadTextEntryText(id: id, text: text)
+        apply(result)
+        return result.incrementsStudyPadRevision || !result.events.isEmpty
     }
 
     /// Updates StudyPad row ordering from Android/shared-client payload keys.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2917,22 +2917,18 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         startOffset: Int? = nil,
         endOffset: Int? = nil
     ) {
-        guard let coordinator = bookmarkActionCoordinator() else {
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else {
             logger.warning("addBookmark: bookmarkService is nil")
             return
         }
-        applyBookmarkActionResult(
-            coordinator.addOrUpdateBibleBookmark(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal,
-                addNote: addNote,
-                wholeVerse: wholeVerse,
-                startOffset: startOffset,
-                endOffset: endOffset,
-                workspaceSettings: activeWindow?.workspace?.workspaceSettings
-            ),
-            bridge: bridge
+        coordinator.addOrUpdateBibleBookmark(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote,
+            wholeVerse: wholeVerse,
+            startOffset: startOffset,
+            endOffset: endOffset
         )
     }
 
@@ -2979,46 +2975,36 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, addGenericBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int, addNote: Bool) {
         logger.info("Add generic bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.addGenericBookmark(
-                bookInitials: bookInitials,
-                osisRef: osisRef,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal,
-                addNote: addNote,
-                workspaceSettings: activeWindow?.workspace?.workspaceSettings
-            ),
-            bridge: bridge
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
+        coordinator.addGenericBookmark(
+            bookInitials: bookInitials,
+            osisRef: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote
         )
     }
 
     /// Creates a Bible paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addParagraphBreakBookmark bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
         logger.info("Add paragraph break bookmark: \(bookInitials)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.addParagraphBreakBibleBookmark(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal
-            ),
-            bridge: bridge
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
+        coordinator.addParagraphBreakBibleBookmark(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
         )
     }
 
     /// Creates a generic paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addGenericParagraphBreakBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int) {
         logger.info("Add generic paragraph break bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.addGenericParagraphBreakBookmark(
-                bookInitials: bookInitials,
-                osisRef: osisRef,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal
-            ),
-            bridge: bridge
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
+        coordinator.addGenericParagraphBreakBookmark(
+            bookInitials: bookInitials,
+            osisRef: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
         )
     }
 
@@ -3035,8 +3021,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeBookmark bookmarkId: String) {
         logger.info("Remove bookmark: \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(coordinator.removeBookmark(bookmarkId), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.removeBookmark(bookmarkId)
     }
 
     /**
@@ -3052,8 +3037,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeGenericBookmark bookmarkId: String) {
         logger.info("Remove generic bookmark: \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(coordinator.removeGenericBookmark(bookmarkId), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.removeGenericBookmark(bookmarkId)
     }
 
     /**
@@ -3071,11 +3055,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, saveBookmarkNote bookmarkId: String, note: String?) {
         logger.info("Save bookmark note: \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.saveBookmarkNote(bookmarkId: bookmarkId, note: note),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.saveBookmarkNote(bookmarkId: bookmarkId, note: note)
     }
 
     private func applyUITestMyNotesAppendTextIfNeeded() {
@@ -3164,10 +3144,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     @discardableResult
     private func saveBookmarkNoteAndNotify(bookmarkId: UUID, note: String?) -> Bool {
-        guard let coordinator = bookmarkActionCoordinator() else { return false }
-        let result = coordinator.saveBookmarkNote(bookmarkId: bookmarkId.uuidString, note: note)
-        applyBookmarkActionResult(result, bridge: bridge)
-        return result.incrementsMyNotesRevision || !result.events.isEmpty
+        annotationBridgeCoordinator(bridge: bridge)?.saveBookmarkNote(
+            bookmarkId: bookmarkId.uuidString,
+            note: note
+        ) ?? false
     }
 
     /**
@@ -3189,12 +3169,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Refresh bookmark data in Vue.js after label changes (called after LabelAssignmentView dismisses).
     public func refreshBookmarkInVueJS(bookmarkId: UUID) {
-        guard let service = bookmarkService,
-              let bookmark = service.bibleBookmark(id: bookmarkId) else { return }
-        bridge.emit(event: "add_or_update_bookmarks", data: [buildBookmarkJSON(bookmark)])
-        sendLabelsToVueJS()
-        // Re-send config to update favouriteLabels in Vue.js appSettings
-        bridge.emit(event: "set_config", data: buildConfigJSON())
+        annotationBridgeCoordinator(bridge: bridge)?.refreshBookmark(bookmarkId: bookmarkId)
     }
 
     /**
@@ -3202,11 +3177,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, toggleBookmarkLabel bookmarkId: String, labelId: String) {
         logger.info("Toggle label \(labelId) on bookmark \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
@@ -3214,11 +3185,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, removeBookmarkLabel bookmarkId: String, labelId: String) {
         logger.info("Remove label \(labelId) from bookmark \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
@@ -3226,11 +3193,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setPrimaryLabel bookmarkId: String, labelId: String) {
         logger.info("Set primary label \(labelId) on bookmark \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
@@ -3238,11 +3201,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkWholeVerse bookmarkId: String, value: Bool) {
         logger.info("Set whole verse \(value) for bookmark \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value)
     }
 
     /**
@@ -3250,11 +3209,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkCustomIcon bookmarkId: String, value: String?) {
         logger.info("Set custom icon for bookmark \(bookmarkId)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value)
     }
 
     // MARK: - BibleBridgeDelegate — StudyPad
@@ -3275,14 +3230,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, createNewStudyPadEntry labelId: String, entryType: String, afterEntryId: String) {
         logger.info("Create StudyPad entry type=\(entryType) after \(afterEntryId) in label \(labelId)")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(
-            coordinator.createNewStudyPadEntry(
-                labelId: labelId,
-                entryType: entryType,
-                afterEntryId: afterEntryId
-            ),
-            bridge: bridge
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
+        coordinator.createNewStudyPadEntry(
+            labelId: labelId,
+            entryType: entryType,
+            afterEntryId: afterEntryId
         )
         applyUITestStudyPadCreatedNoteTextIfNeeded()
     }
@@ -3292,8 +3244,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, deleteStudyPadEntry studyPadId: String) {
         logger.info("Delete StudyPad entry: \(studyPadId)")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(coordinator.deleteStudyPadEntry(studyPadId), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.deleteStudyPadEntry(studyPadId)
     }
 
     /**
@@ -3301,8 +3252,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntry data: String) {
         logger.info("Update StudyPad text entry metadata")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(coordinator.updateStudyPadTextEntry(data: data), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.updateStudyPadTextEntry(data: data)
     }
 
     /**
@@ -3310,11 +3260,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntryText id: String, text: String) {
         logger.info("Update StudyPad entry text: \(id)")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(
-            coordinator.updateStudyPadTextEntryText(id: id, text: text),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.updateStudyPadTextEntryText(id: id, text: text)
     }
 
     /**
@@ -3322,11 +3268,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateOrderNumber labelId: String, data: String) {
         logger.info("Update order numbers for label \(labelId)")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(
-            coordinator.updateOrderNumber(labelId: labelId, data: data),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.updateOrderNumber(labelId: labelId, data: data)
     }
 
     /**
@@ -3334,8 +3276,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateBookmarkToLabel data: String) {
         logger.info("Update BibleBookmarkToLabel")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(coordinator.updateBookmarkToLabel(data: data), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.updateBookmarkToLabel(data: data)
     }
 
     /**
@@ -3343,8 +3284,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, updateGenericBookmarkToLabel data: String) {
         logger.info("Update GenericBookmarkToLabel")
-        guard let coordinator = studyPadActionCoordinator() else { return }
-        applyStudyPadActionResult(coordinator.updateGenericBookmarkToLabel(data: data), bridge: bridge)
+        annotationBridgeCoordinator(bridge: bridge)?.updateGenericBookmarkToLabel(data: data)
     }
 
     /**
@@ -3352,11 +3292,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkEditAction bookmarkId: String, value: String) {
         logger.info("Set edit action on bookmark \(bookmarkId): \(value)")
-        guard let coordinator = bookmarkActionCoordinator() else { return }
-        applyBookmarkActionResult(
-            coordinator.setBookmarkEditAction(bookmarkId: bookmarkId, value: value),
-            bridge: bridge
-        )
+        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkEditAction(bookmarkId: bookmarkId, value: value)
     }
 
     /**
@@ -3376,16 +3312,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func bridge(_ bridge: BibleBridge, setStudyPadCursor labelId: String, orderNumber: Int) {
         logger.info("StudyPad cursor: label=\(labelId) order=\(orderNumber)")
-        guard let uuid = UUID(uuidString: labelId) else { return }
-        if let workspace = activeWindow?.workspace {
-            var settings = workspace.workspaceSettings ?? WorkspaceSettings()
-            settings.studyPadCursors[uuid] = orderNumber
-            settings.normalizeAutoAssignPrimaryLabel()
-            workspace.workspaceSettings = settings
-        }
-        onPersistState?()
-        // Re-emit config so Vue.js gets the updated cursor position
-        bridge.emit(event: "set_config", data: buildConfigJSON())
+        annotationBridgeCoordinator(bridge: bridge)?.setStudyPadCursor(labelId: labelId, orderNumber: orderNumber)
     }
 
     // MARK: - BibleBridgeDelegate — Selection
@@ -3579,8 +3506,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        - startOrdinal: Inclusive start ordinal for the selected generic content.
        - endOrdinal: Inclusive end ordinal for the selected generic content.
        - addNote: Whether the bookmark modal should open with note editing active.
-     - Side effects: Inserts a generic bookmark, emits bookmark update events to Vue, may persist
-       workspace settings, and may refresh labels/config through `applyBookmarkActionResult`.
+     - Side effects: Inserts a generic bookmark through the annotation bridge coordinator, emits
+       bookmark update events to Vue, and may persist workspace settings or refresh labels/config.
      - Failure modes: Returns without side effects when bookmark services are unavailable.
      */
     private func addGenericBookmark(
@@ -3590,20 +3517,16 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         endOrdinal: Int,
         addNote: Bool
     ) {
-        guard let coordinator = bookmarkActionCoordinator() else {
+        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else {
             logger.warning("addGenericBookmark: bookmarkService is nil")
             return
         }
-        applyBookmarkActionResult(
-            coordinator.addGenericBookmark(
-                bookInitials: bookInitials,
-                osisRef: osisRef,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal,
-                addNote: addNote,
-                workspaceSettings: activeWindow?.workspace?.workspaceSettings
-            ),
-            bridge: bridge
+        coordinator.addGenericBookmark(
+            bookInitials: bookInitials,
+            osisRef: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote
         )
     }
 
@@ -5673,175 +5596,54 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     }
 
-    // MARK: - Bookmark Event Helpers
+    // MARK: - Annotation Bridge Coordinator
 
     /**
-     Creates the coordinator that owns bookmark bridge action mutation rules.
+     Creates the coordinator that owns bookmark and StudyPad bridge result application.
 
-     - Returns: A coordinator bound to the current bookmark service and reader payload context, or
+     - Parameter bridge: Bridge instance associated with the delegate callback being handled.
+     - Returns: A coordinator bound to the current bookmark service and controller state hooks, or
        `nil` when bookmark persistence is not available.
-     - Side effects: None during construction; returned coordinator methods mutate persistence.
-     - Failure modes: Returns `nil` rather than accepting bookmark actions without persistence.
+     - Side effects: None during construction; returned coordinator methods mutate persistence,
+       controller-owned revision/config state, and bridge events.
+     - Failure modes: Returns `nil` rather than accepting annotation bridge actions without
+       persistence.
      */
-    private func bookmarkActionCoordinator() -> BibleReaderBookmarkActionCoordinator? {
+    private func annotationBridgeCoordinator(bridge: BibleBridge) -> BibleReaderAnnotationBridgeCoordinator? {
         guard let bookmarkService else { return nil }
-        return BibleReaderBookmarkActionCoordinator(
+        return BibleReaderAnnotationBridgeCoordinator(
+            bridge: bridge,
             bookmarkService: bookmarkService,
             payloadFactory: annotationPayloadFactory(),
             currentBook: currentBook,
             currentNotesContentType: { [weak self] in
                 self?.currentNotesContentType() ?? "HTML"
+            },
+            workspaceSettings: { [weak self] in
+                self?.activeWindow?.workspace?.workspaceSettings
+            },
+            setWorkspaceSettings: { [weak self] settings in
+                self?.activeWindow?.workspace?.workspaceSettings = settings
+            },
+            persistState: { [weak self] in
+                self?.onPersistState?()
+            },
+            incrementMyNotesRevision: { [weak self] in
+                self?.myNotesMutationRevision += 1
+            },
+            incrementStudyPadRevision: { [weak self] in
+                self?.studyPadMutationRevision += 1
+            },
+            trackRecentLabel: { [weak self] labelId in
+                self?.trackRecentLabel(labelId)
+            },
+            sendLabels: { [weak self] in
+                self?.sendLabelsToVueJS()
+            },
+            buildConfigJSON: { [weak self] in
+                self?.buildConfigJSON() ?? "{}"
             }
         )
-    }
-
-    /**
-     Applies a coordinated bookmark action result to controller-owned state and the active bridge.
-
-     - Parameters:
-       - result: Mutation result produced by `BibleReaderBookmarkActionCoordinator`.
-       - bridge: Bridge instance associated with the delegate callback being handled.
-     - Side effects: may advance My Notes revision state, update workspace settings, persist state,
-       refresh labels/config, track recent labels, and emit JavaScript events.
-     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
-     */
-    private func applyBookmarkActionResult(
-        _ result: BibleReaderBookmarkActionResult,
-        bridge: BibleBridge
-    ) {
-        if result.incrementsMyNotesRevision {
-            myNotesMutationRevision += 1
-        }
-        if var updatedWorkspaceSettings = result.updatedWorkspaceSettings {
-            updatedWorkspaceSettings.normalizeAutoAssignPrimaryLabel()
-            activeWindow?.workspace?.workspaceSettings = updatedWorkspaceSettings
-        }
-        if result.requiresPersistState {
-            onPersistState?()
-        }
-        if let recentLabelId = result.recentLabelId {
-            trackRecentLabel(recentLabelId)
-        }
-        for event in result.events {
-            emitBookmarkActionEvent(event, bridge: bridge)
-        }
-        if result.refreshesLabels {
-            sendLabelsToVueJS()
-        }
-        if result.refreshesConfig {
-            bridge.emit(event: "set_config", data: buildConfigJSON())
-        }
-    }
-
-    /**
-     Emits one bookmark action event into Vue.js.
-
-     - Parameters:
-       - event: Typed event produced by the bookmark action coordinator.
-       - bridge: Bridge instance associated with the delegate callback being handled.
-     - Side effects: Sends JavaScript to the web client.
-     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
-     */
-    private func emitBookmarkActionEvent(
-        _ event: BibleReaderBookmarkActionEvent,
-        bridge: BibleBridge
-    ) {
-        switch event {
-        case .bookmarksUpdated(let payloads):
-            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
-        case .genericBookmarksUpdated(let payloads):
-            bridge.emit(event: "add_or_update_bookmarks", data: payloads)
-        case .bookmarksDeleted(let ids):
-            bridge.emitEncoded(event: "delete_bookmarks", data: ids)
-        case .bookmarkClicked(let id, let openLabels, let openNotes):
-            bridge.emit(
-                event: "bookmark_clicked",
-                data: "\"\(id)\", {\"openLabels\":\(openLabels),\"openNotes\":\(openNotes)}"
-            )
-        case .bookmarkNoteModified(let payload):
-            bridge.emit(event: "bookmark_note_modified", data: payload)
-        }
-    }
-
-    // MARK: - StudyPad Event Helpers
-
-    /**
-     Creates the coordinator that owns StudyPad bridge action mutation rules.
-
-     - Returns: A coordinator bound to the current bookmark service and reader payload context, or
-       `nil` when bookmark persistence is not available.
-     - Side effects: None during construction; returned coordinator methods mutate persistence.
-     - Failure modes: Returns `nil` rather than accepting StudyPad actions without persistence.
-     */
-    private func studyPadActionCoordinator() -> BibleReaderStudyPadActionCoordinator? {
-        guard let bookmarkService else { return nil }
-        return BibleReaderStudyPadActionCoordinator(
-            bookmarkService: bookmarkService,
-            payloadFactory: annotationPayloadFactory(),
-            currentNotesContentType: { [weak self] in
-                self?.currentNotesContentType() ?? "HTML"
-            }
-        )
-    }
-
-    /// Emit an updated bookmark (Bible or generic) back to Vue.js after label changes.
-    private func emitBookmarkUpdate(bookmarkId: UUID, type: String? = nil) {
-        guard let service = bookmarkService else { return }
-
-        // Try Bible bookmark first (or if type hint says "bible")
-        if type != "generic", let bookmark = service.bibleBookmark(id: bookmarkId) {
-            bridge.emit(event: "add_or_update_bookmarks", data: [buildBookmarkJSON(bookmark)])
-            return
-        }
-
-        // Try generic bookmark
-        if let bookmark = service.genericBookmark(id: bookmarkId) {
-            bridge.emit(event: "add_or_update_bookmarks", data: [buildGenericBookmarkJSONForStudyPad(bookmark)])
-        }
-    }
-
-    /**
-     Applies a coordinated StudyPad action result to controller-owned state and the active bridge.
-
-     - Parameters:
-       - result: Mutation result produced by `BibleReaderStudyPadActionCoordinator`.
-       - bridge: Bridge instance associated with the delegate callback being handled.
-     - Side effects: may advance `studyPadMutationRevision` and emits JavaScript events.
-     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
-     */
-    private func applyStudyPadActionResult(
-        _ result: BibleReaderStudyPadActionResult,
-        bridge: BibleBridge
-    ) {
-        if result.incrementsStudyPadRevision {
-            studyPadMutationRevision += 1
-        }
-        for event in result.events {
-            emitStudyPadActionEvent(event, bridge: bridge)
-        }
-    }
-
-    /**
-     Emits one StudyPad action event into Vue.js.
-
-     - Parameters:
-       - event: Typed event produced by the StudyPad action coordinator.
-       - bridge: Bridge instance associated with the delegate callback being handled.
-     - Side effects: Sends JavaScript to the web client.
-     - Failure modes: Encoding failures inside `BibleBridge.emit` are swallowed by the bridge.
-     */
-    private func emitStudyPadActionEvent(
-        _ event: BibleReaderStudyPadActionEvent,
-        bridge: BibleBridge
-    ) {
-        switch event {
-        case .studyPadUpdated(let payload):
-            bridge.emit(event: "add_or_update_study_pad", data: payload)
-        case .studyPadTextEntryDeleted(let id):
-            bridge.emitEncoded(event: "delete_study_pad_text_entry", data: id.uuidString)
-        case .bookmarkToLabelUpdated(let payload):
-            bridge.emit(event: "add_or_update_bookmark_to_label", data: payload)
-        }
     }
 
     // MARK: - Active Window State

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -3097,6 +3097,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
               !text.isEmpty,
               let service = bookmarkService,
               let labelId = activeStudyPadLabelId,
+              let coordinator = annotationBridgeCoordinator(bridge: bridge),
               let entry = service.studyPadEntries(labelId: labelId).max(by: { lhs, rhs in
                   if lhs.orderNumber != rhs.orderNumber {
                       return lhs.orderNumber < rhs.orderNumber
@@ -3107,19 +3108,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return false
         }
 
-        service.updateStudyPadTextEntryText(id: entry.id, text: text)
-        studyPadMutationRevision += 1
-        let updatedEntry = service.studyPadEntry(id: entry.id) ?? entry
-        bridge.emit(
-            event: "add_or_update_study_pad",
-            data: StudyPadUpdatePayload(
-                studyPadTextEntry: buildStudyPadEntryJSON(updatedEntry),
-                bookmarkToLabelsOrdered: [],
-                genericBookmarkToLabelsOrdered: [],
-                studyPadItemsOrdered: []
-            )
-        )
-        return true
+        return coordinator.updateStudyPadTextEntryText(id: entry.id.uuidString, text: text)
     }
 
     /**


### PR DESCRIPTION
Summary
- Extract bookmark and StudyPad bridge result application from BibleReaderController into BibleReaderAnnotationBridgeCoordinator.
- Keep the existing Android-aligned bookmark and StudyPad action coordinators as the persistence/contract source of truth.
- Adversarial review closed two remaining ownership gaps: generic bookmark refresh and UI-test StudyPad text injection now route through the same coordinator boundary.

Scope
- In scope: bookmark bridge events, generic bookmark events, StudyPad mutation events, note-save bridge emission, cursor persistence/config refresh, label/config refresh application.
- Out of scope: My Notes/StudyPad document loading and restored/transient/special document loading; those remain separate #146 slices.

Contract references
- Refs #146.
- Closes: none. #146 remains open for the remaining controller-responsibility checklist items.
- Android parity: no iOS-only behavior is introduced; Bible/generic bookmark refreshes and StudyPad text updates use the Android-compatible bridge event paths.

Change details
- Added BibleReaderAnnotationBridgeCoordinator to compose BibleReaderBookmarkActionCoordinator and BibleReaderStudyPadActionCoordinator.
- Moved bookmark/StudyPad result application, bridge event emission, My Notes/StudyPad revision increments, workspace settings persistence, recent-label tracking, labels refresh, and config refresh out of BibleReaderController.
- Rewired controller bridge callbacks to delegate through the annotation bridge coordinator.
- Refreshed generic bookmarks through add_or_update_bookmarks after native label assignment so generic rows do not stale out in Vue.
- Routed updateNewestVisibleStudyPadTextEntry through the annotation coordinator instead of direct controller persistence and bridge emission.

Validation evidence
- python3 scripts/check_repo_standards.py docblocks
- git diff --check
- GitNexus impact before edits: BibleReaderController CRITICAL due centrality; applyBookmarkActionResult LOW; applyStudyPadActionResult LOW; refreshBookmark LOW; refreshBookmarkInVueJS LOW; updateNewestVisibleStudyPadTextEntry LOW.
- GitNexus detect_changes reviewed after adversarial fixes: medium across the branch diff, with affected indexed processes limited to bookmark bridge tests; local CLAUDE.md instruction-file noise remains uncommitted.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer python3 -u scripts/run_xcodebuild_with_test_selection.py --project AndBible.xcodeproj --scheme AndBible --configuration Debug --destination 'generic/platform=iOS Simulator' --derived-data-path .derivedData-annotation-bridge --result-bundle-path .artifacts/annotation-bridge-build.xcresult --code-signing-allowed NO --action build-for-testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -xctestrun .derivedData-annotation-bridge/Build/Products/AndBible_iphonesimulator26.5-arm64-x86_64.xctestrun -destination 'id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F' -resultBundlePath .artifacts/annotation-bridge-tests.xcresult selected bookmark and StudyPad tests test-without-building
- Focused test result after adversarial fixes: 16 bookmark and StudyPad bridge tests passed on iPhone 17 / iOS 26.5.

Risks/follow-ups
- Risk is mainly wiring drift in bridge event application; covered by selected bookmark/StudyPad controller and coordinator tests.
- Remaining #146 chunks still need separate PRs: restored/transient/special document loading, reading progress + memorization bridge, book catalog/versification access, and final ownership audit.