### PR TITLE
test(bibleui): migrate strongs dictionary tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		5126013EC1173F5B6609881C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 451FFBBE453EACF1547FF4B6 /* Localizable.strings */; };
 		B69113624461C63AB21F4144 /* AndBibleTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */; };
 		34F21932E6E652AD0A369D9C /* AndBibleTests+AppAndReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */; };
-		FBE587F989B0D3A1B1A283EF /* AndBibleTests+StrongsAndDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */; };
 		AFD079CE86282D6B4341904C /* AndBibleTests+BridgeAndProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */; };
 		7DEA38853208672406B7FCDA /* AndBibleTests+ReaderNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069F1737655720623BBF1459 /* AndBibleTests+ReaderNavigation.swift */; };
 		E9FA86A2D5CC0A4A4E80DA43 /* AndBibleTests+WorkspaceAndRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD8E8244D3217EB4FF6EFDA /* AndBibleTests+WorkspaceAndRepository.swift */; };
@@ -134,7 +133,6 @@
 		F25455B6A3C4498DA7EC3907 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh-Hant; path = zh-Hant.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTestSupport.swift; sourceTree = "<group>"; };
 		F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AppAndReader.swift"; sourceTree = "<group>"; };
-		753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+StrongsAndDictionary.swift"; sourceTree = "<group>"; };
 		E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+BridgeAndProgress.swift"; sourceTree = "<group>"; };
 		069F1737655720623BBF1459 /* AndBibleTests+ReaderNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ReaderNavigation.swift"; sourceTree = "<group>"; };
 		CBD8E8244D3217EB4FF6EFDA /* AndBibleTests+WorkspaceAndRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+WorkspaceAndRepository.swift"; sourceTree = "<group>"; };
@@ -257,7 +255,6 @@
 				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
-				753C59196517046968D24B93 /* AndBibleTests+StrongsAndDictionary.swift */,
 				E5DF9348CDC2BD0D53181B56 /* AndBibleTests+BridgeAndProgress.swift */,
 				069F1737655720623BBF1459 /* AndBibleTests+ReaderNavigation.swift */,
 				CBD8E8244D3217EB4FF6EFDA /* AndBibleTests+WorkspaceAndRepository.swift */,
@@ -475,7 +472,6 @@
 				605562C8D06E0B4B1A1C232B /* AndBibleTests.swift in Sources */,
 				B69113624461C63AB21F4144 /* AndBibleTestSupport.swift in Sources */,
 				34F21932E6E652AD0A369D9C /* AndBibleTests+AppAndReader.swift in Sources */,
