### PR TITLE
refactor(reader): extract progress bridge coordination

### DIFF
--- a/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -1056,6 +1056,14 @@ extension AndBibleUITests {
                     actionsControl,
                     timeout: min(1, max(0.1, deadline.timeIntervalSinceNow))
                 )
+                if waitForVisibleMyNotesEditorActivationAfterOpeningActions(
+                    editorLabel: editorLabel,
+                    marker: marker,
+                    in: app,
+                    deadline: deadline
+                ) {
+                    return
+                }
             }
 
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
@@ -1070,6 +1078,55 @@ extension AndBibleUITests {
             file: file,
             line: line
         )
+    }
+
+    /**
+     Selects the visible My Notes edit action after the row action menu has been opened.
+
+     - Parameters:
+       - editorLabel: Accessibility label for the row's edit action.
+       - marker: Persisted note text that proves the gated UI-test mutation has completed.
+       - app: Running application under test.
+       - deadline: Absolute retry deadline shared with the parent workflow.
+     - Returns: `true` when the editor opens or the UI-test mutation has already persisted.
+     - Side effects:
+       - taps the production edit command exposed by the expanded My Notes row action menu
+     - Failure modes:
+       - returns `false` when the edit command never becomes actionable before the deadline
+     */
+    private func waitForVisibleMyNotesEditorActivationAfterOpeningActions(
+        editorLabel: String,
+        marker: String,
+        in app: XCUIApplication,
+        deadline: Date
+    ) -> Bool {
+        repeat {
+            let state = readerRenderedContentStateValue(in: app)
+            if state?.contains("myNotesVisible=true") == true,
+               state?.contains("myNotesEditing=true") == true || state?.contains(marker) == true {
+                return true
+            }
+
+            guard let editorControl = optionalMyNotesWebControl(
+                named: editorLabel,
+                in: app,
+                timeout: min(0.5, max(0.1, deadline.timeIntervalSinceNow))
+            ) else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                continue
+            }
+
+            if tapElementIfPossible(editorControl, timeout: min(1, max(0.1, deadline.timeIntervalSinceNow))) {
+                let wait = min(2, max(0.1, deadline.timeIntervalSinceNow))
+                if waitForReaderRenderedContentStateIfPresent(containing: "myNotesEditing=true", in: app, timeout: wait)
+                    || waitForReaderRenderedContentStateIfPresent(containing: marker, in: app, timeout: wait)
+                {
+                    return true
+                }
+            }
+        } while Date() < deadline
+
+        return false
     }
 
     /**
@@ -1262,12 +1319,18 @@ extension AndBibleUITests {
     ) -> XCUIElement? {
         let deadline = Date().addingTimeInterval(max(0, timeout))
         repeat {
+            for candidate in candidates where candidate.exists && elementHasUsableFrame(candidate) {
+                return candidate
+            }
             for candidate in candidates where candidate.exists {
                 return candidate
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         } while Date() < deadline
 
+        if let actionableCandidate = candidates.first(where: { $0.exists && elementHasUsableFrame($0) }) {
+            return actionableCandidate
+        }
         return candidates.first(where: { $0.exists })
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -640,6 +640,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     /// Local iOS reading-progress state backing Android-style chapter-read bridge methods.
     var readingProgressStore: ReadingProgressStore?
 
+    /// Coordinates Android-compatible reading-progress and memorization bridge mutations.
+    @ObservationIgnored
+    private lazy var progressBridgeCoordinator = makeProgressBridgeCoordinator()
+
     /// Callback to persist SwiftData changes (called after PageManager updates).
     var onPersistState: (() -> Void)?
 
@@ -791,6 +795,53 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             },
             loadCurrentContent: { [weak self] in
                 self?.loadCurrentContent()
+            }
+        )
+    }
+
+    /**
+     Builds the coordinator for Android-compatible reading-progress and memorization bridge actions.
+
+     The controller still owns active-document validation, native presentation callbacks, and the
+     concrete `BibleBridge` emitter. The coordinator owns store mutations and emitted progress
+     events so these bridge concerns no longer live inline with the full reader controller.
+     */
+    private func makeProgressBridgeCoordinator() -> BibleReaderProgressBridgeCoordinator {
+        BibleReaderProgressBridgeCoordinator(
+            memorizationStore: { [weak self] in
+                self?.memorizationProgressStore
+            },
+            readingStore: { [weak self] in
+                self?.readingProgressStore
+            },
+            resolveReadingTarget: { [weak self] bookInitials, startOrdinal, chapter in
+                self?.readingProgressBridgeTarget(
+                    bookInitials: bookInitials,
+                    startOrdinal: startOrdinal,
+                    chapter: chapter
+                )
+            },
+            loadMemorizeDocument: { [weak self] bookInitials, startOrdinal, endOrdinal in
+                self?.loadMemorizeDocument(
+                    bookInitials: bookInitials,
+                    startOrdinal: startOrdinal,
+                    endOrdinal: endOrdinal
+                )
+            },
+            showReadingProgress: { [weak self] tab in
+                self?.onShowReadingProgress?(tab)
+            },
+            showReadingProgressSettings: { [weak self] in
+                self?.onShowReadingProgressSettings?()
+            },
+            showChapterReadHistory: { [weak self] target in
+                self?.onShowChapterReadHistory?(target)
+            },
+            emit: { [weak self] event, data in
+                self?.bridge.emit(event: event, data: data)
+            },
+            buildConfigJSON: { [weak self] in
+                self?.buildConfigJSON() ?? "{}"
             }
         )
     }
