### PR TITLE
test(biblecore): migrate module backup tests to package lane

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -274,6 +274,149 @@ jobs:
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
 
+  ios-biblecore-package-tests:
+    name: BibleCore Package Tests (Simulator)
+    runs-on: ${{ needs.repo-standards.outputs.required_checks_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    needs:
+      - repo-standards
+      - localization-guardrails
+    timeout-minutes: 30
+    env:
+      DERIVED_DATA_PATH: .derivedData/BibleCorePackageTests
+      TEST_XCRESULT_BUNDLE_PATH: .artifacts/BibleCoreTests-package.xcresult
+    steps:
+      - name: Required-checks-only pass
+        if: needs.repo-standards.outputs.required_checks_only == 'true'
+        run: echo "Required-checks-only change set; BibleCore package tests are not required."
+
+      - name: Checkout
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Select Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Restore SwiftPM and build caches
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .derivedData/BibleCorePackageTests/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.swiftpm
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-biblecore-package-${{ hashFiles('Package.swift', 'Sources/SwordKit/**', 'Sources/BibleCore/**', 'libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-biblecore-package-
+
+      - name: Restore libsword build cache
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            libsword/sword-src
+            libsword/build
+            libsword/libsword.xcframework
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-${{ hashFiles('libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-
+
+      - name: Show Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: xcodebuild -version
+
+      - name: Ensure iOS simulator runtime is available
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
+            echo "An iOS simulator runtime is already installed."
+          else
+            echo "No iOS simulator runtime was found; downloading it for the selected Xcode."
+            xcodebuild -downloadPlatform iOS
+          fi
+
+      - name: Ensure libsword build prerequisites
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            brew install cmake
+          fi
+          if ! command -v svn >/dev/null 2>&1; then
+            brew install subversion
+          fi
+
+      - name: Build libsword XCFramework
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        working-directory: libsword
+        env:
+          INCLUDE_MACOS_SLICE: "0"
+        run: |
+          if [ -f libsword.xcframework/ios-arm64/libsword.a ] && [ -f libsword.xcframework/ios-arm64_x86_64-simulator/libsword.a ]; then
+            echo "Using cached libsword.xcframework"
+          else
+            ./build-ios.sh
+          fi
+
+      - name: Resolve iOS simulator destination
+        id: simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/resolve_ios_simulator_destination.py
+          --project AndBible.xcodeproj
+          --scheme BibleCoreTests
+          --create-dedicated-device
+          --device-name-prefix "AndBible CI BibleCore"
+
+      - name: Boot selected simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/wait_for_simulator_boot.py
+          --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
+          --timeout-seconds 300
+
+      - name: Run BibleCore package tests
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        timeout-minutes: 10
+        run: |
+          mkdir -p .artifacts
+          xcodebuild test \
+            -project AndBible.xcodeproj \
+            -scheme BibleCoreTests \
+            -configuration Debug \
+            -destination "${{ steps.simulator.outputs.destination }}" \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -resultBundlePath "${TEST_XCRESULT_BUNDLE_PATH}" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload BibleCore package test result bundle
+        id: upload_biblecore_package_xcresult
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-biblecore-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+
+      - name: Retry upload BibleCore package test result bundle
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_biblecore_package_xcresult.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-biblecore-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+          overwrite: true
+
+      - name: Delete dedicated simulator
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
+        run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
+
   bibleview-js:
     name: BibleView JS
     runs-on: ubuntu-latest

--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -43,7 +43,6 @@
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
 		B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */; };
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
-		A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
 		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
 		B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */; };
@@ -89,7 +88,6 @@
 		9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSyncRestoreTests.swift; sourceTree = "<group>"; };
 		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
-		A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidModuleBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
 		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
 		B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+WindowTabBarLayout.swift"; sourceTree = "<group>"; };
@@ -273,7 +271,6 @@
 				D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
-				A15100000000000000000001 /* AndBibleTests+AndroidModuleBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
 				B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */,
 				B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */,
@@ -515,7 +512,6 @@
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
 				B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */,
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
-				A15100000000000000000002 /* AndBibleTests+AndroidModuleBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
 				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,
 				B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BibleCoreTests",
-            dependencies: ["BibleCore"],
+            dependencies: ["BibleCore", "SwordKit"],
             path: "Sources/BibleCore/Tests/BibleCoreTests"
         ),
 

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidModuleBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidModuleBackupTests.swift
@@ -2,7 +2,35 @@ import XCTest
 @testable import BibleCore
 import SwordKit
 
-extension AndBibleTests {
+/**
+ Verifies Android-compatible module backup import/export behavior in the BibleCore package target.
+
+ The suite builds in-memory ZIP archives and temporary SWORD module roots to exercise
+ `AndroidModuleBackupService` without the app host. Failures indicate Android module backup
+ parity regressions, unsafe file overwrite behavior, or broken iOS/Android round-trip export
+ compatibility. Temporary files are registered in `temporaryFilePaths` and removed after each
+ test to keep package-test runs deterministic.
+ */
+final class AndroidModuleBackupTests: XCTestCase {
+    private var temporaryFilePaths: [String] = []
+
+    /**
+     Removes temporary SWORD roots and archive files created by each test.
+
+     The cleanup mirrors the former app-host `AndBibleTests` teardown dependency locally so this
+     package suite does not retain UI-heavy app test support. Cleanup failures are ignored because
+     failed assertions should report the behavior regression while temporary-directory cleanup is
+     best-effort after test completion.
+     */
+    override func tearDown() {
+        let fileManager = FileManager.default
+        for path in temporaryFilePaths {
+            try? fileManager.removeItem(atPath: path)
+        }
+        temporaryFilePaths.removeAll()
+        super.tearDown()
+    }
+
     /**
      Verifies that Android module backups are recognized by the `.abmd.zip` suffix and rejected
      when their manifest declares the database-backup type.
@@ -161,7 +189,7 @@ extension AndBibleTests {
      - restore writes the config and RawLD4 payload files into the module root
 
      Failure meaning:
-     - iOS rejects valid Android production module backups with “references missing data path”
+     - iOS rejects valid Android production module backups with "references missing data path"
        even though Android and SWORD store RawLD4 data as file-stem payloads.
      */
     func testAndroidModuleBackupRestoresRawLD4FileStemModuleFromFileURL() throws {
@@ -480,7 +508,7 @@ extension AndBibleTests {
             at: root.appendingPathComponent("mods.d", isDirectory: true),
             withIntermediateDirectories: true
         )
-        temporarySwordModulePaths.append(root.path)
+        temporaryFilePaths.append(root.path)
         return root
     }
 
@@ -516,7 +544,7 @@ extension AndBibleTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("android-module-backup-\(UUID().uuidString).abmd.zip")
         try archiveData.write(to: url)
-        temporarySwordModulePaths.append(url.path)
+        temporaryFilePaths.append(url.path)
         return url
     }
 

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -1,6 +1,6 @@
 # Test Architecture Migration Plan - Colocate Tests in Package Targets
 
-Status: in progress (Phase 1 pilot started)
+Status: in progress (Phase 2 BibleCore package lane started)
 Owner: TBD
 Last updated: 2026-06-27
 
@@ -121,7 +121,9 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - Gate: chosen command succeeds; identical count/results; app target is not built for the package-test run; keep original until CI proves the new copy green, then delete original in same PR.
 
 ### Phase 2 - BibleCore logic tests
-- Move the 3 BibleCore-only files; same conversion.
+- Move the cleanest BibleCore-only files first, preserving app-host-free package execution after each slice.
+  - `AndBibleTests+AndroidModuleBackup` has moved to `BibleCoreTests` as the first Phase 2 slice because it only needed local temporary-file cleanup after leaving `AndBibleTests`.
+  - `RemoteSyncMyDocumentRestoreTests` and `WorkspaceSyncRestoreTests` are standalone BibleCore tests but carry large SQLite/gzip fixture blocks; move them in follow-up slices after confirming direct `CLibSword` imports and fixture ownership stay local to the package target.
 - Add CI coverage using the chosen Phase 0 mechanism:
   - **Recommended option (b):** per-target simulator scheme job(s) for `SwordKitTests` and `BibleCoreTests`, with no app host.
   - **Optional option (a):** macOS `swift test` job only after the whole-package SwiftPM graph compiles under full Xcode.


### PR DESCRIPTION
## Summary

Stacks on PR #276 and starts Phase 2 by moving Android module backup tests into the `BibleCoreTests` package lane.

## Scope

- Moves `AndBibleTests+AndroidModuleBackup.swift` to `Sources/BibleCore/Tests/BibleCoreTests/AndroidModuleBackupTests.swift`.
- Converts the old `extension AndBibleTests` into a standalone `XCTestCase` with local temporary-file cleanup.
- Removes the moved test file from the app-hosted `AndBibleTests` Xcode target.
- Adds `SwordKit` as an explicit `BibleCoreTests` dependency because the migrated suite imports SwordKit notification and ZIP helpers.
- Adds a `BibleCore Package Tests (Simulator)` CI job.
- Updates the migration plan to show Phase 2 has started with this smaller BibleCore slice.

## Contract references

- Base PR: #276 (`test-architecture-phase1`).
- `docs/test-architecture-migration-plan.md`: Phase 2 package-test migration contract.
- `Package.swift`: `BibleCoreTests` owns BibleCore behavior and now explicitly depends on `SwordKit` for imported helpers.
- `.github/workflows/ios-ci.yml`: new package-test lane proves these tests run without `AndBible.app`.
- GitNexus staged change detection: low risk, 0 affected execution flows.

## Change details

- The migrated suite still validates Android module backup suffix detection, manifest rejection, duplicate archive entry handling, SWORD payload restore, RawLD4 file-stem restore, overwrite behavior, unsupported-only content rejection, Android-compatible export shape, UTF-8 ZIP flags, and selected-module export filtering.
- The package-local `tearDown()` only removes temporary SWORD roots and archive files created by these tests; it does not pull in `AndBibleTestSupport`, `BibleUI`, `BibleView`, UIKit, or WebKit.
- The app-hosted test target no longer references the moved file, so the same tests are not compiled in both targets.

## Validation evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-biblecore-after-package-dep CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-app-build-after-biblecore-move CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 scripts/check_repo_standards.py docblocks --base-ref test-architecture-phase1 --head-ref HEAD --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref test-architecture-phase1 --head-ref HEAD`
- `git diff --check`
- GitNexus `detect_changes`: low risk, 0 affected flows.

## Risks/follow-ups

Adversarial review:

- Merit: yes. This is another real app-host decoupling step: 12 Android module backup tests now build and run in `BibleCoreTests`, and the local package run builds only package targets, not `AndBible.app`.
- Root cause: BibleCore backup behavior was still coupled to the monolithic `AndBibleTests` class for teardown only. The proper fix is local package-test cleanup, not moving app-test support into the package target.
- Proper fix in this PR: keep the suite package-owned, remove the stale app target membership, and add CI coverage for the BibleCore package lane.
- Scope boundary: this intentionally does not move `RemoteSyncMyDocumentRestoreTests` or `WorkspaceSyncRestoreTests` yet. They are BibleCore-owned, but they carry large SQLite/gzip fixture blocks and should move as their own reviewable slices.
- Remaining risk: CI job duplication grows with each package lane. This PR keeps duplication to avoid destabilizing the green SwordKit lane in PR #276; a later cleanup should consolidate package-test jobs once the lane shape is proven across more targets.
- Remaining risk: synthesized package schemes still depend on Xcode resolving `BibleCoreTests`; if CI fails to resolve it, the right fix is explicit shared package test schemes, not reverting tests to the app host.

## Issue closure reference

Closes: none

Verified with GitHub issue search for `test architecture migration` and `BibleCore package tests`; no applicable open or closed issue matched this migration slice.
