### PR TITLE
Update GitHub Sponsors username in FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: AndBible # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
## Summary
Add `.github/FUNDING.yml` so GitHub shows a "Sponsor" button on the
repository, letting users fund AndBible development directly from the
project page.

## Scope
In scope:
- Add the GitHub funding metadata file with the GitHub Sponsors username
  set to `AndBible`.

Out of scope:
- Any other funding platforms (Patreon, Open Collective, Ko-fi, etc.) are
  left blank.
- Application, build, or runtime code.

## Contract References
- `commit-message-standard.md`

## Change Details
- New file `.github/FUNDING.yml` based on GitHub's default funding
  template, with `github: AndBible` set and all other platforms blank.
- No application, build, or frontend code is touched.

## Validation Evidence
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main --head-ref HEAD`

## Risks / Follow-ups
none

## Screenshots
none

## Closes
Closes: none
