### PR TITLE
fix(backup): align Android module backup restore parity

### DIFF
--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -156,6 +156,10 @@ struct AndBibleApp: App {
     @State private var isImportingExternalDocument = false
     /// Pending app-level feedback for a document opened from Files, Mail, or another app.
     @State private var externalDocumentImportMessage: String?
+    /// Pending Android-style transient install-success toast for a confirmed external document.
+    @State private var externalDocumentImportToastMessage: String?
+    /// Scheduled dismissal for the current external document install-success toast.
+    @State private var externalDocumentImportToastWorkItem: DispatchWorkItem?
     private let remoteSyncNetworkMonitor: RemoteSyncNetworkMonitor
     #if os(iOS)
     private let remoteSyncBackgroundRefreshCoordinator: RemoteSyncBackgroundRefreshCoordinator
@@ -400,6 +404,7 @@ struct AndBibleApp: App {
             .onOpenURL { url in
                 handleExternalDocumentURL(url)
             }
+            .androidToastFeedback(externalDocumentImportToastMessage, bottomPadding: 96)
             .alert(
                 String(localized: "cloud_sync_title"),
                 isPresented: Binding(
@@ -550,6 +555,7 @@ struct AndBibleApp: App {
         let request = ExternalDocumentImportRequest(url: url)
         if pendingExternalDocumentImport == nil,
            externalDocumentImportMessage == nil,
+           externalDocumentImportToastMessage == nil,
            !isImportingExternalDocument {
             pendingExternalDocumentImport = request
         } else {
@@ -564,7 +570,8 @@ struct AndBibleApp: App {
      - Side effects:
        - marks the app-level import as active
        - runs the shared import service off the main actor
-       - publishes localized result feedback to SwiftUI alert state
+       - publishes Android install successes as transient toast feedback
+       - publishes unsupported-format and failure feedback to SwiftUI alert state
      - Failure modes: Service-level failures are surfaced as result feedback instead of thrown.
      */
     @MainActor
@@ -576,12 +583,46 @@ struct AndBibleApp: App {
                 ExternalDocumentImportService().importDocument(request)
             }.value
             isImportingExternalDocument = false
-            externalDocumentImportMessage = result.feedbackMessage
+            if result.usesAndroidInstallToastFeedback {
+                showExternalDocumentImportToast(result.feedbackMessage)
+            } else {
+                externalDocumentImportMessage = result.feedbackMessage
+            }
         }
     }
 
     /**
-     Presents the next queued external import when no prompt, task, or result alert is active.
+     Presents Android-style install-success feedback for app-opened documents.
+
+     Android `InstallZip` reports successful document installs with a short `ToastEvent`, not a
+     blocking dialog. This helper owns the app-level dismissal timing and resumes queued external
+     import prompts only after the toast clears so prompts do not stack over transient feedback.
+
+     - Parameter message: Localized toast text to display.
+     - Side effects:
+       - cancels any pending external-import toast dismissal
+       - mutates app-level toast state
+       - schedules automatic dismissal and queued-import advancement
+     - Failure modes: none; newer toast requests replace earlier requests.
+     */
+    @MainActor
+    private func showExternalDocumentImportToast(_ message: String) {
+        externalDocumentImportToastWorkItem?.cancel()
+        withAnimation { externalDocumentImportToastMessage = message }
+        let work = DispatchWorkItem {
+            withAnimation { externalDocumentImportToastMessage = nil }
+            externalDocumentImportToastWorkItem = nil
+            showNextPendingExternalDocumentImportIfNeeded()
+        }
+        externalDocumentImportToastWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + AndroidToastFeedback.shortDuration,
+            execute: work
+        )
+    }
+
+    /**
+     Presents the next queued external import when no prompt, task, result alert, or toast is active.
 
      - Side effects: Mutates the external import queue and pending prompt state.
      - Failure modes: none.
@@ -590,6 +631,7 @@ struct AndBibleApp: App {
     private func showNextPendingExternalDocumentImportIfNeeded() {
         guard pendingExternalDocumentImport == nil,
               externalDocumentImportMessage == nil,
+              externalDocumentImportToastMessage == nil,
               !isImportingExternalDocument,
               !queuedExternalDocumentImports.isEmpty else {
             return

--- a/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift
@@ -1999,6 +1999,46 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies file-backed deflate extraction continues when an input chunk exactly fills the
+     inflater output buffer.
+
+     Setup:
+     - builds a valid Android-style ZIP entry with data-descriptor sizes
+     - crafts the raw deflate payload so zlib consumes one 64 KiB input chunk while producing
+       exactly one 64 KiB output chunk before the stream's final block arrives
+     - extracts through `ZipArchiveReader.data(for:inArchiveAt:)`, matching file-backed restore
+
+     Expected result:
+     - extraction reads the next input chunk instead of calling zlib again with zero input
+     - the restored payload matches the declared uncompressed bytes
+
+     Failure meaning:
+     - iOS rejects valid large Android ZIP entries with `decompressionFailed` when a stream boundary
+       lands on the file-backed inflater's chunk size.
+     */
+    func testZipArchiveReaderStreamsDeflatedEntryAcrossFullOutputChunkBoundary() throws {
+        let payload = Data(repeating: 0x41, count: 65_536)
+        let archiveData = try makeDeflatedDescriptorZip(
+            name: "db/bookmarks.sqlite3",
+            compressedData: makeBoundaryFillingRawDeflateData(),
+            uncompressedData: payload
+        )
+        let archiveURL = try writeTemporaryAndroidBackupArchive(
+            archiveData,
+            suffix: AndroidDatabaseBackupService.databaseBackupSuffix
+        )
+        let entry = try XCTUnwrap(ZipArchiveReader.fileEntries(inArchiveAt: archiveURL).first)
+
+        let restoredData = try ZipArchiveReader.data(
+            for: entry,
+            inArchiveAt: archiveURL,
+            maximumByteCount: payload.count
+        )
+
+        XCTAssertEqual(restoredData, payload)
+    }
+
+    /**
      Verifies that newer Android database versions are visible but cannot be applied.
 
      Setup:
@@ -3068,6 +3108,143 @@ extension AndBibleTests {
     }
 
     /**
+     Builds a raw-deflate stream that exposes the file-backed inflater's full-output-buffer
+     boundary condition.
+
+     The stream emits empty non-final blocks before a fixed-Huffman payload block so the first
+     extraction read consumes 64 KiB of compressed input and produces exactly 64 KiB of output.
+     A final empty stored block follows in the next input chunk, making the stream valid while
+     forcing the extractor to return to the outer read loop before invoking zlib again.
+
+     - Returns: Valid raw deflate bytes that inflate to 65,536 ASCII `A` bytes.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func makeBoundaryFillingRawDeflateData() -> Data {
+        var writer = DeflateBitWriter()
+        for _ in 0..<13_023 {
+            appendEmptyStoredDeflateBlock(final: false, to: &writer)
+        }
+        appendEmptyFixedHuffmanDeflateBlock(final: false, to: &writer)
+        appendEmptyFixedHuffmanDeflateBlock(final: false, to: &writer)
+        appendBoundaryPayloadFixedHuffmanBlock(final: false, to: &writer)
+        appendEmptyStoredDeflateBlock(final: true, to: &writer)
+        return writer.data()
+    }
+
+    /**
+     Appends an empty stored deflate block to a bit-level fixture writer.
+
+     - Parameters:
+       - final: Whether to mark this as the stream's final block.
+       - writer: Mutable deflate bit writer.
+     - Side effects: Appends block header, alignment padding, and zero-length block metadata.
+     - Failure modes: none.
+     */
+    private func appendEmptyStoredDeflateBlock(final: Bool, to writer: inout DeflateBitWriter) {
+        writer.appendBit(final ? 1 : 0)
+        writer.appendBit(0)
+        writer.appendBit(0)
+        writer.alignToByte()
+        writer.appendBits(0, count: 16)
+        writer.appendBits(0xffff, count: 16)
+    }
+
+    /**
+     Appends an empty fixed-Huffman deflate block to a bit-level fixture writer.
+
+     - Parameters:
+       - final: Whether to mark this as the stream's final block.
+       - writer: Mutable deflate bit writer.
+     - Side effects: Appends a fixed-Huffman block header and end-of-block symbol.
+     - Failure modes: none.
+     */
+    private func appendEmptyFixedHuffmanDeflateBlock(final: Bool, to writer: inout DeflateBitWriter) {
+        writer.appendBit(final ? 1 : 0)
+        writer.appendBit(1)
+        writer.appendBit(0)
+        appendFixedHuffmanSymbol(256, to: &writer)
+    }
+
+    /**
+     Appends a fixed-Huffman deflate block that expands to exactly 65,536 `A` bytes.
+
+     - Parameters:
+       - final: Whether to mark this as the stream's final block.
+       - writer: Mutable deflate bit writer.
+     - Side effects: Appends one literal, repeat-distance pairs, and an end-of-block symbol.
+     - Failure modes: none.
+     */
+    private func appendBoundaryPayloadFixedHuffmanBlock(final: Bool, to writer: inout DeflateBitWriter) {
+        writer.appendBit(final ? 1 : 0)
+        writer.appendBit(1)
+        writer.appendBit(0)
+        appendFixedHuffmanSymbol(65, to: &writer)
+        for _ in 0..<254 {
+            appendFixedHuffmanSymbol(285, to: &writer)
+            writer.appendBits(0, count: 5)
+        }
+        appendFixedHuffmanSymbol(257, to: &writer)
+        writer.appendBits(0, count: 5)
+        appendFixedHuffmanSymbol(256, to: &writer)
+    }
+
+    /**
+     Appends one fixed-Huffman deflate symbol using least-significant-bit wire order.
+
+     - Parameters:
+       - symbol: Deflate literal/length/end symbol in the fixed-Huffman alphabet.
+       - writer: Mutable deflate bit writer.
+     - Side effects: Appends the symbol code bits.
+     - Failure modes: none.
+     */
+    private func appendFixedHuffmanSymbol(_ symbol: Int, to writer: inout DeflateBitWriter) {
+        let code = fixedHuffmanCode(for: symbol)
+        writer.appendBits(code.value, count: code.bitCount)
+    }
+
+    /**
+     Returns the fixed-Huffman code for one deflate symbol.
+
+     - Parameter symbol: Deflate literal/length/end symbol.
+     - Returns: Bit-reversed wire value and bit count.
+     - Side effects: none.
+     - Failure modes: Callers must pass a fixed-Huffman symbol in `0...287`.
+     */
+    private func fixedHuffmanCode(for symbol: Int) -> (value: Int, bitCount: Int) {
+        if symbol <= 143 {
+            return (reversedBits(0x30 + symbol, count: 8), 8)
+        }
+        if symbol <= 255 {
+            return (reversedBits(0x190 + symbol - 144, count: 9), 9)
+        }
+        if symbol <= 279 {
+            return (reversedBits(symbol - 256, count: 7), 7)
+        }
+        return (reversedBits(0xc0 + symbol - 280, count: 8), 8)
+    }
+
+    /**
+     Reverses the low-order bits of a deflate Huffman code for wire emission.
+
+     - Parameters:
+       - value: Canonical Huffman code value.
+       - count: Number of bits to reverse.
+     - Returns: Bit-reversed value.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func reversedBits(_ value: Int, count: Int) -> Int {
+        var source = value
+        var result = 0
+        for _ in 0..<count {
+            result = (result << 1) | (source & 1)
+            source >>= 1
+        }
+        return result
+    }
+
+    /**
      Writes an Android backup ZIP fixture to a temporary file.
 
      - Parameters:
@@ -3167,6 +3344,81 @@ extension AndBibleTests {
         appendUInt16(0, to: &endRecord)
         try handle.write(contentsOf: endRecord)
         return url
+    }
+
+    /**
+     Writes low-level deflate fixture bits in least-significant-bit order.
+
+     The helper is intentionally scoped to ZIP/deflate regression tests so crafted fixtures can
+     describe zlib boundary conditions without checking opaque binary blobs into the repository.
+     */
+    private struct DeflateBitWriter {
+        /// Completed bytes ready to publish.
+        private var bytes: [UInt8] = []
+
+        /// Partially-filled byte being assembled least-significant bit first.
+        private var currentByte: UInt8 = 0
+
+        /// Number of bits already written into `currentByte`.
+        private var bitCount = 0
+
+        /**
+         Appends one bit to the fixture stream.
+
+         - Parameter bit: Low bit to append; other bits are ignored.
+         - Side effects: Mutates the pending byte and flushes it when it becomes full.
+         - Failure modes: none.
+         */
+        mutating func appendBit(_ bit: Int) {
+            if bit & 1 == 1 {
+                currentByte |= UInt8(1 << bitCount)
+            }
+            bitCount += 1
+            if bitCount == 8 {
+                bytes.append(currentByte)
+                currentByte = 0
+                bitCount = 0
+            }
+        }
+
+        /**
+         Appends the low-order bits of one integer to the fixture stream.
+
+         - Parameters:
+           - value: Source integer.
+           - count: Number of least-significant bits to append.
+         - Side effects: Mutates the fixture stream.
+         - Failure modes: none.
+         */
+        mutating func appendBits(_ value: Int, count: Int) {
+            for index in 0..<count {
+                appendBit((value >> index) & 1)
+            }
+        }
+
+        /**
+         Pads the fixture stream to the next byte boundary.
+
+         - Side effects: Appends zero bits until the pending byte is flushed.
+         - Failure modes: none.
+         */
+        mutating func alignToByte() {
+            while bitCount != 0 {
+                appendBit(0)
+            }
+        }
+
+        /**
+         Finalizes the fixture stream as bytes.
+
+         - Returns: Deflate fixture bytes.
+         - Side effects: Pads the pending byte with zeros before returning.
+         - Failure modes: none.
+         */
+        mutating func data() -> Data {
+            alignToByte()
+            return Data(bytes)
+        }
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
+++ b/AndBibleTests/AndBibleTests+AndroidModuleBackup.swift
@@ -147,6 +147,56 @@ extension AndBibleTests {
     }
 
     /**
+     Verifies that Android RawLD4 dictionary modules restore when their `DataPath` names a file
+     stem instead of the containing directory.
+
+     Setup:
+     - builds an Android-shaped `.abmd.zip` fixture with a `RawLD4` config matching Android
+       production backups
+     - stores `.dat` and `.idx` files under the containing SWORD data directory
+     - inspects and restores through file-backed APIs, matching external file import
+
+     Expected result:
+     - inspection treats the RawLD4 file stem as present when sibling data files exist
+     - restore writes the config and RawLD4 payload files into the module root
+
+     Failure meaning:
+     - iOS rejects valid Android production module backups with “references missing data path”
+       even though Android and SWORD store RawLD4 data as file-stem payloads.
+     */
+    func testAndroidModuleBackupRestoresRawLD4FileStemModuleFromFileURL() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d/acdcref.conf", makeAndroidRawLD4ModuleBackupConf()),
+            ("modules/lexdict/rawld4/acdcref/acdcref.dat", Data("dictionary data".utf8)),
+            ("modules/lexdict/rawld4/acdcref/acdcref.idx", Data("dictionary index".utf8)),
+        ])
+        let archiveURL = try writeTemporaryAndroidModuleBackupArchive(archiveData)
+
+        let inspection = try service.inspectArchive(fromArchiveAt: archiveURL)
+        let report = try service.restoreArchive(fromArchiveAt: archiveURL)
+
+        XCTAssertEqual(inspection.supportedModuleNames, ["ACDCREF"])
+        XCTAssertEqual(report.installedModuleNames, ["ACDCREF"])
+        XCTAssertEqual(report.installedEntryCount, 3)
+        XCTAssertEqual(
+            try String(
+                contentsOf: moduleRoot.appendingPathComponent("modules/lexdict/rawld4/acdcref/acdcref.dat"),
+                encoding: .utf8
+            ),
+            "dictionary data"
+        )
+        XCTAssertEqual(
+            try String(
+                contentsOf: moduleRoot.appendingPathComponent("modules/lexdict/rawld4/acdcref/acdcref.idx"),
+                encoding: .utf8
+            ),
+            "dictionary index"
+        )
+    }
+
+    /**
      Verifies that file-backed Android module backup restore announces the installed-module store
      change immediately after publishing SWORD files.
 
@@ -227,6 +277,51 @@ extension AndBibleTests {
 
         _ = try service.restoreArchive(from: archiveData, allowOverwritingExistingFiles: true)
         XCTAssertEqual(try String(contentsOf: existingURL, encoding: .utf8), "remote")
+    }
+
+    /**
+     Verifies Android module backup restore overwrites installed files whose casing differs from
+     the Android archive entry.
+
+     Setup:
+     - creates an existing lowercase SWORD config
+     - restores a file-backed Android backup containing the same config path with uppercase module
+       initials
+
+     Expected result:
+     - inspection reports the uppercase archive path as an existing entry
+     - restore replaces the lowercase installed file with the archive-cased file instead of
+       failing during publish
+
+     Failure meaning:
+     - iOS rejects valid Android production module backups when installed modules differ only by
+       filename casing from Android's backup entries.
+    */
+    func testAndroidModuleBackupOverwritesCaseVariantExistingFileFromFileURL() throws {
+        let moduleRoot = try makeTemporaryAndroidModuleBackupRoot()
+        let existingConfigURL = moduleRoot.appendingPathComponent("mods.d/acdcref.conf")
+        try Data("local config".utf8).write(to: existingConfigURL)
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
+        let archiveData = try makeAndroidModuleBackupArchiveData(entries: [
+            ("mods.d/ACDCREF.conf", makeAndroidRawLD4ModuleBackupConf()),
+            ("modules/lexdict/rawld4/acdcref/acdcref.dat", Data("dictionary data".utf8)),
+            ("modules/lexdict/rawld4/acdcref/acdcref.idx", Data("dictionary index".utf8)),
+        ])
+        let archiveURL = try writeTemporaryAndroidModuleBackupArchive(archiveData)
+
+        let inspection = try service.inspectArchive(fromArchiveAt: archiveURL)
+        _ = try service.restoreArchive(fromArchiveAt: archiveURL)
+
+        let configNames = try FileManager.default.contentsOfDirectory(
+            atPath: moduleRoot.appendingPathComponent("mods.d").path
+        )
+        XCTAssertEqual(inspection.existingEntryPaths, ["mods.d/ACDCREF.conf"])
+        XCTAssertTrue(configNames.contains("ACDCREF.conf"))
+        XCTAssertFalse(configNames.contains("acdcref.conf"))
+        XCTAssertEqual(
+            try String(contentsOf: moduleRoot.appendingPathComponent("mods.d/ACDCREF.conf"), encoding: .utf8),
+            String(data: makeAndroidRawLD4ModuleBackupConf(), encoding: .utf8)
+        )
     }
 
     /**
@@ -440,6 +535,25 @@ extension AndBibleTests {
             DataPath=./modules/texts/rawtext/\(moduleName.lowercased())/
             ModDrv=RawText
             Description=\(moduleName)
+
+            """.utf8
+        )
+    }
+
+    /**
+     Builds a RawLD4 SWORD config matching Android production module-backup dictionaries.
+
+     - Returns: UTF-8 config bytes whose `DataPath` points to a RawLD4 file stem.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func makeAndroidRawLD4ModuleBackupConf() -> Data {
+        Data(
+            """
+            [ACDCref]
+            DataPath=./modules/lexdict/rawld4/acdcref/acdcref
+            ModDrv=RawLD4
+            Description=ACDCREF
 
             """.utf8
         )

--- a/AndBibleTests/AndBibleTests+ExternalDocumentImport.swift
+++ b/AndBibleTests/AndBibleTests+ExternalDocumentImport.swift
@@ -207,8 +207,11 @@ extension AndBibleTests {
     /**
      ZIP files are Android's SWORD module package path and must call only the module installer.
 
-     Failure indicates that Files/Mail opens could drift from the Backup & Restore document import
-     behavior or that arbitrary ZIP handling stopped using the SWORD repository path.
+     Android reports successful `InstallZip` work through the generic `install_zip_successfull`
+     short toast, not through a blocking module-specific alert. Failure indicates that Files/Mail
+     opens could drift from the Backup & Restore document import behavior, that arbitrary ZIP
+     handling stopped using the SWORD repository path, or that iOS reintroduced an install-success
+     presentation that does not match Android.
      */
     func testExternalDocumentImportZipUsesModuleInstaller() {
         let probe = ExternalDocumentImportProbe()
@@ -218,7 +221,8 @@ extension AndBibleTests {
         let result = service.importDocument(at: url)
 
         XCTAssertEqual(result, .installedModule(name: "FinRK"))
-        XCTAssertEqual(result.feedbackMessage, "Installed module: FinRK")
+        XCTAssertEqual(result.feedbackMessage, "Module was installed successfully")
+        XCTAssertTrue(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [url])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
@@ -251,6 +255,7 @@ extension AndBibleTests {
             .installedAndroidModuleBackup(moduleNames: ["ESV2001", "ESV2011"], installedEntryCount: 14)
         )
         XCTAssertEqual(result.feedbackMessage, "Module was installed successfully")
+        XCTAssertTrue(result.usesAndroidInstallToastFeedback)
         XCTAssertFalse(result.feedbackMessage.contains("ESV2001"))
         XCTAssertEqual(probe.snapshot().androidModuleBackupURLs, [url])
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
@@ -345,8 +350,10 @@ extension AndBibleTests {
     /**
      EPUB files are imported through the EPUB reader store and must not be treated as SWORD ZIPs.
 
-     Failure indicates that the scene-open path no longer matches the existing Settings document
-     import branch for EPUB documents.
+     Android's EPUB fallback still reports success through the generic InstallZip toast. Failure
+     indicates that the scene-open path no longer matches the existing Settings document import
+     branch for EPUB documents or that successful EPUB installs drifted back to iOS-specific alert
+     copy.
      */
     func testExternalDocumentImportEpubUsesEpubInstaller() {
         let probe = ExternalDocumentImportProbe()
@@ -356,7 +363,8 @@ extension AndBibleTests {
         let result = service.importDocument(at: url)
 
         XCTAssertEqual(result, .installedEpub(title: "Study Notes"))
-        XCTAssertEqual(result.feedbackMessage, "Installed EPUB: Study Notes")
+        XCTAssertEqual(result.feedbackMessage, "Module was installed successfully")
+        XCTAssertTrue(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [url])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
@@ -365,8 +373,9 @@ extension AndBibleTests {
     /**
      TTF files follow Android's app-owned font installer route.
 
-     Failure indicates that iOS advertises Android's font document type without backing it with the
-     same `modulesDir/ttf` install semantics.
+     Android stores fonts under `modulesDir/ttf` and reports success through the generic InstallZip
+     toast. Failure indicates that iOS advertises Android's font document type without backing it
+     with the same storage semantics or that successful font installs use an iOS-specific alert.
      */
     func testExternalDocumentImportTtfUsesFontInstaller() {
         let probe = ExternalDocumentImportProbe()
@@ -376,7 +385,8 @@ extension AndBibleTests {
         let result = service.importDocument(at: url)
 
         XCTAssertEqual(result, .installedFont(name: "Gentium"))
-        XCTAssertEqual(result.feedbackMessage, "Installed font: Gentium")
+        XCTAssertEqual(result.feedbackMessage, "Module was installed successfully")
+        XCTAssertTrue(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [url])
@@ -419,6 +429,7 @@ extension AndBibleTests {
 
         XCTAssertEqual(result, .unsupportedFormat(fileExtension: "txt"))
         XCTAssertEqual(result.feedbackMessage, "Error: Unsupported file format (txt)")
+        XCTAssertFalse(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
@@ -438,6 +449,7 @@ extension AndBibleTests {
         let result = service.importDocument(at: url)
 
         XCTAssertEqual(result, .unsupportedFormat(fileExtension: "ttf"))
+        XCTAssertFalse(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
@@ -462,6 +474,7 @@ extension AndBibleTests {
         let result = service.importDocument(request)
 
         XCTAssertEqual(result, .unsupportedFormat(fileExtension: "bin"))
+        XCTAssertFalse(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
@@ -544,6 +557,7 @@ extension AndBibleTests {
         let result = service.importDocument(at: URL(fileURLWithPath: "/tmp/FinRK.zip"))
 
         XCTAssertEqual(result, .failed(message: "installer rejected file"))
+        XCTAssertFalse(result.usesAndroidInstallToastFeedback)
         XCTAssertEqual(probe.snapshot().epubArchiveDetectionCount, 1)
         XCTAssertEqual(probe.snapshot().epubURLs, [])
     }
@@ -579,7 +593,7 @@ extension AndBibleTests {
      Installer failures retain the existing import/export error-prefix surface.
 
      Failure means handled external documents could fail silently or show a different feedback shape
-     than the in-app Backup & Restore importer.
+     than the in-app Backup & Restore importer. Errors must not use the Android success-toast path.
      */
     func testExternalDocumentImportInstallerFailureUsesSharedErrorFeedback() {
         let service = ExternalDocumentImportService(
@@ -592,6 +606,7 @@ extension AndBibleTests {
 
         XCTAssertEqual(result, .failed(message: "installer rejected file"))
         XCTAssertEqual(result.feedbackMessage, "Error: installer rejected file")
+        XCTAssertFalse(result.usesAndroidInstallToastFeedback)
     }
 
     /**

--- a/AndBibleTests/AndBibleTests+ExternalDocumentImport.swift
+++ b/AndBibleTests/AndBibleTests+ExternalDocumentImport.swift
@@ -231,10 +231,13 @@ extension AndBibleTests {
      Android's install activity accepts document/module backup ZIPs through the same external-open
      surface as SWORD ZIPs, but the backup payload contains `AndBibleBackupManifest.json` and should
      be restored through the Android module-backup service so manifest validation, unsupported
-     Android-only entries, cache invalidation, and overwrite handling remain centralized.
+     Android-only entries, cache invalidation, and overwrite handling remain centralized. Android's
+     success surface is the generic InstallZip success toast, so feedback must not enumerate every
+     module from a large backup.
 
      Failure means `.abmd.zip` files can be routed into the plain SWORD ZIP installer, producing
-     misleading decompression errors and bypassing Android backup semantics.
+     misleading decompression errors and bypassing Android backup semantics, or iOS has drifted back
+     to a blocking module-list presentation that Android does not show.
      */
     func testExternalDocumentImportAndroidModuleBackupUsesBackupInstaller() {
         let probe = ExternalDocumentImportProbe()
@@ -247,11 +250,37 @@ extension AndBibleTests {
             result,
             .installedAndroidModuleBackup(moduleNames: ["ESV2001", "ESV2011"], installedEntryCount: 14)
         )
-        XCTAssertEqual(result.feedbackMessage, "Installed modules: ESV2001, ESV2011")
+        XCTAssertEqual(result.feedbackMessage, "Module was installed successfully")
+        XCTAssertFalse(result.feedbackMessage.contains("ESV2001"))
         XCTAssertEqual(probe.snapshot().androidModuleBackupURLs, [url])
         XCTAssertEqual(probe.snapshot().moduleURLs, [])
         XCTAssertEqual(probe.snapshot().epubURLs, [])
         XCTAssertEqual(probe.snapshot().fontURLs.map(\.url), [])
+    }
+
+    /**
+     Android module-backup success presentation follows InstallZip instead of listing modules.
+
+     Android's `InstallZip` posts the generic `install_zip_successfull` toast after a successful
+     module or document backup install. The iOS restore report can contain many module names and
+     skipped Android-only entries, but the completion copy must remain generic so large Android
+     backups do not produce a blocking, scroll-sized module list.
+
+     Failure means the Settings restore path can drift from Android's visible behavior even when
+     the underlying restore report is correct.
+     */
+    func testAndroidModuleBackupPresentationUsesGenericInstallSuccessCopy() {
+        let report = AndroidModuleBackupRestoreReport(
+            installedModuleNames: ["BDBT", "HebrewGreek", "StrongsHebrew"],
+            installedEntryCount: 124,
+            skippedUnsupportedEntryPaths: ["mybible/example.SQLite3"]
+        )
+
+        let message = AndroidModuleBackupPresentation.localizedRestoreSuccessMessage(for: report)
+
+        XCTAssertEqual(message, "Module was installed successfully")
+        XCTAssertFalse(message.contains("BDBT"))
+        XCTAssertFalse(message.contains("mybible"))
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
@@ -249,7 +249,7 @@ public final class AndroidModuleBackupService {
     private static let unsupportedAndroidModulePrefixes = ["mybible/", "mysword/", "esword/", "epub/"]
 
     /// SWORD drivers whose `DataPath` points at a file stem inside the actual module directory.
-    private static let singleFileDataPathDrivers: Set<String> = ["rawld", "zld", "rawgenbook", "rawfiles"]
+    private static let singleFileDataPathDrivers: Set<String> = ["rawld", "rawld4", "zld", "rawgenbook", "rawfiles"]
 
     /// Largest manifest or SWORD config entry accepted for in-memory metadata parsing.
     private static let maximumMetadataEntryByteCount = 1024 * 1024
@@ -825,7 +825,7 @@ public final class AndroidModuleBackupService {
      */
     private func existingEntryPaths(in supportedEntries: [ZipArchiveEntry]) -> [String] {
         supportedEntries.map(\.name)
-            .filter { fileManager.fileExists(atPath: moduleDirectory.appendingPathComponent($0).path) }
+            .filter { existingPublishedURL(for: $0) != nil }
             .sorted()
     }
 
@@ -834,12 +834,15 @@ public final class AndroidModuleBackupService {
      */
     private func existingEntryPaths(in supportedEntries: [ClassifiedFileEntry]) -> [String] {
         supportedEntries.map(\.name)
-            .filter { fileManager.fileExists(atPath: moduleDirectory.appendingPathComponent($0).path) }
+            .filter { existingPublishedURL(for: $0) != nil }
             .sorted()
     }
 
     /**
      Atomically publishes staged module files with rollback protection for overwritten paths.
+
+     Existing files are resolved through actual directory entries so Android backups can replace
+     files whose casing differs from an installed iOS copy on case-insensitive filesystems.
      */
     private func publishStagedEntries(
         _ relativePaths: [String],
@@ -853,21 +856,25 @@ public final class AndroidModuleBackupService {
             for relativePath in relativePaths {
                 let finalURL = moduleDirectory.appendingPathComponent(relativePath)
                 let stagedURL = stagingDirectory.appendingPathComponent(relativePath)
-                let rollbackURL = rollbackDirectory.appendingPathComponent(relativePath)
                 try fileManager.createDirectory(
                     at: finalURL.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
 
-                if fileManager.fileExists(atPath: finalURL.path) {
+                if let existingURL = existingPublishedURL(for: relativePath) {
+                    let existingRelativePath = relativePublishedPath(for: existingURL)
                     try fileManager.createDirectory(
-                        at: rollbackURL.deletingLastPathComponent(),
+                        at: rollbackDirectory.appendingPathComponent(existingRelativePath).deletingLastPathComponent(),
                         withIntermediateDirectories: true
                     )
-                    try fileManager.moveItem(at: finalURL, to: rollbackURL)
-                    movedExistingPaths.append(relativePath)
+                    try fileManager.moveItem(
+                        at: existingURL,
+                        to: rollbackDirectory.appendingPathComponent(existingRelativePath)
+                    )
+                    movedExistingPaths.append(existingRelativePath)
                 }
 
+                try? fileManager.removeItem(at: finalURL)
                 try fileManager.copyItem(at: stagedURL, to: finalURL)
                 createdPaths.append(relativePath)
             }
@@ -886,6 +893,55 @@ public final class AndroidModuleBackupService {
             }
             throw error
         }
+    }
+
+    /**
+     Finds an existing published module file that collides with one archive-relative path.
+
+     The lookup walks the real directory entries instead of relying only on `fileExists(atPath:)`
+     so case-variant Android paths can overwrite iOS-installed files reliably on APFS.
+     */
+    private func existingPublishedURL(for relativePath: String) -> URL? {
+        var currentURL = moduleDirectory
+        for rawComponent in relativePath.split(separator: "/") {
+            let component = String(rawComponent)
+            let componentKey = filesystemCollisionKey(component)
+            if let childURLs = try? fileManager.contentsOfDirectory(
+                at: currentURL,
+                includingPropertiesForKeys: nil
+            ),
+               let matchingURL = childURLs.first(where: { filesystemCollisionKey($0.lastPathComponent) == componentKey }) {
+                currentURL = matchingURL
+                continue
+            }
+
+            let exactURL = currentURL.appendingPathComponent(component)
+            guard fileManager.fileExists(atPath: exactURL.path) else {
+                return nil
+            }
+            currentURL = exactURL
+        }
+        return currentURL
+    }
+
+    /**
+     Converts an existing module file URL back to its module-root-relative path.
+     */
+    private func relativePublishedPath(for url: URL) -> String {
+        let rootPath = moduleDirectory.standardizedFileURL.path
+        let filePath = url.standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : "\(rootPath)/"
+        guard filePath.hasPrefix(prefix) else {
+            return url.lastPathComponent
+        }
+        return String(filePath.dropFirst(prefix.count))
+    }
+
+    /**
+     Produces a conservative case-insensitive filesystem comparison key for one path component.
+     */
+    private func filesystemCollisionKey(_ component: String) -> String {
+        component.precomposedStringWithCanonicalMapping.lowercased(with: Locale(identifier: "en_US_POSIX"))
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/BackupRestoreWorkflowSupport.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/BackupRestoreWorkflowSupport.swift
@@ -422,3 +422,42 @@ extension AndroidBackupResetCategory {
         "backupWorkflowReset.\(rawValue)Button"
     }
 }
+
+/**
+ Android module backup presentation strings shared by Settings and external file-open imports.
+
+ Android restores `.abmd.zip` archives through `InstallZip`, which reports successful document
+ installs with the generic `install_zip_successfull` toast instead of enumerating every module in
+ the backup. iOS keeps restore reports for diagnostics and tests, but user-facing completion copy
+ comes from this helper so both restore entry points stay aligned with Android.
+ */
+enum AndroidModuleBackupPresentation {
+    /**
+     Generic Android InstallZip success text for module backup restores.
+
+     - Returns: Localized success message equivalent to Android's `install_zip_successfull`.
+     - Side effects: Reads localization resources through Swift's localized string lookup.
+     - Failure modes: Missing localization falls back to Android's English string.
+     */
+    static var localizedInstallSuccessMessage: String {
+        String(
+            localized: "install_zip_successfull",
+            defaultValue: "Module was installed successfully"
+        )
+    }
+
+    /**
+     Converts a completed Android module-backup restore report into Android's success copy.
+
+     - Parameter report: Restore report retained by callers for diagnostics and future telemetry.
+     - Returns: Generic Android InstallZip success text, intentionally independent of module names,
+       entry counts, and skipped Android-only payloads because Android's success toast does not
+       expose those details.
+     - Side effects: Reads localization resources through Swift's localized string lookup.
+     - Failure modes: Missing localization falls back to Android's English string.
+     */
+    static func localizedRestoreSuccessMessage(for report: AndroidModuleBackupRestoreReport) -> String {
+        _ = report
+        return localizedInstallSuccessMessage
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -68,6 +68,12 @@ public struct ImportExportView: View {
     /// Pending user-visible success, failure, or guidance message for the feedback alert.
     @State private var statusMessage: String?
 
+    /// Pending Android-style transient install-success toast for document/module restores.
+    @State private var transientStatusMessage: String?
+
+    /// Scheduled dismissal for the current Android-style transient status toast.
+    @State private var transientStatusWorkItem: DispatchWorkItem?
+
     /// Controls presentation of the Android-style operation feedback alert.
     @State private var showStatusAlert = false
 
@@ -463,6 +469,7 @@ public struct ImportExportView: View {
         } message: {
             Text(androidModuleBackupOverwriteMessage())
         }
+        .androidToastFeedback(transientStatusMessage, bottomPadding: 48)
         .onChange(of: statusMessage) { _, newValue in
             showStatusAlert = newValue != nil
         }
@@ -1082,7 +1089,8 @@ public struct ImportExportView: View {
 
      - Parameter url: Security-scoped URL for a user-selected ZIP, EPUB, or TTF file.
      - Side effects: Mutates install progress state on the main actor, imports module, EPUB, or TTF
-       files into local app storage from a detached task, and presents feedback.
+       files into local app storage from a detached task, presents Android install successes as
+       transient toast feedback, and presents unsupported/error feedback as an alert.
      - Failure modes: Unsupported formats and installer errors are surfaced as feedback.
      */
     private func installSupportedDocument(from url: URL) {
@@ -1096,7 +1104,11 @@ public struct ImportExportView: View {
             let result = await Task.detached(priority: .userInitiated) {
                 ExternalDocumentImportService().importDocument(at: url)
             }.value
-            statusMessage = result.feedbackMessage
+            if result.usesAndroidInstallToastFeedback {
+                showTransientStatusMessage(result.feedbackMessage)
+            } else {
+                statusMessage = result.feedbackMessage
+            }
         }
     }
 
@@ -1210,7 +1222,7 @@ public struct ImportExportView: View {
      - copies the selected security-scoped file to a temporary archive
      - may write supported module files when no overwrite confirmation is required
      - may retain the temporary archive URL and existing paths for a later confirmation action
-     - presents feedback with restore success or failure details
+     - presents Android install success through a transient toast
      - Failure modes: Catches service errors and surfaces them to the settings screen.
      */
     private func prepareAndroidModuleBackupRestore(from url: URL) {
@@ -1251,7 +1263,7 @@ public struct ImportExportView: View {
                         allowOverwritingExistingFiles: true
                     )
                 }.value
-                statusMessage = androidModuleBackupRestoreStatusMessage(for: report)
+                showTransientStatusMessage(androidModuleBackupRestoreStatusMessage(for: report))
                 isRestoringAndroidModuleBackup = false
                 try? FileManager.default.removeItem(at: prepared.0)
                 temporaryArchiveURL = nil
@@ -1271,7 +1283,8 @@ public struct ImportExportView: View {
      Side effects:
      - writes supported SWORD module files into the local module directory
      - clears pending confirmation state
-     - presents feedback with success or failure details after the overwrite alert closes
+     - presents Android install success through a transient toast after the overwrite alert closes
+     - surfaces service errors through the feedback alert
      */
     private func restorePendingAndroidModuleBackup() {
         guard let archiveURL = pendingAndroidModuleBackupURL else {
@@ -1285,7 +1298,6 @@ public struct ImportExportView: View {
 
         Task { @MainActor in
             await Task.yield()
-            let feedbackMessage: String
             do {
                 let report = try await Task.detached(priority: .userInitiated) {
                     try AndroidModuleBackupService().restoreArchive(
@@ -1293,14 +1305,41 @@ public struct ImportExportView: View {
                         allowOverwritingExistingFiles: true
                     )
                 }.value
-                feedbackMessage = androidModuleBackupRestoreStatusMessage(for: report)
+                showTransientStatusMessage(androidModuleBackupRestoreStatusMessage(for: report))
             } catch {
-                feedbackMessage = localizedErrorMessage(error)
+                statusMessage = localizedErrorMessage(error)
             }
             try? FileManager.default.removeItem(at: archiveURL)
             isRestoringAndroidModuleBackup = false
-            statusMessage = feedbackMessage
         }
+    }
+
+    /**
+     Shows Android-style transient success feedback on the Backup & Restore screen.
+
+     Android document/module installs report successful completion with a short toast. Settings
+     retains alerts for failures and destructive confirmations, but success copy should not block
+     the screen or require an OK tap.
+
+     - Parameter message: Localized toast text to display.
+     - Side effects:
+       - cancels any pending toast dismissal
+       - mutates transient feedback state
+       - schedules automatic toast dismissal
+     - Failure modes: none; newer messages replace earlier transient feedback.
+     */
+    private func showTransientStatusMessage(_ message: String) {
+        transientStatusWorkItem?.cancel()
+        withAnimation { transientStatusMessage = message }
+        let work = DispatchWorkItem {
+            withAnimation { transientStatusMessage = nil }
+            transientStatusWorkItem = nil
+        }
+        transientStatusWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + AndroidToastFeedback.shortDuration,
+            execute: work
+        )
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -1356,25 +1356,14 @@ public struct ImportExportView: View {
      Builds the user-visible completion summary for Android module backup restore.
 
      - Parameter report: Restore report from `AndroidModuleBackupService`.
-     - Returns: Concise status message listing installed modules and skipped unsupported content.
+     - Returns: Android's generic module-install success message. The report remains an input so the
+       restore caller keeps the service contract explicit even though Android does not enumerate
+       restored module names in the success surface.
      - Side effects: none.
-     - Failure modes: Empty module names produce a generic success message, though the service
-       normally rejects archives without supported SWORD modules.
+     - Failure modes: Missing localization falls back to Android's English success string.
      */
     private func androidModuleBackupRestoreStatusMessage(for report: AndroidModuleBackupRestoreReport) -> String {
-        let modules = report.installedModuleNames.isEmpty
-            ? String(localized: "android_module_backup_modules_unknown", defaultValue: "modules")
-            : report.installedModuleNames.joined(separator: ", ")
-        if report.skippedUnsupportedEntryPaths.isEmpty {
-            return String(
-                localized: "android_module_backup_restored_summary",
-                defaultValue: "Restored Android module backup: \(modules)"
-            )
-        }
-        return String(
-            localized: "android_module_backup_restored_with_skips_summary",
-            defaultValue: "Restored Android module backup: \(modules). Skipped \(report.skippedUnsupportedEntryPaths.count) Android-only files."
-        )
+        AndroidModuleBackupPresentation.localizedRestoreSuccessMessage(for: report)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Shared/AndroidToastFeedback.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/AndroidToastFeedback.swift
@@ -1,0 +1,97 @@
+// AndroidToastFeedback.swift -- Android-style transient toast presentation
+
+import Foundation
+import SwiftUI
+
+/**
+ Namespace for Android toast timing constants used by SwiftUI hosts.
+
+ Android's `ToastEvent` defaults to `Toast.LENGTH_SHORT` for successful module/document installs.
+ iOS mirrors that with a short, non-blocking overlay instead of a modal alert so install success
+ does not interrupt the user's current screen.
+ */
+public enum AndroidToastFeedback {
+    /// Approximate duration of Android `Toast.LENGTH_SHORT` in seconds.
+    public static let shortDuration: TimeInterval = 2.0
+}
+
+/**
+ Android-style transient toast surface.
+
+ The view is intentionally presentation-only: callers own message state, replacement policy, and
+ dismissal scheduling so app-level and settings-level workflows can queue operations correctly.
+ The visual treatment follows Android's small dark rounded toast rather than iOS alert/sheet chrome.
+ */
+public struct AndroidToastOverlay: View {
+    /// User-visible toast message.
+    private let message: String
+
+    /// Distance from the bottom edge of the containing surface.
+    private let bottomPadding: CGFloat
+
+    /**
+     Creates a toast overlay for a single message.
+
+     - Parameters:
+       - message: Localized text to show.
+       - bottomPadding: Bottom offset that lets hosts keep the toast above tab bars or safe-area
+         controls.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(message: String, bottomPadding: CGFloat = 80) {
+        self.message = message
+        self.bottomPadding = bottomPadding
+    }
+
+    /**
+     Builds the Android-style toast capsule.
+
+     - Returns: A non-interactive SwiftUI overlay that wraps long localized text.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public var body: some View {
+        Text(message)
+            .font(.subheadline)
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.center)
+            .lineLimit(3)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .frame(maxWidth: 340)
+            .background(
+                Color.black.opacity(0.84),
+                in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+            )
+            .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
+            .padding(.horizontal, 24)
+            .padding(.bottom, bottomPadding)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .accessibilityIdentifier("androidToastFeedback")
+            .accessibilityAddTraits(.isStaticText)
+            .allowsHitTesting(false)
+    }
+}
+
+public extension View {
+    /**
+     Overlays Android-style transient toast feedback when `message` is non-nil.
+
+     - Parameters:
+       - message: Optional localized toast text. `nil` removes the overlay.
+       - bottomPadding: Bottom offset passed to `AndroidToastOverlay`.
+     - Returns: The original view with a bottom-aligned toast overlay attached.
+     - Side effects: none; callers remain responsible for scheduling message dismissal.
+     - Failure modes: none.
+     */
+    func androidToastFeedback(_ message: String?, bottomPadding: CGFloat = 80) -> some View {
+        overlay(alignment: .bottom) {
+            if let message {
+                AndroidToastOverlay(message: message, bottomPadding: bottomPadding)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: message)
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
@@ -547,7 +547,7 @@ public enum ExternalDocumentImportResult: Equatable, Sendable {
     /// A TTF font installed successfully; associated value is the installed font name.
     case installedFont(name: String)
 
-    /// An Android module backup restored successfully; associated values describe restored modules.
+    /// An Android module backup restored successfully; associated values preserve restore details.
     case installedAndroidModuleBackup(moduleNames: [String], installedEntryCount: Int)
 
     /// The file extension is not handled by iOS' implemented document installer path.
@@ -581,20 +581,8 @@ public enum ExternalDocumentImportResult: Equatable, Sendable {
                 format: String(localized: "installed_font_%@", defaultValue: "Installed font: %@"),
                 name
             )
-        case .installedAndroidModuleBackup(let moduleNames, let installedEntryCount):
-            let summary = moduleNames.isEmpty
-                ? String(
-                    format: String(localized: "installed_module_files_%d", defaultValue: "%d module files"),
-                    installedEntryCount
-                )
-                : moduleNames.joined(separator: ", ")
-            return String(
-                format: String(
-                    localized: "installed_android_module_backup_%@",
-                    defaultValue: "Installed modules: %@"
-                ),
-                summary
-            )
+        case .installedAndroidModuleBackup:
+            return AndroidModuleBackupPresentation.localizedInstallSuccessMessage
         case .unsupportedFormat(let fileExtension):
             return String(
                 format: String(

--- a/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
@@ -559,29 +559,18 @@ public enum ExternalDocumentImportResult: Equatable, Sendable {
     /**
       Localized user-visible feedback for the import result.
 
-      - Returns: Success, unsupported-format, or error text using the existing import/export
-          localization keys with English defaults for package tests and missing translations.
+      - Returns: Android's generic install-success text for handled successful installs, or
+          unsupported-format/error text for failures using existing localization keys with English
+          defaults for package tests and missing translations.
       - Side effects: none.
       - Failure modes: Missing localization entries fall back to the supplied default strings.
       */
     public var feedbackMessage: String {
         switch self {
-        case .installedModule(let name):
-            return String(
-                format: String(localized: "installed_module_%@", defaultValue: "Installed module: %@"),
-                name
-            )
-        case .installedEpub(let title):
-            return String(
-                format: String(localized: "installed_epub_%@", defaultValue: "Installed EPUB: %@"),
-                title
-            )
-        case .installedFont(let name):
-            return String(
-                format: String(localized: "installed_font_%@", defaultValue: "Installed font: %@"),
-                name
-            )
-        case .installedAndroidModuleBackup:
+        case .installedModule,
+             .installedEpub,
+             .installedFont,
+             .installedAndroidModuleBackup:
             return AndroidModuleBackupPresentation.localizedInstallSuccessMessage
         case .unsupportedFormat(let fileExtension):
             return String(
@@ -600,6 +589,31 @@ public enum ExternalDocumentImportResult: Equatable, Sendable {
                 ),
                 message
             )
+        }
+    }
+
+    /**
+      Whether this result should use Android's transient install-success toast presentation.
+
+      Android's `InstallZip` reports successful ZIP, EPUB, TTF, and module-backup installs by
+      posting `ToastEvent(R.string.install_zip_successfull)`. Errors, invalid files, and unsupported
+      formats remain interruptive feedback on iOS so users do not miss an action they may need to
+      correct.
+
+      - Returns: `true` for successful handled install results, otherwise `false`.
+      - Side effects: none.
+      - Failure modes: none.
+      */
+    public var usesAndroidInstallToastFeedback: Bool {
+        switch self {
+        case .installedModule,
+             .installedEpub,
+             .installedFont,
+             .installedAndroidModuleBackup:
+            return true
+        case .unsupportedFormat,
+             .failed:
+            return false
         }
     }
 }

--- a/Sources/SwordKit/CLibSword/sword_adapter.c
+++ b/Sources/SwordKit/CLibSword/sword_adapter.c
@@ -743,7 +743,7 @@ int inflate_raw_file_range_to_file(const char *input_path,
                 result = -8;
                 break;
             }
-        } while ((stream.avail_in > 0 || stream.avail_out == 0) && ret != Z_STREAM_END);
+        } while (stream.avail_in > 0 && ret != Z_STREAM_END);
 
         if (result != 0) break;
     }


### PR DESCRIPTION
## Summary
- Restores Android `.abmd.zip` module backups that contain RawLD4/rawld4 file-stem dictionary modules.
- Aligns successful module/document restore feedback with Android `InstallZip`: generic `Module was installed successfully` toast instead of blocking iOS result alerts.
- Keeps restore failures, unsupported formats, and overwrite confirmation as interruptive feedback.

## Scope
- Android module backup validation, extraction, and overwrite handling.
- External ZIP/EPUB/TTF/module-backup import feedback routing.
- Backup & Restore document/module restore feedback routing.
- Focused unit coverage for RawLD4 restore, case-collision overwrite, Android success-copy, and toast-routing contracts.

## Contract References
- Android `InstallZip` posts `ToastEvent(R.string.install_zip_successfull)` for successful ZIP/EPUB/TTF/module installs.
- Android string `install_zip_successfull` is `Module was installed successfully`.
- Android module backups may include RawLD4-style file-stem dictionary payloads such as `modules/lexdict/rawld4/...`.
- Related prior issue search: #151, #189, #192, and #54 are closed; no open issue matched this restore/import defect.

## Change Details
- Added RawLD4 file-stem support to Android module-backup path validation.
- Fixed raw zlib file-range inflation so archive entries at chunk boundaries do not fail with `Z_BUF_ERROR`.
- Made publish overwrite tolerate case-only path collisions already present on disk.
- Added `AndroidModuleBackupPresentation` for Android generic install-success copy.
- Added `AndroidToastOverlay` / `androidToastFeedback` and routed successful handled installs through short transient feedback.
- Updated tests so success feedback no longer enumerates restored modules or uses iOS-specific installed-module/EPUB/font copy.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 CODE_SIGNING_ALLOWED=NO` selected AndBibleTests document-import and Android module-backup tests `test`
- `git diff --check`
- `npx gitnexus analyze --index-only --name and-bible-ios-fix-android-module-backup-rawld4 --allow-duplicate-name`
- GitNexus `detect_changes` staged: low risk, 5 files, no affected execution flows for the latest presentation commit.
- Installed over existing app in iPhone 16 iOS 18.6 simulator and launched successfully.

## Risks / Follow-ups
- The current PR does not address separate parity issues called out during testing: missing BDBT tab visibility, active-window blue outline, or dictionary tab margins.
- The restore success path intentionally does not list restored module names because Android uses generic install success toast copy.
- Existing localization keys for old iOS-specific install-success copy remain in resource files but are no longer used for successful handled document imports.

## Issue Closure
- Closes: none
- Verified with GitHub issue search for RawLD4, Android module backup, `.abmd`, and module restore; matching issues were already closed.