-				FBE587F989B0D3A1B1A283EF /* AndBibleTests+StrongsAndDictionary.swift in Sources */,
 				AFD079CE86282D6B4341904C /* AndBibleTests+BridgeAndProgress.swift in Sources */,
 				7DEA38853208672406B7FCDA /* AndBibleTests+ReaderNavigation.swift in Sources */,
 				E9FA86A2D5CC0A4A4E80DA43 /* AndBibleTests+WorkspaceAndRepository.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -100,7 +100,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BibleUITests",
-            dependencies: ["BibleUI", "BibleCore", "SwordKit"],
+            dependencies: ["BibleUI", "BibleCore", "BibleView", "SwordKit"],
             path: "Sources/BibleUI/Tests/BibleUITests"
         ),
         .executableTarget(

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUISwordFixtureTestCase.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUISwordFixtureTestCase.swift
@@ -1,0 +1,88 @@
+import Foundation
+import XCTest
+
+/**
+ Base test case for BibleUI package tests that need temporary bundled SWORD modules.
+
+ The fixture mirrors the app-host test helper's behavior without depending on the shared
+ `AndBibleTests` superclass. Each test receives a copied `AndBible/Resources/sword` tree under a
+ unique temporary directory, and teardown removes every path registered through
+ `makeTemporaryBundledSwordPath()`.
+ */
+class BibleUISwordFixtureTestCase: XCTestCase {
+    private var temporarySwordModulePaths: [String] = []
+
+    /**
+     Removes every temporary SWORD directory created by the test.
+
+     - Side effects: Deletes filesystem paths registered during the test and clears the registry.
+     - Failure modes: Cleanup errors are intentionally ignored so the original test failure remains
+       the reported XCTest failure.
+     */
+    override func tearDown() {
+        let fileManager = FileManager.default
+        for path in temporarySwordModulePaths {
+            try? fileManager.removeItem(atPath: path)
+        }
+        temporarySwordModulePaths.removeAll()
+        super.tearDown()
+    }
+
+    /**
+     Copies the repository-bundled SWORD fixture into an isolated temporary module root.
+
+     - Returns: Filesystem path to the temporary `sword` directory containing `mods.d` and module
+       data files.
+     - Side effects: Creates a temporary directory and copies bundled fixture files into it.
+     - Failure modes: Throws filesystem errors from directory creation or recursive copying; records
+       an XCTest failure if the repository fixture path cannot be found.
+     */
+    func makeTemporaryBundledSwordPath() throws -> String {
+        let fileManager = FileManager.default
+        let sourceRoot = try BibleUITestSourceLocator.repositoryRoot(
+            containing: "AndBible/Resources/sword"
+        )
+        let bundledSwordURL = sourceRoot
+            .appendingPathComponent("AndBible", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("sword", isDirectory: true)
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: bundledSwordURL.path),
+            "Expected repo-bundled sword resources at \(bundledSwordURL.path)"
+        )
+
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("sword", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try copyDirectoryContents(from: bundledSwordURL, to: tempRoot)
+
+        temporarySwordModulePaths.append(tempRoot.path)
+        return tempRoot.path
+    }
+
+    /**
+     Recursively copies all source directory contents into a destination directory.
+
+     - Parameters:
+       - source: Directory whose children should be copied.
+       - destination: Directory that will receive the copied children.
+     - Side effects: Creates destination directories and copies files.
+     - Failure modes: Propagates filesystem enumeration, metadata, directory creation, and copy
+       errors.
+     */
+    private func copyDirectoryContents(from source: URL, to destination: URL) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        for item in try fileManager.contentsOfDirectory(at: source, includingPropertiesForKeys: [.isDirectoryKey]) {
+            let target = destination.appendingPathComponent(item.lastPathComponent, isDirectory: true)
+            let values = try item.resourceValues(forKeys: [.isDirectoryKey])
+            if values.isDirectory == true {
+                try copyDirectoryContents(from: item, to: target)
+            } else {
+                try fileManager.copyItem(at: item, to: target)
+            }
+        }
+    }
+}

--- a/Sources/BibleUI/Tests/BibleUITests/StrongsAndDictionaryTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/StrongsAndDictionaryTests.swift
@@ -1,21 +1,9 @@
 import XCTest
-import AVFoundation
 @testable import BibleCore
-import CLibSword
 @testable import SwordKit
-import SwiftData
 import SQLite3
 @testable import BibleUI
 @testable import BibleView
-import struct SwiftUI.Binding
-import enum SwiftUI.ColorScheme
-import struct SwiftUI.EdgeInsets
-import struct SwiftUI.EmptyView
-#if os(iOS)
-import UIKit
-import WebKit
-import struct SwiftUI.Color
-#endif
 
 /// SQLite destructor marker used by the temporary MyBible dictionary fixtures in this file.
 private let myBibleDictionaryFixtureSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
@@ -59,7 +47,15 @@ private final class SwordConcurrencyFailureRecorder: @unchecked Sendable {
     }
 }
 
