### PR TITLE
test(bibleui): migrate passage grid tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
 		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
-		B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
 		8736B1F0D4ED3F4C47BD692A /* AndBibleUITests+PlansDownloadsWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1FF7DFF60A342B10407D17 /* AndBibleUITests+PlansDownloadsWorkspace.swift */; };
@@ -81,7 +80,6 @@
 		8174AF1F3D15BAFB4EB66A1E /* AndBible.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AndBible.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
-		B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+PassageGrid.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
 		CA1C01A1D3E74B1F00A1C001 /* CalculatorIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CalculatorIcon.png; sourceTree = "<group>"; };
@@ -258,7 +256,6 @@
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
-				B20600000000000000000001 /* AndBibleTests+PassageGrid.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
@@ -492,7 +489,6 @@
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
-				B20600000000000000000002 /* AndBibleTests+PassageGrid.swift in Sources */,
 				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BibleUI/CLAUDE.md
+++ b/Sources/BibleUI/CLAUDE.md
@@ -49,7 +49,7 @@ transition to Bible content. Must look/function as a real calculator.
 
 ## Testing
 ```bash
-swift test --filter BibleUITests
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17'
 ```
 
 ## Reference (Android equivalents)

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUITestSourceLocator.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUITestSourceLocator.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/**
+ Shared source-file locator for BibleUI package tests that intentionally scan production Swift.
+
+ The helper walks upward from a test source path until it finds a requested repo-relative path.
+ This keeps source-string guardrails deterministic after app-host tests move into nested package
+ test directories. It performs read-only filesystem checks and throws when the checkout layout does
+ not contain the expected source file.
+ */
+enum BibleUITestSourceLocator {
+    /**
+     Finds the repository root that contains a known repo-relative source path.
+
+     - Parameter relativePath: Source-controlled path expected to exist below the repository root.
+     - Parameter filePath: Starting file path used for the upward search.
+     - Returns: Directory URL for the repository root containing `relativePath`.
+     - Throws: An `NSError` when no parent directory contains the requested path.
+     */
+    static func repositoryRoot(containing relativePath: String, from filePath: String = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        while true {
+            let candidate = directory.appendingPathComponent(relativePath)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return directory
+            }
+
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path {
+                throw NSError(
+                    domain: "BibleUITestSourceLocator",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Unable to locate repository root containing \(relativePath) from \(filePath)"
+                    ]
+                )
+            }
+            directory = parent
+        }
+    }
+
+    /**
+     Reads a repo-relative source file for source-string guardrail tests.
+
+     - Parameter relativePath: Source-controlled file path below the repository root.
+     - Parameter filePath: Starting file path used to locate the root.
+     - Returns: UTF-8 contents of the requested source file.
+     - Throws: Filesystem or decoding errors from root lookup or source loading.
+     */
+    static func source(at relativePath: String, from filePath: String = #filePath) throws -> String {
+        let root = try repositoryRoot(containing: relativePath, from: filePath)
+        let sourceURL = root.appendingPathComponent(relativePath)
+        return try String(contentsOf: sourceURL, encoding: .utf8)
+    }
+}

--- a/Sources/BibleUI/Tests/BibleUITests/PassageGridTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/PassageGridTests.swift
@@ -3,7 +3,14 @@ import XCTest
 @testable import BibleUI
 @testable import SwordKit
 
-extension AndBibleTests {
+/**
+ BibleUI passage chooser and grid parity coverage for Android navigation behavior.
+
+ These tests assert package-level chooser state, layout, palette, progress, and source guardrails
+ without app bootstrap. Failures indicate iOS passage navigation has drifted from Android's
+ `GridChoosePassage*` contracts or from the shared reading/memorization progress semantics.
+ */
+final class PassageGridTests: XCTestCase {
     /**
      Verifies the chooser option state machine mirrors Android's overflow-menu behavior.
 
@@ -86,15 +93,9 @@ extension AndBibleTests {
      menu rows: `on` when checked and `off` when unchecked.
      */
     func testPassageChooserMenuRowsExposeCheckedStateAccessibilityValue() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
         )
-
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
         XCTAssertTrue(source.contains(".accessibilityValue(isChecked(entry.option) ? \"on\" : \"off\")"))
     }
@@ -175,15 +176,9 @@ extension AndBibleTests {
      switch inside the options popup or modeled it as a persisted preference.
      */
     func testPassageChooserExposesDeuterocanonicalActionOutsideOverflow() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
         )
-
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
 
         XCTAssertTrue(source.contains("@State private var bookScope = PassageBookScriptureScope.scripture"))
         XCTAssertTrue(source.contains("PassageBookScriptureScope.books(from: books, scope: bookScope)"))
