### PR TITLE
refactor(reader): extract special document coordination

### DIFF
--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2341,10 +2341,21 @@ extension AndBibleTests {
             pageDocumentInitials: "Multi",
             pageKey: nil
         )
+        let missingInitialsRequest = BibleReaderTransientDocumentRequest(
+            documentJSON: #"{"id":"missing-initials"}"#,
+            renderedBook: "Multi",
+            renderedKey: "multi",
+            renderedCategory: .generalBook,
+            renderedModuleName: "Multi",
+            pageCategory: .generalBook,
+            pageDocumentInitials: nil,
+            pageKey: "KJV:Gen.1.1"
+        )
 
         let validUpdate = coordinator.pageIdentityUpdate(for: validRequest)
         XCTAssertEqual(validUpdate.currentCategory, .generalBook)
         XCTAssertTrue(validUpdate.clearsActiveGeneralBookModule)
+        XCTAssertTrue(validUpdate.assignsActiveGeneralBookModuleName)
         XCTAssertEqual(validUpdate.activeGeneralBookModuleName, "Multi")
         XCTAssertEqual(validUpdate.currentGeneralBookKey, "KJV:Gen.1.1")
         XCTAssertEqual(validUpdate.pageManagerCategoryName, DocumentCategory.generalBook.pageManagerKey)
