### PR TITLE
test(biblecore): migrate my document restore tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */; };
 		A1B2C3D4E5F60718293A4B5C /* AndBibleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */; };
 		8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */; };
-		D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */; };
 		D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13400000000000000000001 /* AndBibleTests+Downloads.swift */; };
 		64688F48FF7396937F81D0B5 /* SwordSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA144AB77AEE518F1465DCC /* SwordSetup.swift */; };
 		793CB31DA9E0B8F6F4AC7677 /* AndBibleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */; };
@@ -86,7 +85,6 @@
 		A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITests.swift; sourceTree = "<group>"; };
 		8174AF1F3D15BAFB4EB66A1E /* AndBible.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AndBible.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSyncRestoreTests.swift; sourceTree = "<group>"; };
-		D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSyncMyDocumentRestoreTests.swift; sourceTree = "<group>"; };
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
 		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
@@ -268,7 +266,6 @@
 			children = (
 				DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */,
 				9B8F65108C5F5E1DAF2B3C4D /* WorkspaceSyncRestoreTests.swift */,
-				D10500000000000000000001 /* RemoteSyncMyDocumentRestoreTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
@@ -495,7 +492,6 @@
 			files = (
 				605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */,
 				8A7E540F7B4E4D0C9E1A2B3C /* WorkspaceSyncRestoreTests.swift in Sources */,