-extension AndBibleTests {
+/**
+ BibleUI Strongs, dictionary, and search parity coverage.
+
+ These tests protect Android-aligned Strong's query normalization, SWORD-backed search/indexing,
+ dictionary rendering, restored MyBible dictionary handling, and related reader document builders.
+ They run in the app-host-free BibleUI package lane while still using temporary bundled SWORD
+ fixtures through `BibleUISwordFixtureTestCase`.
+ */
+final class StrongsAndDictionaryTests: BibleUISwordFixtureTestCase {
     func testCSVSetEncodingAndDecodingRoundTrip() {
         let encoded = AppPreferenceRegistry.encodeCSVSet(["  KJV  ", "", "ESV", "KJV", "  "])
         XCTAssertEqual(encoded, "ESV,KJV,KJV")
@@ -212,15 +208,9 @@ extension AndBibleTests {
      - Side effects: Reads `SearchView.swift` from the checked-out source tree.
      */
     func testSearchCriteriaScreenUsesAndroidFormStructure() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let searchViewURL = repoRoot.appendingPathComponent(
-            "Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift"
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Search/SearchView.swift"
         )
-
-        let source = try String(contentsOf: searchViewURL, encoding: .utf8)
 
         XCTAssertTrue(source.contains("private var searchCriteriaForm"))
         XCTAssertTrue(source.contains("private var searchSubmitButton"))

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -138,6 +138,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - `AndBibleTests+WindowTabBarLayout` has moved to `BibleUITests` because it exercises pure BibleUI footer layout constants and Android-parity layout decisions without app bootstrap.
 - `AndBibleTests+SettingsIcons` has moved to `BibleUITests` because it exercises BibleUI settings catalogs, text-display editor state, and reader chrome palette contracts without app bootstrap.
 - `AndBibleTests+PassageGrid` has moved to `BibleUITests` because it exercises BibleUI passage chooser layout, palette, progress, and Android source guardrails without app bootstrap.
+- `AndBibleTests+StrongsAndDictionary` has moved to `BibleUITests` because it exercises BibleUI Strong's, dictionary, search, and Android restored-MyBible dictionary contracts without app bootstrap.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
Moves the Strongs, dictionary, search, and restored-MyBible dictionary XCTest coverage from the app-host AndBibleTests bundle into the BibleUI package test target.

## Scope
- Stack base: test-architecture-phase3-passage-grid
- Test-only migration for the Strongs/dictionary/search coverage slice
- No production behavior changes intended

## Contract References
- docs/test-architecture-migration-plan.md Phase 3 BibleUI bulk migration
- Android parity contracts encoded by the migrated Strong's, dictionary, search, and restored-MyBible dictionary assertions

## Change Details
- Moved AndBibleTests+StrongsAndDictionary into Sources/BibleUI/Tests/BibleUITests/StrongsAndDictionaryTests.swift.
- Added BibleUISwordFixtureTestCase so package tests can use isolated temporary bundled SWORD fixtures without depending on the shared AndBibleTests superclass.
- Added BibleView as an explicit BibleUITests dependency for bridge-contract assertions used by this migrated suite.
- Removed the migrated file from the app-host Xcode test target.
- Updated the migration plan with this Phase 3 slice.

## Validation Evidence
- xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 -only-testing:BibleUITests/StrongsAndDictionaryTests CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 CODE_SIGNING_ALLOWED=NO
- xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination platform=iOS Simulator,name=iPhone 17 CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests
- python3 -m unittest discover -s scripts -p test_*.py
- python3 scripts/check_repo_standards.py docblocks --all-files
- python3 scripts/check_repo_standards.py commits --rev-range HEAD~1..HEAD
- plutil -lint AndBible.xcodeproj/project.pbxproj
- swift package describe --type json
- git diff --check
- GitNexus detect_changes staged scope: low risk, no affected execution flows
- Adversarial sub-agent review: no blocking findings

## Risks / Follow-ups
- This PR depends on #284.
- Remaining Phase 3 migrations still need separate stacked PRs for ReaderNavigation, AppAndReader split, and other app-host leftovers.

## Issue Closure
Closes: none. Verified no dedicated GitHub issue exists for this migration slice; the tracked contract is docs/test-architecture-migration-plan.md.