### PR TITLE
test(bibleui): migrate settings icon tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		906F7E8A3810F315334D7BB0 /* AndBibleTests+RemoteSyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BC95812B90ED267EC66D6B /* AndBibleTests+RemoteSyncState.swift */; };
 		DF4297E4F6F61467148CB772 /* AndBibleTests+RemoteSyncLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ED2258F0F324029C56991 /* AndBibleTests+RemoteSyncLifecycle.swift */; };
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
-		B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */; };
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
 		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
@@ -149,7 +148,6 @@
 		B47ED2258F0F324029C56991 /* AndBibleTests+RemoteSyncLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+RemoteSyncLifecycle.swift"; sourceTree = "<group>"; };
 		EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+Bookmarks.swift"; sourceTree = "<group>"; };
 		D13400000000000000000001 /* AndBibleTests+Downloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+Downloads.swift"; sourceTree = "<group>"; };
-		B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+SettingsIcons.swift"; sourceTree = "<group>"; };
 		90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITestSupport.swift; sourceTree = "<group>"; };
 		4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleUITests+Search.swift"; sourceTree = "<group>"; };
 		6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleUITests+PlansDownloadsWorkspace.swift"; sourceTree = "<group>"; };
@@ -274,7 +272,6 @@
 				B47ED2258F0F324029C56991 /* AndBibleTests+RemoteSyncLifecycle.swift */,
 				EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */,
 				D13400000000000000000001 /* AndBibleTests+Downloads.swift */,
-				B166C0DE0000000000000001 /* AndBibleTests+SettingsIcons.swift */,
 				5172B5175C1984FA05E10E75 /* AndBibleTests+BridgeIOS.swift */,
 			);
 			path = AndBibleTests;
@@ -493,7 +490,6 @@
 				DF4297E4F6F61467148CB772 /* AndBibleTests+RemoteSyncLifecycle.swift in Sources */,
 				4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */,
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
-				B166C0DE0000000000000002 /* AndBibleTests+SettingsIcons.swift in Sources */,
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
 				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,

--- a/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
@@ -1,9 +1,18 @@
 import XCTest
+import Foundation
 import SwiftUI
 @testable import BibleCore
 @testable import BibleUI
 
-extension AndBibleTests {
+/**
+ BibleUI settings icon and text-display presentation parity coverage.
+
+ These tests live in the app-host-free `BibleUITests` package lane because they assert package
+ presentation catalogs, editor state, and reader chrome palette contracts rather than app delegate
+ bootstrap. Failures mean iOS has drifted from Android settings metadata, durable scope ownership,
+ or text-display widget behavior.
+ */
+final class SettingsIconsTests: XCTestCase {
     func testApplicationPreferenceIconsComeFromAndroidSettingsXml() {
         XCTAssertEqual(
             AndBibleIconCatalog.settingsIcon(forAndroidKey: "navigate_to_verse_pref")?.androidDrawableName,
@@ -759,13 +768,9 @@ extension AndBibleTests {
      picker or SwiftUI sheet/Form editor with iOS chrome.
      */
     func testTextDisplayPreferenceEditorsAvoidNativeIOSPickerAndSheetRoutes() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Settings/TextDisplaySettingsView.swift"
-        )
+        let sourceRelativePath = "Sources/BibleUI/Sources/BibleUI/Settings/TextDisplaySettingsView.swift"
+        let repoRoot = try Self.repositoryRoot(containing: sourceRelativePath)
+        let sourceURL = repoRoot.appendingPathComponent(sourceRelativePath)
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
         XCTAssertFalse(source.contains("UIFontPickerViewController"))
@@ -823,5 +828,40 @@ extension AndBibleTests {
                 "PAGE_BUTTONS",
             ]
         )
+    }
+
+    /**
+     Finds the repository root from this test source file by walking upward until a known
+     repo-relative source path exists.
+
+     - Parameter relativePath: A source-controlled path expected to exist below the repository root.
+     - Parameter filePath: The current test file path. Defaults to Swift's compile-time `#filePath`.
+     - Returns: The directory URL that contains `relativePath`.
+     - Throws: An `NSError` when the test is compiled from an unexpected checkout layout.
+
+     This keeps source-scan tests deterministic after migration from `AndBibleTests/` to nested
+     package test directories, without hard-coding a fixed number of parent components.
+     */
+    private static func repositoryRoot(containing relativePath: String, from filePath: String = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        while true {
+            let candidate = directory.appendingPathComponent(relativePath)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return directory
+            }
+
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path {
+                throw NSError(
+                    domain: "SettingsIconsTests",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Unable to locate repository root containing \(relativePath) from \(filePath)"
+                    ]
+                )
+            }
+            directory = parent
+        }
     }
 }

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -136,6 +136,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - CI now includes an app-host-free `ios-bibleui-package-tests` simulator job so moved BibleUI tests remain enforced outside the app-target bundle.
 - `AndBibleTests+WindowPaneMenu` has been retired from the app-host bundle because equivalent Android-parity coverage already lives in `BibleWindowPaneMenuModelTests` under the `BibleUITests` package target.
 - `AndBibleTests+WindowTabBarLayout` has moved to `BibleUITests` because it exercises pure BibleUI footer layout constants and Android-parity layout decisions without app bootstrap.