-				D10500000000000000000002 /* RemoteSyncMyDocumentRestoreTests.swift in Sources */,
 				B69113624461C63AB21F4144 /* AndBibleTestSupport.swift in Sources */,
 				34F21932E6E652AD0A369D9C /* AndBibleTests+AppAndReader.swift in Sources */,
 				FBE587F989B0D3A1B1A283EF /* AndBibleTests+StrongsAndDictionary.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BibleCoreTests",
-            dependencies: ["BibleCore", "SwordKit"],
+            dependencies: ["BibleCore", "SwordKit", "CLibSword"],
             path: "Sources/BibleCore/Tests/BibleCoreTests"
         ),
 

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -8,6 +8,16 @@ import SwiftData
 
 private let myDocumentRestoreSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
+/**
+ Android-compatible My Documents restore, patch replay, and upload coverage for BibleCore.
+
+ The suite builds Android-shaped SQLite and gzip fixtures in the process temporary directory,
+ restores them into in-memory SwiftData containers, and verifies that BibleCore preserves
+ Android backup contracts without needing the app-host test target.
+
+ Side effects are limited to temporary fixture files and in-memory SwiftData stores created
+ per test; failures indicate Android backup parity or local My Documents data-safety drift.
+ */
 final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
     /**
      Verifies local My Documents insertion keeps Android bridge initials unique after

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -123,7 +123,8 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 ### Phase 2 - BibleCore logic tests
 - Move the cleanest BibleCore-only files first, preserving app-host-free package execution after each slice.
   - `AndBibleTests+AndroidModuleBackup` has moved to `BibleCoreTests` as the first Phase 2 slice because it only needed local temporary-file cleanup after leaving `AndBibleTests`.
-  - `RemoteSyncMyDocumentRestoreTests` and `WorkspaceSyncRestoreTests` are standalone BibleCore tests but carry large SQLite/gzip fixture blocks; move them in follow-up slices after confirming direct `CLibSword` imports and fixture ownership stay local to the package target.
+  - `RemoteSyncMyDocumentRestoreTests` has moved to `BibleCoreTests` as the second Phase 2 slice because it is already a standalone `XCTestCase`; its direct `CLibSword` import is now an explicit `BibleCoreTests` dependency.
+  - `WorkspaceSyncRestoreTests` is standalone BibleCore coverage but still carries the larger SQLite/gzip fixture block; move it in a follow-up slice after confirming fixture ownership stays local to the package target.
 - Add CI coverage using the chosen Phase 0 mechanism:
   - **Recommended option (b):** per-target simulator scheme job(s) for `SwordKitTests` and `BibleCoreTests`, with no app host.
   - **Optional option (a):** macOS `swift test` job only after the whole-package SwiftPM graph compiles under full Xcode.


### PR DESCRIPTION
## Summary

Moves `RemoteSyncMyDocumentRestoreTests` out of the app-host `AndBibleTests` bundle and into the app-host-free `BibleCoreTests` package lane.

This stacks on PR #277 and keeps Phase 2 moving one standalone BibleCore restore suite at a time.

## Scope

In scope:
- Relocate `RemoteSyncMyDocumentRestoreTests` to `Sources/BibleCore/Tests/BibleCoreTests`.
- Remove stale `AndBibleTests` Xcode project membership for that file.
- Add `CLibSword` as an explicit `BibleCoreTests` dependency because the moved fixture helpers import it directly.
- Update the test architecture migration plan with this second Phase 2 BibleCore slice.

Out of scope:
- Moving `WorkspaceSyncRestoreTests`; it remains a separate follow-up slice because it carries the larger workspace SQLite/gzip fixture block.
- Retiring app-host unit CI or UI sharding.
- Any production behavior changes.

## Contract References

- `docs/test-architecture-migration-plan.md` Phase 2: BibleCore logic tests should move to package test lanes while preserving app-host-free execution after each slice.
- Android backup parity contract remains covered by the moved My Documents restore, patch replay, and upload tests.

## Change Details

- `RemoteSyncMyDocumentRestoreTests` is now compiled by `BibleCoreTests` instead of `AndBibleTests`.
- The suite remains a standalone `XCTestCase`; no shared `AndBibleTests` support or app-host fixture dependency was introduced.
- Added a suite docblock documenting the Android-compatible backup contract, temp-file side effects, and failure meaning.
- Project metadata now stops listing the file in the app-host test target.

## Validation Evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-biblecore-after-mydoc-move CODE_SIGNING_ALLOWED=NO`
  - Passed: 50 tests, including 23 `RemoteSyncMyDocumentRestoreTests`.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-app-build-after-mydoc-move CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
  - Passed.
- `python3 scripts/check_repo_standards.py docblocks --base-ref test-architecture-phase2-biblecore --head-ref HEAD --all-files`
  - Passed.
- `python3 scripts/check_bridge_parity_inventory.py`
  - Passed.
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
  - Passed: 149 tests.
- `git diff --check`
  - Passed.
- GitNexus impact on `RemoteSyncMyDocumentRestoreTests`: CRITICAL import-target risk from app-test bundle membership, but 0 affected execution flows and 0 affected modules.
- GitNexus staged detect-changes: low risk, 0 affected execution flows.

## Adversarial Review

Merit: yes.

Root cause: these My Documents restore tests exercise BibleCore remote-sync and SwiftData behavior, but were still trapped in the app-host XCTest bundle. That preserved the structural test-suite problem by making pure package coverage pay app build/install cost.

Proper fix: move the whole standalone suite, including post-class mock adapter and SQLite/gzip helpers, into `BibleCoreTests`; remove only the old app-target membership; make the direct `CLibSword` import explicit in the package target dependencies. This avoids relying on transitive target visibility and avoids changing production behavior.

Scope check: I intentionally did not move `WorkspaceSyncRestoreTests` in this PR. It is also package-test friendly, but at 3.5k lines with a larger fixture surface it should be reviewed and validated as the next discrete slice.

Risk: the suite creates temporary SQLite and gzip fixtures. The tests already clean those files with local `defer` blocks and passed in the package lane, so this PR does not add shared global cleanup or app-host coupling.

## Risks / Follow-ups

- Follow-up: migrate `WorkspaceSyncRestoreTests` after the same fixture-ownership review.
- Follow-up: continue shrinking app-host `AndBibleTests` once the BibleCore slices are moved.

## Issue Closure Reference

Closes: none

Verified with GitHub issue searches for `test architecture migration` and `BibleCore package tests`; no matching issue exists for this migration slice.