@@ -2355,9 +2366,18 @@ extension AndBibleTests {
         let malformedUpdate = coordinator.pageIdentityUpdate(for: malformedRequest)
         XCTAssertEqual(malformedUpdate.currentCategory, .generalBook)
         XCTAssertTrue(malformedUpdate.clearsActiveGeneralBookModule)
+        XCTAssertTrue(malformedUpdate.assignsActiveGeneralBookModuleName)
         XCTAssertEqual(malformedUpdate.activeGeneralBookModuleName, "Multi")
         XCTAssertNil(malformedUpdate.currentGeneralBookKey)
         XCTAssertFalse(malformedUpdate.persistsPageManagerState)
+
+        let missingInitialsUpdate = coordinator.pageIdentityUpdate(for: missingInitialsRequest)
+        XCTAssertEqual(missingInitialsUpdate.currentCategory, .generalBook)
+        XCTAssertTrue(missingInitialsUpdate.clearsActiveGeneralBookModule)
+        XCTAssertTrue(missingInitialsUpdate.assignsActiveGeneralBookModuleName)
+        XCTAssertNil(missingInitialsUpdate.activeGeneralBookModuleName)
+        XCTAssertNil(missingInitialsUpdate.currentGeneralBookKey)
+        XCTAssertFalse(missingInitialsUpdate.persistsPageManagerState)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+ReaderNavigation.swift
+++ b/AndBibleTests/AndBibleTests+ReaderNavigation.swift
@@ -2309,6 +2309,58 @@ extension AndBibleTests {
     }
 
     /**
+     Protects the extracted special-document coordinator's Android fake-document identity rule.
+
+     Android renders links-window results as Vue `MultiDocument` content while native page state is
+     persisted as `general_book/Multi` plus a `BookAndKeyList` key. The setup sends both a valid
+     durable `Multi` request and a malformed request without a durable key. The expected result is
+     that valid requests produce a PageManager persistence plan, while malformed requests still move
+     the visible category to general book without erasing the previous restorable key. A failure
+     means the controller could regress into either iOS-only transient state or data-lossy restore
+     semantics.
+     */
+    func testReaderSpecialDocumentCoordinatorBuildsAndroidMultiPageIdentityPlan() {
+        let coordinator = BibleReaderSpecialDocumentCoordinator()
+        let validRequest = BibleReaderTransientDocumentRequest(
+            documentJSON: #"{"id":"valid"}"#,
+            renderedBook: "Multi",
+            renderedKey: "multi",
+            renderedCategory: .generalBook,
+            renderedModuleName: "Multi",
+            pageCategory: .generalBook,
+            pageDocumentInitials: "Multi",
+            pageKey: "KJV:Gen.1.1"
+        )
+        let malformedRequest = BibleReaderTransientDocumentRequest(
+            documentJSON: #"{"id":"bad"}"#,
+            renderedBook: "Multi",
+            renderedKey: "multi",
+            renderedCategory: .generalBook,
+            renderedModuleName: "Multi",
+            pageCategory: .generalBook,
+            pageDocumentInitials: "Multi",
+            pageKey: nil
+        )
+
+        let validUpdate = coordinator.pageIdentityUpdate(for: validRequest)
+        XCTAssertEqual(validUpdate.currentCategory, .generalBook)
+        XCTAssertTrue(validUpdate.clearsActiveGeneralBookModule)
+        XCTAssertEqual(validUpdate.activeGeneralBookModuleName, "Multi")
+        XCTAssertEqual(validUpdate.currentGeneralBookKey, "KJV:Gen.1.1")
+        XCTAssertEqual(validUpdate.pageManagerCategoryName, DocumentCategory.generalBook.pageManagerKey)
+        XCTAssertEqual(validUpdate.pageManagerGeneralBookDocument, "Multi")
+        XCTAssertEqual(validUpdate.pageManagerGeneralBookKey, "KJV:Gen.1.1")
+        XCTAssertTrue(validUpdate.persistsPageManagerState)
+
+        let malformedUpdate = coordinator.pageIdentityUpdate(for: malformedRequest)
+        XCTAssertEqual(malformedUpdate.currentCategory, .generalBook)
+        XCTAssertTrue(malformedUpdate.clearsActiveGeneralBookModule)
+        XCTAssertEqual(malformedUpdate.activeGeneralBookModuleName, "Multi")
+        XCTAssertNil(malformedUpdate.currentGeneralBookKey)
+        XCTAssertFalse(malformedUpdate.persistsPageManagerState)
+    }
+
+    /**
      Protects My Documents active-page identity as a coordinator-owned reader state rule.
 
      Android treats My Documents as generated general-book modules, so iOS must keep the active

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1301,8 +1301,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         if update.clearsActiveGeneralBookModule {
             activeGeneralBookModule = nil
         }
-        if let activeGeneralBookModuleName = update.activeGeneralBookModuleName {
-            self.activeGeneralBookModuleName = activeGeneralBookModuleName
+        if update.assignsActiveGeneralBookModuleName {
+            activeGeneralBookModuleName = update.activeGeneralBookModuleName
         }
         if let currentGeneralBookKey = update.currentGeneralBookKey {
             self.currentGeneralBookKey = currentGeneralBookKey

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -134,31 +134,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     static let emptyRenderedContentState = BibleReaderRenderedContentState.empty.encodedValue
     private static let issueTrackerURLString = "https://github.com/AndBible/and-bible/issues"
     private(set) var renderedContentState: String = BibleReaderController.emptyRenderedContentState
-    /// State machine for pending and active Android-style transient `MultiDocument` pages.
-    private var transientDocumentCoordinator = BibleReaderTransientDocumentCoordinator()
+    /// Coordinator for Android-style transient `MultiDocument` state and fake-document identity.
+    private var specialDocumentCoordinator = BibleReaderSpecialDocumentCoordinator()
     /// Reader-local My Documents active page state and document payload assembly.
     private var myDocumentCoordinator = BibleReaderMyDocumentCoordinator()
 
     /// Reader-local loaded-range state for Vue infinite-scroll prepend/append requests.
     private var infiniteScrollCoordinator = BibleReaderInfiniteScrollCoordinator()
-
-    /**
-     Serialized payload rebuilt from Android's durable `Multi` PageManager key.
-
-     Android restores `FakeBookFactory.multiDocument` by converting the saved `BookAndKeyList` key
-     back into fragments. This structure carries the resulting Vue payload plus the rendered-content
-     key that native chrome should expose after restoration.
-     */
-    private struct RestoredAndroidMultiDocumentRequest {
-        /// Serialized Vue `MultiDocument` payload rebuilt from persisted PageManager state.
-        let documentJSON: String
-
-        /// Rendered-content key token, normally `multi` or `strongs`.
-        let renderedKey: String
-
-        /// Original Android `BookAndKeyList.osisRef` persistence string.
-        let pageKey: String
-    }
 
     /**
      Legacy ordinal fallback used only when no SWORD verse-key module can resolve the reference.
@@ -1072,7 +1054,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Load the appropriate content for the current category.
     public func loadCurrentContent() {
         if isShowingAndroidMultiDocument {
-            if let activeRequest = transientDocumentCoordinator.activeRequest(
+            if let activeRequest = specialDocumentCoordinator.activeRequest(
                 isShowingAndroidMultiDocument: isShowingAndroidMultiDocument
             ) {
                 emitTransientMultiDocument(activeRequest)
@@ -1140,7 +1122,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        installed source documents, or cannot be encoded.
      */
     private func loadRestoredAndroidMultiDocument() -> Bool {
-        guard let restored = buildRestoredAndroidMultiDocument() else { return false }
+        guard let restored = restoredMultiDocumentBuilder().build(pageKey: currentGeneralBookKey) else { return false }
         loadTransientMultiDocument(
             restored.documentJSON,
             renderedBook: AndroidSpecialDocumentIdentity.multiDocumentInitials,
@@ -1155,241 +1137,29 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
-     Reconstructs the Vue `MultiDocument` payload Android derives from a restored `BookAndKeyList`.
+     Builds the restored Android `Multi` payload builder bound to this pane's SWORD/catalog state.
 
-     Each persisted child entry identifies the source document and key that originally contributed a
-     fragment to `FakeBookFactory.multiDocument`. Bible children are rendered from their exact SWORD
-     verse reference; dictionary/glossary children are rendered from the referenced module key.
+     The controller keeps only the orchestration decision of whether a restored fake document should
+     render now. The builder owns Android's `BookAndKeyList` reconstruction rules while these
+     closures preserve the active module versification used elsewhere in the reader.
 
-     - Returns: A restored payload plus rendered-content key, or `nil` when no child can be resolved.
-     - Side effects: Reads SWORD module content and may temporarily move module cursors through
-       `SwordModule` inspection helpers that restore previous cursor state.
-     - Failure modes: Drops individual malformed/unavailable children, matching Android's
-       `mapNotNull` restore behavior; returns `nil` if all children drop or encoding fails.
+     - Returns: A builder configured with the active SWORD manager, active Bible module, and
+       active-versification book metadata.
+     - Side effects: None.
+     - Failure modes: Missing SWORD/module state is deferred to the builder, which returns `nil`
+       when it cannot rebuild a valid document.
      */
-    private func buildRestoredAndroidMultiDocument() -> RestoredAndroidMultiDocumentRequest? {
-        let pageKey = currentGeneralBookKey
-        let references = AndroidSpecialDocumentIdentity.parseBookAndKeyListReference(pageKey)
-        guard !references.isEmpty, let pageKey else { return nil }
-
-        var fragments: [OsisFragment] = []
-        var hasStrongsOrMorphologyContent = false
-        for reference in references {
-            guard let restoredFragment = restoredAndroidMultiDocumentFragment(for: reference) else {
-                continue
+    private func restoredMultiDocumentBuilder() -> BibleReaderRestoredMultiDocumentBuilder {
+        BibleReaderRestoredMultiDocumentBuilder(
+            swordManager: swordManager,
+            activeModule: activeModule,
+            bookNameForOsisId: { [weak self] osisId in
+                self?.bookName(forOsisId: osisId) ?? Self.bookName(forOsisId: osisId)
+            },
+            isNewTestament: { [weak self] bookName in
+                self?.isNewTestament(bookName) ?? Self.isNewTestament(bookName)
             }
-            fragments.append(restoredFragment.fragment)
-            hasStrongsOrMorphologyContent = hasStrongsOrMorphologyContent || restoredFragment.usesStrongsContentType
-        }
-        guard !fragments.isEmpty else { return nil }
-
-        let renderedKey = hasStrongsOrMorphologyContent
-            ? AndroidSpecialDocumentIdentity.strongsRenderedKey
-            : AndroidSpecialDocumentIdentity.multiRenderedKey
-        let payload = MultiFragmentDocumentPayload(
-            id: "multi-\(UUID().uuidString)",
-            type: "multi",
-            osisFragments: fragments,
-            compare: false,
-            contentType: hasStrongsOrMorphologyContent ? "strongs" : nil,
-            state: nil
         )
-        guard let data = try? bridgeEncoder.encode(payload),
-              let documentJSON = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to encode restored Android Multi bridge document")
-            return nil
-        }
-        return RestoredAndroidMultiDocumentRequest(
-            documentJSON: documentJSON,
-            renderedKey: renderedKey,
-            pageKey: pageKey
-        )
-    }
-
-    /**
-     Resolves one restored Android `BookAndKey` child into a Vue fragment.
-
-     - Parameter reference: Parsed source document/key pair from the persisted `Multi` key.
-     - Returns: A fragment and whether it should force Vue's Strong's document mode, or `nil` if the
-       source document/key cannot be resolved.
-     - Side effects: May read SWORD content and move source module cursors through restoring helpers.
-     - Failure modes: Unavailable modules, invalid Bible references, or dictionary lookup misses return
-       `nil`, mirroring Android's restored-child `mapNotNull` behavior.
-     */
-    private func restoredAndroidMultiDocumentFragment(
-        for reference: AndroidSpecialDocumentIdentity.BookAndKeyReference
-    ) -> (fragment: OsisFragment, usesStrongsContentType: Bool)? {
-        let sourceModule: SwordModule?
-        if let documentInitials = reference.documentInitials {
-            sourceModule = swordManager?.module(named: documentInitials)
-        } else {
-            sourceModule = activeModule
-        }
-
-        if sourceModule?.info.category == .bible,
-           let osisReference = parseOsisRef(reference.key) {
-            return restoredBibleMultiDocumentFragment(
-                for: osisReference,
-                sourceModule: sourceModule,
-                sourceDocumentInitials: reference.documentInitials
-            ).map { ($0, false) }
-        }
-
-        guard let sourceModule else { return nil }
-        switch sourceModule.info.category {
-        case .dictionary, .glossary:
-            return restoredDictionaryMultiDocumentFragment(
-                for: reference.key,
-                sourceModule: sourceModule
-            )
-        default:
-            return nil
-        }
-    }
-
-    /**
-     Builds one restored Bible fragment for Android `Multi` document restore.
-
-     - Parameters:
-       - ref: Parsed OSIS verse reference from the saved child key.
-       - sourceModule: SWORD Bible module that owns the child key.
-       - sourceDocumentInitials: Persisted source initials. `nil` means Android's `null:` current-Bible
-         marker, so the active Bible module is used.
-     - Returns: A Vue OSIS fragment, or `nil` if the source Bible cannot resolve the verse.
-     - Side effects: Reads the SWORD verse and restores the source module cursor afterward.
-     - Failure modes: Missing source module or missing verse ordinal returns `nil`.
-     */
-    private func restoredBibleMultiDocumentFragment(
-        for ref: OsisRef,
-        sourceModule: SwordModule?,
-        sourceDocumentInitials: String?
-    ) -> OsisFragment? {
-        guard let sourceModule else { return nil }
-        let moduleName = sourceDocumentInitials ?? sourceModule.info.name
-        guard let ordinal = sourceModule.verseOrdinal(
-            osisBookId: ref.osisId,
-            chapter: ref.chapter,
-            verse: ref.verse
-        ) else {
-            return nil
-        }
-        let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
-        return OsisFragment(
-            xml: buildBibleMultiReferenceXML(ref: ref, module: sourceModule, ordinal: ordinal),
-            key: "\(moduleName)--\(osisRef)",
-            keyName: ref.displayName,
-            v11n: "KJVA",
-            bookCategory: DocumentCategory.bible.rawValue,
-            bookInitials: moduleName,
-            bookAbbreviation: ref.osisId,
-            osisRef: osisRef,
-            isNewTestament: isNewTestament(ref.book),
-            features: OsisFeatures(),
-            hasStrongs: sourceModule.info.features.contains(.strongsNumbers),
-            ordinalRange: [ordinal, ordinal],
-            language: sourceModule.info.language.isEmpty ? "en" : sourceModule.info.language,
-            direction: sourceModule.info.isRightToLeft ? "rtl" : "ltr"
-        )
-    }
-
-    /**
-     Builds one restored dictionary/glossary fragment for Android `Multi` document restore.
-
-     - Parameters:
-       - key: Persisted child key for the source dictionary or glossary module.
-       - sourceModule: Installed source module that owns the key.
-     - Returns: A Vue fragment plus whether the aggregate document should use Strong's mode.
-     - Side effects: Reads the source module and restores its cursor through `lookupInModule`.
-     - Failure modes: Returns `nil` when the source module cannot resolve the key exactly enough to
-       satisfy the dictionary lookup contract.
-     */
-    private func restoredDictionaryMultiDocumentFragment(
-        for key: String,
-        sourceModule: SwordModule
-    ) -> (fragment: OsisFragment, usesStrongsContentType: Bool)? {
-        let keyOptions = restoredDictionaryLookupKeys(for: key, sourceModule: sourceModule)
-        guard let lookup = lookupInModule(sourceModule, keyOptions: keyOptions) else {
-            return nil
-        }
-        let isStrongsDefinition = sourceModule.info.features.contains(.hebrewDef)
-            || sourceModule.info.features.contains(.greekDef)
-        let isMorphologyDefinition = sourceModule.info.features.contains(.hebrewParse)
-            || sourceModule.info.features.contains(.greekParse)
-        let keyName = isStrongsDefinition
-            ? BibleReaderStrongsDocumentBuilder.canonicalStrongsKeyName(
-                requested: key,
-                actualKey: lookup.actualKey,
-                rawEntry: lookup.rawEntry
-            )
-            : lookup.actualKey
-        let features = restoredDictionaryFeatures(for: sourceModule, keyName: keyName)
-        let xml = BibleReaderStrongsDocumentBuilder.buildDictionaryEntryXML(
-            rawEntry: lookup.rawEntry,
-            renderedText: lookup.renderedText,
-            fallbackTitle: keyName,
-            strongsLinkPrefix: BibleReaderStrongsDocumentBuilder.strongsLinkPrefix(forModuleName: sourceModule.info.name)
-                ?? BibleReaderStrongsDocumentBuilder.strongsLinkPrefix(for: key)
-        )
-        let fragment = OsisFragment(
-            xml: xml,
-            key: "\(sourceModule.info.name)--\(keyName)",
-            keyName: keyName,
-            v11n: "KJVA",
-            bookCategory: DocumentCategory.dictionary.rawValue,
-            bookInitials: sourceModule.info.name,
-            bookAbbreviation: BibleReaderStrongsDocumentBuilder.moduleDisplayLabel(sourceModule),
-            osisRef: keyName,
-            isNewTestament: false,
-            features: features,
-            hasStrongs: features.type != nil,
-            ordinalRange: [0, 0],
-            language: sourceModule.info.language.isEmpty ? "en" : sourceModule.info.language,
-            direction: sourceModule.info.isRightToLeft ? "rtl" : "ltr"
-        )
-        return (fragment, isStrongsDefinition || isMorphologyDefinition)
-    }
-
-    /**
-     Chooses lookup keys for a restored dictionary child.
-
-     Strong's modules need the same key-family expansion used by live Strong's links because persisted
-     Android keys may be numeric while local modules expect prefixed or zero-stripped variants. Plain
-     dictionaries use the persisted key directly, matching Android's `book.getKey(savedKey)` restore.
-
-     - Parameters:
-       - key: Persisted child key from Android's `BookAndKeyList.osisRef`.
-       - sourceModule: Dictionary or glossary module that owns the key.
-     - Returns: Ordered lookup candidates to try against `sourceModule`.
-     - Side effects: None.
-     - Failure modes: None; lookup failure is handled by the caller.
-     */
-    private func restoredDictionaryLookupKeys(for key: String, sourceModule: SwordModule) -> [String] {
-        if sourceModule.info.features.contains(.hebrewDef)
-            || sourceModule.info.features.contains(.greekDef) {
-            return BibleReaderStrongsDocumentBuilder.strongsLookupKeyOptions(for: key)
-        }
-        return [key]
-    }
-
-    /**
-     Maps restored dictionary module features into Vue `OsisFeatures`.
-
-     - Parameters:
-       - sourceModule: Dictionary/glossary module that produced the fragment.
-       - keyName: Canonical key name resolved from the source module.
-     - Returns: Feature metadata for Strong's dictionaries, or an empty feature set for plain
-       dictionaries and morphology modules.
-     - Side effects: None.
-     - Failure modes: None.
-     */
-    private func restoredDictionaryFeatures(for sourceModule: SwordModule, keyName: String) -> OsisFeatures {
-        if sourceModule.info.features.contains(.hebrewDef) {
-            return OsisFeatures(type: "hebrew", keyName: keyName)
-        }
-        if sourceModule.info.features.contains(.greekDef) {
-            return OsisFeatures(type: "greek", keyName: keyName)
-        }
-        return OsisFeatures()
     }
 
     /**
@@ -1467,7 +1237,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             pageDocumentInitials: pageDocumentInitials,
             pageKey: pageKey
         )
-        transientDocumentCoordinator.store(request, clientReady: clientReady)
+        specialDocumentCoordinator.store(request, clientReady: clientReady)
         emitTransientMultiDocument(request)
     }
 
@@ -1513,10 +1283,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
      Android link-result windows do not stay on the source Bible category when they display aggregate
      result content. For `FakeBookFactory.multiDocument`, the destination window becomes a
-     `GENERAL_BOOK` page with document initials `Multi` and a `BookAndKeyList` key. This method keeps
-     the controller's category, the PageManager fields, and same-session reload state aligned with
-     that Android model while preserving the old Bible identity for transient documents that do not
-     declare a durable fake-document page.
+     `GENERAL_BOOK` page with document initials `Multi` and a `BookAndKeyList` key. The special
+     document coordinator owns that mapping; this method applies its transition plan to controller
+     and PageManager state.
 
      - Parameter request: Transient document request carrying optional durable PageManager fields.
      - Side effects: Mutates `currentCategory`, category-specific controller fields, active
@@ -1527,31 +1296,28 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        payloads cannot erase the last restorable Android `Multi` key.
      */
     private func applyTransientPageIdentity(_ request: BibleReaderTransientDocumentRequest) {
-        guard let pageCategory = request.pageCategory else {
-            currentCategory = .bible
-            return
-        }
-
-        currentCategory = pageCategory
-        if pageCategory == .generalBook {
+        let update = specialDocumentCoordinator.pageIdentityUpdate(for: request)
+        currentCategory = update.currentCategory
+        if update.clearsActiveGeneralBookModule {
             activeGeneralBookModule = nil
-            activeGeneralBookModuleName = request.pageDocumentInitials
-            guard let pageDocumentInitials = request.pageDocumentInitials, !pageDocumentInitials.isEmpty,
-                  let pageKey = request.pageKey, !pageKey.isEmpty else {
-                return
-            }
-            currentGeneralBookKey = pageKey
-
-            guard let pm = activeWindow?.pageManager else { return }
-            pm.currentCategoryName = pageCategory.pageManagerKey
-            pm.generalBookDocument = pageDocumentInitials
-            pm.generalBookKey = pageKey
-            onPersistState?()
-            return
         }
-
-        guard let pm = activeWindow?.pageManager else { return }
-        pm.currentCategoryName = pageCategory.pageManagerKey
+        if let activeGeneralBookModuleName = update.activeGeneralBookModuleName {
+            self.activeGeneralBookModuleName = activeGeneralBookModuleName
+        }
+        if let currentGeneralBookKey = update.currentGeneralBookKey {
+            self.currentGeneralBookKey = currentGeneralBookKey
+        }
+        guard update.persistsPageManagerState,
+              let pm = activeWindow?.pageManager else { return }
+        if let pageManagerCategoryName = update.pageManagerCategoryName {
+            pm.currentCategoryName = pageManagerCategoryName
+        }
+        if let pageManagerGeneralBookDocument = update.pageManagerGeneralBookDocument {
+            pm.generalBookDocument = pageManagerGeneralBookDocument
+        }
+        if let pageManagerGeneralBookKey = update.pageManagerGeneralBookKey {
+            pm.generalBookKey = pageManagerGeneralBookKey
+        }
         onPersistState?()
     }
 
@@ -2431,7 +2197,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      accessibility/export state aligned.
      */
     private func reloadVisibleDocumentAfterClientReady() {
-        if let pendingClientReadyRequest = transientDocumentCoordinator.consumePendingClientReadyRequest() {
+        if let pendingClientReadyRequest = specialDocumentCoordinator.consumePendingClientReadyRequest() {
             emitTransientMultiDocument(pendingClientReadyRequest)
             return
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderRestoredMultiDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderRestoredMultiDocumentBuilder.swift
@@ -1,0 +1,351 @@
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+import os.log
+
+private let restoredMultiDocumentBuilderLogger = Logger(
+    subsystem: "org.andbible",
+    category: "BibleReaderRestoredMultiDocumentBuilder"
+)
+
+/**
+ Serialized payload rebuilt from Android's durable `Multi` PageManager key.
+
+ Android restores `FakeBookFactory.multiDocument` by converting the saved `BookAndKeyList` key
+ back into source document/key fragments. This value carries the resulting Vue payload plus the
+ rendered-content key that native chrome should expose after restoration.
+
+ - Side effects: None; this is an immutable value returned by
+   `BibleReaderRestoredMultiDocumentBuilder`.
+ - Failure modes: Invalid or unavailable persisted children are filtered before this value is
+   created, so callers only receive complete bridge payloads.
+ */
+struct BibleReaderRestoredMultiDocumentRequest {
+    /// Serialized Vue `MultiDocument` payload rebuilt from persisted PageManager state.
+    let documentJSON: String
+
+    /// Rendered-content key token, normally `multi` or `strongs`.
+    let renderedKey: String
+
+    /// Original Android `BookAndKeyList.osisRef` persistence string.
+    let pageKey: String
+}
+
+/**
+ Rebuilds Android-style restored `Multi` documents from durable PageManager identity.
+
+ Android does not persist rendered links-window HTML directly. It persists a fake
+ `general_book/Multi` document whose key is a `BookAndKeyList` string, then reconstructs a
+ `MultiFragmentDocument` from the referenced source documents after restore. This builder owns the
+ iOS equivalent so `BibleReaderController` no longer needs to know how Bible, dictionary, Strong's,
+ and morphology children are rehydrated into Vue fragments.
+
+ - Side effects: Reads SWORD module content and may temporarily move module cursors through
+   `SwordModule` inspection helpers that restore previous cursor state.
+ - Failure modes: Returns `nil` when the persisted key is absent, malformed, references no
+   installed source documents, or cannot be encoded. Individual bad children are dropped, matching
+   Android's restored-child filtering behavior.
+ - Note: The builder is deterministic for a fixed installed-module set and persisted key except for
+   the generated `MultiDocument` id, which intentionally mirrors the transient document payloads.
+ */
+struct BibleReaderRestoredMultiDocumentBuilder {
+    /// Resolves source modules named in Android `BookAndKey` children.
+    private let swordManager: SwordManager?
+
+    /// Active Bible module used for Android `null:` current-Bible children.
+    private let activeModule: SwordModule?
+
+    /// Active-versification-aware OSIS id to display-name lookup supplied by the controller.
+    private let bookNameForOsisId: (String) -> String?
+
+    /// Active-versification-aware testament classifier supplied by the controller.
+    private let isNewTestament: (String) -> Bool
+
+    /**
+     Creates a restored-document builder for one reader pane.
+
+     - Parameters:
+       - swordManager: SWORD manager containing installed source modules.
+       - activeModule: Active Bible module used by Android `null:` current-Bible references.
+       - bookNameForOsisId: Closure that maps OSIS ids through the pane's active versification.
+       - isNewTestament: Closure that classifies display book names through the same catalog.
+     - Side effects: None during construction.
+     - Failure modes: Missing SWORD state is handled by returning `nil` from `build(pageKey:)`.
+     */
+    init(
+        swordManager: SwordManager?,
+        activeModule: SwordModule?,
+        bookNameForOsisId: @escaping (String) -> String?,
+        isNewTestament: @escaping (String) -> Bool
+    ) {
+        self.swordManager = swordManager
+        self.activeModule = activeModule
+        self.bookNameForOsisId = bookNameForOsisId
+        self.isNewTestament = isNewTestament
+    }
+
+    /**
+     Reconstructs the Vue `MultiDocument` payload Android derives from a restored `BookAndKeyList`.
+
+     - Parameter pageKey: Persisted Android `BookAndKeyList.osisRef` value from `PageManager`.
+     - Returns: A restored payload plus rendered-content key, or `nil` when no child can be
+       resolved.
+     - Side effects: Reads SWORD module content and may temporarily move module cursors through
+       restoring helpers.
+     - Failure modes: Drops individual malformed/unavailable children, matching Android's
+       `mapNotNull` restore behavior; returns `nil` if all children drop or encoding fails.
+     */
+    func build(pageKey: String?) -> BibleReaderRestoredMultiDocumentRequest? {
+        let references = AndroidSpecialDocumentIdentity.parseBookAndKeyListReference(pageKey)
+        guard !references.isEmpty, let pageKey else { return nil }
+
+        var fragments: [OsisFragment] = []
+        var hasStrongsOrMorphologyContent = false
+        for reference in references {
+            guard let restoredFragment = restoredFragment(for: reference) else {
+                continue
+            }
+            fragments.append(restoredFragment.fragment)
+            hasStrongsOrMorphologyContent = hasStrongsOrMorphologyContent || restoredFragment.usesStrongsContentType
+        }
+        guard !fragments.isEmpty else { return nil }
+
+        let renderedKey = hasStrongsOrMorphologyContent
+            ? AndroidSpecialDocumentIdentity.strongsRenderedKey
+            : AndroidSpecialDocumentIdentity.multiRenderedKey
+        let payload = MultiFragmentDocumentPayload(
+            id: "multi-\(UUID().uuidString)",
+            type: "multi",
+            osisFragments: fragments,
+            compare: false,
+            contentType: hasStrongsOrMorphologyContent ? "strongs" : nil,
+            state: nil
+        )
+        guard let data = try? bridgeEncoder.encode(payload),
+              let documentJSON = String(data: data, encoding: .utf8) else {
+            restoredMultiDocumentBuilderLogger.error("Failed to encode restored Android Multi bridge document")
+            return nil
+        }
+        return BibleReaderRestoredMultiDocumentRequest(
+            documentJSON: documentJSON,
+            renderedKey: renderedKey,
+            pageKey: pageKey
+        )
+    }
+
+    /**
+     Resolves one restored Android `BookAndKey` child into a Vue fragment.
+
+     - Parameter reference: Parsed source document/key pair from the persisted `Multi` key.
+     - Returns: A fragment and whether it should force Vue's Strong's document mode, or `nil` if
+       the source document/key cannot be resolved.
+     - Side effects: May read SWORD content and move source module cursors through restoring
+       helpers.
+     - Failure modes: Unavailable modules, invalid Bible references, or dictionary lookup misses
+       return `nil`, mirroring Android's restored-child filtering behavior.
+     */
+    private func restoredFragment(
+        for reference: AndroidSpecialDocumentIdentity.BookAndKeyReference
+    ) -> (fragment: OsisFragment, usesStrongsContentType: Bool)? {
+        let sourceModule: SwordModule?
+        if let documentInitials = reference.documentInitials {
+            sourceModule = swordManager?.module(named: documentInitials)
+        } else {
+            sourceModule = activeModule
+        }
+
+        if sourceModule?.info.category == .bible,
+           let osisReference = parseOsisRef(reference.key) {
+            return restoredBibleFragment(
+                for: osisReference,
+                sourceModule: sourceModule,
+                sourceDocumentInitials: reference.documentInitials
+            ).map { ($0, false) }
+        }
+
+        guard let sourceModule else { return nil }
+        switch sourceModule.info.category {
+        case .dictionary, .glossary:
+            return restoredDictionaryFragment(
+                for: reference.key,
+                sourceModule: sourceModule
+            )
+        default:
+            return nil
+        }
+    }
+
+    /**
+     Parses a persisted OSIS key into the shared reader reference value.
+
+     - Parameter osis: OSIS verse key saved in one Android `BookAndKey` child.
+     - Returns: Parsed reference coordinates, or `nil` if the key is not a single verse.
+     - Side effects: None.
+     - Failure modes: Malformed keys or unknown OSIS book ids return `nil` so restore can drop only
+       the bad child.
+     */
+    private func parseOsisRef(_ osis: String) -> OsisRef? {
+        let parts = osis.split(separator: ".").map(String.init)
+        guard parts.count >= 3,
+              let chapter = Int(parts[1]),
+              let verse = Int(parts[2]) else {
+            return nil
+        }
+
+        let osisId = parts[0]
+        guard let book = bookNameForOsisId(osisId) else { return nil }
+        return OsisRef(book: book, chapter: chapter, verse: verse, osisId: osisId)
+    }
+
+    /**
+     Builds one restored Bible fragment for Android `Multi` document restore.
+
+     - Parameters:
+       - ref: Parsed OSIS verse reference from the saved child key.
+       - sourceModule: SWORD Bible module that owns the child key.
+       - sourceDocumentInitials: Persisted source initials. `nil` means Android's `null:` current
+         Bible marker, so the active Bible module identity is used.
+     - Returns: A Vue OSIS fragment, or `nil` if the source Bible cannot resolve the verse.
+     - Side effects: Reads the SWORD verse and restores the source module cursor afterward.
+     - Failure modes: Missing source module or missing verse ordinal returns `nil`.
+     */
+    private func restoredBibleFragment(
+        for ref: OsisRef,
+        sourceModule: SwordModule?,
+        sourceDocumentInitials: String?
+    ) -> OsisFragment? {
+        guard let sourceModule else { return nil }
+        let moduleName = sourceDocumentInitials ?? sourceModule.info.name
+        guard let ordinal = sourceModule.verseOrdinal(
+            osisBookId: ref.osisId,
+            chapter: ref.chapter,
+            verse: ref.verse
+        ) else {
+            return nil
+        }
+        let osisRef = "\(ref.osisId).\(ref.chapter).\(ref.verse)"
+        return OsisFragment(
+            xml: BibleReaderMultiReferenceDocumentBuilder.buildBibleMultiReferenceXML(
+                ref: ref,
+                module: sourceModule,
+                ordinal: ordinal
+            ),
+            key: "\(moduleName)--\(osisRef)",
+            keyName: ref.displayName,
+            v11n: "KJVA",
+            bookCategory: DocumentCategory.bible.rawValue,
+            bookInitials: moduleName,
+            bookAbbreviation: ref.osisId,
+            osisRef: osisRef,
+            isNewTestament: isNewTestament(ref.book),
+            features: OsisFeatures(),
+            hasStrongs: sourceModule.info.features.contains(.strongsNumbers),
+            ordinalRange: [ordinal, ordinal],
+            language: sourceModule.info.language.isEmpty ? "en" : sourceModule.info.language,
+            direction: sourceModule.info.isRightToLeft ? "rtl" : "ltr"
+        )
+    }
+
+    /**
+     Builds one restored dictionary/glossary fragment for Android `Multi` document restore.
+
+     - Parameters:
+       - key: Persisted child key for the source dictionary or glossary module.
+       - sourceModule: Installed source module that owns the key.
+     - Returns: A Vue fragment plus whether the aggregate document should use Strong's mode.
+     - Side effects: Reads the source module and restores its cursor through
+       `BibleReaderStrongsDocumentBuilder.lookupInModule`.
+     - Failure modes: Returns `nil` when the source module cannot resolve the key exactly enough to
+       satisfy the dictionary lookup contract.
+     */
+    private func restoredDictionaryFragment(
+        for key: String,
+        sourceModule: SwordModule
+    ) -> (fragment: OsisFragment, usesStrongsContentType: Bool)? {
+        let keyOptions = restoredDictionaryLookupKeys(for: key, sourceModule: sourceModule)
+        guard let lookup = BibleReaderStrongsDocumentBuilder.lookupInModule(sourceModule, keyOptions: keyOptions) else {
+            return nil
+        }
+        let isStrongsDefinition = sourceModule.info.features.contains(.hebrewDef)
+            || sourceModule.info.features.contains(.greekDef)
+        let isMorphologyDefinition = sourceModule.info.features.contains(.hebrewParse)
+            || sourceModule.info.features.contains(.greekParse)
+        let keyName = isStrongsDefinition
+            ? BibleReaderStrongsDocumentBuilder.canonicalStrongsKeyName(
+                requested: key,
+                actualKey: lookup.actualKey,
+                rawEntry: lookup.rawEntry
+            )
+            : lookup.actualKey
+        let features = restoredDictionaryFeatures(for: sourceModule, keyName: keyName)
+        let xml = BibleReaderStrongsDocumentBuilder.buildDictionaryEntryXML(
+            rawEntry: lookup.rawEntry,
+            renderedText: lookup.renderedText,
+            fallbackTitle: keyName,
+            strongsLinkPrefix: BibleReaderStrongsDocumentBuilder.strongsLinkPrefix(forModuleName: sourceModule.info.name)
+                ?? BibleReaderStrongsDocumentBuilder.strongsLinkPrefix(for: key)
+        )
+        let fragment = OsisFragment(
+            xml: xml,
+            key: "\(sourceModule.info.name)--\(keyName)",
+            keyName: keyName,
+            v11n: "KJVA",
+            bookCategory: DocumentCategory.dictionary.rawValue,
+            bookInitials: sourceModule.info.name,
+            bookAbbreviation: BibleReaderStrongsDocumentBuilder.moduleDisplayLabel(sourceModule),
+            osisRef: keyName,
+            isNewTestament: false,
+            features: features,
+            hasStrongs: features.type != nil,
+            ordinalRange: [0, 0],
+            language: sourceModule.info.language.isEmpty ? "en" : sourceModule.info.language,
+            direction: sourceModule.info.isRightToLeft ? "rtl" : "ltr"
+        )
+        return (fragment, isStrongsDefinition || isMorphologyDefinition)
+    }
+
+    /**
+     Chooses lookup keys for a restored dictionary child.
+
+     Strong's modules need the same key-family expansion used by live Strong's links because
+     persisted Android keys may be numeric while local modules expect prefixed or zero-stripped
+     variants. Plain dictionaries use the persisted key directly, matching Android's
+     `book.getKey(savedKey)` restore.
+
+     - Parameters:
+       - key: Persisted child key from Android's `BookAndKeyList.osisRef`.
+       - sourceModule: Dictionary or glossary module that owns the key.
+     - Returns: Ordered lookup candidates to try against `sourceModule`.
+     - Side effects: None.
+     - Failure modes: None; lookup failure is handled by the caller.
+     */
+    private func restoredDictionaryLookupKeys(for key: String, sourceModule: SwordModule) -> [String] {
+        if sourceModule.info.features.contains(.hebrewDef)
+            || sourceModule.info.features.contains(.greekDef) {
+            return BibleReaderStrongsDocumentBuilder.strongsLookupKeyOptions(for: key)
+        }
+        return [key]
+    }
+
+    /**
+     Maps restored dictionary module features into Vue `OsisFeatures`.
+
+     - Parameters:
+       - sourceModule: Dictionary/glossary module that produced the fragment.
+       - keyName: Canonical key name resolved from the source module.
+     - Returns: Feature metadata for Strong's dictionaries, or an empty feature set for plain
+       dictionaries and morphology modules.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private func restoredDictionaryFeatures(for sourceModule: SwordModule, keyName: String) -> OsisFeatures {
+        if sourceModule.info.features.contains(.hebrewDef) {
+            return OsisFeatures(type: "hebrew", keyName: keyName)
+        }
+        if sourceModule.info.features.contains(.greekDef) {
+            return OsisFeatures(type: "greek", keyName: keyName)
+        }
+        return OsisFeatures()
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpecialDocumentCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpecialDocumentCoordinator.swift
@@ -1,0 +1,166 @@
+import BibleCore
+
+/**
+ Native state transition plan for Android-style transient special documents.
+
+ Android stores links-window `Multi` pages as fake `general_book/Multi` pages while Vue renders the
+ actual multi-document payload. This value describes the native category and optional PageManager
+ mutation that the controller must apply before emitting the Vue payload.
+
+ - Side effects: None; this is an immutable transition plan.
+ - Failure modes: Malformed transient requests produce a non-persisting general-book transition so
+   invalid bridge payloads cannot erase the last restorable Android `Multi` key.
+ */
+struct BibleReaderSpecialDocumentPageIdentityUpdate {
+    /// Category that should become the controller's current category.
+    let currentCategory: DocumentCategory
+
+    /// Whether the controller should clear its concrete general-book module reference.
+    let clearsActiveGeneralBookModule: Bool
+
+    /// General-book document initials to expose when the transition targets Android `Multi`.
+    let activeGeneralBookModuleName: String?
+
+    /// General-book key to expose when the request has a durable fake-document key.
+    let currentGeneralBookKey: String?
+
+    /// PageManager category key to persist, or `nil` when no durable page identity should be saved.
+    let pageManagerCategoryName: String?
+
+    /// PageManager general-book document initials to persist.
+    let pageManagerGeneralBookDocument: String?
+
+    /// PageManager general-book key to persist.
+    let pageManagerGeneralBookKey: String?
+
+    /// Whether applying the PageManager fields should trigger pane/workspace persistence.
+    let persistsPageManagerState: Bool
+}
+
+/**
+ Coordinates Android-style special document state for one reader pane.
+
+ This coordinator owns the transient `MultiDocument` pending/active slots and the PageManager
+ identity rules for Android fake documents. The controller remains responsible for actually
+ mutating its fields and emitting bridge events, but it no longer owns the decision logic for when
+ a transient document is active, when it should replay after client-ready, or how a request maps to
+ durable `general_book/Multi` state.
+
+ - Side effects: Mutates only in-memory pending/active transient request state.
+ - Failure modes: Invalid document JSON is treated as an opaque string, preserving the bridge
+   contract that payload builders validate before requesting a transient render. Invalid durable
+   fake-document fields produce a non-persisting identity update.
+ - Note: Android parity is centered on `FakeBookFactory.multiDocument`: special link-result pages
+   use `general_book/Multi` for native state and Vue `MultiDocument` for rendered content.
+ */
+struct BibleReaderSpecialDocumentCoordinator {
+    /// Pending/active transient request state machine.
+    private var transientDocumentCoordinator = BibleReaderTransientDocumentCoordinator()
+
+    /**
+     Stores a transient document request using the current client-ready state.
+
+     - Parameters:
+       - request: Opaque transient document payload and native identity to remember.
+       - clientReady: Whether the Vue client can currently receive bridge document events.
+     - Side effects: Replaces the active request and either stores or clears the pending replay
+       request.
+     - Failure modes: None; callers emit the request separately after storage.
+     */
+    mutating func store(_ request: BibleReaderTransientDocumentRequest, clientReady: Bool) {
+        transientDocumentCoordinator.store(request, clientReady: clientReady)
+    }
+
+    /**
+     Returns the active transient request only while native state is on Android's fake document.
+
+     - Parameter isShowingAndroidMultiDocument: Caller-computed predicate for the current
+       PageManager/controller category and document identity.
+     - Returns: Stored active request when the caller is still showing Android `Multi`; otherwise
+       `nil`.
+     - Side effects: None.
+     - Failure modes: None; stale active requests are suppressed by the predicate.
+     */
+    func activeRequest(isShowingAndroidMultiDocument: Bool) -> BibleReaderTransientDocumentRequest? {
+        transientDocumentCoordinator.activeRequest(isShowingAndroidMultiDocument: isShowingAndroidMultiDocument)
+    }
+
+    /**
+     Consumes the pending client-ready replay request.
+
+     - Returns: The pre-ready transient request to replay, or `nil` when none is pending.
+     - Side effects: Clears the pending replay slot so client-ready replay happens once.
+     - Failure modes: None.
+     */
+    mutating func consumePendingClientReadyRequest() -> BibleReaderTransientDocumentRequest? {
+        transientDocumentCoordinator.consumePendingClientReadyRequest()
+    }
+
+    /**
+     Builds the native identity transition for a transient rendered document.
+
+     Requests without a durable page category preserve the legacy transient-Bible identity. Android
+     `Multi` requests become `general_book/Multi` pages and persist only when both document initials
+     and key are non-empty; that prevents malformed transient payloads from overwriting the last
+     restorable `Multi` key.
+
+     - Parameter request: Transient request carrying optional durable PageManager fields.
+     - Returns: A native state transition plan for the controller to apply.
+     - Side effects: None.
+     - Failure modes: Missing required durable general-book fields yield a non-persisting update
+       rather than throwing.
+     */
+    func pageIdentityUpdate(
+        for request: BibleReaderTransientDocumentRequest
+    ) -> BibleReaderSpecialDocumentPageIdentityUpdate {
+        guard let pageCategory = request.pageCategory else {
+            return BibleReaderSpecialDocumentPageIdentityUpdate(
+                currentCategory: .bible,
+                clearsActiveGeneralBookModule: false,
+                activeGeneralBookModuleName: nil,
+                currentGeneralBookKey: nil,
+                pageManagerCategoryName: nil,
+                pageManagerGeneralBookDocument: nil,
+                pageManagerGeneralBookKey: nil,
+                persistsPageManagerState: false
+            )
+        }
+
+        if pageCategory == .generalBook {
+            guard let pageDocumentInitials = request.pageDocumentInitials, !pageDocumentInitials.isEmpty,
+                  let pageKey = request.pageKey, !pageKey.isEmpty else {
+                return BibleReaderSpecialDocumentPageIdentityUpdate(
+                    currentCategory: pageCategory,
+                    clearsActiveGeneralBookModule: true,
+                    activeGeneralBookModuleName: request.pageDocumentInitials,
+                    currentGeneralBookKey: nil,
+                    pageManagerCategoryName: nil,
+                    pageManagerGeneralBookDocument: nil,
+                    pageManagerGeneralBookKey: nil,
+                    persistsPageManagerState: false
+                )
+            }
+            return BibleReaderSpecialDocumentPageIdentityUpdate(
+                currentCategory: pageCategory,
+                clearsActiveGeneralBookModule: true,
+                activeGeneralBookModuleName: pageDocumentInitials,
+                currentGeneralBookKey: pageKey,
+                pageManagerCategoryName: pageCategory.pageManagerKey,
+                pageManagerGeneralBookDocument: pageDocumentInitials,
+                pageManagerGeneralBookKey: pageKey,
+                persistsPageManagerState: true
+            )
+        }
+
+        return BibleReaderSpecialDocumentPageIdentityUpdate(
+            currentCategory: pageCategory,
+            clearsActiveGeneralBookModule: false,
+            activeGeneralBookModuleName: nil,
+            currentGeneralBookKey: nil,
+            pageManagerCategoryName: pageCategory.pageManagerKey,
+            pageManagerGeneralBookDocument: nil,
+            pageManagerGeneralBookKey: nil,
+            persistsPageManagerState: true
+        )
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpecialDocumentCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpecialDocumentCoordinator.swift
@@ -18,6 +18,9 @@ struct BibleReaderSpecialDocumentPageIdentityUpdate {
     /// Whether the controller should clear its concrete general-book module reference.
     let clearsActiveGeneralBookModule: Bool
 
+    /// Whether the controller should assign `activeGeneralBookModuleName`, including `nil`.
+    let assignsActiveGeneralBookModuleName: Bool
+
     /// General-book document initials to expose when the transition targets Android `Multi`.
     let activeGeneralBookModuleName: String?
 
@@ -117,6 +120,7 @@ struct BibleReaderSpecialDocumentCoordinator {
             return BibleReaderSpecialDocumentPageIdentityUpdate(
                 currentCategory: .bible,
                 clearsActiveGeneralBookModule: false,
+                assignsActiveGeneralBookModuleName: false,
                 activeGeneralBookModuleName: nil,
                 currentGeneralBookKey: nil,
                 pageManagerCategoryName: nil,
@@ -132,6 +136,7 @@ struct BibleReaderSpecialDocumentCoordinator {
                 return BibleReaderSpecialDocumentPageIdentityUpdate(
                     currentCategory: pageCategory,
                     clearsActiveGeneralBookModule: true,
+                    assignsActiveGeneralBookModuleName: true,
                     activeGeneralBookModuleName: request.pageDocumentInitials,
                     currentGeneralBookKey: nil,
                     pageManagerCategoryName: nil,
@@ -143,6 +148,7 @@ struct BibleReaderSpecialDocumentCoordinator {
             return BibleReaderSpecialDocumentPageIdentityUpdate(
                 currentCategory: pageCategory,
                 clearsActiveGeneralBookModule: true,
+                assignsActiveGeneralBookModuleName: true,
                 activeGeneralBookModuleName: pageDocumentInitials,
                 currentGeneralBookKey: pageKey,
                 pageManagerCategoryName: pageCategory.pageManagerKey,
@@ -155,6 +161,7 @@ struct BibleReaderSpecialDocumentCoordinator {
         return BibleReaderSpecialDocumentPageIdentityUpdate(
             currentCategory: pageCategory,
             clearsActiveGeneralBookModule: false,
+            assignsActiveGeneralBookModuleName: false,
             activeGeneralBookModuleName: nil,
             currentGeneralBookKey: nil,
             pageManagerCategoryName: pageCategory.pageManagerKey,


### PR DESCRIPTION
Summary
- Extract restored Android Multi document reconstruction from BibleReaderController into BibleReaderRestoredMultiDocumentBuilder.
- Extract transient MultiDocument pending/active state and Android general_book/Multi identity planning into BibleReaderSpecialDocumentCoordinator.
- Keep bridge event emission in BibleReaderController as orchestration while moving Android parity rules into focused collaborators.

Scope
- In scope: restored Android BookAndKeyList-backed Multi payload rebuilding, transient MultiDocument pending/client-ready replay state, and fake-document PageManager identity planning.
- Out of scope: reading progress + memorization bridge, book catalog/versification access, and final controller ownership audit; those remain separate #146 slices.

Contract references
- Refs #146.
- Closes: none. #146 remains open for the remaining controller-responsibility checklist items.
- Android parity: preserves FakeBookFactory.multiDocument behavior by keeping native state as general_book/Multi with BookAndKeyList keys while Vue receives MultiDocument payloads.

Change details
- Added BibleReaderRestoredMultiDocumentBuilder to rebuild restored Multi documents from persisted PageManager keys using existing Bible multi-reference and Strong's/dictionary fragment helpers.
- Added BibleReaderSpecialDocumentCoordinator to own transient request replay state and page identity transition plans.
- Rewired BibleReaderController to call the restored builder and special-document coordinator instead of owning those rules directly.
- Added a focused unit test for the Android Multi page identity plan, including malformed transient requests that must not erase restorable keys.

Validation evidence
- git diff --check
- python3 scripts/check_repo_standards.py docblocks
- GitNexus impact before edits: loadCurrentContent CRITICAL, loadTransientMultiDocument CRITICAL, loadRestoredAndroidMultiDocument CRITICAL, buildRestoredAndroidMultiDocument CRITICAL, emitTransientMultiDocument CRITICAL, applyTransientPageIdentity CRITICAL, reloadVisibleDocumentAfterClientReady CRITICAL due central reader reload and transient document flows.
- GitNexus detect_changes after indexing this worktree: low risk, no affected indexed processes.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath .derivedData-special-documents -resultBundlePath .artifacts/special-documents-build.xcresult CODE_SIGNING_ALLOWED=NO build-for-testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -xctestrun .derivedData-special-documents/Build/Products/AndBible_iphonesimulator26.5-arm64-x86_64.xctestrun -destination 'id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F' -resultBundlePath .artifacts/special-documents-tests.xcresult selected restored/transient/compare tests test-without-building
- Focused test result: 10 restored/transient/compare tests passed on iPhone 17 / iOS 26.5.

Risks/follow-ups
- Risk is mainly wiring drift in restored/transient special-document state; covered by restored Multi, definition replay, malformed Multi, compare, and coordinator tests.
- Remaining #146 chunks still need separate PRs: reading progress + memorization bridge, book catalog/versification access, and final controller ownership audit.