### PR TITLE
test(swordkit): migrate planner tests to package lane

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -131,6 +131,149 @@ jobs:
       - name: Run SETPAR-603 guardrails
         run: python3 scripts/check_settings_localization_guardrails.py
 
+  ios-swordkit-package-tests:
+    name: SwordKit Package Tests (Simulator)
+    runs-on: ${{ needs.repo-standards.outputs.required_checks_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    needs:
+      - repo-standards
+      - localization-guardrails
+    timeout-minutes: 30
+    env:
+      DERIVED_DATA_PATH: .derivedData/SwordKitPackageTests
+      TEST_XCRESULT_BUNDLE_PATH: .artifacts/SwordKitTests-package.xcresult
+    steps:
+      - name: Required-checks-only pass
+        if: needs.repo-standards.outputs.required_checks_only == 'true'
+        run: echo "Required-checks-only change set; SwordKit package tests are not required."
+
+      - name: Checkout
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Select Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Restore SwiftPM and build caches
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .derivedData/SwordKitPackageTests/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.swiftpm
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-swordkit-package-${{ hashFiles('Package.swift', 'Sources/SwordKit/**', 'libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-swordkit-package-
+
+      - name: Restore libsword build cache
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            libsword/sword-src
+            libsword/build
+            libsword/libsword.xcframework
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-${{ hashFiles('libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-
+
+      - name: Show Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: xcodebuild -version
+
+      - name: Ensure iOS simulator runtime is available
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
+            echo "An iOS simulator runtime is already installed."
+          else
+            echo "No iOS simulator runtime was found; downloading it for the selected Xcode."
+            xcodebuild -downloadPlatform iOS
+          fi
+
+      - name: Ensure libsword build prerequisites
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            brew install cmake
+          fi
+          if ! command -v svn >/dev/null 2>&1; then
+            brew install subversion
+          fi
+
+      - name: Build libsword XCFramework
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        working-directory: libsword
+        env:
+          INCLUDE_MACOS_SLICE: "0"
+        run: |
+          if [ -f libsword.xcframework/ios-arm64/libsword.a ] && [ -f libsword.xcframework/ios-arm64_x86_64-simulator/libsword.a ]; then
+            echo "Using cached libsword.xcframework"
+          else
+            ./build-ios.sh
+          fi
+
+      - name: Resolve iOS simulator destination
+        id: simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/resolve_ios_simulator_destination.py
+          --project AndBible.xcodeproj
+          --scheme SwordKitTests
+          --create-dedicated-device
+          --device-name-prefix "AndBible CI SwordKit"
+
+      - name: Boot selected simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/wait_for_simulator_boot.py
+          --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
+          --timeout-seconds 300
+
+      - name: Run SwordKit package tests
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        timeout-minutes: 10
+        run: |
+          mkdir -p .artifacts
+          xcodebuild test \
+            -project AndBible.xcodeproj \
+            -scheme SwordKitTests \
+            -configuration Debug \
+            -destination "${{ steps.simulator.outputs.destination }}" \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -resultBundlePath "${TEST_XCRESULT_BUNDLE_PATH}" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload SwordKit package test result bundle
+        id: upload_swordkit_package_xcresult
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-swordkit-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+
+      - name: Retry upload SwordKit package test result bundle
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_swordkit_package_xcresult.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-swordkit-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+          overwrite: true
+
+      - name: Delete dedicated simulator
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
+        run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
+
   bibleview-js:
     name: BibleView JS
     runs-on: ubuntu-latest

--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		A1B2C3D4E5F60718293A4B5C /* AndBibleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */; };
 		8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */; };
 		D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */; };
-		D13300000000000000000002 /* DefaultDocumentDownloadPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */; };
 		D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13400000000000000000001 /* AndBibleTests+Downloads.swift */; };
 		64688F48FF7396937F81D0B5 /* SwordSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA144AB77AEE518F1465DCC /* SwordSetup.swift */; };
 		793CB31DA9E0B8F6F4AC7677 /* AndBibleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */; };
@@ -89,7 +88,6 @@
 		8174AF1F3D15BAFB4EB66A1E /* AndBible.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AndBible.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSyncRestoreTests.swift; sourceTree = "<group>"; };
 		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
-		D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDocumentDownloadPlannerTests.swift; sourceTree = "<group>"; };
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidModuleBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
@@ -273,7 +271,6 @@
 				DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */,
 				9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */,
 				D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */,
-				D13300000000000000000001 /* DefaultDocumentDownloadPlannerTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */,
@@ -502,7 +499,6 @@
 				605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */,
 				8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */,
 				D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */,
-				D13300000000000000000002 /* DefaultDocumentDownloadPlannerTests.swift in Sources */,
 				B69113624461C63AB21F4144 /* AndBibleTestSupport.swift in Sources */,
 				34F21932E6E652AD0A369D9C /* AndBibleTests+AppAndReader.swift in Sources */,
 				FBE587F989B0D3A1B1A283EF /* AndBibleTests+StrongsAndDictionary.swift in Sources */,

--- a/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/AndBibleUITests/AndBibleUITests+Search.swift
@@ -227,11 +227,60 @@ extension AndBibleUITests {
             waitForReaderShellReady(in: app, timeout: 20),
             "Expected reader shell to remain alive after pane-menu Close."
         )
-        waitForElementExistence("windowTabButton::1", in: app, shouldExist: false, timeout: 10)
+        waitForClosedWindowOrder(1, in: app, timeout: 15)
         let finalState = readerRenderedContentStateValue(in: app) ?? "nil"
         XCTAssertFalse(finalState.contains("windowOrder=none"), "Expected an active reader window after Close; state=\(finalState)")
         XCTAssertTrue(requireElement("windowPaneMenuButton::0", in: app, timeout: 10).exists)
         XCTAssertTrue(requireElement("windowTabAddButton", in: app, timeout: 10).exists)
+    }
+
+    /**
+     Waits until the reader's live footer model no longer contains a closed window order.
+
+     The tab bar is backed by `WindowManager.allWindows`, which the compact reader state exposes as
+     `windowTabOrders`. Watching that model keeps the assertion tied to the close transaction itself
+     instead of a stale accessibility snapshot from the removed SwiftUI button.
+     *
+     * - Parameters:
+     *   - order: Window order that should be removed from the footer model.
+     *   - app: Running application under test.
+     *   - timeout: Maximum time to wait for SwiftData deletion and SwiftUI reconciliation.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Side effects: polls the compact reader state export.
+     * - Failure modes: records an XCTest failure when the closed order remains present or the
+     *   reader loses its active-window state.
+     */
+    private func waitForClosedWindowOrder(
+        _ order: Int,
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastState = readerRenderedContentStateValue(in: app) ?? "nil"
+        var lastOrders = windowTabOrdersFromReaderState(in: app)
+        repeat {
+            lastState = readerRenderedContentStateValue(in: app) ?? "nil"
+            lastOrders = windowTabOrdersFromReaderState(in: app)
+            if let lastOrders,
+               !lastOrders.contains(order),
+               !lastState.contains("windowOrder=none") {
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let failureMessage = """
+            Expected window order \(order) to be removed within \(timeout) seconds; \
+            orders=\(String(describing: lastOrders)), state=\(lastState)
+            """
+        XCTFail(
+            failureMessage,
+            file: file,
+            line: line
+        )
     }
 
     /**
@@ -288,9 +337,10 @@ extension AndBibleUITests {
      *   - timeout: Maximum time to search while scrolling.
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
-     * - Returns: The first matching row with a usable frame, or the unresolved query after failure.
+     * - Returns: The first matching row that XCTest reports as hittable, or the unresolved query
+     *   after failure.
      * - Side effects: swipes the `windowPaneMenu` popup surface upward while re-querying rows.
-     * - Failure modes: records an XCTest failure when the row never materializes.
+     * - Failure modes: records an XCTest failure when the row never becomes hittable.
      */
     private func requirePaneMenuItem(
         _ identifier: String,
@@ -302,7 +352,9 @@ extension AndBibleUITests {
         let deadline = Date().addingTimeInterval(timeout)
         repeat {
             if let item = resolvedPaneMenuItem(identifier, in: app) {
-                return item
+                if waitForElementToBecomeHittable(item, timeout: 0.2) {
+                    return item
+                }
             }
 
             if let menuSurface = resolvedPaneMenuSurface(in: app) {
@@ -315,8 +367,8 @@ extension AndBibleUITests {
             ? app.buttons[identifier].firstMatch
             : unresolvedElement(identifier, in: app)
         XCTAssertTrue(
-            item.exists,
-            "Expected pane menu item '\(identifier)' to become visible within \(timeout) seconds.",
+            item.exists && item.isHittable,
+            "Expected pane menu item '\(identifier)' to become hittable within \(timeout) seconds.",
             file: file,
             line: line
         )

--- a/Sources/SwordKit/Tests/SwordKitTests/DefaultDocumentDownloadPlannerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/DefaultDocumentDownloadPlannerTests.swift
@@ -3,7 +3,25 @@
 import XCTest
 @testable import SwordKit
 
+/**
+ Verifies the SwordKit startup document planner without requiring the app host.
+
+ These tests protect Android startup-download parity: fixture rows simulate the
+ remote catalog, installed modules, and recommended-document metadata that the
+ app receives before it decides which default modules should be queued.
+ Failures indicate a user-visible startup download ordering or filtering
+ regression, not merely a package-test wiring issue. The suite has no
+ filesystem, simulator state, or persisted preference side effects.
+ */
 final class DefaultDocumentDownloadPlannerTests: XCTestCase {
+    /**
+     Confirms Android bucket ordering across recommended module categories.
+
+     The fixture includes every supported default bucket plus duplicate module
+     names from different repositories. The selected order must remain bible,
+     commentary, addon, book, dictionary, map so iOS presents the same initial
+     install set Android users receive.
+     */
     func testSelectsEnglishDefaultsInAndroidBucketOrder() {
         let configuration = ModuleDownloadConfiguration(
             bibles: ["en": ["KJV::CrossWire"]],
@@ -36,6 +54,12 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
         )
     }
 
+    /**
+     Ensures unavailable, already installed, missing, and duplicate defaults do not get queued.
+
+     A failure means startup downloads may retry modules the user already has
+     or surface catalog entries Android would skip as unavailable/missing.
+     */
     func testSkipsInstalledUnavailableMissingAndDuplicateDefaults() {
         let configuration = ModuleDownloadConfiguration(
             bibles: ["en": ["KJV", "KJV", "MissingBible"]],
@@ -60,6 +84,13 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
         XCTAssertEqual(selected.map(\.name), ["StrongsHebrew"])
     }
 
+    /**
+     Preserves Android's first-visible-catalog-row behavior for unscoped defaults.
+
+     The setup intentionally provides the same module from multiple sources;
+     unscoped tokens should bind to the first matching visible row so fallback
+     behavior is deterministic.
+     */
     func testUnscopedTokenUsesFirstMatchingCatalogRow() {
         let configuration = ModuleDownloadConfiguration(
             bibles: ["en": ["KJV"]]
@@ -78,6 +109,13 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
         XCTAssertEqual(selected.map(\.sourceName), ["CrossWire"])
     }
 
+    /**
+     Ensures source-scoped defaults can still select rows hidden by visible-row deduplication.
+
+     Android recommendations may include repository-qualified tokens. The
+     planner must search the full catalog so a deduplicated picker row does not
+     silently point users at the wrong repository.
+     */
     func testSourceScopedTokenUsesFullCatalogWhenVisibleRowsAreDeduplicated() {
         let configuration = ModuleDownloadConfiguration(
             bibles: ["en": ["KJV::CrossWire"]]
@@ -96,6 +134,12 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
         XCTAssertEqual(selected.map(\.sourceName), ["CrossWire"])
     }
 
+    /**
+     Creates a remote catalog fixture with only the fields the planner consumes.
+
+     The helper is deterministic and has no side effects; keeping the fixture
+     local avoids pulling app-level download state into SwordKit package tests.
+     */
     private func remoteModule(
         _ name: String,
         category: ModuleCategory,
@@ -112,6 +156,12 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
         )
     }
 
+    /**
+     Creates an installed-module fixture used to prove startup defaults skip owned modules.
+
+     The returned value is an in-memory model only; no SWORD module files or
+     database rows are created.
+     */
     private func installedModule(_ name: String, category: ModuleCategory) -> ModuleInfo {
         ModuleInfo(
             name: name,
@@ -122,7 +172,17 @@ final class DefaultDocumentDownloadPlannerTests: XCTestCase {
     }
 }
 
+/**
+ Verifies Android-compatible module-row actions without entering Downloads UI.
+
+ These package tests protect the action contract consumed by iOS download and
+ module-picker screens. Failures indicate that installed, encrypted, or
+ actively installing module rows will expose actions that drift from Android's
+ management behavior. The suite mutates no shared state and uses only
+ in-memory `ModuleInfo` fixtures.
+ */
 final class ModuleDownloadRowActionPlannerTests: XCTestCase {
+    /// Installable remote-only rows should only expose the about action.
     func testInstallableRemoteRowsExposeAboutOnly() {
         let actions = ModuleDownloadRowActionPlanner.availableActions(
             installedModule: nil,
@@ -132,6 +192,7 @@ final class ModuleDownloadRowActionPlannerTests: XCTestCase {
         XCTAssertEqual(actions, [.about])
     }
 
+    /// Installed rows should expose the Android management actions: about, uninstall, and delete index.
     func testInstalledRowsExposeAndroidManagementActions() {
         let actions = ModuleDownloadRowActionPlanner.availableActions(
             installedModule: installedModule("KJV", category: .bible),
@@ -141,6 +202,7 @@ final class ModuleDownloadRowActionPlannerTests: XCTestCase {
         XCTAssertEqual(actions, [.about, .uninstall, .deleteIndex])
     }
 
+    /// Encrypted installed rows include unlock only when a cipher coordinator exists.
     func testEncryptedInstalledRowsIncludeUnlockWhenCipherCoordinatorIsSupported() {
         let actions = ModuleDownloadRowActionPlanner.availableActions(
             installedModule: installedModule("KJV", category: .bible, isEncrypted: true),
@@ -151,6 +213,13 @@ final class ModuleDownloadRowActionPlannerTests: XCTestCase {
         XCTAssertEqual(actions, [.about, .uninstall, .deleteIndex, .unlock])
     }
 
+    /**
+     Documents the current iOS unlock gap so encrypted rows do not expose a dead unlock command.
+
+     Android supports unlock through its cipher flow. Until iOS has an
+     equivalent coordinator, the default action list must stay limited to
+     actions that actually work.
+     */
     func testEncryptedInstalledRowsDocumentIOSUnlockGapByDefault() {
         let actions = ModuleDownloadRowActionPlanner.availableActions(
             installedModule: installedModule("KJV", category: .bible, isEncrypted: true),
@@ -160,6 +229,7 @@ final class ModuleDownloadRowActionPlannerTests: XCTestCase {
         XCTAssertEqual(actions, [.about, .uninstall, .deleteIndex])
     }
 
+    /// Active install rows hide inline about while retaining installed-module management parity.
     func testBeingInstalledRowsHideInlineAboutButKeepInstalledManagementParity() {
         let actions = ModuleDownloadRowActionPlanner.availableActions(
             installedModule: installedModule("KJV", category: .bible),
@@ -169,6 +239,12 @@ final class ModuleDownloadRowActionPlannerTests: XCTestCase {
         XCTAssertEqual(actions, [.uninstall, .deleteIndex])
     }
 
+    /**
+     Creates an installed module fixture for row-action planning tests.
+
+     Encryption flags are modeled in memory only; the helper does not create
+     module files, keys, indexes, or database records.
+     */
     private func installedModule(
         _ name: String,
         category: ModuleCategory,

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -1,0 +1,155 @@
+# Test Architecture Migration Plan - Colocate Tests in Package Targets
+
+Status: in progress (Phase 1 pilot started)
+Owner: TBD
+Last updated: 2026-06-27
+
+## Why (adversarial review summary)
+
+The test suite's slowness and brittleness are structural, not per-test flakiness.
+
+Root cause: ~38,000 lines of pure package-logic unit tests live inside the
+app-target XCUITest bundle (`AndBibleTests/`), so every "unit" test pays the full
+app-build + simulator-boot + app-install tax and cannot use the fast `swift test`
+path. The sharding scripts, timing files, retry-upload steps, and 400+ `.xcresult`
+rerun bundles are machinery built to cope with that root cause rather than remove it.
+
+Evidence captured during review:
+
+| Signal | Value | Source |
+|---|---|---|
+| "Unit" test funcs in the app target | 633 funcs / 3,593 asserts / ~38k LOC | `AndBibleTests/` |
+| Of those, files importing the app module | 0 (all `@testable import` package modules) | grep |
+| Test funcs in actual package test targets | 42 (fast lane nearly empty) | `Sources/*/Tests/` |
+| UI tests | 68 funcs / 184 asserts (~2.7 asserts/test) | `AndBibleUITests/` |
+| UI suite serial wall-clock | ~150 min, avg 145s/test, slowest 317s | `scripts/ui_test_timings.json` |
+| App relaunches | 66 `app.launch()` ~ one cold launch per test | grep |
+| Brittleness machinery | 102 polling loops, 463 `firstMatch`, sharding-by-timings, retry-upload | grep / `ios-ci.yml` |
+| `.xcresult` rerun artifacts on disk | 434 (`rerun`/`fix`/`reliab`/`flak`/`retry`) | `.artifacts/` |
+| Does CI ever run `swift test`? | No | `.github/workflows/ios-ci.yml` |
+
+### Findings (most to least severe)
+- **F1** Package-logic tests misfiled into the app-target bundle (root cause of "slow"). 26 of 27 `AndBibleTests/` files import only package modules. Genuinely app/source-aware tests are a small minority and live inside `+AppAndReader.swift` (80 funcs total): `AndBibleApplicationDelegate.sceneConfiguration` (line 2328) and `testContentViewDoesNotContainLegacyRootSidebarShell` (line 2361, reads `AndBible/ContentView.swift` from disk). The other ~78 funcs in that file are BibleUI logic.
+- **F2** "God partial class": 633 tests on a single `AndBibleTests: XCTestCase` split across 27 `extension AndBibleTests` files (largest 4,168 lines), sharing setUp/tearDown state - ordering coupling, no per-file parallelism, merge-conflict magnet. Same pattern in `AndBibleUITests` (~11,700 lines of `...Support.swift` behind 68 tests).
+- **F3** UI tests are full-app E2E doing unit/integration work (e.g. `testSettingsReadingProgressLinkOpensReadingProgressSettings` = 317s to assert one navigation). Launch+seed dominates wall-clock.
+- **F4** Scattered layout: app-target bundle vs package targets vs host-side fixture tool, with no single "where does my test go" rule.
+- **F5** CI is largely flake-mitigation scaffolding (dynamic shard planner, build-product reuse experiment, duplicated retry-upload steps, 90-min UI timeout, 8+ python tests about the harness itself).
+- **F6** `CLAUDE.md` + `.github/copilot-instructions.md` steer contributors toward the slow app-target lane ("`swift test` is supplemental").
+
+## Decision
+
+Converge on **colocated package tests** (idiomatic SPM, biggest speed win).
+Reserve app-target bundles for tests that genuinely need the running app.
+
+Target structure:
+
+```
+Sources/
+  SwordKit/Tests/SwordKitTests/        <- libsword wrapper logic
+  BibleCore/Tests/BibleCoreTests/      <- models, services, sync, backup, downloads, bookmarks
+  BibleView/Tests/BibleViewTests/      <- bridge payload / contract tests
+  BibleUI/Tests/BibleUITests/          <- view-model / catalog / navigation logic (no live app)
+AndBibleTests/                         <- ONLY app-host unit tests (AppDelegate/scene/bootstrap)
+AndBibleUITests/                       <- ONLY true end-to-end journeys, trimmed to a small smoke set
+```
+
+## Destination mapping
+
+**Classify by behavior under test, NOT by today's imports.** The current files
+`@testable import` UI-heavy shared support (`AndBibleTestSupport`), so a sync or
+backup test that exercises only BibleCore today still drags in BibleUI/UIKit. Mapping
+by "highest module imported" would launder that pollution forward and defeat the speed
+goal - a `RemoteSync*` test would land in the simulator-bound BibleUITests when its
+behavior is pure BibleCore. Therefore destination is decided **after Phase 0 extracts
+the shared helpers**, by asking "what module's behavior does this test actually
+assert?" The dependency order (SwordKit < BibleCore < BibleView < BibleUI) only breaks
+ties; it does not drive placement.
+
+Concretely, after Phase 0 each file's `@testable import` set is re-minimized (drop UI
+imports that came only from shared support), then placed at the lowest module that
+still compiles it. Expect most `+RemoteSync*`, `+AndroidDatabaseBackup`, and bridge
+payload tests to fall to **BibleCoreTests / BibleViewTests**, not BibleUITests. Under
+the recommended option (b), those still run through app-host-free per-target simulator
+schemes; macOS `swift test` is used only if Phase 0 proves option (a).
+
+The table below is the **provisional** target; the import-reduction step in each phase
+confirms or lowers each destination.
+
+| Destination | Files (provisional) | Runs on | Notes |
+|---|---|---|---|
+| **SwordKitTests** | `DefaultDocumentDownloadPlannerTests`, `ModuleDownloadRowActionPlannerTests` | per-target simulator scheme baseline; optional macOS `swift test` only under option (a) | no UI frameworks |
+| **BibleCoreTests** | `+AndroidModuleBackup`, `RemoteSyncMyDocumentRestoreTests`, `WorkspaceSyncRestoreTests`, plus most `+RemoteSync*` and `+AndroidDatabaseBackup` once UI imports are dropped | per-target simulator scheme baseline; optional macOS `swift test` only under option (a) | SwiftData host compatibility is still useful, but not required for the baseline migration |
+| **BibleViewTests** | `+Bridge*` (bridge payload/contract behavior) once decoupled from UI support | per-target simulator scheme baseline; optional macOS `swift test` only under option (a) | reclassify per-file after Phase 0 |
+| **BibleUITests** | genuinely BibleUI-behavior tests only: `+BookCatalog`, `+ReaderNavigation`, `+WindowPaneMenu`, `+WindowTabBarLayout`, `+SettingsIcons`, `+Strongs*`, `+PassageGrid`, `+ExternalDocumentImport`, view-model portions of `+AppAndReader`, `AndBibleTests.swift` (base) | iOS simulator via committed package test scheme (no app host) - see Phase 0 task | BibleUI pulls SwiftUI/UIKit/WebKit -> simulator-bound, but free of the app build/install |
+| **stays in `AndBibleTests` (app host)** | `+AppAndReader` is **80 test funcs**, mostly BibleUI logic -> BibleUITests. App/source-aware ones that must NOT silently move: `AndBibleApplicationDelegate.sceneConfiguration` (line 2328, app host) and `testContentViewDoesNotContainLegacyRootSidebarShell` (line 2361, reads `AndBible/ContentView.swift` from disk) | app host or repo-standards | split the file deliberately; the ContentView source-scan test is a static guardrail and may instead become a `scripts/check_repo_standards.py` check rather than an app-hosted XCTest - decide explicitly, do not relocate it to BibleUITests |
+
+## Phases (CI stays green after every phase - strangler approach: stand up new, prove parity, then delete old)
+
+### Phase 0 - Shared test-support strategy (keystone; no test moves yet)
+Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` every test calls via `self`.
+- Create a **`BibleTestSupport`** helper library target for framework-agnostic fixtures needing no `@testable` access: `MockURLProtocol`, `FakeSpeechSynthesizer`, `Android*Row` structs, `webDAVMultiStatusXML`, dir-copy utils. Each package test target depends on it.
+- Helpers needing `@testable` internals (`makeInMemorySettingsStore`/`ModelContainer`, SWORD-module seeding) become free functions / a base `XCTestCase` subclass **inside** the relevant test target (`BibleCoreTestCase`, `BibleUITestCase`).
+- Replace the single `final class AndBibleTests` with a small per-target base carrying `temporarySwordModulePaths` teardown; moved files become `final class ...Tests: BibleUITestCase`.
+- **Toolchain (do first - blocks all `swift`-driven work).** The machine's default toolchain is the Command Line Tools (`xcode-select -p` -> `/Library/Developer/CommandLineTools`), under which `swift build`/`swift test` fail. Run under the installed full Xcode (`/Applications/Xcode.app`, verified present):
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test`
+  (or a one-time `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`).
+- **Whole-package SwiftPM compile decision (do first - blocks the macOS `swift test` lane and determines the Phase 1 command).** `swift test` builds the **entire package graph for the macOS host** regardless of `--filter`; it does not build only the filtered target. Today that build **fails**: e.g. `BibleCore` declares `public final class Window` (`Sources/BibleCore/Sources/BibleCore/Models/Window.swift:13`) which collides with `SwiftUI.Window` (macOS 14+) where BibleUI imports SwiftUI, plus other macOS-host errors ("extra `for:` arguments"). Consequences:
+  - The "fast macOS `swift test` lane" is **conditional**, not free. Either (a) make the whole package compile for the macOS host (disambiguate `Window`, platform-gate iOS-only code, fix the `for:` sites), or (b) drop macOS-host `swift test` and run every test target on the **iOS simulator via per-target xcodebuild schemes** - still app-host-free (the actual win), just not macOS-host-fast.
+  - **Decision required here**: pick (a) or (b) before Phase 1. Recommended default is **(b) per-target simulator schemes** as the baseline mechanism, with macOS-host `swift test` pursued later as a stretch optimization for SwordKit/BibleCore only once the host compile is green. This makes the Phase 1 command a scoped `xcodebuild test -scheme SwordKitTests` (builds only SwordKit + CLibSword), not whole-graph `swift test`.
+- **Package test schemes (do first - blocks Phase 3 and may block some option (b) targets).** `AndBible.xcscheme` is the only listed shared scheme, but Xcode 26 can synthesize project-integrated package test schemes from `Package.swift`: a clean worktree with a valid `libsword/libsword.xcframework` successfully ran `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme SwordKitTests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-swordkit-pre-dd CODE_SIGNING_ALLOWED=NO -only-testing:SwordKitTests/SwordManagerTests/testModuleInfoCreation` and built only `CLibSword`, `SwordKit`, and `SwordKitTests`. Treat that command shape as the Phase 1 baseline. For later targets, if CI or Xcode stops resolving the synthesized package-test schemes, create and commit one shared scheme per test target (`SwordKitTests`, `BibleCoreTests`, `BibleViewTests`, `BibleUITests`). **Scheme location vs `.gitignore`:** Xcode writes shared package schemes to `.swiftpm/xcode/xcshareddata/xcschemes/`, but `.gitignore:29` ignores `.swiftpm/`. Add a precise un-ignore so the schemes are committable, e.g.:
+  ```
+  .swiftpm/*
+  !.swiftpm/
+  !.swiftpm/xcode/
+  .swiftpm/xcode/*
+  !.swiftpm/xcode/xcshareddata/
+  .swiftpm/xcode/xcshareddata/*
+  !.swiftpm/xcode/xcshareddata/xcschemes/
+  !.swiftpm/xcode/xcshareddata/xcschemes/*.xcscheme
+  ```
+  (keep `xcuserdata` ignored). Confirm `git status` actually tracks the committed `.xcscheme` files before relying on explicit scheme files in CI. Verify each synthesized or explicit package-test scheme runs without the app host:
+  `xcodebuild test -project AndBible.xcodeproj -scheme SwordKitTests -destination 'platform=iOS Simulator,name=iPhone 17'`.
+- Gate: support compiles; the chosen run mechanism (a: whole-package `swift test` host build is green, or b: each package-test target builds and runs >=1 test on the simulator **without** building the app) is demonstrated; if explicit schemes were needed, `git status` shows the schemes tracked; nothing deleted.
+
+### Phase 1 - Pilot SwordKit (smallest, fully reversible)
+- Move `DefaultDocumentDownloadPlannerTests` and same-file `ModuleDownloadRowActionPlannerTests` -> `SwordKitTests`; both are already `final class ...: XCTestCase`.
+- Run with the Phase 0 mechanism:
+  - **Recommended option (b):**
+    `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme SwordKitTests -destination 'platform=iOS Simulator,name=iPhone 17'`
+  - **Only if Phase 0 chose option (a) and whole-package macOS SwiftPM compile is green:**
+    `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter SwordKitTests`
+- Gate: chosen command succeeds; identical count/results; app target is not built for the package-test run; keep original until CI proves the new copy green, then delete original in same PR.
+
+### Phase 2 - BibleCore logic tests
+- Move the 3 BibleCore-only files; same conversion.
+- Add CI coverage using the chosen Phase 0 mechanism:
+  - **Recommended option (b):** per-target simulator scheme job(s) for `SwordKitTests` and `BibleCoreTests`, with no app host.
+  - **Optional option (a):** macOS `swift test` job only after the whole-package SwiftPM graph compiles under full Xcode.
+- Gate: new package-test CI lane green; counts match; app build/install are not part of these package-test jobs; delete originals.
+
+### Phase 3 - BibleUI bulk (largest; 3-4 sub-batch PRs by theme)
+- **Per batch, first re-minimize imports** (drop UI imports inherited only from shared support) and re-confirm destination - many `+RemoteSync*` / `+Bridge*` tests should drop to BibleCoreTests/BibleViewTests and run in the package-test lane rather than BibleUITests. Under option (b), that still means per-target simulator schemes; under option (a), eligible targets may use macOS `swift test`.
+- Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
+- **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
+- Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).
+- Gate per batch: moved batch green in new target; equal count removed from app bundle; app build still green.
+
+### Phase 4 - Retire scaffolding & lock structure
+- Delete near-empty `AndBibleTests` extensions and `AndBibleTestSupport`; keep only app-host tests.
+- Simplify CI: replace `ios-simulator-unit-tests` app-build path with app-host-free package-test lanes. Baseline is per-target simulator schemes; macOS `swift test` is an optimization only for targets proven to compile under SwiftPM. Reassess shard planner, timings file, build-product-reuse experiment.
+- Trim `AndBibleUITests` to an explicit smoke set (target <=15 journeys); demote/convert the rest.
+- Update `CLAUDE.md` + `.github/copilot-instructions.md`: replace "swift test is supplemental" with the actual placement rule - *new tests go in the lowest package test target that owns the behavior after imports are minimized; app-host only for true app-delegate/scene/bootstrap behavior.*
+
+## Risks & mitigations
+- **`@testable` re-export from shared lib** - can't re-expose internals; keep internal-touching helpers inside test targets (Phase 0).
+- **Hidden inter-test state on shared `AndBibleTests` class** - per-class conversion may expose order-dependence; run each migrated file in isolation (`-only-testing`) early.
+- **SwiftData/CLibSword on macOS host** - verify in Phase 2 that BibleCore links libsword on macOS; route any simulator-only slice to the simulator job rather than blocking the macOS lane.
+- **Large diff churn** - batch by module/theme, parity-then-delete, never bulk-move in one PR.
+- **Missing package test scheme / toolchain** - Phase 3 simulator runs and all `swift test` runs are blocked until the Phase 0 tasks (prove synthesized package-test schemes or commit explicit shared package test schemes; standardize `DEVELOPER_DIR` on full Xcode) are done and verified. CI's package-test lanes must use the same full-Xcode toolchain and must not rely on user-local Xcode state. A macOS `swift test` lane must additionally prove the whole package graph compiles under SwiftPM before it becomes required.
+- **Classification by polluted imports** - placing files by today's `@testable import` set sends BibleCore-behavior tests into the simulator-bound BibleUITests and forfeits the speed win. Always re-minimize imports after Phase 0 and place at the lowest module that compiles.
+
+## Success criteria
+- ~38k lines of logic tests build against libraries, not the app. Baseline execution is app-host-free per-target package schemes; framework-agnostic targets may later run via macOS `swift test` once SwiftPM host compile is proven.
+- `AndBibleTests` holds only app-host tests; `AndBibleUITests` is a small intentional smoke set.
+- CI has fast app-host-free package-test lanes; the old app-host unit-test simulator job and much sharding machinery are retired. A macOS `swift test` lane is a stretch optimization, not a prerequisite for the migration's main win.
+- One documented rule for test placement.


### PR DESCRIPTION
## Summary

Starts the test architecture migration with the smallest app-host-free package lane: SwordKit planner tests now live in `SwordKitTests` and run through a dedicated simulator package-test CI job.

## Scope

- Moves `DefaultDocumentDownloadPlannerTests` and same-file `ModuleDownloadRowActionPlannerTests` from `AndBibleTests` into `Sources/SwordKit/Tests/SwordKitTests/`.
- Removes the moved file from the app-hosted `AndBibleTests` Xcode target.
- Adds a `SwordKit Package Tests (Simulator)` CI job that runs `xcodebuild test -scheme SwordKitTests` without building or installing `AndBible.app`.
- Adds `docs/test-architecture-migration-plan.md` with the migration target, phase gates, and known SwiftPM/toolchain constraints.

## Contract references

- `docs/test-architecture-migration-plan.md`: records the placement rule and phased migration contract.
- `Package.swift`: `SwordKitTests` is the owning package test target for SwordKit behavior.
- `.github/workflows/ios-ci.yml`: new package-test lane proves the moved tests do not depend on the app host.
- GitNexus staged change detection: low risk, 0 affected execution flows.

## Change details

- The moved tests still exercise the same SwordKit planner behavior, including Android-compatible startup default ordering, duplicate/source filtering, row-action availability, and the documented iOS encrypted-unlock gap.
- The Xcode project no longer compiles this file into the app-hosted unit test target.
- CI uses the synthesized `SwordKitTests` package scheme that was verified locally with Xcode 26. If future targets cannot rely on synthesized schemes, the migration plan documents the fallback to committed shared package test schemes.

## Validation evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme SwordKitTests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-swordkit-post-docblocks CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-app-build-check CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_repo_standards.py docblocks --base-ref origin/main --head-ref HEAD --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main --head-ref HEAD`
- `git diff --check`
- GitNexus `detect_changes` on staged worktree: low risk, 0 affected execution flows.

## Risks/follow-ups

Adversarial review:

- Merit: yes. This addresses the root structural issue for the pilot file: pure package logic was trapped in the app-hosted test bundle. The new lane proves these tests can run against `SwordKitTests` without `AndBible.app`.
- Root cause: test ownership and execution substrate were coupled to the app target even when the behavior under test belonged to a package.
- Proper fix in this PR: move the tests to their owning package target, remove the old target membership, and add CI coverage for that package lane. This is not a timeout or shard tweak.
- Scope boundary: this does not yet migrate BibleCore/BibleView/BibleUI tests or retire the old sharding machinery. The migration plan records that larger work and the import-minimization rule needed before moving mixed-support files.
- Remaining risk: CI must resolve the synthesized `SwordKitTests` scheme the same way local Xcode 26 did. If it does not, the correct fix is to commit explicit shared package test schemes, not move tests back to the app host.

## Issue closure reference

Closes: none

Verified with GitHub issue search for `test architecture migration` and `test architecture`; no applicable open or closed issue matched this migration.