+- `AndBibleTests+SettingsIcons` has moved to `BibleUITests` because it exercises BibleUI settings catalogs, text-display editor state, and reader chrome palette contracts without app bootstrap.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
Moves the Settings Icons/Text Display parity tests out of the app-host `AndBibleTests` bundle and into the app-host-free `BibleUITests` package lane.

## Scope
- Converts `AndBibleTests+SettingsIcons` into standalone `SettingsIconsTests` under `Sources/BibleUI/Tests/BibleUITests`.
- Removes the old app-target project references for the moved test file.
- Updates `docs/test-architecture-migration-plan.md` to record this Phase 3 slice.
- Leaves unrelated local environment files unstaged.

## Contract references
- `docs/test-architecture-migration-plan.md` Phase 3: move genuinely BibleUI-behavior tests into the committed `BibleUITests` package scheme.
- Android settings/text-display parity assertions already encoded in the migrated test methods.
- GitNexus impact analysis for `AndBibleTests`: CRITICAL due shared app-test partial class, but 0 affected execution flows and 0 affected modules; this PR removes one piece of that shared-class coupling.

## Change details
- Preserves all 28 Settings Icons/Text Display test methods in the package test target.
- Adds a suite-level docblock documenting app-host-free ownership and parity failure meaning.
- Replaces a fixed `#filePath` parent-count assumption with an upward repository-root search for the source-scan guardrail.
- Keeps the app target buildable after deleting the old file reference.

## Validation evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-settings-icons-bibleui CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-settings-icons-app-build CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `python3 scripts/check_bridge_parity_inventory.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_repo_standards.py docblocks --base-ref test-architecture-phase3-window-tab-bar-layout --head-ref HEAD --all-files`
- `python3 scripts/check_repo_standards.py commits --base-ref test-architecture-phase3-window-tab-bar-layout --head-ref HEAD`
- `plutil -lint AndBible.xcodeproj/project.pbxproj`
- `git diff --check -- AndBible.xcodeproj/project.pbxproj AndBibleTests/AndBibleTests+SettingsIcons.swift Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift docs/test-architecture-migration-plan.md`
- Adversarial review sub-agent: no findings; requested real simulator `BibleUITests` package-lane validation, covered above.

## Risks/follow-ups
- This does not retire the remaining app-hosted partial-class test files; it is one more Phase 3 slice.
- The source-scan guardrail still reads production source text directly, matching the prior contract but now using a relocation-safe root finder.

## Issue closure reference
Closes: none - continuation of the accepted test-architecture migration plan, with no single GitHub issue mapped to this slice.
