### PR TITLE
refactor(reader): extract annotation bridge routing

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeHandler.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeHandler.swift
@@ -1,0 +1,389 @@
+import Foundation
+import BibleCore
+import BibleView
+import os.log
+
+private let annotationBridgeHandlerLogger = Logger(
+    subsystem: "org.andbible",
+    category: "BibleReaderAnnotationBridgeHandler"
+)
+
+/**
+ Routes bookmark, My Notes, and StudyPad bridge delegate calls for one reader pane.
+
+ `BibleReaderController` must remain the `BibleBridgeDelegate`, but bookmark and StudyPad bridge
+ behavior is a coherent annotation boundary rather than reader orchestration. This handler keeps the
+ delegate method routing, Android-compatible logging, UI-test mutation guards, native label
+ assignment handoff, and coordinator lookup together while the lower-level
+ `BibleReaderAnnotationBridgeCoordinator` continues to own persistence-result application and Vue
+ event emission.
+
+ Inputs:
+ - `BibleBridge` delegate callback parameters from BibleView
+ - a coordinator factory bound to the controller's current bookmark service and bridge state hooks
+ - controller state closures for editing mode, visible My Notes/StudyPad state, and UI-test
+   annotation fixtures
+
+ Outputs:
+ - calls into `BibleReaderAnnotationBridgeCoordinator`
+ - native label-assignment callback requests
+ - editing-mode updates through the injected setter
+
+ Side effects:
+ - mutates bookmark/StudyPad persistence through the annotation bridge coordinator
+ - may emit BibleView bridge events through the coordinator
+ - mutates controller editing state and one-shot UI-test annotation guards
+
+ Failure modes:
+ - missing bookmark persistence logs or returns without side effects, matching the previous
+   controller behavior
+ - malformed UUIDs, stale StudyPad rows, or disabled UI-test fixture configuration are ignored
+   without throwing
+ */
+struct BibleReaderAnnotationBridgeHandler {
+    /// Builds the coordinator that performs persistence and bridge event application.
+    private let coordinator: (BibleBridge) -> BibleReaderAnnotationBridgeCoordinator?
+    /// Supplies the currently configured bookmark service for UI-test StudyPad row lookup.
+    private let bookmarkService: () -> BookmarkService?
+    /// Indicates whether My Notes is currently the visible document.
+    private let isShowingMyNotes: () -> Bool
+    /// Indicates whether StudyPad is currently the visible document.
+    private let isShowingStudyPad: () -> Bool
+    /// Supplies the active StudyPad label id when StudyPad is visible.
+    private let activeStudyPadLabelId: () -> UUID?
+    /// Supplies note-backed bookmarks currently visible in My Notes.
+    private let currentChapterMyNotesBookmarks: () -> [BibleBookmark]
+    /// Applies WebView editing state back to the controller.
+    private let setEditingInWebView: (Bool) -> Void
+    /// Requests native label-assignment UI from the owning SwiftUI view.
+    private let assignLabels: (UUID) -> Void
+
+    /// One-shot guard for UI-test My Notes append fixtures.
+    private var didApplyUITestMyNotesAppendText = false
+    /// One-shot guard for UI-test StudyPad created-note fixtures.
+    private var didApplyUITestStudyPadCreatedNoteText = false
+
+    /**
+     Creates a bridge handler bound to a controller's current state accessors.
+
+     - Parameters:
+       - coordinator: Factory for a bridge-specific annotation coordinator.
+       - bookmarkService: Bookmark persistence supplier used for UI-test StudyPad row lookup.
+       - isShowingMyNotes: Closure returning whether My Notes is visible.
+       - isShowingStudyPad: Closure returning whether StudyPad is visible.
+       - activeStudyPadLabelId: Closure returning the active StudyPad label id.
+       - currentChapterMyNotesBookmarks: Closure returning visible My Notes bookmark rows.
+       - setEditingInWebView: Closure applying editing-mode state to the controller.
+       - assignLabels: Closure requesting native label assignment.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        coordinator: @escaping (BibleBridge) -> BibleReaderAnnotationBridgeCoordinator?,
+        bookmarkService: @escaping () -> BookmarkService?,
+        isShowingMyNotes: @escaping () -> Bool,
+        isShowingStudyPad: @escaping () -> Bool,
+        activeStudyPadLabelId: @escaping () -> UUID?,
+        currentChapterMyNotesBookmarks: @escaping () -> [BibleBookmark],
+        setEditingInWebView: @escaping (Bool) -> Void,
+        assignLabels: @escaping (UUID) -> Void
+    ) {
+        self.coordinator = coordinator
+        self.bookmarkService = bookmarkService
+        self.isShowingMyNotes = isShowingMyNotes
+        self.isShowingStudyPad = isShowingStudyPad
+        self.activeStudyPadLabelId = activeStudyPadLabelId
+        self.currentChapterMyNotesBookmarks = currentChapterMyNotesBookmarks
+        self.setEditingInWebView = setEditingInWebView
+        self.assignLabels = assignLabels
+    }
+
+    /// Shared bookmark creation/update path used by JS bridge and native selection actions.
+    mutating func addOrUpdateBibleBookmark(
+        bridge: BibleBridge,
+        bookInitials: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool,
+        wholeVerse: Bool,
+        startOffset: Int? = nil,
+        endOffset: Int? = nil
+    ) {
+        guard let coordinator = coordinator(bridge) else {
+            annotationBridgeHandlerLogger.warning("addBookmark: bookmarkService is nil")
+            return
+        }
+        coordinator.addOrUpdateBibleBookmark(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote,
+            wholeVerse: wholeVerse,
+            startOffset: startOffset,
+            endOffset: endOffset
+        )
+    }
+
+    /// Creates a Bible bookmark requested from the web client.
+    mutating func addBookmark(
+        bridge: BibleBridge,
+        bookInitials: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool
+    ) {
+        addOrUpdateBibleBookmark(
+            bridge: bridge,
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote,
+            wholeVerse: true
+        )
+    }
+
+    /// Creates a generic bookmark for non-Bible content from a web-client request.
+    func addGenericBookmark(
+        bridge: BibleBridge,
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int,
+        addNote: Bool
+    ) {
+        annotationBridgeHandlerLogger.info("Add generic bookmark: \(bookInitials) ref=\(osisRef)")
+        coordinator(bridge)?.addGenericBookmark(
+            bookInitials: bookInitials,
+            osisRef: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal,
+            addNote: addNote
+        )
+    }
+
+    /// Creates a Bible paragraph-break bookmark requested from the web client.
+    func addParagraphBreakBookmark(bridge: BibleBridge, bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        annotationBridgeHandlerLogger.info("Add paragraph break bookmark: \(bookInitials)")
+        coordinator(bridge)?.addParagraphBreakBibleBookmark(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Creates a generic paragraph-break bookmark requested from the web client.
+    func addGenericParagraphBreakBookmark(
+        bridge: BibleBridge,
+        bookInitials: String,
+        osisRef: String,
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) {
+        annotationBridgeHandlerLogger.info("Add generic paragraph break bookmark: \(bookInitials) ref=\(osisRef)")
+        coordinator(bridge)?.addGenericParagraphBreakBookmark(
+            bookInitials: bookInitials,
+            osisRef: osisRef,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Deletes a Bible bookmark requested from the web client.
+    func removeBookmark(bridge: BibleBridge, bookmarkId: String) {
+        annotationBridgeHandlerLogger.info("Remove bookmark: \(bookmarkId)")
+        coordinator(bridge)?.removeBookmark(bookmarkId)
+    }
+
+    /// Deletes a generic bookmark requested from the web client.
+    func removeGenericBookmark(bridge: BibleBridge, bookmarkId: String) {
+        annotationBridgeHandlerLogger.info("Remove generic bookmark: \(bookmarkId)")
+        coordinator(bridge)?.removeGenericBookmark(bookmarkId)
+    }
+
+    /// Persists note text for an existing bookmark and notifies the web client.
+    func saveBookmarkNote(bridge: BibleBridge, bookmarkId: String, note: String?) {
+        annotationBridgeHandlerLogger.info("Save bookmark note: \(bookmarkId)")
+        _ = coordinator(bridge)?.saveBookmarkNote(bookmarkId: bookmarkId, note: note)
+    }
+
+    /// Requests native label-assignment UI for a bookmark from the owning SwiftUI view.
+    func assignLabels(bookmarkId: String) {
+        annotationBridgeHandlerLogger.info("Assign labels requested for: \(bookmarkId)")
+        guard let uuid = UUID(uuidString: bookmarkId) else { return }
+        assignLabels(uuid)
+    }
+
+    /// Refreshes one bookmark payload after native label assignment dismisses.
+    func refreshBookmark(bridge: BibleBridge, bookmarkId: UUID) {
+        coordinator(bridge)?.refreshBookmark(bookmarkId: bookmarkId)
+    }
+
+    /// Toggles one label assignment on a bookmark and re-emits updated state.
+    func toggleBookmarkLabel(bridge: BibleBridge, bookmarkId: String, labelId: String) {
+        annotationBridgeHandlerLogger.info("Toggle label \(labelId) on bookmark \(bookmarkId)")
+        coordinator(bridge)?.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
+    }
+
+    /// Removes one label assignment from a bookmark and re-emits updated state.
+    func removeBookmarkLabel(bridge: BibleBridge, bookmarkId: String, labelId: String) {
+        annotationBridgeHandlerLogger.info("Remove label \(labelId) from bookmark \(bookmarkId)")
+        coordinator(bridge)?.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
+    }
+
+    /// Sets the primary label used to style a bookmark in Vue.js.
+    func setPrimaryLabel(bridge: BibleBridge, bookmarkId: String, labelId: String) {
+        annotationBridgeHandlerLogger.info("Set primary label \(labelId) on bookmark \(bookmarkId)")
+        coordinator(bridge)?.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId)
+    }
+
+    /// Updates whether a bookmark should highlight whole verses or a text-range selection.
+    func setBookmarkWholeVerse(bridge: BibleBridge, bookmarkId: String, value: Bool) {
+        annotationBridgeHandlerLogger.info("Set whole verse \(value) for bookmark \(bookmarkId)")
+        coordinator(bridge)?.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value)
+    }
+
+    /// Updates the custom icon attached to a bookmark.
+    func setBookmarkCustomIcon(bridge: BibleBridge, bookmarkId: String, value: String?) {
+        annotationBridgeHandlerLogger.info("Set custom icon for bookmark \(bookmarkId)")
+        coordinator(bridge)?.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value)
+    }
+
+    /// Creates a new StudyPad text entry relative to an existing bookmark or note row.
+    mutating func createNewStudyPadEntry(
+        bridge: BibleBridge,
+        labelId: String,
+        entryType: String,
+        afterEntryId: String
+    ) {
+        annotationBridgeHandlerLogger.info("Create StudyPad entry type=\(entryType) after \(afterEntryId) in label \(labelId)")
+        coordinator(bridge)?.createNewStudyPadEntry(
+            labelId: labelId,
+            entryType: entryType,
+            afterEntryId: afterEntryId
+        )
+        applyUITestStudyPadCreatedNoteTextIfNeeded(bridge: bridge)
+    }
+
+    /// Deletes one StudyPad text entry and emits the resulting reordered state.
+    func deleteStudyPadEntry(bridge: BibleBridge, studyPadId: String) {
+        annotationBridgeHandlerLogger.info("Delete StudyPad entry: \(studyPadId)")
+        coordinator(bridge)?.deleteStudyPadEntry(studyPadId)
+    }
+
+    /// Updates StudyPad entry metadata such as indent level or order number.
+    func updateStudyPadTextEntry(bridge: BibleBridge, data: String) {
+        annotationBridgeHandlerLogger.info("Update StudyPad text entry metadata")
+        coordinator(bridge)?.updateStudyPadTextEntry(data: data)
+    }
+
+    /// Persists edited text for one StudyPad text entry.
+    func updateStudyPadTextEntryText(bridge: BibleBridge, id: String, text: String) {
+        annotationBridgeHandlerLogger.info("Update StudyPad entry text: \(id)")
+        _ = coordinator(bridge)?.updateStudyPadTextEntryText(id: id, text: text)
+    }
+
+    /// Persists reordered StudyPad rows and bookmark associations for one label.
+    func updateOrderNumber(bridge: BibleBridge, labelId: String, data: String) {
+        annotationBridgeHandlerLogger.info("Update order numbers for label \(labelId)")
+        coordinator(bridge)?.updateOrderNumber(labelId: labelId, data: data)
+    }
+
+    /// Updates one `BibleBookmarkToLabel` association from a JSON payload emitted by Vue.js.
+    func updateBookmarkToLabel(bridge: BibleBridge, data: String) {
+        annotationBridgeHandlerLogger.info("Update BibleBookmarkToLabel")
+        coordinator(bridge)?.updateBookmarkToLabel(data: data)
+    }
+
+    /// Updates one `GenericBookmarkToLabel` association from a JSON payload emitted by Vue.js.
+    func updateGenericBookmarkToLabel(bridge: BibleBridge, data: String) {
+        annotationBridgeHandlerLogger.info("Update GenericBookmarkToLabel")
+        coordinator(bridge)?.updateGenericBookmarkToLabel(data: data)
+    }
+
+    /// Persists an optional bookmark edit action configured in the web client.
+    func setBookmarkEditAction(bridge: BibleBridge, bookmarkId: String, value: String) {
+        annotationBridgeHandlerLogger.info("Set edit action on bookmark \(bookmarkId): \(value)")
+        coordinator(bridge)?.setBookmarkEditAction(bookmarkId: bookmarkId, value: value)
+    }
+
+    /**
+     Tracks whether the embedded web client is currently editing content.
+
+     When UI-test fixture hooks are active, entering editing mode is also the deterministic signal
+     that the created note/editor row exists and can receive seeded text.
+     */
+    mutating func setEditing(bridge: BibleBridge, enabled: Bool) {
+        annotationBridgeHandlerLogger.info("WebView editing mode: \(enabled)")
+        setEditingInWebView(enabled)
+        if enabled {
+            applyUITestMyNotesAppendTextIfNeeded(bridge: bridge)
+            applyUITestStudyPadCreatedNoteTextIfNeeded(bridge: bridge)
+        }
+    }
+
+    /// Persists the current insertion cursor position for a StudyPad label.
+    func setStudyPadCursor(bridge: BibleBridge, labelId: String, orderNumber: Int) {
+        annotationBridgeHandlerLogger.info("StudyPad cursor: label=\(labelId) order=\(orderNumber)")
+        coordinator(bridge)?.setStudyPadCursor(labelId: labelId, orderNumber: orderNumber)
+    }
+
+    @discardableResult
+    private mutating func applyUITestMyNotesAppendTextIfNeeded(bridge: BibleBridge) -> Bool {
+        guard !didApplyUITestMyNotesAppendText,
+              let appendText = UITestRuntimeConfiguration.myNotesAppendText,
+              appendUITestTextToFirstVisibleMyNotesNote(appendText, bridge: bridge) else {
+            return false
+        }
+        didApplyUITestMyNotesAppendText = true
+        return true
+    }
+
+    @discardableResult
+    private func appendUITestTextToFirstVisibleMyNotesNote(_ text: String, bridge: BibleBridge) -> Bool {
+        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports,
+              isShowingMyNotes(),
+              !text.isEmpty,
+              let bookmark = currentChapterMyNotesBookmarks().first
+        else {
+            return false
+        }
+
+        let currentNote = bookmark.notes?.notes ?? ""
+        return coordinator(bridge)?.saveBookmarkNote(
+            bookmarkId: bookmark.id.uuidString,
+            note: currentNote + text
+        ) ?? false
+    }
+
+    @discardableResult
+    private mutating func applyUITestStudyPadCreatedNoteTextIfNeeded(bridge: BibleBridge) -> Bool {
+        guard !didApplyUITestStudyPadCreatedNoteText,
+              let noteText = UITestRuntimeConfiguration.studyPadCreatedNoteText,
+              updateNewestVisibleStudyPadTextEntry(noteText, bridge: bridge) else {
+            return false
+        }
+        didApplyUITestStudyPadCreatedNoteText = true
+        return true
+    }
+
+    @discardableResult
+    private func updateNewestVisibleStudyPadTextEntry(_ text: String, bridge: BibleBridge) -> Bool {
+        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports,
+              isShowingStudyPad(),
+              !text.isEmpty,
+              let service = bookmarkService(),
+              let labelId = activeStudyPadLabelId(),
+              let coordinator = coordinator(bridge),
+              let entry = service.studyPadEntries(labelId: labelId).max(by: { lhs, rhs in
+                  if lhs.orderNumber != rhs.orderNumber {
+                      return lhs.orderNumber < rhs.orderNumber
+                  }
+                  return lhs.id.uuidString < rhs.id.uuidString
+              })
+        else {
+            return false
+        }
+
+        return coordinator.updateStudyPadTextEntryText(id: entry.id.uuidString, text: text)
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeHandler.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeHandler.swift
@@ -152,7 +152,11 @@ struct BibleReaderAnnotationBridgeHandler {
         addNote: Bool
     ) {
         annotationBridgeHandlerLogger.info("Add generic bookmark: \(bookInitials) ref=\(osisRef)")
-        coordinator(bridge)?.addGenericBookmark(
+        guard let coordinator = coordinator(bridge) else {
+            annotationBridgeHandlerLogger.warning("addGenericBookmark: bookmarkService is nil")
+            return
+        }
+        coordinator.addGenericBookmark(
             bookInitials: bookInitials,
             osisRef: osisRef,
             startOrdinal: startOrdinal,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -3185,11 +3185,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         endOrdinal: Int,
         addNote: Bool
     ) {
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else {
-            logger.warning("addGenericBookmark: bookmarkService is nil")
-            return
-        }
-        coordinator.addGenericBookmark(
+        annotationBridgeHandler.addGenericBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             osisRef: osisRef,
             startOrdinal: startOrdinal,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -49,15 +49,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     private var pendingClientReadyMyNotesJumpOrdinal: Int?
     /// Monotonic marker used by lightweight UI-test exports when My Notes state or documents rebuild.
     private(set) var myNotesMutationRevision = 0
-    /// Prevents a launch-seeded UI-test append from firing more than once in the same reader session.
-    private var didApplyUITestMyNotesAppendText = false
 
     /// Whether the WebView is currently showing a StudyPad document.
     private(set) var showingStudyPad = false
     /// Monotonic marker used by lightweight UI-test exports when StudyPad state mutates.
     private(set) var studyPadMutationRevision = 0
-    /// Prevents a launch-seeded UI-test StudyPad note from firing more than once per reader session.
-    private var didApplyUITestStudyPadCreatedNoteText = false
     /// The label ID of the currently active StudyPad.
     private(set) var activeStudyPadLabelId: UUID?
     /// The name of the currently active StudyPad label (for the header).
@@ -69,6 +65,9 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Router for bridge events whose behavior is limited to pane-local modal and host callbacks.
     @ObservationIgnored
     private lazy var bridgeEventRouter = makeBridgeEventRouter()
+    /// Router for annotation bridge delegate calls and UI-test annotation mutation hooks.
+    @ObservationIgnored
+    private lazy var annotationBridgeHandler = makeAnnotationBridgeHandler()
     /// Pure classifier for Android-compatible external link and pseudo-link strings.
     private let externalLinkRouter = BibleReaderExternalLinkRouter()
 
@@ -2711,11 +2710,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         startOffset: Int? = nil,
         endOffset: Int? = nil
     ) {
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else {
-            logger.warning("addBookmark: bookmarkService is nil")
-            return
-        }
-        coordinator.addOrUpdateBibleBookmark(
+        annotationBridgeHandler.addOrUpdateBibleBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal,
@@ -2740,14 +2736,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
        the bookmark modal in the web client
      */
     public func bridge(_ bridge: BibleBridge, addBookmark bookInitials: String, startOrdinal: Int, endOrdinal: Int, addNote: Bool) {
-        addOrUpdateBibleBookmark(
+        annotationBridgeHandler.addBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal,
-            addNote: addNote,
-            wholeVerse: true,
-            startOffset: nil,
-            endOffset: nil
+            addNote: addNote
         )
     }
 
@@ -2768,9 +2762,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when bookmark services are unavailable
      */
     public func bridge(_ bridge: BibleBridge, addGenericBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int, addNote: Bool) {
-        logger.info("Add generic bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
-        coordinator.addGenericBookmark(
+        annotationBridgeHandler.addGenericBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             osisRef: osisRef,
             startOrdinal: startOrdinal,
@@ -2781,9 +2774,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Creates a Bible paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addParagraphBreakBookmark bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        logger.info("Add paragraph break bookmark: \(bookInitials)")
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
-        coordinator.addParagraphBreakBibleBookmark(
+        annotationBridgeHandler.addParagraphBreakBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal
@@ -2792,9 +2784,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Creates a generic paragraph-break bookmark requested from the web client.
     public func bridge(_ bridge: BibleBridge, addGenericParagraphBreakBookmark bookInitials: String, osisRef: String, startOrdinal: Int, endOrdinal: Int) {
-        logger.info("Add generic paragraph break bookmark: \(bookInitials) ref=\(osisRef)")
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
-        coordinator.addGenericParagraphBreakBookmark(
+        annotationBridgeHandler.addGenericParagraphBreakBookmark(
+            bridge: bridge,
             bookInitials: bookInitials,
             osisRef: osisRef,
             startOrdinal: startOrdinal,
@@ -2814,8 +2805,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when the bookmark service is unavailable or the identifier is invalid
      */
     public func bridge(_ bridge: BibleBridge, removeBookmark bookmarkId: String) {
-        logger.info("Remove bookmark: \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.removeBookmark(bookmarkId)
+        annotationBridgeHandler.removeBookmark(bridge: bridge, bookmarkId: bookmarkId)
     }
 
     /**
@@ -2830,8 +2820,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when the bookmark service is unavailable or the identifier is invalid
      */
     public func bridge(_ bridge: BibleBridge, removeGenericBookmark bookmarkId: String) {
-        logger.info("Remove generic bookmark: \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.removeGenericBookmark(bookmarkId)
+        annotationBridgeHandler.removeGenericBookmark(bridge: bridge, bookmarkId: bookmarkId)
     }
 
     /**
@@ -2848,89 +2837,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when the bookmark service is unavailable or the identifier is invalid
      */
     public func bridge(_ bridge: BibleBridge, saveBookmarkNote bookmarkId: String, note: String?) {
-        logger.info("Save bookmark note: \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.saveBookmarkNote(bookmarkId: bookmarkId, note: note)
-    }
-
-    private func applyUITestMyNotesAppendTextIfNeeded() {
-        guard !didApplyUITestMyNotesAppendText,
-              let appendText = UITestRuntimeConfiguration.myNotesAppendText,
-              appendUITestTextToFirstVisibleMyNotesNote(appendText) else {
-            return
-        }
-        didApplyUITestMyNotesAppendText = true
-    }
-
-    @discardableResult
-    private func appendUITestTextToFirstVisibleMyNotesNote(_ text: String) -> Bool {
-        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports,
-              showingMyNotes,
-              !text.isEmpty,
-              let bookmark = currentChapterMyNotesBookmarks().first
-        else {
-            return false
-        }
-
-        let currentNote = bookmark.notes?.notes ?? ""
-        return saveBookmarkNoteAndNotify(bookmarkId: bookmark.id, note: currentNote + text)
-    }
-
-    private func applyUITestStudyPadCreatedNoteTextIfNeeded() {
-        guard !didApplyUITestStudyPadCreatedNoteText,
-              let noteText = UITestRuntimeConfiguration.studyPadCreatedNoteText,
-              updateNewestVisibleStudyPadTextEntry(noteText) else {
-            return
-        }
-        didApplyUITestStudyPadCreatedNoteText = true
-    }
-
-    @discardableResult
-    private func updateNewestVisibleStudyPadTextEntry(_ text: String) -> Bool {
-        guard UITestRuntimeConfiguration.enablesDetailedAccessibilityExports,
-              showingStudyPad,
-              !text.isEmpty,
-              let service = bookmarkService,
-              let labelId = activeStudyPadLabelId,
-              let coordinator = annotationBridgeCoordinator(bridge: bridge),
-              let entry = service.studyPadEntries(labelId: labelId).max(by: { lhs, rhs in
-                  if lhs.orderNumber != rhs.orderNumber {
-                      return lhs.orderNumber < rhs.orderNumber
-                  }
-                  return lhs.id.uuidString < rhs.id.uuidString
-              })
-        else {
-            return false
-        }
-
-        return coordinator.updateStudyPadTextEntryText(id: entry.id.uuidString, text: text)
-    }
-
-    /**
-     Persists a bookmark note update from the web reader and emits the JavaScript bridge mutation event
-     from the stored row state.
-
-     - Parameters:
-       - bookmarkId: Identifier for either a Bible bookmark or generic bookmark note row.
-       - note: Raw note text supplied by the web editor. Whitespace-only text is delegated to the
-         bookmark service, which treats it as a delete to match Android bridge behavior.
-     - Returns: `true` when the service is available and the bridge payload could be serialized,
-       otherwise `false`.
-
-     Side effects:
-     - mutates bookmark note persistence through `BookmarkService`
-     - increments `myNotesMutationRevision`
-     - emits `bookmark_note_modified` to the embedded BibleView runtime
-
-     Failure modes:
-     - returns `false` without persistence when no bookmark service is configured
-     - returns `false` after persistence when JSON serialization unexpectedly fails
-     */
-    @discardableResult
-    private func saveBookmarkNoteAndNotify(bookmarkId: UUID, note: String?) -> Bool {
-        annotationBridgeCoordinator(bridge: bridge)?.saveBookmarkNote(
-            bookmarkId: bookmarkId.uuidString,
-            note: note
-        ) ?? false
+        annotationBridgeHandler.saveBookmarkNote(bridge: bridge, bookmarkId: bookmarkId, note: note)
     }
 
     /**
@@ -2945,54 +2852,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when the identifier is invalid
      */
     public func bridge(_ bridge: BibleBridge, assignLabels bookmarkId: String) {
-        logger.info("Assign labels requested for: \(bookmarkId)")
-        guard let uuid = UUID(uuidString: bookmarkId) else { return }
-        onAssignLabels?(uuid)
+        annotationBridgeHandler.assignLabels(bookmarkId: bookmarkId)
     }
 
     /// Refresh bookmark data in Vue.js after label changes (called after LabelAssignmentView dismisses).
     public func refreshBookmarkInVueJS(bookmarkId: UUID) {
-        annotationBridgeCoordinator(bridge: bridge)?.refreshBookmark(bookmarkId: bookmarkId)
+        annotationBridgeHandler.refreshBookmark(bridge: bridge, bookmarkId: bookmarkId)
     }
 
     /**
      Toggles one label assignment on a bookmark and re-emits the updated bookmark state.
      */
     public func bridge(_ bridge: BibleBridge, toggleBookmarkLabel bookmarkId: String, labelId: String) {
-        logger.info("Toggle label \(labelId) on bookmark \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.toggleBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
+        annotationBridgeHandler.toggleBookmarkLabel(bridge: bridge, bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
      Removes one label assignment from a bookmark and re-emits the updated bookmark state.
      */
     public func bridge(_ bridge: BibleBridge, removeBookmarkLabel bookmarkId: String, labelId: String) {
-        logger.info("Remove label \(labelId) from bookmark \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.removeBookmarkLabel(bookmarkId: bookmarkId, labelId: labelId)
+        annotationBridgeHandler.removeBookmarkLabel(bridge: bridge, bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
      Sets the primary label used to style a bookmark in Vue.js.
      */
     public func bridge(_ bridge: BibleBridge, setPrimaryLabel bookmarkId: String, labelId: String) {
-        logger.info("Set primary label \(labelId) on bookmark \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.setPrimaryLabel(bookmarkId: bookmarkId, labelId: labelId)
+        annotationBridgeHandler.setPrimaryLabel(bridge: bridge, bookmarkId: bookmarkId, labelId: labelId)
     }
 
     /**
      Updates whether a bookmark should highlight whole verses or a text-range selection.
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkWholeVerse bookmarkId: String, value: Bool) {
-        logger.info("Set whole verse \(value) for bookmark \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkWholeVerse(bookmarkId: bookmarkId, value: value)
+        annotationBridgeHandler.setBookmarkWholeVerse(bridge: bridge, bookmarkId: bookmarkId, value: value)
     }
 
     /**
      Updates the custom icon attached to a bookmark.
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkCustomIcon bookmarkId: String, value: String?) {
-        logger.info("Set custom icon for bookmark \(bookmarkId)")
-        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkCustomIcon(bookmarkId: bookmarkId, value: value)
+        annotationBridgeHandler.setBookmarkCustomIcon(bridge: bridge, bookmarkId: bookmarkId, value: value)
     }
 
     // MARK: - BibleBridgeDelegate — StudyPad
@@ -3012,90 +2912,75 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - returns without side effects when identifiers are invalid or StudyPad creation fails
      */
     public func bridge(_ bridge: BibleBridge, createNewStudyPadEntry labelId: String, entryType: String, afterEntryId: String) {
-        logger.info("Create StudyPad entry type=\(entryType) after \(afterEntryId) in label \(labelId)")
-        guard let coordinator = annotationBridgeCoordinator(bridge: bridge) else { return }
-        coordinator.createNewStudyPadEntry(
+        annotationBridgeHandler.createNewStudyPadEntry(
+            bridge: bridge,
             labelId: labelId,
             entryType: entryType,
             afterEntryId: afterEntryId
         )
-        applyUITestStudyPadCreatedNoteTextIfNeeded()
     }
 
     /**
      Deletes one StudyPad text entry and emits the resulting reordered state.
      */
     public func bridge(_ bridge: BibleBridge, deleteStudyPadEntry studyPadId: String) {
-        logger.info("Delete StudyPad entry: \(studyPadId)")
-        annotationBridgeCoordinator(bridge: bridge)?.deleteStudyPadEntry(studyPadId)
+        annotationBridgeHandler.deleteStudyPadEntry(bridge: bridge, studyPadId: studyPadId)
     }
 
     /**
      Updates StudyPad entry metadata such as indent level or order number from a Vue.js payload.
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntry data: String) {
-        logger.info("Update StudyPad text entry metadata")
-        annotationBridgeCoordinator(bridge: bridge)?.updateStudyPadTextEntry(data: data)
+        annotationBridgeHandler.updateStudyPadTextEntry(bridge: bridge, data: data)
     }
 
     /**
      Persists edited text for one StudyPad text entry.
      */
     public func bridge(_ bridge: BibleBridge, updateStudyPadTextEntryText id: String, text: String) {
-        logger.info("Update StudyPad entry text: \(id)")
-        annotationBridgeCoordinator(bridge: bridge)?.updateStudyPadTextEntryText(id: id, text: text)
+        annotationBridgeHandler.updateStudyPadTextEntryText(bridge: bridge, id: id, text: text)
     }
 
     /**
      Persists reordered StudyPad rows and bookmark associations for one label.
      */
     public func bridge(_ bridge: BibleBridge, updateOrderNumber labelId: String, data: String) {
-        logger.info("Update order numbers for label \(labelId)")
-        annotationBridgeCoordinator(bridge: bridge)?.updateOrderNumber(labelId: labelId, data: data)
+        annotationBridgeHandler.updateOrderNumber(bridge: bridge, labelId: labelId, data: data)
     }
 
     /**
      Updates one `BibleBookmarkToLabel` association from a JSON payload emitted by Vue.js.
      */
     public func bridge(_ bridge: BibleBridge, updateBookmarkToLabel data: String) {
-        logger.info("Update BibleBookmarkToLabel")
-        annotationBridgeCoordinator(bridge: bridge)?.updateBookmarkToLabel(data: data)
+        annotationBridgeHandler.updateBookmarkToLabel(bridge: bridge, data: data)
     }
 
     /**
      Updates one `GenericBookmarkToLabel` association from a JSON payload emitted by Vue.js.
      */
     public func bridge(_ bridge: BibleBridge, updateGenericBookmarkToLabel data: String) {
-        logger.info("Update GenericBookmarkToLabel")
-        annotationBridgeCoordinator(bridge: bridge)?.updateGenericBookmarkToLabel(data: data)
+        annotationBridgeHandler.updateGenericBookmarkToLabel(bridge: bridge, data: data)
     }
 
     /**
      Persists an optional bookmark edit action configured in the web client.
      */
     public func bridge(_ bridge: BibleBridge, setBookmarkEditAction bookmarkId: String, value: String) {
-        logger.info("Set edit action on bookmark \(bookmarkId): \(value)")
-        annotationBridgeCoordinator(bridge: bridge)?.setBookmarkEditAction(bookmarkId: bookmarkId, value: value)
+        annotationBridgeHandler.setBookmarkEditAction(bridge: bridge, bookmarkId: bookmarkId, value: value)
     }
 
     /**
      Tracks whether the embedded web client is currently editing content.
      */
     public func bridge(_ bridge: BibleBridge, setEditing enabled: Bool) {
-        logger.info("WebView editing mode: \(enabled)")
-        editingInWebView = enabled
-        if enabled {
-            applyUITestMyNotesAppendTextIfNeeded()
-            applyUITestStudyPadCreatedNoteTextIfNeeded()
-        }
+        annotationBridgeHandler.setEditing(bridge: bridge, enabled: enabled)
     }
 
     /**
      Persists the current insertion cursor position for a StudyPad label.
      */
     public func bridge(_ bridge: BibleBridge, setStudyPadCursor labelId: String, orderNumber: Int) {
-        logger.info("StudyPad cursor: label=\(labelId) order=\(orderNumber)")
-        annotationBridgeCoordinator(bridge: bridge)?.setStudyPadCursor(labelId: labelId, orderNumber: orderNumber)
+        annotationBridgeHandler.setStudyPadCursor(bridge: bridge, labelId: labelId, orderNumber: orderNumber)
     }
 
     // MARK: - BibleBridgeDelegate — Selection
@@ -5396,6 +5281,48 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     // MARK: - Annotation Bridge Coordinator
+
+    /**
+     Creates the persistent annotation bridge handler for delegate routing and UI-test fixtures.
+
+     The handler owns bookmark/StudyPad bridge dispatch while this controller supplies only the
+     reader state accessors that must remain controller-owned: visible My Notes/StudyPad state,
+     editing mode, native label-assignment presentation, and current bookmark rows for UI-test
+     fixture mutation.
+
+     - Returns: Handler bound to this controller's bridge coordinator factory and state closures.
+     - Side effects: None during construction; handler methods mutate controller state only through
+       explicit closures.
+     - Failure modes: None.
+     */
+    private func makeAnnotationBridgeHandler() -> BibleReaderAnnotationBridgeHandler {
+        BibleReaderAnnotationBridgeHandler(
+            coordinator: { [weak self] bridge in
+                self?.annotationBridgeCoordinator(bridge: bridge)
+            },
+            bookmarkService: { [weak self] in
+                self?.bookmarkService
+            },
+            isShowingMyNotes: { [weak self] in
+                self?.showingMyNotes ?? false
+            },
+            isShowingStudyPad: { [weak self] in
+                self?.showingStudyPad ?? false
+            },
+            activeStudyPadLabelId: { [weak self] in
+                self?.activeStudyPadLabelId
+            },
+            currentChapterMyNotesBookmarks: { [weak self] in
+                self?.currentChapterMyNotesBookmarks() ?? []
+            },
+            setEditingInWebView: { [weak self] enabled in
+                self?.editingInWebView = enabled
+            },
+            assignLabels: { [weak self] bookmarkId in
+                self?.onAssignLabels?(bookmarkId)
+            }
+        )
+    }
 
     /**
      Creates the coordinator that owns bookmark and StudyPad bridge result application.


### PR DESCRIPTION
## Summary

Extracts the remaining bookmark, My Notes, and StudyPad bridge delegate routing from BibleReaderController into BibleReaderAnnotationBridgeHandler.

## Scope

- Adds a focused annotation bridge handler for bookmark and StudyPad delegate calls.
- Keeps BibleReaderController as the public BibleBridgeDelegate shim.
- Moves one-shot UI-test My Notes and StudyPad mutation guards into the handler.
- Does not change bridge payload contracts or Android-compatible mutation semantics.

## Contract references

- Issue: Refs #146
- Android parity: bookmark and StudyPad bridge behavior remains routed through the existing annotation coordinators and payload factories; no iOS-only behavior is introduced.
- Public API: BibleBridgeDelegate method signatures are unchanged.

## Change details

- Added BibleReaderAnnotationBridgeHandler with a docblock contract for inputs, outputs, side effects, and failure modes.
- Rewired bookmark, label, My Notes, and StudyPad delegate methods in BibleReaderController to delegate to the handler.
- Kept persistence-result application and Vue event emission in BibleReaderAnnotationBridgeCoordinator.
- Reduced controller-owned annotation state by moving UI-test mutation guards out of BibleReaderController.

## Validation evidence

- python3 scripts/check_repo_standards.py docblocks
- git diff --check
- xcodebuild build-for-testing for AndBible Debug on generic iOS Simulator
- xcodebuild test-without-building for 13 focused bookmark and StudyPad bridge tests
- GitNexus impact before edits: addOrUpdateBibleBookmark HIGH risk, saveBookmarkNoteAndNotify LOW risk, updateNewestVisibleStudyPadTextEntry LOW risk
- GitNexus detect_changes on staged diff: medium risk, one affected annotation payload process

## Risks / follow-ups

- Risk is concentrated in annotation bridge dispatch, so this PR intentionally avoids payload and persistence semantics changes.
- Remaining #146 slices still need separate PRs: reading progress plus memorization bridge, book catalog plus versification access, and final controller ownership audit.

## Issue closure reference

Refs #146. This PR does not close #146 because the checklist still has remaining ownership slices.