### PR TITLE
test(bibleui): migrate book catalog tests to package lane

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -417,6 +417,149 @@ jobs:
         if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
         run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
 
+  ios-bibleui-package-tests:
+    name: BibleUI Package Tests (Simulator)
+    runs-on: ${{ needs.repo-standards.outputs.required_checks_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
+    needs:
+      - repo-standards
+      - localization-guardrails
+    timeout-minutes: 30
+    env:
+      DERIVED_DATA_PATH: .derivedData/BibleUIPackageTests
+      TEST_XCRESULT_BUNDLE_PATH: .artifacts/BibleUITests-package.xcresult
+    steps:
+      - name: Required-checks-only pass
+        if: needs.repo-standards.outputs.required_checks_only == 'true'
+        run: echo "Required-checks-only change set; BibleUI package tests are not required."
+
+      - name: Checkout
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Select Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Restore SwiftPM and build caches
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            .derivedData/BibleUIPackageTests/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.swiftpm
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-bibleui-package-${{ hashFiles('Package.swift', 'Sources/SwordKit/**', 'Sources/BibleCore/**', 'Sources/BibleView/**', 'Sources/BibleUI/**', 'libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-bibleui-package-
+
+      - name: Restore libsword build cache
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            libsword/sword-src
+            libsword/build
+            libsword/libsword.xcframework
+          key: ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-${{ hashFiles('libsword/build-ios.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-${{ env.XCODE_VERSION }}-libsword-iosonly-
+
+      - name: Show Xcode version
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: xcodebuild -version
+
+      - name: Ensure iOS simulator runtime is available
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if xcrun simctl list runtimes available | grep -Fq 'iOS '; then
+            echo "An iOS simulator runtime is already installed."
+          else
+            echo "No iOS simulator runtime was found; downloading it for the selected Xcode."
+            xcodebuild -downloadPlatform iOS
+          fi
+
+      - name: Ensure libsword build prerequisites
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            brew install cmake
+          fi
+          if ! command -v svn >/dev/null 2>&1; then
+            brew install subversion
+          fi
+
+      - name: Build libsword XCFramework
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        working-directory: libsword
+        env:
+          INCLUDE_MACOS_SLICE: "0"
+        run: |
+          if [ -f libsword.xcframework/ios-arm64/libsword.a ] && [ -f libsword.xcframework/ios-arm64_x86_64-simulator/libsword.a ]; then
+            echo "Using cached libsword.xcframework"
+          else
+            ./build-ios.sh
+          fi
+
+      - name: Resolve iOS simulator destination
+        id: simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/resolve_ios_simulator_destination.py
+          --project AndBible.xcodeproj
+          --scheme BibleUITests
+          --create-dedicated-device
+          --device-name-prefix "AndBible CI BibleUI"
+
+      - name: Boot selected simulator
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        run: >-
+          python3 -u scripts/wait_for_simulator_boot.py
+          --simulator-id "${{ steps.simulator.outputs.simulator_id }}"
+          --timeout-seconds 300
+
+      - name: Run BibleUI package tests
+        if: needs.repo-standards.outputs.required_checks_only != 'true'
+        timeout-minutes: 10
+        run: |
+          mkdir -p .artifacts
+          xcodebuild test \
+            -project AndBible.xcodeproj \
+            -scheme BibleUITests \
+            -configuration Debug \
+            -destination "${{ steps.simulator.outputs.destination }}" \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -resultBundlePath "${TEST_XCRESULT_BUNDLE_PATH}" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload BibleUI package test result bundle
+        id: upload_bibleui_package_xcresult
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-bibleui-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+
+      - name: Retry upload BibleUI package test result bundle
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.upload_bibleui_package_xcresult.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: andbible-xcresult-${{ github.run_id }}-bibleui-package
+          path: .artifacts/*.xcresult
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
+          overwrite: true
+
+      - name: Delete dedicated simulator
+        if: always() && needs.repo-standards.outputs.required_checks_only != 'true' && steps.simulator.outputs.simulator_created == 'true'
+        run: xcrun simctl delete "${{ steps.simulator.outputs.simulator_id }}"
+
   bibleview-js:
     name: BibleView JS
     runs-on: ubuntu-latest

--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
 		B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */; };
 		B23100000000000000000002 /* AndBibleTests+WindowPaneMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23100000000000000000001 /* AndBibleTests+WindowPaneMenu.swift */; };
-		B146BC000000000000000002 /* AndBibleTests+BookCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B146BC000000000000000001 /* AndBibleTests+BookCatalog.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -88,7 +87,6 @@
 		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
 		B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+WindowTabBarLayout.swift"; sourceTree = "<group>"; };
 		B23100000000000000000001 /* AndBibleTests+WindowPaneMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+WindowPaneMenu.swift"; sourceTree = "<group>"; };
-		B146BC000000000000000001 /* AndBibleTests+BookCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+BookCatalog.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -269,7 +267,6 @@
 				B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */,
 				B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */,
 				B23100000000000000000001 /* AndBibleTests+WindowPaneMenu.swift */,
-				B146BC000000000000000001 /* AndBibleTests+BookCatalog.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -508,7 +505,6 @@
 				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,
 				B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */,
 				B23100000000000000000002 /* AndBibleTests+WindowPaneMenu.swift in Sources */,
-				B146BC000000000000000002 /* AndBibleTests+BookCatalog.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BibleUITests",
-            dependencies: ["BibleUI", "BibleCore"],
+            dependencies: ["BibleUI", "BibleCore", "SwordKit"],
             path: "Sources/BibleUI/Tests/BibleUITests"
         ),
         .executableTarget(

--- a/Sources/BibleUI/Tests/BibleUITests/BibleWindowPaneMenuModelTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleWindowPaneMenuModelTests.swift
@@ -76,7 +76,7 @@ final class BibleWindowPaneMenuModelTests: XCTestCase {
      A synchronized window shows Disable synchronize, then Group 1 through Group 6 except the
      currently selected group. Group selection is one-based in the UI and zero-based in the action.
      */
-    func testSynchronizedWindowSubmenuShowsDisableAndSkipsCurrentGroup() {
+    func testSynchronizedWindowSubmenuShowsDisableAndSkipsCurrentGroup() throws {
         let model = BibleWindowPaneMenuModel(snapshot: .fixture(
             isSynchronized: true,
             syncGroup: 2

--- a/Sources/BibleUI/Tests/BibleUITests/BookCatalogTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookCatalogTests.swift
@@ -1,10 +1,17 @@
-// AndBibleTests+BookCatalog.swift -- Reader book catalog parity tests
+// BookCatalogTests.swift -- Reader book catalog parity tests
 
 import XCTest
 @testable import BibleUI
 import SwordKit
 
-extension AndBibleTests {
+/**
+ BibleUI reader book-catalog parity coverage for fallback and module-provided metadata.
+
+ These tests keep catalog behavior in the app-host-free `BibleUITests` package lane because the
+ contract belongs to the BibleUI reader model, not app bootstrap. Failures indicate iOS has drifted
+ from Android/JSword-compatible startup placeholders or active-module book ordering semantics.
+ */
+final class BookCatalogTests: XCTestCase {
     /**
      Protects the no-module compatibility catalog used before any SWORD Bible is available.
 

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -1,8 +1,8 @@
 # Test Architecture Migration Plan - Colocate Tests in Package Targets
 
-Status: in progress (Phase 2 BibleCore package lane started)
+Status: in progress (Phase 3 BibleUI package lane started)
 Owner: TBD
-Last updated: 2026-06-27
+Last updated: 2026-06-28
 
 ## Why (adversarial review summary)
 
@@ -132,6 +132,8 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 
 ### Phase 3 - BibleUI bulk (largest; 3-4 sub-batch PRs by theme)
 - **Per batch, first re-minimize imports** (drop UI imports inherited only from shared support) and re-confirm destination - many `+RemoteSync*` / `+Bridge*` tests should drop to BibleCoreTests/BibleViewTests and run in the package-test lane rather than BibleUITests. Under option (b), that still means per-target simulator schemes; under option (a), eligible targets may use macOS `swift test`.
+- `AndBibleTests+BookCatalog` has moved to `BibleUITests` as the first Phase 3 slice because it exercises BibleUI reader catalog behavior without app bootstrap. Its direct `SwordKit` types are now an explicit `BibleUITests` dependency.
+- CI now includes an app-host-free `ios-bibleui-package-tests` simulator job so moved BibleUI tests remain enforced outside the app-target bundle.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
- Moves the Bible reader BookCatalog tests from the app-host `AndBibleTests` bundle into the app-host-free `BibleUITests` package lane.
- Adds a required BibleUI package simulator job to iOS CI so the migrated tests remain enforced.

## Scope
- In scope: BookCatalog test relocation, explicit `SwordKit` dependency for `BibleUITests`, stale app-test project reference cleanup, BibleUI package CI wiring, and migration-plan status update.
- Out of scope: additional Phase 3 bulk moves, UI-test sharding changes, macOS-host `swift test`, or behavior changes to `BibleReaderBookCatalog`.

## Contract References
- `docs/test-architecture-migration-plan.md` Phase 3: BibleUI behavior tests should move to app-host-free package schemes.
- `BibleReaderBookCatalog` contract: fallback catalog behavior remains a BibleUI reader-model concern, not app bootstrap.
- Android/JSword compatibility: module-provided book ordering and fallback placeholder semantics must remain covered.

## Change Details
- Converted `AndBibleTests+BookCatalog.swift` into `Sources/BibleUI/Tests/BibleUITests/BookCatalogTests.swift` as a standalone `XCTestCase`.
- Added `SwordKit` to the `BibleUITests` package target because the migrated tests directly use `BookInfo`.
- Removed the old app-test project file/build references so the tests are no longer built in the app-host bundle.
- Added `ios-bibleui-package-tests` to `.github/workflows/ios-ci.yml`, patterned after the existing SwordKit/BibleCore package simulator lanes.
- Fixed an existing `BibleUITests` package compile blocker by marking the synchronized-window submenu test as throwing.
- Updated the migration plan to record the Phase 3 BookCatalog slice and CI coverage.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bibleui-book-catalog-final CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-book-catalog-app-build CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_repo_standards.py docblocks --base-ref origin/main --head-ref HEAD --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main --head-ref HEAD`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-ci.yml")'`
- GitNexus `detect_changes`: low risk, no affected execution flows.

## Adversarial Review
- Coverage-drop check: the tests were removed from the app-host project and added to the package path covered by the new CI job, so coverage is moved rather than lost.
- App-host check: local `BibleUITests` package target built only package dependencies, not the app target.
- Dependency check: `SwordKit` is explicit because the migrated tests directly instantiate `BookInfo`; this avoids relying on transitive imports.
- CI check: the new job mirrors existing package simulator lanes rather than introducing a separate test mechanism.
- Project-file check: app `build-for-testing` still succeeds after removing the stale app-test entry.

## Risks / Follow-ups
- The new CI job adds a macOS runner lane, but this is required to enforce Phase 3 package coverage rather than silently migrating tests out of CI.
- `actionlint` is not installed locally, so workflow validation used YAML parsing plus local command-shape validation; CI remains the authoritative workflow validation.
- Future Phase 3 slices should continue moving only behavior-owned BibleUI tests and should avoid dumping lower-level BibleCore/BibleView tests into `BibleUITests`.

## Issue Closure
Closes: none

Verified no applicable GitHub issue mapping via searches for `test architecture migration`, `BookCatalog package tests`, and `BibleUI package tests`; returned issue #223 was unrelated to this test-architecture slice.