@@ -462,10 +457,6 @@ extension AndBibleTests {
      each Android-style chooser grid should use it only for leading and trailing padding.
      */
     func testPassageGridViewsApplyHorizontalOnlyOuterPadding() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
         let relativePaths = [
             "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift",
             "Sources/BibleUI/Sources/BibleUI/Navigation/ChapterChooserView.swift",
@@ -473,8 +464,7 @@ extension AndBibleTests {
         ]
 
         for relativePath in relativePaths {
-            let sourceURL = repoRoot.appendingPathComponent(relativePath)
-            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            let source = try BibleUITestSourceLocator.source(at: relativePath)
 
             XCTAssertTrue(
                 source.contains(".padding(.horizontal, PassageGridMetrics.horizontalPadding)"),
@@ -515,15 +505,9 @@ extension AndBibleTests {
      so iOS must render that app bar explicitly inside `BookChooserView`.
      */
     func testPassageChooserOwnsExplicitAndroidAppBar() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let chooserViewURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Navigation/BookChooserView.swift"
         )
-
-        let source = try String(contentsOf: chooserViewURL, encoding: .utf8)
 
         XCTAssertTrue(source.contains("PassageChooserAppBar("))
         XCTAssertTrue(source.contains(".toolbar(.hidden, for: .navigationBar)"))
@@ -622,14 +606,9 @@ extension AndBibleTests {
      filter/map intermediates before building the chapter set.
      */
     func testPassageGridBookProgressUsesSinglePassReadingChapterAggregation() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift"
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Navigation/PassageGrid.swift"
         )
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
         let bookProgressStart = try XCTUnwrap(source.range(of: "static func bookProgress("))
         let bookProgressEnd = try XCTUnwrap(
             source.range(of: "static func chapterProgress(", range: bookProgressStart.upperBound..<source.endIndex)

--- a/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Foundation
 import SwiftUI
 @testable import BibleCore
 @testable import BibleUI
@@ -768,10 +767,9 @@ final class SettingsIconsTests: XCTestCase {
      picker or SwiftUI sheet/Form editor with iOS chrome.
      */
     func testTextDisplayPreferenceEditorsAvoidNativeIOSPickerAndSheetRoutes() throws {
-        let sourceRelativePath = "Sources/BibleUI/Sources/BibleUI/Settings/TextDisplaySettingsView.swift"
-        let repoRoot = try Self.repositoryRoot(containing: sourceRelativePath)
-        let sourceURL = repoRoot.appendingPathComponent(sourceRelativePath)
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Settings/TextDisplaySettingsView.swift"
+        )
 
         XCTAssertFalse(source.contains("UIFontPickerViewController"))
         XCTAssertFalse(source.contains(".sheet(item: $activePreferenceEditor)"))
@@ -830,38 +828,4 @@ final class SettingsIconsTests: XCTestCase {
         )
     }
 
-    /**
-     Finds the repository root from this test source file by walking upward until a known
-     repo-relative source path exists.
-
-     - Parameter relativePath: A source-controlled path expected to exist below the repository root.
-     - Parameter filePath: The current test file path. Defaults to Swift's compile-time `#filePath`.
-     - Returns: The directory URL that contains `relativePath`.
-     - Throws: An `NSError` when the test is compiled from an unexpected checkout layout.
-
-     This keeps source-scan tests deterministic after migration from `AndBibleTests/` to nested
-     package test directories, without hard-coding a fixed number of parent components.
-     */
-    private static func repositoryRoot(containing relativePath: String, from filePath: String = #filePath) throws -> URL {
-        var directory = URL(fileURLWithPath: filePath).deletingLastPathComponent()
-        while true {
-            let candidate = directory.appendingPathComponent(relativePath)
-            if FileManager.default.fileExists(atPath: candidate.path) {
-                return directory
-            }
-
-            let parent = directory.deletingLastPathComponent()
-            if parent.path == directory.path {
-                throw NSError(
-                    domain: "SettingsIconsTests",
-                    code: 1,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Unable to locate repository root containing \(relativePath) from \(filePath)"
-                    ]
-                )
-            }
-            directory = parent
-        }
-    }
 }

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -137,6 +137,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - `AndBibleTests+WindowPaneMenu` has been retired from the app-host bundle because equivalent Android-parity coverage already lives in `BibleWindowPaneMenuModelTests` under the `BibleUITests` package target.
 - `AndBibleTests+WindowTabBarLayout` has moved to `BibleUITests` because it exercises pure BibleUI footer layout constants and Android-parity layout decisions without app bootstrap.
 - `AndBibleTests+SettingsIcons` has moved to `BibleUITests` because it exercises BibleUI settings catalogs, text-display editor state, and reader chrome palette contracts without app bootstrap.
+- `AndBibleTests+PassageGrid` has moved to `BibleUITests` because it exercises BibleUI passage chooser layout, palette, progress, and Android source guardrails without app bootstrap.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
Moves the PassageGrid XCTest coverage from the app-host AndBibleTests bundle into the BibleUI package test target.

## Scope
- Stack base: test-architecture-phase3-settings-icons
- Test-only migration for PassageGrid and shared source-location helpers
- No production behavior changes intended

## Contract References
- docs/test-architecture-migration-plan.md Phase 3 BibleUI bulk migration
- Android parity contracts already covered by the migrated PassageGrid assertions

## Change Details
- Moved AndBibleTests+PassageGrid into Sources/BibleUI/Tests/BibleUITests/PassageGridTests.swift.
- Added BibleUITestSourceLocator for package-lane source scans.
- Updated SettingsIconsTests to share the source locator instead of carrying its own source-root logic.
- Removed the migrated PassageGrid file from the app-host Xcode test target.
- Updated the BibleUI local testing guidance and migration plan.

## Validation Evidence
- xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 -only-testing:BibleUITests/PassageGridTests CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 CODE_SIGNING_ALLOWED=NO
- xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests
- python3 -m unittest discover -s scripts -p test_*.py
- python3 scripts/check_repo_standards.py docblocks --all-files
- plutil -lint AndBible.xcodeproj/project.pbxproj
- swift package describe --type json
- git diff --check
- GitNexus detect_changes staged scope: low risk, no affected execution flows
- Adversarial sub-agent review: no blocking findings

## Risks / Follow-ups
- This PR depends on #283.
- Remaining Phase 3 migrations still need separate stacked PRs for ReaderNavigation, AppAndReader split, and other app-host leftovers.

## Issue Closure
Closes: none. Verified no dedicated GitHub issue exists for this migration slice; the tracked contract is docs/test-architecture-migration-plan.md.