### PR TITLE
refactor(bible): extract annotation document loader

### DIFF
--- a/AndBibleTests/AndBibleTests+BridgeAndProgress.swift
+++ b/AndBibleTests/AndBibleTests+BridgeAndProgress.swift
@@ -270,6 +270,70 @@ extension AndBibleTests {
         XCTAssertEqual(store.memorizedOrdinals(bookInitials: "KJV", startOrdinal: 1, endOrdinal: 3), [1])
     }
 
+    /**
+     Verifies the reader's Memorize bridge action emits Android's fake-document payload.
+
+     Android opens memorization practice as a reader document after adding the selected ordinal
+     range as a target. The iOS bridge must preserve that user-visible contract when document
+     assembly is moved out of `BibleReaderController`: the emitted document remains `type=memorize`,
+     includes selected verse text, carries target ordinals, and sends a normal `setup_content`
+     payload.
+
+     Setup:
+     - loads the bundled KJV module so ordinals resolve through SWORD/JSword-compatible metadata
+     - records bridge emissions instead of requiring a live WebView
+
+     Failure meaning:
+     - the refactor broke Android parity by mutating progress state without opening the expected
+       Memorize reader document, or by emitting a malformed document/setup payload.
+     */
+    @MainActor
+    func testReaderMemorizeBridgeEmitsAndroidStyleDocumentPayload() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporaryBundledSwordPath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        controller.settingsStore = try makeInMemorySettingsStore()
+        let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
+        let startOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 1))
+        let endOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 2))
+
+        controller.bridgeDidSetClientReady(bridge)
+        let initialScriptCount = recordedScripts().count
+
+        controller.bridge(
+            bridge,
+            memorize: "KJV",
+            startOrdinal: startOrdinal,
+            endOrdinal: endOrdinal
+        )
+
+        let memorizeScripts = Array(recordedScripts().dropFirst(initialScriptCount))
+        let document = try XCTUnwrap(
+            bridgeEmissionPayload(from: memorizeScripts, event: "add_documents") as? [String: Any]
+        )
+        XCTAssertEqual(document["type"] as? String, "memorize")
+        XCTAssertEqual(document["bookInitials"] as? String, "KJV")
+        XCTAssertEqual(document["title"] as? String, "Genesis 1:1-2")
+        XCTAssertEqual(document["osisRef"] as? String, "Gen.1.1-Gen.1.2")
+        XCTAssertEqual(document["startOrdinal"] as? Int, startOrdinal)
+        XCTAssertEqual(document["endOrdinal"] as? Int, endOrdinal)
+        XCTAssertEqual(document["targetOrdinals"] as? [Int], [startOrdinal, endOrdinal])
+
+        let texts = try XCTUnwrap(document["texts"] as? [[String: String]])
+        XCTAssertEqual(texts.map { $0["key"] }, ["Gen.1.1", "Gen.1.2"])
+        XCTAssertTrue(texts.first?["text"]?.contains("In the beginning") == true)
+
+        let setupPayload = try XCTUnwrap(
+            bridgeEmissionPayload(from: memorizeScripts, event: "setup_content") as? [String: Any]
+        )
+        XCTAssertTrue(setupPayload["jumpToOrdinal"] is NSNull)
+        XCTAssertTrue(setupPayload["jumpToAnchor"] is NSNull)
+        XCTAssertTrue(setupPayload["jumpToId"] is NSNull)
+        XCTAssertEqual(setupPayload["topOffset"] as? Int, 0)
+        XCTAssertEqual(setupPayload["bottomOffset"] as? Int, 0)
+    }
+
     func testReadingProgressStorePersistsChapterHistoryAndClearsActiveCycle() throws {
         let settingsStore = try makeInMemorySettingsStore()
         let store = ReadingProgressStore(settingsStore: settingsStore)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationDocumentLoader.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationDocumentLoader.swift
@@ -1,0 +1,508 @@
+// BibleReaderAnnotationDocumentLoader.swift -- My Notes, StudyPad, and Memorize document emission
+
+import Foundation
+import BibleCore
+import BibleView
+import SwordKit
+import os.log
+
+private let annotationDocumentLoaderLogger = Logger(
+    subsystem: "org.andbible",
+    category: "BibleReaderAnnotationDocumentLoader"
+)
+
+/**
+ Emits annotation-backed fake documents into the shared BibleView renderer.
+
+ Android represents My Notes, StudyPad, and Memorize as reader documents rather than native sheets.
+ This loader owns the payload assembly and bridge emission sequence for those Android-shaped
+ documents while `BibleReaderController` keeps pane state ownership: which special document is
+ visible, current selection/editing flags, and the active rendered-content export.
+
+ Inputs:
+ - live bookmark/study-pad persistence through `BookmarkService`
+ - active reader coordinates and SWORD verse lookup closures supplied by the controller
+ - payload factories shared with bookmark bridge events
+ - bridge event and rendered-content callbacks
+
+ Outputs:
+ - `clear_document`, `add_documents`, and `setup_content` bridge events consumed by Vue/BibleView
+ - rendered-content state updates through the supplied callback
+ - My Notes mutation revision increments through the supplied callback
+
+ Side effects:
+ - reads bookmark, StudyPad, reading-progress, and memorization stores
+ - mutates the active SWORD module cursor while building Memorize text, matching the previous
+   controller behavior
+ - emits JavaScript bridge events through `BibleBridge`
+
+ Failure modes:
+ - returns `false` when required client/module/range/label data cannot be resolved
+ - logs failed payload serialization or stale StudyPad labels without throwing
+ */
+struct BibleReaderAnnotationDocumentLoader {
+    /// Resolved ordinal range for one chapter.
+    typealias ChapterOrdinalRange = (start: Int, end: Int, verseCount: Int)
+    /// Resolves a visible chapter range from the active SWORD/JSword versification.
+    typealias ChapterRangeProvider = () -> ChapterOrdinalRange?
+    /// Returns current-chapter note-backed bookmarks.
+    typealias MyNotesBookmarkProvider = () -> [BibleBookmark]
+    /// Projects a Bible bookmark into the shared Vue bridge DTO.
+    typealias BibleBookmarkPayloadBuilder = (BibleBookmark) -> BibleBookmarkData
+    /// Projects a generic bookmark into the shared Vue bridge DTO.
+    typealias GenericBookmarkPayloadBuilder = (GenericBookmark) -> GenericBookmarkData
+    /// Projects a persisted label into the shared Vue bridge DTO.
+    typealias LabelPayloadBuilder = (Label) -> LabelData?
+    /// Projects a Bible bookmark-label relationship into the shared Vue bridge DTO.
+    typealias BibleBookmarkToLabelPayloadBuilder = (BibleBookmarkToLabel) -> BookmarkToLabelData?
+    /// Projects a generic bookmark-label relationship into the shared Vue bridge DTO.
+    typealias GenericBookmarkToLabelPayloadBuilder = (GenericBookmarkToLabel) -> BookmarkToLabelData?
+    /// Projects a StudyPad text entry into the shared Vue bridge DTO.
+    typealias StudyPadEntryPayloadBuilder = (StudyPadTextEntry) -> StudyPadTextItemData
+    /// Resolves a persisted ordinal into the active reader chapter/verse.
+    typealias VerseReferenceProvider = (String, Int) -> VerseKeyReference?
+    /// Parses a SWORD key such as `Genesis 1:1`.
+    typealias VerseKeyParser = (String) -> (String, Int, Int)?
+    /// Produces no-module placeholder text for Memorize documents.
+    typealias PlaceholderVerseTextProvider = (String, Int, Int) -> String
+    /// Reads memorization state for a rendered ordinal range.
+    typealias OrdinalProgressProvider = (String, Int, Int) -> [Int]
+    /// Updates the compact rendered-content state owned by the controller.
+    typealias RenderedContentStateSetter = (DocumentCategory, String?, String, Int?, String?) -> Void
+
+    /// Bridge used for Vue event emission.
+    private let bridge: BibleBridge
+    /// Optional persistence facade for bookmark and StudyPad documents.
+    private let bookmarkService: BookmarkService?
+    /// Emits the current label list before annotation documents that render bookmark labels.
+    private let sendLabels: () -> Void
+    /// Applies rendered-content identity to controller-owned state.
+    private let setRenderedContentState: RenderedContentStateSetter
+    /// Advances My Notes mutation revision after successful document emission.
+    private let incrementMyNotesRevision: () -> Void
+    /// Applies reader background after special document emission.
+    private let applyNightModeBackground: () -> Void
+    /// Clears the current WebView selection after Memorize document emission.
+    private let clearSelection: () -> Void
+
+    /**
+     Creates an annotation document loader for one reader pane.
+
+     - Parameters:
+       - bridge: Active WebView bridge.
+       - bookmarkService: Bookmark/StudyPad persistence facade, or `nil` when annotations are
+         unavailable.
+       - sendLabels: Callback that emits label state to Vue.
+       - setRenderedContentState: Callback that updates controller-owned rendered-content state.
+       - incrementMyNotesRevision: Callback that advances My Notes visible-state revision.
+       - applyNightModeBackground: Callback that reapplies reader background styling.
+       - clearSelection: Callback that clears native WebView selection.
+     - Side effects: None during initialization.
+     - Failure modes: None.
+     */
+    init(
+        bridge: BibleBridge,
+        bookmarkService: BookmarkService?,
+        sendLabels: @escaping () -> Void,
+        setRenderedContentState: @escaping RenderedContentStateSetter,
+        incrementMyNotesRevision: @escaping () -> Void,
+        applyNightModeBackground: @escaping () -> Void,
+        clearSelection: @escaping () -> Void
+    ) {
+        self.bridge = bridge
+        self.bookmarkService = bookmarkService
+        self.sendLabels = sendLabels
+        self.setRenderedContentState = setRenderedContentState
+        self.incrementMyNotesRevision = incrementMyNotesRevision
+        self.applyNightModeBackground = applyNightModeBackground
+        self.clearSelection = clearSelection
+    }
+
+    /**
+     Emits the My Notes fake document for the active chapter.
+
+     - Parameters:
+       - currentBook: Active display book name.
+       - currentChapter: Active chapter number.
+       - osisBookId: Active OSIS book identifier.
+       - jumpToOrdinal: Optional row ordinal to scroll to after Vue renders the document.
+       - chapterRange: Closure resolving the current chapter ordinal range.
+       - bookmarks: Closure returning note-backed bookmarks for the current chapter.
+       - bookmarkPayload: Shared bookmark payload projector.
+       - prepareVisibleState: Controller callback that marks My Notes as visible before range
+         validation, preserving the previous pending-visible behavior.
+     - Returns: `true` when the document was emitted; otherwise `false`.
+     - Side effects: Emits bridge events, sends labels, updates rendered-content state, and
+       increments the My Notes mutation revision on success.
+     - Failure modes: Returns `false` when the active chapter range cannot be resolved.
+     */
+    @discardableResult
+    func loadMyNotesDocument(
+        currentBook: String,
+        currentChapter: Int,
+        osisBookId: String,
+        jumpToOrdinal: Int?,
+        chapterRange: ChapterRangeProvider,
+        bookmarks: MyNotesBookmarkProvider,
+        bookmarkPayload: BibleBookmarkPayloadBuilder,
+        prepareVisibleState: () -> Void
+    ) -> Bool {
+        prepareVisibleState()
+        guard let range = chapterRange() else {
+            annotationDocumentLoaderLogger.error(
+                "Failed to resolve My Notes chapter range for \(currentBook, privacy: .public) \(currentChapter)"
+            )
+            return false
+        }
+
+        let verseRange = "\(currentBook) \(currentChapter):1-\(range.verseCount)"
+        let docId = "\(osisBookId).\(currentChapter).1-\(osisBookId).\(currentChapter).\(range.verseCount)"
+        let document = MyNotesDocumentPayload(
+            id: docId,
+            type: "notes",
+            bookmarks: bookmarks().map { bookmarkPayload($0) },
+            verseRange: verseRange,
+            ordinalRange: [range.start, range.end]
+        )
+
+        bridge.emit(event: "clear_document")
+        sendLabels()
+        bridge.emit(event: "add_documents", data: document)
+        bridge.emit(
+            event: "setup_content",
+            data: ReaderSetupContentPayload(jumpToOrdinal: jumpToOrdinal)
+        )
+        setRenderedContentState(.bible, "My Notes", "My Notes", currentChapter, docId)
+        incrementMyNotesRevision()
+        return true
+    }
+
+    /**
+     Emits a StudyPad fake document for one label.
+
+     - Parameters:
+       - labelId: StudyPad label identifier.
+       - bookmarkId: Optional bookmark row to scroll to after Vue renders the document.
+       - labelPayload: Shared label payload projector.
+       - bookmarkPayload: Shared Bible bookmark payload projector.
+       - genericBookmarkPayload: Shared generic bookmark payload projector.
+       - bibleBookmarkToLabelPayload: Shared Bible bookmark-label relationship projector.
+       - genericBookmarkToLabelPayload: Shared generic bookmark-label relationship projector.
+       - studyPadEntryPayload: Shared StudyPad text entry projector.
+       - prepareVisibleState: Controller callback that applies visible StudyPad state after the
+         label has been validated but before payload rows are fetched.
+     - Returns: `true` when the document was emitted; otherwise `false`.
+     - Side effects: Reads StudyPad rows, emits bridge events, sends labels, updates
+       rendered-content state, and reapplies background styling.
+     - Failure modes: Returns `false` when annotations are unavailable, the label is stale, or the
+       label payload cannot be serialized.
+     */
+    @discardableResult
+    func loadStudyPadDocument(
+        labelId: UUID,
+        bookmarkId: UUID?,
+        labelPayload: LabelPayloadBuilder,
+        bookmarkPayload: BibleBookmarkPayloadBuilder,
+        genericBookmarkPayload: GenericBookmarkPayloadBuilder,
+        bibleBookmarkToLabelPayload: BibleBookmarkToLabelPayloadBuilder,
+        genericBookmarkToLabelPayload: GenericBookmarkToLabelPayloadBuilder,
+        studyPadEntryPayload: StudyPadEntryPayloadBuilder,
+        prepareVisibleState: (String) -> Void
+    ) -> Bool {
+        guard let bookmarkService else { return false }
+        guard let label = bookmarkService.label(id: labelId) else {
+            annotationDocumentLoaderLogger.warning("loadStudyPadDocument: label not found for \(labelId)")
+            return false
+        }
+        guard let labelData = labelPayload(label) else {
+            annotationDocumentLoaderLogger.warning("loadStudyPadDocument: label deleted before serialization for \(labelId)")
+            return false
+        }
+
+        prepareVisibleState(label.name)
+
+        let document = StudyPadDocumentPayload(
+            id: "journal_\(labelId.uuidString)",
+            type: "journal",
+            label: labelData,
+            bookmarks: bookmarkService.bibleBookmarks(withLabel: labelId).map { bookmarkPayload($0) },
+            genericBookmarks: bookmarkService.genericBookmarks(withLabel: labelId).map { genericBookmarkPayload($0) },
+            bookmarkToLabels: bookmarkService.bibleBookmarkToLabels(labelId: labelId).compactMap {
+                bibleBookmarkToLabelPayload($0)
+            },
+            genericBookmarkToLabels: bookmarkService.genericBookmarkToLabels(labelId: labelId).compactMap {
+                genericBookmarkToLabelPayload($0)
+            },
+            journalTextEntries: bookmarkService.studyPadEntries(labelId: labelId).map { studyPadEntryPayload($0) }
+        )
+
+        bridge.emit(event: "clear_document")
+        sendLabels()
+        bridge.emit(event: "add_documents", data: document)
+        bridge.emit(
+            event: "setup_content",
+            data: ReaderSetupContentPayload(jumpToId: bookmarkId?.uuidString)
+        )
+        setRenderedContentState(.bible, "StudyPad", label.name, nil, "journal_\(labelId.uuidString)")
+        applyNightModeBackground()
+        return true
+    }
+
+    /**
+     Emits the Memorize fake document for a selected verse range.
+
+     - Parameters:
+       - request: Active reader/module data needed to build the Memorize document.
+       - prepareVisibleState: Controller callback that clears competing visible special-document
+         state after the document can be built.
+     - Returns: `true` when the document was emitted; otherwise `false`.
+     - Side effects: May move the active SWORD module cursor, emits bridge events, updates
+       rendered-content state, clears selection, and reapplies background styling.
+     - Failure modes: Returns `false` when the selected ordinals do not map to visible verses or
+       JSON serialization fails.
+     */
+    @discardableResult
+    func loadMemorizeDocument(
+        request: MemorizeDocumentRequest,
+        prepareVisibleState: () -> Void
+    ) -> Bool {
+        guard let document = buildMemorizeDocumentJSON(request) else { return false }
+        prepareVisibleState()
+        bridge.emit(event: "clear_document")
+        bridge.emit(event: "add_documents", data: document)
+        bridge.emit(event: "setup_content", data: ReaderSetupContentPayload())
+        setRenderedContentState(
+            .bible,
+            request.activeModuleName,
+            "Memorize",
+            request.currentChapter,
+            "memorize:\(request.bookInitials):\(request.startOrdinal)-\(request.endOrdinal)"
+        )
+        clearSelection()
+        applyNightModeBackground()
+        return true
+    }
+
+    /**
+     Builds serialized Memorize document JSON for the Vue reader.
+
+     - Parameter request: Active reader state and store providers.
+     - Returns: JSON string for one Memorize document, or `nil` when no verse text can be resolved.
+     - Side effects: May move the active SWORD module cursor while collecting verse text.
+     - Failure modes: Returns `nil` for invalid ordinal ranges or JSON serialization failure.
+     */
+    private func buildMemorizeDocumentJSON(_ request: MemorizeDocumentRequest) -> String? {
+        let textItems = memorizeTextItems(request)
+        guard !textItems.isEmpty else { return nil }
+
+        let document: [String: Any] = [
+            "id": "memorize-\(request.bookInitials)-\(request.startOrdinal)-\(request.endOrdinal)",
+            "type": "memorize",
+            "title": memorizeReferenceTitle(request),
+            "texts": textItems,
+            "state": [
+                "memorize": [
+                    "mode": "blur",
+                    "modeConfig": [String: Any](),
+                ] as [String: Any],
+            ] as [String: Any],
+            "bookInitials": request.bookInitials,
+            "v11n": "KJVA",
+            "osisRef": memorizeOsisRef(request),
+            "startOrdinal": request.startOrdinal,
+            "endOrdinal": request.endOrdinal,
+            "memorizedOrdinals": request.memorizedOrdinals(
+                request.bookInitials,
+                request.startOrdinal,
+                request.endOrdinal
+            ),
+            "targetOrdinals": request.targetOrdinals(
+                request.bookInitials,
+                request.startOrdinal,
+                request.endOrdinal
+            ),
+            "readingProgressSettings": request.readingProgressSettings(),
+        ]
+
+        guard JSONSerialization.isValidJSONObject(document),
+              let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            annotationDocumentLoaderLogger.error("Failed to serialize Memorize document JSON")
+            return nil
+        }
+        return json
+    }
+
+    /**
+     Builds ordered verse text rows for Memorize.
+
+     - Parameter request: Active reader/module data.
+     - Returns: Verse key/text rows for the selected same-chapter range.
+     - Side effects: May move the active SWORD module cursor.
+     - Failure modes: Returns an empty array when ordinals cannot be mapped to visible verses.
+     */
+    private func memorizeTextItems(_ request: MemorizeDocumentRequest) -> [[String: String]] {
+        guard let startVerse = ordinalToVerse(request.startOrdinal, request: request),
+              let endVerse = ordinalToVerse(request.endOrdinal, request: request),
+              startVerse <= endVerse else {
+            return []
+        }
+
+        if let activeModule = request.activeModule {
+            return swordMemorizeTextItems(
+                module: activeModule,
+                request: request,
+                startVerse: startVerse,
+                endVerse: endVerse
+            )
+        }
+
+        let boundedEndVerse = min(endVerse, BibleReaderBookCatalog.verseCount(
+            for: request.currentBook,
+            chapter: request.currentChapter
+        ))
+        guard startVerse <= boundedEndVerse else { return [] }
+        return (startVerse...boundedEndVerse).map { verse in
+            [
+                "key": "\(request.osisBookId).\(request.currentChapter).\(verse)",
+                "text": request.placeholderVerseText(request.currentBook, request.currentChapter, verse),
+            ]
+        }
+    }
+
+    /**
+     Builds Memorize rows from a live SWORD module.
+
+     - Parameters:
+       - module: Active Bible module.
+       - request: Active reader state.
+       - startVerse: First visible verse in the selected range.
+       - endVerse: Last visible verse in the selected range.
+     - Returns: Non-empty verse text rows when SWORD exposes text for the selected range.
+     - Side effects: Moves the module cursor through the current chapter.
+     - Failure modes: Stops at unparsable keys, chapter changes, or failed cursor advancement.
+     */
+    private func swordMemorizeTextItems(
+        module: SwordModule,
+        request: MemorizeDocumentRequest,
+        startVerse: Int,
+        endVerse: Int
+    ) -> [[String: String]] {
+        module.setKey("\(request.osisBookId) \(request.currentChapter):1")
+        var items: [[String: String]] = []
+
+        while true {
+            let key = module.currentKey()
+            guard let (_, parsedChapter, parsedVerse) = request.parseVerseKey(key) else { break }
+            if parsedChapter != request.currentChapter { break }
+
+            if parsedVerse >= startVerse && parsedVerse <= endVerse {
+                let verseText = module.stripText().trimmingCharacters(in: .whitespacesAndNewlines)
+                if !verseText.isEmpty {
+                    items.append([
+                        "key": "\(request.osisBookId).\(request.currentChapter).\(parsedVerse)",
+                        "text": verseText,
+                    ])
+                }
+            }
+            if parsedVerse > endVerse { break }
+            if !module.next() { break }
+        }
+
+        return items
+    }
+
+    /**
+     Converts an ordinal to the visible verse number for the request chapter.
+
+     - Parameters:
+       - ordinal: SWORD/JSword ordinal to resolve.
+       - request: Active reader state.
+     - Returns: Visible verse number, or `nil` when the ordinal is outside the current chapter.
+     - Side effects: May query active SWORD versification through the supplied closure.
+     - Failure modes: Invalid ordinals return `nil`.
+     */
+    private func ordinalToVerse(_ ordinal: Int, request: MemorizeDocumentRequest) -> Int? {
+        guard let reference = request.verseReference(request.currentBook, ordinal),
+              reference.chapter == request.currentChapter else {
+            return nil
+        }
+        return reference.verse
+    }
+
+    /**
+     Builds the human-readable Memorize title.
+
+     - Parameter request: Active reader state.
+     - Returns: `Book chapter:verse-range` when ordinals resolve, otherwise `Book chapter`.
+     - Side effects: May query active SWORD versification through the supplied closure.
+     - Failure modes: Falls back to chapter-only title for invalid ordinals.
+     */
+    private func memorizeReferenceTitle(_ request: MemorizeDocumentRequest) -> String {
+        guard let startVerse = ordinalToVerse(request.startOrdinal, request: request),
+              let endVerse = ordinalToVerse(request.endOrdinal, request: request) else {
+            return "\(request.currentBook) \(request.currentChapter)"
+        }
+        let verseSuffix = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)-\(endVerse)"
+        return "\(request.currentBook) \(request.currentChapter):\(verseSuffix)"
+    }
+
+    /**
+     Builds the OSIS reference for the Memorize document.
+
+     - Parameter request: Active reader state.
+     - Returns: Verse OSIS range when ordinals resolve, otherwise chapter OSIS reference.
+     - Side effects: May query active SWORD versification through the supplied closure.
+     - Failure modes: Falls back to chapter-only OSIS reference for invalid ordinals.
+     */
+    private func memorizeOsisRef(_ request: MemorizeDocumentRequest) -> String {
+        guard let startVerse = ordinalToVerse(request.startOrdinal, request: request),
+              let endVerse = ordinalToVerse(request.endOrdinal, request: request) else {
+            return "\(request.osisBookId).\(request.currentChapter)"
+        }
+        let startRef = "\(request.osisBookId).\(request.currentChapter).\(startVerse)"
+        let endRef = "\(request.osisBookId).\(request.currentChapter).\(endVerse)"
+        return startVerse == endVerse ? startRef : "\(startRef)-\(endRef)"
+    }
+}
+
+/**
+ Active reader state needed to build one Memorize fake document.
+
+ The request is intentionally immutable so tests can verify Memorize payload construction without
+ needing a full `BibleReaderController`. It mirrors Android's bridge handoff: selected module,
+ selected ordinal range, active chapter context, and progress state are read at document-open time.
+
+ Side effects: None during initialization.
+ Failure modes: None during initialization; invalid values are rejected by the loader.
+ */
+struct MemorizeDocumentRequest {
+    /// Selected module initials.
+    let bookInitials: String
+    /// Selected start ordinal.
+    let startOrdinal: Int
+    /// Selected end ordinal.
+    let endOrdinal: Int
+    /// Active Bible module initials shown in rendered-content state.
+    let activeModuleName: String
+    /// Active display book name.
+    let currentBook: String
+    /// Active chapter number.
+    let currentChapter: Int
+    /// Active OSIS book identifier.
+    let osisBookId: String
+    /// Active SWORD module, or `nil` for no-module placeholder behavior.
+    let activeModule: SwordModule?
+    /// Resolves ordinals using active versification.
+    let verseReference: BibleReaderAnnotationDocumentLoader.VerseReferenceProvider
+    /// Parses SWORD verse keys.
+    let parseVerseKey: BibleReaderAnnotationDocumentLoader.VerseKeyParser
+    /// Supplies no-module placeholder text.
+    let placeholderVerseText: BibleReaderAnnotationDocumentLoader.PlaceholderVerseTextProvider
+    /// Reads memorized ordinals for the selected range.
+    let memorizedOrdinals: BibleReaderAnnotationDocumentLoader.OrdinalProgressProvider
+    /// Reads target ordinals for the selected range.
+    let targetOrdinals: BibleReaderAnnotationDocumentLoader.OrdinalProgressProvider
+    /// Builds current reading-progress settings payload.
+    let readingProgressSettings: () -> [String: Any]
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -3763,52 +3763,23 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return
         }
         pendingClientReadyMyNotesJumpOrdinal = nil