@@ -3607,100 +3658,57 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Adds the selected verse range as a memorization target and opens the bundled Memorize document.
      */
     public func bridge(_ bridge: BibleBridge, memorize bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        memorizationProgressStore?.addMemorizationTargetIfNeeded(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
-        )
-        loadMemorizeDocument(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
+        progressBridgeCoordinator.memorize(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
     }
 
     /**
      Marks the selected verse range as memorized in local iOS memorization state.
      */
     public func bridge(_ bridge: BibleBridge, markAsMemorized bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        memorizationProgressStore?.markAsMemorized(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
-        )
+        progressBridgeCoordinator.markAsMemorized(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
     }
 
     /**
      Adds the selected verse range to local iOS memorization targets.
      */
     public func bridge(_ bridge: BibleBridge, addMemorizationTarget bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        memorizationProgressStore?.addMemorizationTarget(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
-        )
+        progressBridgeCoordinator.addMemorizationTarget(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
     }
 
     /**
      Removes the selected verse range from local iOS memorization targets.
      */
     public func bridge(_ bridge: BibleBridge, removeMemorizationTarget bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        memorizationProgressStore?.removeMemorizationTarget(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
-        )
+        progressBridgeCoordinator.removeMemorizationTarget(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
     }
 
     /**
      Removes the selected verse range from local iOS memorized ranges.
      */
     public func bridge(_ bridge: BibleBridge, unmarkMemorized bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        memorizationProgressStore?.unmarkMemorized(
-            bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal
-        )
+        progressBridgeCoordinator.unmarkMemorized(bookInitials: bookInitials, startOrdinal: startOrdinal, endOrdinal: endOrdinal)
     }
 
     /**
      Records one chapter-read history row in local iOS reading-progress state.
      */
     public func bridge(_ bridge: BibleBridge, recordChapterRead bookInitials: String, startOrdinal: Int, chapter: Int, source: String) {
-        guard let store = readingProgressStore,
-              let target = readingProgressBridgeTarget(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                chapter: chapter
-              ) else {
-            return
-        }
-        let count = store.recordChapterRead(
+        progressBridgeCoordinator.recordChapterRead(
             bookInitials: bookInitials,
             startOrdinal: startOrdinal,
-            kjvBookOrdinal: target.kjvBookOrdinal,
             chapter: chapter,
-            source: ReadingProgressSource(bridgeValue: source)
+            source: source
         )
-        emitChapterReadStatus(chapter: chapter, count: count)
     }
 
     /**
      Opens native chapter-read history for the active Bible chapter identity.
      */
     public func bridge(_ bridge: BibleBridge, openChapterReadHistory bookInitials: String, startOrdinal: Int, chapter: Int) {
-        guard readingProgressStore != nil,
-              let target = readingProgressBridgeTarget(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                chapter: chapter
-              ) else {
-            return
-        }
-        onShowChapterReadHistory?(
-            ChapterReadHistoryTarget(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                kjvBookOrdinal: target.kjvBookOrdinal,
-                bookName: target.bookName,
-                chapter: chapter
-            )
+        progressBridgeCoordinator.openChapterReadHistory(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            chapter: chapter
         )
     }
 
@@ -3708,41 +3716,28 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Opens native reading-progress UI using Android's numeric tab positions.
      */
     public func bridge(_ bridge: BibleBridge, openReadingProgress tab: Int) {
-        onShowReadingProgress?(tab)
+        progressBridgeCoordinator.openReadingProgress(tab: tab)
     }
 
     /**
      Opens native reading-progress settings UI.
      */
     public func bridgeDidRequestOpenReadingProgressSettings(_ bridge: BibleBridge) {
-        onShowReadingProgressSettings?()
+        progressBridgeCoordinator.openReadingProgressSettings()
     }
 
     /**
      Persists Android-compatible reading-progress settings and notifies the embedded client.
      */
     public func bridge(_ bridge: BibleBridge, setReadingProgressSettings json: String) {
-        guard readingProgressStore?.applySettingsBundle(json: json) == true else {
-            return
-        }
-        emitReadingProgressSettings()
-        bridge.emit(event: "set_config", data: buildConfigJSON())
+        progressBridgeCoordinator.setReadingProgressSettings(json: json)
     }
 
     /**
      Clears chapter-read status for the active reading-progress cycle.
      */
     public func bridge(_ bridge: BibleBridge, unmarkChapterRead bookInitials: String, startOrdinal: Int, chapter: Int) {
-        guard let store = readingProgressStore,
-              let target = readingProgressBridgeTarget(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                chapter: chapter
-              ) else {
-            return
-        }
-        let count = store.clearChapterReadStatus(kjvBookOrdinal: target.kjvBookOrdinal, chapter: chapter)
-        emitChapterReadStatus(chapter: chapter, count: count)
+        progressBridgeCoordinator.unmarkChapterRead(bookInitials: bookInitials, startOrdinal: startOrdinal, chapter: chapter)
     }
 
     // MARK: - BibleBridgeDelegate — Navigation Actions
@@ -4751,7 +4746,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
                 startOrdinal: startOrdinal,
                 endOrdinal: endOrdinal
             ) ?? [],
-            "readingProgressSettings": readingProgressSettingsPayload(),
+            "readingProgressSettings": progressBridgeCoordinator.readingProgressSettingsPayload(),
         ]
 
         guard JSONSerialization.isValidJSONObject(document),
@@ -5435,18 +5430,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         settingsStore?.getStringSet(key) ?? []
     }
 
-    private func readingProgressSettingsPayload() -> [String: Any] {
-        let bundle = readingProgressStore?.settingsBundle() ?? ReadingProgressSettingsBundle()
-        return [
-            "autoMarkMemorized": bundle.autoMarkMemorized,
-            "memorizeTypeFullWords": bundle.memorizeTypeFullWords,
-            "memorizeWordVisibility": bundle.memorizeWordVisibility,
-            "memorizeErrorHeatmap": bundle.memorizeErrorHeatmap,
-            "memorizeScrambleHideUsed": bundle.memorizeScrambleHideUsed,
-            "memorizeIncludeReference": bundle.memorizeIncludeReference,
-        ]
-    }
-
     /**
      Encodes the combined reader/configuration payload consumed by the Vue.js application.
 
@@ -5798,16 +5781,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         return Self.jswordBibleBookOrdinalByOsisId[osisId]
     }
 
-    private struct ReadingProgressBridgeTarget {
-        let kjvBookOrdinal: Int
-        let bookName: String
-    }
-
+    /// Resolves the active Bible chapter into the JSword/KJVA identity used by reading progress.
     private func readingProgressBridgeTarget(
         bookInitials: String,
         startOrdinal: Int,
         chapter: Int
-    ) -> ReadingProgressBridgeTarget? {
+    ) -> BibleReaderProgressBridgeCoordinator.ReadingProgressBridgeTarget? {
         guard let chapterRange = currentChapterOrdinalRange(),
               currentCategory == .bible,
               !bookInitials.isEmpty,
@@ -5818,28 +5797,15 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
               let kjvBookOrdinal = kjvBookOrdinal(for: currentBook) else {
             return nil
         }
-        return ReadingProgressBridgeTarget(kjvBookOrdinal: kjvBookOrdinal, bookName: currentBook)
-    }
-
-    private func emitChapterReadStatus(chapter: Int, count: Int) {
-        bridge.emit(
-            event: "update_chapter_read_status",
-            data: "{\"chapter\":\(chapter),\"count\":\(count)}"
+        return BibleReaderProgressBridgeCoordinator.ReadingProgressBridgeTarget(
+            kjvBookOrdinal: kjvBookOrdinal,
+            bookName: currentBook
         )
     }
 
     @discardableResult
     func saveReadingProgressSettings(_ settings: ReadingProgressSettingsSnapshot) -> ReadingProgressSettingsSnapshot? {
-        guard let store = readingProgressStore else { return nil }
-        let savedSettings = store.saveSettings(settings)
-        emitReadingProgressSettings()
-        bridge.emit(event: "set_config", data: buildConfigJSON())
-        return savedSettings
-    }
-
-    private func emitReadingProgressSettings() {
-        guard let settingsJSON = readingProgressStore?.settingsBundleJSON() else { return }
-        bridge.emit(event: "update_reading_progress_settings", data: settingsJSON)
+        progressBridgeCoordinator.saveReadingProgressSettings(settings)
     }
 
     /// Static OSIS book ID lookup using the default list.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderProgressBridgeCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderProgressBridgeCoordinator.swift
@@ -1,0 +1,258 @@
+import Foundation
+import BibleCore
+import BibleView
+
+/**
+ Coordinates Android-compatible reading-progress and memorization bridge actions for one reader.
+
+ Android exposes memorization and reading-progress mutations from `BibleJavascriptInterface` and
+ delegates persistence to `ProgressControl`. iOS mirrors that boundary by keeping the public
+ `BibleBridgeDelegate` methods on `BibleReaderController` while moving the store mutation,
+ chapter-read event emission, settings refresh, and native presentation handoff into this focused
+ coordinator.
+
+ Inputs:
+ - bridge callback payloads from the shared BibleView JavaScript runtime
+ - local `ReadingProgressStore` and `MemorizationProgressStore` suppliers
+ - resolver closure that validates the active Bible chapter and maps it to JSword/KJVA book ordinal
+ - native presentation callbacks for reading progress, settings, and chapter read history
+
+ Outputs:
+ - persisted local memorization target and memorized-verse state
+ - persisted local chapter-read history and reading-progress settings
+ - BibleView events matching the shared Android client event names
+ - native iOS presentation callbacks for progress screens
+
+ Side effects:
+ - mutates `SettingsStore`-backed progress stores
+ - emits JavaScript bridge events through the injected `BibleBridge`
+ - invokes native UI callbacks supplied by the owning reader
+
+ Failure modes:
+ - missing stores, invalid active chapter targets, malformed JSON settings, or invalid verse ranges
+   return without side effects, matching Android's bridge guards around missing books/versifications
+ */
+struct BibleReaderProgressBridgeCoordinator {
+    /// Resolved chapter identity used by Android-compatible reading-progress persistence.
+    struct ReadingProgressBridgeTarget {
+        /// JSword/KJVA `BibleBook.ordinal` persisted by Android progress rows.
+        let kjvBookOrdinal: Int
+        /// Human-readable book name used by native iOS read-history presentation.
+        let bookName: String
+    }
+
+    /// Supplies the active memorization store.
+    private let memorizationStore: () -> MemorizationProgressStore?
+    /// Supplies the active reading-progress store.
+    private let readingStore: () -> ReadingProgressStore?
+    /// Resolves and validates a bridge chapter target against the current reader document.
+    private let resolveReadingTarget: (String, Int, Int) -> ReadingProgressBridgeTarget?
+    /// Opens the bundled Memorize Vue document for a selected verse range.
+    private let loadMemorizeDocument: (String, Int, Int) -> Void
+    /// Presents the native reading-progress UI using Android tab indexes.
+    private let showReadingProgress: (Int) -> Void
+    /// Presents native reading-progress settings.
+    private let showReadingProgressSettings: () -> Void
+    /// Presents native read-history UI for one chapter.
+    private let showChapterReadHistory: (ChapterReadHistoryTarget) -> Void
+    /// Emits a JavaScript bridge event to BibleView.
+    private let emitEvent: (String, String) -> Void
+    /// Builds the current reader config JSON for `set_config` refreshes.
+    private let buildConfigJSON: () -> String
+
+    /**
+     Creates a progress bridge coordinator bound to reader-owned stores and callbacks.
+
+     - Parameters:
+       - memorizationStore: Supplier for local memorization persistence.
+       - readingStore: Supplier for local reading-progress persistence.
+       - resolveReadingTarget: Closure that validates bridge chapter identity and returns KJVA data.
+       - loadMemorizeDocument: Closure opening the Memorize document for a selected range.
+       - showReadingProgress: Native progress UI callback.
+       - showReadingProgressSettings: Native settings UI callback.
+       - showChapterReadHistory: Native read-history UI callback.
+       - emit: BibleView event emitter.
+       - buildConfigJSON: Config payload builder for settings changes.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        memorizationStore: @escaping () -> MemorizationProgressStore?,
+        readingStore: @escaping () -> ReadingProgressStore?,
+        resolveReadingTarget: @escaping (String, Int, Int) -> ReadingProgressBridgeTarget?,
+        loadMemorizeDocument: @escaping (String, Int, Int) -> Void,
+        showReadingProgress: @escaping (Int) -> Void,
+        showReadingProgressSettings: @escaping () -> Void,
+        showChapterReadHistory: @escaping (ChapterReadHistoryTarget) -> Void,
+        emit: @escaping (String, String) -> Void,
+        buildConfigJSON: @escaping () -> String
+    ) {
+        self.memorizationStore = memorizationStore
+        self.readingStore = readingStore
+        self.resolveReadingTarget = resolveReadingTarget
+        self.loadMemorizeDocument = loadMemorizeDocument
+        self.showReadingProgress = showReadingProgress
+        self.showReadingProgressSettings = showReadingProgressSettings
+        self.showChapterReadHistory = showChapterReadHistory
+        self.emitEvent = emit
+        self.buildConfigJSON = buildConfigJSON
+    }
+
+    /// Adds the selected verse range as a memorization target and opens the Memorize document.
+    func memorize(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        memorizationStore()?.addMemorizationTargetIfNeeded(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+        loadMemorizeDocument(bookInitials, startOrdinal, endOrdinal)
+    }
+
+    /// Marks the selected verse range as memorized in local iOS progress state.
+    func markAsMemorized(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        memorizationStore()?.markAsMemorized(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Adds the selected verse range to local memorization targets.
+    func addMemorizationTarget(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        memorizationStore()?.addMemorizationTarget(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Removes the selected verse range from local memorization targets.
+    func removeMemorizationTarget(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        memorizationStore()?.removeMemorizationTarget(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Removes the selected verse range from local memorized ranges.
+    func unmarkMemorized(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
+        memorizationStore()?.unmarkMemorized(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+    }
+
+    /// Records one chapter-read history row and emits the new chapter-read count to BibleView.
+    func recordChapterRead(bookInitials: String, startOrdinal: Int, chapter: Int, source: String) {
+        guard let store = readingStore(),
+              let target = resolveReadingTarget(bookInitials, startOrdinal, chapter) else {
+            return
+        }
+        let count = store.recordChapterRead(
+            bookInitials: bookInitials,
+            startOrdinal: startOrdinal,
+            kjvBookOrdinal: target.kjvBookOrdinal,
+            chapter: chapter,
+            source: ReadingProgressSource(bridgeValue: source)
+        )
+        emitChapterReadStatus(chapter: chapter, count: count)
+    }
+
+    /// Opens native chapter-read history for the active Bible chapter identity.
+    func openChapterReadHistory(bookInitials: String, startOrdinal: Int, chapter: Int) {
+        guard readingStore() != nil,
+              let target = resolveReadingTarget(bookInitials, startOrdinal, chapter) else {
+            return
+        }
+        showChapterReadHistory(
+            ChapterReadHistoryTarget(
+                bookInitials: bookInitials,
+                startOrdinal: startOrdinal,
+                kjvBookOrdinal: target.kjvBookOrdinal,
+                bookName: target.bookName,
+                chapter: chapter
+            )
+        )
+    }
+
+    /// Opens native reading-progress UI using Android's numeric tab positions.
+    func openReadingProgress(tab: Int) {
+        showReadingProgress(tab)
+    }
+
+    /// Opens native reading-progress settings UI.
+    func openReadingProgressSettings() {
+        showReadingProgressSettings()
+    }
+
+    /// Persists Android-compatible reading-progress settings and notifies the embedded client.
+    func setReadingProgressSettings(json: String) {
+        guard readingStore()?.applySettingsBundle(json: json) == true else {
+            return
+        }
+        emitReadingProgressSettings()
+        emit(event: "set_config", data: buildConfigJSON())
+    }
+
+    /// Clears chapter-read status for the active reading-progress cycle and emits the new count.
+    func unmarkChapterRead(bookInitials: String, startOrdinal: Int, chapter: Int) {
+        guard let store = readingStore(),
+              let target = resolveReadingTarget(bookInitials, startOrdinal, chapter) else {
+            return
+        }
+        let count = store.clearChapterReadStatus(kjvBookOrdinal: target.kjvBookOrdinal, chapter: chapter)
+        emitChapterReadStatus(chapter: chapter, count: count)
+    }
+
+    /// Builds the reading-progress settings object embedded in Memorize document payloads.
+    func readingProgressSettingsPayload() -> [String: Any] {
+        let bundle = readingStore()?.settingsBundle() ?? ReadingProgressSettingsBundle()
+        return [
+            "autoMarkMemorized": bundle.autoMarkMemorized,
+            "memorizeTypeFullWords": bundle.memorizeTypeFullWords,
+            "memorizeWordVisibility": bundle.memorizeWordVisibility,
+            "memorizeErrorHeatmap": bundle.memorizeErrorHeatmap,
+            "memorizeScrambleHideUsed": bundle.memorizeScrambleHideUsed,
+            "memorizeIncludeReference": bundle.memorizeIncludeReference,
+        ]
+    }
+
+    /**
+     Saves native reading-progress settings and refreshes Vue-side settings/config payloads.
+
+     - Parameter settings: Complete native settings snapshot from the SwiftUI settings view.
+     - Returns: Saved normalized settings, or `nil` when no reading-progress store is configured.
+     - Side effects: Persists settings JSON, emits `update_reading_progress_settings`, and refreshes
+       `set_config` so the embedded client observes the same values.
+     - Failure modes: Returns `nil` without events when the reading store is unavailable.
+     */
+    @discardableResult
+    func saveReadingProgressSettings(_ settings: ReadingProgressSettingsSnapshot) -> ReadingProgressSettingsSnapshot? {
+        guard let store = readingStore() else { return nil }
+        let savedSettings = store.saveSettings(settings)
+        emitReadingProgressSettings()
+        emit(event: "set_config", data: buildConfigJSON())
+        return savedSettings
+    }
+
+    /// Emits a shared-client chapter-read status update for one chapter.
+    private func emitChapterReadStatus(chapter: Int, count: Int) {
+        emit(
+            event: "update_chapter_read_status",
+            data: "{\"chapter\":\(chapter),\"count\":\(count)}"
+        )
+    }
+
+    /// Emits the Android-compatible reading-progress settings bundle to BibleView.
+    private func emitReadingProgressSettings() {
+        guard let settingsJSON = readingStore()?.settingsBundleJSON() else { return }
+        emit(event: "update_reading_progress_settings", data: settingsJSON)
+    }
+
+    /// Emits a named BibleView event.
+    private func emit(event: String, data: String) {
+        emitEvent(event, data)
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderProgressBridgeCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderProgressBridgeCoordinator.swift
@@ -29,8 +29,11 @@ import BibleView
  - invokes native UI callbacks supplied by the owning reader
 
  Failure modes:
- - missing stores, invalid active chapter targets, malformed JSON settings, or invalid verse ranges
-   return without side effects, matching Android's bridge guards around missing books/versifications
+ - reading-progress requests with missing stores or invalid active chapter targets return without
+   side effects, matching Android's guards around missing books/versifications
+ - malformed reading-progress settings JSON returns without persistence or bridge events
+ - memorization target persistence is skipped when no memorization store exists, while `memorize`
+   still opens the Memorize document to match Android's UI handoff after a guarded target insert
  */
 struct BibleReaderProgressBridgeCoordinator {
     /// Resolved chapter identity used by Android-compatible reading-progress persistence.


### PR DESCRIPTION
## Summary
- Extracts Android-compatible memorization and reading-progress bridge mutation/event handling from `BibleReaderController` into `BibleReaderProgressBridgeCoordinator`.
- Keeps the existing public `BibleBridgeDelegate` methods as thin shims so the web/native contract does not change.

## Scope
- In scope: reading-progress bridge actions, memorization bridge actions, progress settings payload/event emission, native progress/settings/history presentation handoffs.
- Out of scope: book catalog/versification service extraction and final controller ownership audit, which remain open on #146.

## Contract references
- Android parity: mirrors `BibleJavascriptInterface` delegation to `ProgressControl` for guarded progress/memorization mutations.
- Bridge contract: preserves existing event names `update_chapter_read_status`, `update_reading_progress_settings`, and `set_config`.
- Issue: Refs #146.

## Change details
- Added `BibleReaderProgressBridgeCoordinator` with injected stores, active chapter resolver, native presentation callbacks, bridge emitter, and config builder.
- Replaced inline controller store mutations and bridge emissions with coordinator calls.
- Kept active Bible/current chapter validation in the controller because it depends on reader state and current versification context.

## Validation evidence
- `python3 scripts/check_repo_standards.py docblocks`
- `python3 scripts/check_repo_standards.py all`
- `git diff --check`
- `xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath .derivedData-progress-memorization -resultBundlePath .artifacts/progress-memorization-build.xcresult CODE_SIGNING_ALLOWED=NO build-for-testing`
- Focused `xcodebuild test-without-building` on iPhone 17 / iOS 26.5 for 8 bridge/progress/document payload tests.
- `gitnexus detect_changes` on staged scope: medium risk; relevant scope is bridge/progress methods and memorize payload assembly, with nearby display/navigation hits reviewed as hunk-boundary false positives.

## Risks/follow-ups
- Risk: controller still owns active-document validation because it depends on reader state; this is intentional for this slice.
- Follow-up: continue #146 with book catalog / versification access, then final controller ownership audit.

Refs #146