### PR TITLE
test(bibleui): migrate window tab bar layout tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -43,7 +43,6 @@
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
 		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
-		B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -84,7 +83,6 @@
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
 		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
-		B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+WindowTabBarLayout.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -263,7 +261,6 @@
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
 				B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */,
-				B22900000000000000000001 /* AndBibleTests+WindowTabBarLayout.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -500,7 +497,6 @@
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
 				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,
-				B22900000000000000000002 /* AndBibleTests+WindowTabBarLayout.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
@@ -1,7 +1,9 @@
 import XCTest
 @testable import BibleUI
 
-extension AndBibleTests {
+/// Verifies the bottom reader window-strip layout contracts that mirror Android's compact
+/// multi-window footer behavior without requiring the app-host XCTest bundle.
+final class WindowTabBarLayoutTests: XCTestCase {
     /**
      Protects Android-style compact bottom window buttons on phone-width readers.
 

--- a/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
@@ -1,8 +1,10 @@
 import XCTest
 @testable import BibleUI
 
-/// Verifies the bottom reader window-strip layout contracts that mirror Android's compact
-/// multi-window footer behavior without requiring the app-host XCTest bundle.
+/**
+ Verifies the bottom reader window-strip layout contracts that mirror Android's compact
+ multi-window footer behavior without requiring the app-host XCTest bundle.
+ */
 final class WindowTabBarLayoutTests: XCTestCase {
     /**
      Protects Android-style compact bottom window buttons on phone-width readers.

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -135,6 +135,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - `AndBibleTests+BookCatalog` has moved to `BibleUITests` as the first Phase 3 slice because it exercises BibleUI reader catalog behavior without app bootstrap. Its direct `SwordKit` types are now an explicit `BibleUITests` dependency.
 - CI now includes an app-host-free `ios-bibleui-package-tests` simulator job so moved BibleUI tests remain enforced outside the app-target bundle.
 - `AndBibleTests+WindowPaneMenu` has been retired from the app-host bundle because equivalent Android-parity coverage already lives in `BibleWindowPaneMenuModelTests` under the `BibleUITests` package target.
+- `AndBibleTests+WindowTabBarLayout` has moved to `BibleUITests` because it exercises pure BibleUI footer layout constants and Android-parity layout decisions without app bootstrap.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
Move the Android-parity `WindowTabBarLayout` tests out of the app-host `AndBibleTests` bundle and into the app-host-free `BibleUITests` package lane.

## Scope
- Stack base: `test-architecture-phase3-window-pane-menu` / PR #281.
- Test-only migration for `WindowTabBarLayout` coverage.
- No production behavior changes.
- Leaves unrelated local `CLAUDE.md`, `.claude/`, and `AGENTS.md` files out of this PR.

## Contract References
- `docs/test-architecture-migration-plan.md` Phase 3: BibleUI tests should move to package targets when they exercise BibleUI behavior without app bootstrap.
- Android parity preserved by carrying over the existing footer layout tests and their Android-behavior docblocks.

## Change Details
- Renamed `AndBibleTests+WindowTabBarLayout.swift` to `WindowTabBarLayoutTests.swift` under `Sources/BibleUI/Tests/BibleUITests`.
- Converted the app-host `extension AndBibleTests` wrapper into a standalone `XCTestCase`.
- Removed the old app-target project references from `AndBible.xcodeproj/project.pbxproj`.
- Updated the migration plan to mark this slice complete.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-window-tab-bar-layout-bibleui-rerun CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-window-tab-bar-layout-app-build CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_repo_standards.py docblocks --base-ref test-architecture-phase3-window-pane-menu --head-ref HEAD --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref test-architecture-phase3-window-pane-menu --head-ref HEAD`
- `plutil -lint AndBible.xcodeproj/project.pbxproj`
- `git diff --check`
- GitNexus staged detect: low risk, no affected execution flows.
- Adversarial review by sub-agent: no blockers; confirmed package test run did not build `AndBible.app` or `AndBibleTests`.

## Risks / Follow-ups
- GitNexus impact reports CRITICAL through broad Swift import edges around test classes, but with 0 affected execution flows and 0 affected modules; this is expected during the monolithic `AndBibleTests` decomposition.
- Remaining Phase 3 work still needs further BibleUI slices (`ReaderNavigation`, `Bookmarks/Strongs`, `Settings`, and view-model parts of `AppAndReader`).

## Issue Closure
Closes: none; this is a planned follow-up slice from `docs/test-architecture-migration-plan.md`, not a standalone GitHub issue.