-        showingMyNotes = true
-        showingStudyPad = false
-        activeStudyPadLabelId = nil
-        activeStudyPadLabelName = nil
-        editingInWebView = false
-        clearNativeSelectionState()
-
-        let osisBookId = osisBookId(for: currentBook)
-        guard let range = currentChapterOrdinalRange() else {
-            logger.error("Failed to resolve My Notes chapter range for \(self.currentBook, privacy: .public) \(self.currentChapter)")
-            return
-        }
-        let verseCount = range.verseCount
-
-        // Get bookmarks with notes for this chapter
-        let bookmarks = currentChapterMyNotesBookmarks()
-
-        let verseRange = "\(currentBook) \(currentChapter):1-\(verseCount)"
-        let docId = "\(osisBookId).\(currentChapter).1-\(osisBookId).\(currentChapter).\(verseCount)"
-
-        let document = MyNotesDocumentPayload(
-            id: docId,
-            type: "notes",
-            bookmarks: bookmarks.map { buildBookmarkJSONForMyNotes($0) },
-            verseRange: verseRange,
-            ordinalRange: [range.start, range.end]
+        annotationDocumentLoader().loadMyNotesDocument(
+            currentBook: currentBook,
+            currentChapter: currentChapter,
+            osisBookId: osisBookId(for: currentBook),
+            jumpToOrdinal: jumpToOrdinal,
+            chapterRange: { [weak self] in self?.currentChapterOrdinalRange() },
+            bookmarks: { [weak self] in self?.currentChapterMyNotesBookmarks() ?? [] },
+            bookmarkPayload: { [self] bookmark in buildBookmarkJSONForMyNotes(bookmark) },
+            prepareVisibleState: { [weak self] in
+                self?.showingMyNotes = true
+                self?.showingStudyPad = false
+                self?.activeStudyPadLabelId = nil
+                self?.activeStudyPadLabelName = nil
+                self?.editingInWebView = false
+                self?.clearNativeSelectionState()
+            }
         )
-
-        // Send to Vue.js using the same sequence as loadCurrentChapter
-        bridge.emit(event: "clear_document")
-        sendLabelsToVueJS()
-        bridge.emit(event: "add_documents", data: document)
-        bridge.emit(
-            event: "setup_content",
-            data: ReaderSetupContentPayload(jumpToOrdinal: jumpToOrdinal)
-        )
-
-        setRenderedContentState(
-            category: .bible,
-            moduleName: "My Notes",
-            book: "My Notes",
-            chapter: currentChapter,
-            key: docId
-        )
-
-        myNotesMutationRevision += 1
     }
 
     /**
@@ -3820,36 +3791,53 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      target/memorized controls.
      */
     private func loadMemorizeDocument(bookInitials: String, startOrdinal: Int, endOrdinal: Int) {
-        guard clientReady,
-              let document = buildMemorizeDocumentJSON(
+        guard clientReady else { return }
+        annotationDocumentLoader().loadMemorizeDocument(
+            request: MemorizeDocumentRequest(
                 bookInitials: bookInitials,
                 startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal
-              ) else {
-            return
-        }
-
-        showingMyNotes = false
-        showingStudyPad = false
-        activeStudyPadLabelId = nil
-        activeStudyPadLabelName = nil
-        editingInWebView = false
-        clearNativeSelectionState()
-
-        bridge.emit(event: "clear_document")
-        bridge.emit(event: "add_documents", data: document)
-        bridge.emit(event: "setup_content", data: """
-        {"jumpToOrdinal":null,"jumpToAnchor":null,"jumpToId":null,"topOffset":0,"bottomOffset":0}
-        """)
-        setRenderedContentState(
-            category: .bible,
-            moduleName: activeModuleName,
-            book: "Memorize",
-            chapter: currentChapter,
-            key: "memorize:\(bookInitials):\(startOrdinal)-\(endOrdinal)"
+                endOrdinal: endOrdinal,
+                activeModuleName: activeModuleName,
+                currentBook: currentBook,
+                currentChapter: currentChapter,
+                osisBookId: osisBookId(for: currentBook),
+                activeModule: activeModule,
+                verseReference: { [weak self] book, ordinal in
+                    self?.verseReference(book: book, ordinal: ordinal)
+                },
+                parseVerseKey: { [weak self] key in
+                    self?.parseVerseKey(key)
+                },
+                placeholderVerseText: { book, chapter, verse in
+                    Self.placeholderVerseText(book: book, chapter: chapter, verse: verse)
+                },
+                memorizedOrdinals: { [memorizationProgressStore] bookInitials, startOrdinal, endOrdinal in
+                    memorizationProgressStore?.memorizedOrdinals(
+                        bookInitials: bookInitials,
+                        startOrdinal: startOrdinal,
+                        endOrdinal: endOrdinal
+                    ) ?? []
+                },
+                targetOrdinals: { [memorizationProgressStore] bookInitials, startOrdinal, endOrdinal in
+                    memorizationProgressStore?.targetOrdinals(
+                        bookInitials: bookInitials,
+                        startOrdinal: startOrdinal,
+                        endOrdinal: endOrdinal
+                    ) ?? []
+                },
+                readingProgressSettings: { [progressBridgeCoordinator] in
+                    progressBridgeCoordinator.readingProgressSettingsPayload()
+                }
+            ),
+            prepareVisibleState: { [weak self] in
+                self?.showingMyNotes = false
+                self?.showingStudyPad = false
+                self?.activeStudyPadLabelId = nil
+                self?.activeStudyPadLabelName = nil
+                self?.editingInWebView = false
+                self?.clearNativeSelectionState()
+            }
         )
-        bridge.clearSelection()
-        applyNightModeBackground()
     }
 
     /// Return from My Notes to the Bible text view.
@@ -3861,60 +3849,25 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Load a StudyPad document for a label into the WebView.
     public func loadStudyPadDocument(labelId: UUID, bookmarkId: UUID? = nil) {
-        guard clientReady, let service = bookmarkService else { return }
-        guard let label = service.label(id: labelId) else {
-            logger.warning("loadStudyPadDocument: label not found for \(labelId)")
-            return
-        }
-        guard let labelData = buildLabelData(label) else {
-            logger.warning("loadStudyPadDocument: label deleted before serialization for \(labelId)")
-            return
-        }
-
-        showingMyNotes = false
-        showingStudyPad = true
-        activeStudyPadLabelId = labelId
-        activeStudyPadLabelName = label.name
-        editingInWebView = false
-        clearNativeSelectionState()
-
-        // Fetch all data for this StudyPad
-        let bibleBookmarks = service.bibleBookmarks(withLabel: labelId)
-        let genericBookmarks = service.genericBookmarks(withLabel: labelId)
-        let bibleBtls = service.bibleBookmarkToLabels(labelId: labelId)
-        let genericBtls = service.genericBookmarkToLabels(labelId: labelId)
-        let entries = service.studyPadEntries(labelId: labelId)
-
-        let document = StudyPadDocumentPayload(
-            id: "journal_\(labelId.uuidString)",
-            type: "journal",
-            label: labelData,
-            bookmarks: bibleBookmarks.map { buildBookmarkJSONForStudyPad($0) },
-            genericBookmarks: genericBookmarks.map { buildGenericBookmarkJSONForStudyPad($0) },
-            bookmarkToLabels: bibleBtls.compactMap { buildBibleBookmarkToLabelJSON($0) },
-            genericBookmarkToLabels: genericBtls.compactMap { buildGenericBookmarkToLabelJSON($0) },
-            journalTextEntries: entries.map { buildStudyPadEntryJSON($0) }
+        guard clientReady else { return }
+        annotationDocumentLoader().loadStudyPadDocument(
+            labelId: labelId,
+            bookmarkId: bookmarkId,
+            labelPayload: { [self] label in buildLabelData(label) },
+            bookmarkPayload: { [self] bookmark in buildBookmarkJSONForStudyPad(bookmark) },
+            genericBookmarkPayload: { [self] bookmark in buildGenericBookmarkJSONForStudyPad(bookmark) },
+            bibleBookmarkToLabelPayload: { [self] relation in buildBibleBookmarkToLabelJSON(relation) },
+            genericBookmarkToLabelPayload: { [self] relation in buildGenericBookmarkToLabelJSON(relation) },
+            studyPadEntryPayload: { [self] entry in buildStudyPadEntryJSON(entry) },
+            prepareVisibleState: { [weak self] labelName in
+                self?.showingMyNotes = false
+                self?.showingStudyPad = true
+                self?.activeStudyPadLabelId = labelId
+                self?.activeStudyPadLabelName = labelName
+                self?.editingInWebView = false
+                self?.clearNativeSelectionState()
+            }
         )
-
-        // Send to Vue.js
-        bridge.emit(event: "clear_document")
-        sendLabelsToVueJS()
-        bridge.emit(event: "add_documents", data: document)
-
-        // Setup content with optional jump target
-        bridge.emit(
-            event: "setup_content",
-            data: ReaderSetupContentPayload(jumpToId: bookmarkId?.uuidString)
-        )
-
-        setRenderedContentState(
-            category: .bible,
-            moduleName: "StudyPad",
-            book: label.name,
-            key: "journal_\(labelId.uuidString)"
-        )
-
-        applyNightModeBackground()
     }
 
     /// Return from StudyPad to the Bible text view.
@@ -4674,118 +4627,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func buildMemorizeDocumentJSON(
-        bookInitials: String,
-        startOrdinal: Int,
-        endOrdinal: Int
-    ) -> String? {
-        let textItems = memorizeTextItems(startOrdinal: startOrdinal, endOrdinal: endOrdinal)
-        guard !textItems.isEmpty else { return nil }
-
-        let document: [String: Any] = [
-            "id": "memorize-\(bookInitials)-\(startOrdinal)-\(endOrdinal)",
-            "type": "memorize",
-            "title": memorizeReferenceTitle(startOrdinal: startOrdinal, endOrdinal: endOrdinal),
-            "texts": textItems,
-            "state": [
-                "memorize": [
-                    "mode": "blur",
-                    "modeConfig": [String: Any](),
-                ] as [String: Any],
-            ] as [String: Any],
-            "bookInitials": bookInitials,
-            "v11n": "KJVA",
-            "osisRef": memorizeOsisRef(startOrdinal: startOrdinal, endOrdinal: endOrdinal),
-            "startOrdinal": startOrdinal,
-            "endOrdinal": endOrdinal,
-            "memorizedOrdinals": memorizationProgressStore?.memorizedOrdinals(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal
-            ) ?? [],
-            "targetOrdinals": memorizationProgressStore?.targetOrdinals(
-                bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal
-            ) ?? [],
-            "readingProgressSettings": progressBridgeCoordinator.readingProgressSettingsPayload(),
-        ]
-
-        guard JSONSerialization.isValidJSONObject(document),
-              let data = try? JSONSerialization.data(withJSONObject: document, options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else {
-            logger.error("Failed to serialize Memorize document JSON")
-            return nil
-        }
-        return json
-    }
-
-    private func memorizeTextItems(startOrdinal: Int, endOrdinal: Int) -> [[String: String]] {
-        guard let startVerse = ordinalToVerse(startOrdinal),
-              let endVerse = ordinalToVerse(endOrdinal),
-              startVerse <= endVerse else {
-            return []
-        }
-
-        let osisBookId = osisBookId(for: currentBook)
-        let chapter = currentChapter
-
-        guard let module = activeModule else {
-            let verseCount = Self.verseCount(for: currentBook, chapter: chapter)
-            let boundedEndVerse = min(endVerse, verseCount)
-            guard startVerse <= boundedEndVerse else { return [] }
-            return (startVerse...boundedEndVerse).map { verse in
-                [
-                    "key": "\(osisBookId).\(chapter).\(verse)",
-                    "text": Self.placeholderVerseText(book: currentBook, chapter: chapter, verse: verse),
-                ]
-            }
-        }
-
-        module.setKey("\(osisBookId) \(chapter):1")
-        var items: [[String: String]] = []
-
-        while true {
-            let key = module.currentKey()
-            guard let (_, parsedChapter, parsedVerse) = parseVerseKey(key) else { break }
-            if parsedChapter != chapter { break }
-
-            if parsedVerse >= startVerse && parsedVerse <= endVerse {
-                let verseText = module.stripText().trimmingCharacters(in: .whitespacesAndNewlines)
-                if !verseText.isEmpty {
-                    items.append([
-                        "key": "\(osisBookId).\(chapter).\(parsedVerse)",
-                        "text": verseText,
-                    ])
-                }
-            }
-            if parsedVerse > endVerse { break }
-            if !module.next() { break }
-        }
-
-        return items
-    }
-
-    private func memorizeReferenceTitle(startOrdinal: Int, endOrdinal: Int) -> String {
-        guard let startVerse = ordinalToVerse(startOrdinal),
-              let endVerse = ordinalToVerse(endOrdinal) else {
-            return "\(currentBook) \(currentChapter)"
-        }
-        let verseSuffix = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)-\(endVerse)"
-        return "\(currentBook) \(currentChapter):\(verseSuffix)"
-    }
-
-    private func memorizeOsisRef(startOrdinal: Int, endOrdinal: Int) -> String {
-        let osisBookId = osisBookId(for: currentBook)
-        guard let startVerse = ordinalToVerse(startOrdinal),
-              let endVerse = ordinalToVerse(endOrdinal) else {
-            return "\(osisBookId).\(currentChapter)"
-        }
-        let startRef = "\(osisBookId).\(currentChapter).\(startVerse)"
-        let endRef = "\(osisBookId).\(currentChapter).\(endVerse)"
-        return startVerse == endVerse ? startRef : "\(startRef)-\(endRef)"
-    }
-
     // MARK: - Content Loading
 
     /**
@@ -5232,6 +5073,48 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             logger.error("Failed to parse saved bridge state JSON: \(error.localizedDescription, privacy: .public)")
             return nil
         }
+    }
+
+    // MARK: - Annotation Document Loader
+
+    /**
+     Builds the loader for Android-style My Notes, StudyPad, and Memorize fake documents.
+
+     The controller keeps visible pane state and public entry points. The loader owns document
+     payload assembly and bridge emission order so annotation document rendering does not remain
+     embedded in the controller's bridge delegate surface.
+
+     - Returns: Loader bound to this pane's bridge and controller state callbacks.
+     - Side effects: None during construction; supplied closures may emit bridge events and mutate
+       rendered-content state when loader methods are invoked.
+     - Failure modes: None during construction.
+     */
+    private func annotationDocumentLoader() -> BibleReaderAnnotationDocumentLoader {
+        BibleReaderAnnotationDocumentLoader(
+            bridge: bridge,
+            bookmarkService: bookmarkService,
+            sendLabels: { [weak self] in
+                self?.sendLabelsToVueJS()
+            },
+            setRenderedContentState: { [weak self] category, moduleName, book, chapter, key in
+                self?.setRenderedContentState(
+                    category: category,
+                    moduleName: moduleName,
+                    book: book,
+                    chapter: chapter,
+                    key: key
+                )
+            },
+            incrementMyNotesRevision: { [weak self] in
+                self?.myNotesMutationRevision += 1
+            },
+            applyNightModeBackground: { [weak self] in
+                self?.applyNightModeBackground()
+            },
+            clearSelection: { [weak self] in
+                self?.bridge.clearSelection()
+            }
+        )
     }
 
     // MARK: - Annotation Bridge Coordinator


### PR DESCRIPTION
## Summary

Extracts the remaining annotation-backed fake-document rendering responsibility from `BibleReaderController` into `BibleReaderAnnotationDocumentLoader`.

## Scope

- Moves My Notes, StudyPad, and Memorize document payload assembly plus bridge emission order into a focused collaborator.
- Keeps controller-owned visible pane state, public entry points, and rendered-content state callbacks in `BibleReaderController`.
- Adds a Memorize bridge regression test for the Android-style fake-document payload.

## Contract References

- Android parity: My Notes, StudyPad, and Memorize continue to render as reader fake documents through the shared Vue/BibleView bridge.
- Bridge contract: preserves `clear_document`, `add_documents`, and `setup_content` event sequencing and payload shapes.
- Issue #146 decomposition guardrail: controller should remain orchestration-focused instead of owning annotation document assembly.

## Change Details

- Added `BibleReaderAnnotationDocumentLoader` with documented inputs, outputs, side effects, and failure modes.
- Rewired `loadMyNotesDocument`, `loadStudyPadDocument`, and the Memorize bridge handoff to delegate document emission while preserving public APIs.
- Removed duplicate Memorize JSON helper logic from the controller.
- Added `testReaderMemorizeBridgeEmitsAndroidStyleDocumentPayload` to cover the moved fake-document contract.

## Validation Evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:AndBibleTests/AndBibleTests/testReaderMemorizeBridgeEmitsAndroidStyleDocumentPayload -only-testing:AndBibleTests/AndBibleTests/testBridgeMemorizationMessagesMutateNativeStore -only-testing:AndBibleTests/AndBibleTests/testReaderMyNotesDocumentRequestedBeforeClientReadyReplaysAfterClientReady -only-testing:AndBibleTests/AndBibleTests/testReaderStudyPadDocumentBridgeEmissionUsesJSwordCrossChapterRangePayload -only-testing:AndBibleTests/AndBibleTests/testReaderStudyPadDocumentBridgeEmissionUsesTypedNestedPayloads`
- `python3 scripts/check_repo_standards.py docblocks`
- `python3 scripts/check_repo_standards.py commits`
- `git diff --cached --check`
- GitNexus impact before edits reported CRITICAL bridge-visible blast radius for My Notes/StudyPad, so public wrappers and event contracts were kept stable.
- GitNexus `detect_changes` on staged scope returned no changed symbols, likely because the worktree/new-file path was not detected by the current index.

## Risks / Follow-ups

- Risk is bridge-contract regression in annotation fake-document rendering; covered by existing My Notes/StudyPad tests plus the new Memorize payload test.
- No follow-up is expected for #146 after this final ownership-audit slice unless review or CI identifies an unextracted controller responsibility that is still more than orchestration.

Closes #146
