### PR TITLE
test(bibleview): migrate bridge ios tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -51,7 +51,6 @@
 		D0771529B952829C77DBE023 /* AndBibleUITestReaderSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319E22F2B51D98677DD41DA6 /* AndBibleUITestReaderSupport.swift */; };
 		D53BEDB9C39D5C410E0643B4 /* AndBibleUITestInteractionSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A04A880CDBD0810AACD52F /* AndBibleUITestInteractionSupport.swift */; };
 		CA70F982E1D8C8A49D27292A /* AndBibleUITestStateSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C892FA089280ABEE52D95C2F /* AndBibleUITestStateSupport.swift */; };
-		F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5172B5175C1984FA05E10E75 /* AndBibleTests+BridgeIOS.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,7 +154,6 @@
 		319E22F2B51D98677DD41DA6 /* AndBibleUITestReaderSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITestReaderSupport.swift; sourceTree = "<group>"; };
 		A4A04A880CDBD0810AACD52F /* AndBibleUITestInteractionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITestInteractionSupport.swift; sourceTree = "<group>"; };
 		C892FA089280ABEE52D95C2F /* AndBibleUITestStateSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITestStateSupport.swift; sourceTree = "<group>"; };
-		5172B5175C1984FA05E10E75 /* AndBibleTests+BridgeIOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+BridgeIOS.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,7 +264,6 @@
 				B47ED2258F0F324029C56991 /* AndBibleTests+RemoteSyncLifecycle.swift */,
 				EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */,
 				D13400000000000000000001 /* AndBibleTests+Downloads.swift */,
-				5172B5175C1984FA05E10E75 /* AndBibleTests+BridgeIOS.swift */,
 			);
 			path = AndBibleTests;
 			sourceTree = "<group>";
@@ -485,7 +482,6 @@
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
 				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
-				F89C2FD58B1DFD132EEC5839 /* AndBibleTests+BridgeIOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUIBridgeTestSupport.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUIBridgeTestSupport.swift
@@ -1,10 +1,9 @@
-import XCTest
 @testable import BibleView
 
 /**
- Creates a Bible bridge that records JavaScript evaluations for package-lane bridge tests.
+ Creates a Bible bridge that records JavaScript evaluations for BibleUI reader bridge tests.
 
- - Returns: A bridge plus a closure that exposes scripts in emission order for payload assertions.
+ - Returns: A bridge plus a closure that exposes scripts in emission order for reader assertions.
  - Side effects: Installs `javaScriptEvaluationObserver` on the returned bridge.
  - Failure modes: none; callers validate expected emissions with XCTest assertions.
  */
@@ -15,48 +14,4 @@ func makeRecordingBridge() -> (BibleBridge, () -> [String]) {
         evaluatedScripts.append(script)
     }
     return (bridge, { evaluatedScripts })
-}
-
-/**
- Extracts the payload argument from a recorded `try { void bibleView.emit(...) } catch` wrapper.
-
- Production bridge emissions normally pass JSON, but this helper intentionally treats the payload as
- raw text before callers decide whether to parse it. It finds the wrapper suffix with a backwards
- search so payload content that resembles `); } catch` does not truncate the extracted contract.
-
- - Parameters:
-   - scripts: Recorded JavaScript evaluations from `makeRecordingBridge`.
-   - event: Vue event name passed to `bibleView.emit`.
-   - file: XCTest source location used when reporting extraction failures.
-   - line: XCTest source location used when reporting extraction failures.
- - Returns: The raw payload text between the emit prefix and the outer bridge suffix.
- - Side effects: none.
- - Failure modes: Throws XCTest unwrap errors when the event emission, prefix, or suffix is missing.
- */
-func bridgeEmissionPayloadJSON(
-    from scripts: [String],
-    event: String,
-    file: StaticString = #filePath,
-    line: UInt = #line
-) throws -> String {
-    let prefix = "bibleView.emit('\(event)', "
-    let script = try XCTUnwrap(
-        scripts.first { $0.contains(prefix) },
-        "Expected a \(event) bridge emission",
-        file: file,
-        line: line
-    )
-    let start = try XCTUnwrap(
-        script.range(of: prefix)?.upperBound,
-        "Expected \(event) payload prefix in script: \(script)",
-        file: file,
-        line: line
-    )
-    let end = try XCTUnwrap(
-        script.range(of: "); } catch", options: .backwards, range: start..<script.endIndex)?.lowerBound,
-        "Expected \(event) payload suffix in script: \(script)",
-        file: file,
-        line: line
-    )
-    return String(script[start..<end])
 }

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUIBridgeTestSupport.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUIBridgeTestSupport.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import BibleView
+
+/**
+ Creates a Bible bridge that records JavaScript evaluations for package-lane bridge tests.
+
+ - Returns: A bridge plus a closure that exposes scripts in emission order for payload assertions.
+ - Side effects: Installs `javaScriptEvaluationObserver` on the returned bridge.
+ - Failure modes: none; callers validate expected emissions with XCTest assertions.
+ */
+func makeRecordingBridge() -> (BibleBridge, () -> [String]) {
+    let bridge = BibleBridge()
+    var evaluatedScripts: [String] = []
+    bridge.javaScriptEvaluationObserver = { script in
+        evaluatedScripts.append(script)
+    }
+    return (bridge, { evaluatedScripts })
+}
+
+/**
+ Extracts the payload argument from a recorded `try { void bibleView.emit(...) } catch` wrapper.
+
+ Production bridge emissions normally pass JSON, but this helper intentionally treats the payload as
+ raw text before callers decide whether to parse it. It finds the wrapper suffix with a backwards
+ search so payload content that resembles `); } catch` does not truncate the extracted contract.
+
+ - Parameters:
+   - scripts: Recorded JavaScript evaluations from `makeRecordingBridge`.
+   - event: Vue event name passed to `bibleView.emit`.
+   - file: XCTest source location used when reporting extraction failures.
+   - line: XCTest source location used when reporting extraction failures.
+ - Returns: The raw payload text between the emit prefix and the outer bridge suffix.
+ - Side effects: none.
+ - Failure modes: Throws XCTest unwrap errors when the event emission, prefix, or suffix is missing.
+ */
+func bridgeEmissionPayloadJSON(
+    from scripts: [String],
+    event: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> String {
+    let prefix = "bibleView.emit('\(event)', "
+    let script = try XCTUnwrap(
+        scripts.first { $0.contains(prefix) },
+        "Expected a \(event) bridge emission",
+        file: file,
+        line: line
+    )
+    let start = try XCTUnwrap(
+        script.range(of: prefix)?.upperBound,
+        "Expected \(event) payload prefix in script: \(script)",
+        file: file,
+        line: line
+    )
+    let end = try XCTUnwrap(
+        script.range(of: "); } catch", options: .backwards, range: start..<script.endIndex)?.lowerBound,
+        "Expected \(event) payload suffix in script: \(script)",
+        file: file,
+        line: line
+    )
+    return String(script[start..<end])
+}

--- a/Sources/BibleUI/Tests/BibleUITests/BridgeIOSTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BridgeIOSTests.swift
@@ -1,24 +1,20 @@
 import XCTest
-import AVFoundation
-@testable import BibleCore
-import CLibSword
-@testable import SwordKit
-import SwiftData
-import SQLite3
 @testable import BibleUI
 @testable import BibleView
-import struct SwiftUI.Binding
-import enum SwiftUI.ColorScheme
-import struct SwiftUI.EdgeInsets
-import struct SwiftUI.EmptyView
+
 #if os(iOS)
 import UIKit
 import WebKit
-import struct SwiftUI.Color
-#endif
 
-extension AndBibleTests {
-    #if os(iOS)
+/**
+ BibleUI and BibleView bridge behavior that requires iOS WebKit/UIKit types.
+
+ These tests protect bridge lifecycle, native user-interaction reporting, JavaScript emission,
+ and reader modal-key routing contracts without booting the app host. They remain in the iOS-only
+ package test lane because the behavior under test depends on `WKWebView`, UIKit gesture
+ recognizers, and the reader bridge router.
+ */
+final class BridgeIOSTests: XCTestCase {
     @MainActor
     func testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks() {
         let bridge = BibleBridge()
@@ -193,6 +189,5 @@ extension AndBibleTests {
         router.requestToggleFullScreen()
         XCTAssertEqual(fullscreenToggleCount, 1)
     }
-    #endif
-
 }
+#endif

--- a/Sources/BibleUI/Tests/BibleUITests/BridgeIOSTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BridgeIOSTests.swift
@@ -3,103 +3,15 @@ import XCTest
 @testable import BibleView
 
 #if os(iOS)
-import UIKit
-import WebKit
 
 /**
- BibleUI and BibleView bridge behavior that requires iOS WebKit/UIKit types.
+ BibleUI reader bridge behavior that requires iOS package execution but not the app host.
 
- These tests protect bridge lifecycle, native user-interaction reporting, JavaScript emission,
- and reader modal-key routing contracts without booting the app host. They remain in the iOS-only
- package test lane because the behavior under test depends on `WKWebView`, UIKit gesture
- recognizers, and the reader bridge router.
+ These tests protect reader modal-key routing contracts that sit above the raw BibleView bridge.
+ The lower-level `BibleBridge` and `WebViewCoordinator` lifecycle tests live in `BibleViewTests`
+ so package placement follows the migration plan's lowest-owning-module rule.
  */
 final class BridgeIOSTests: XCTestCase {
-    @MainActor
-    func testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks() {
-        let bridge = BibleBridge()
-        let webView = WKWebView()
-
-        bridge.bindWebView(webView)
-
-        XCTAssertTrue(bridge.webView === webView)
-    }
-
-    @MainActor
-    func testWebViewCoordinatorInstallsPassiveTapRecognizerForNativeFocus() {
-        let bridge = BibleBridge()
-        let coordinator = WebViewCoordinator(bridge: bridge)
-        let webView = UIView()
-
-        coordinator.installSwipeRecognizersIfNeeded(on: webView)
-
-        let passiveTap = webView.gestureRecognizers?
-            .compactMap { $0 as? UITapGestureRecognizer }
-            .first { gesture in
-                !gesture.cancelsTouchesInView && gesture.delegate === coordinator
-            }
-        XCTAssertNotNil(passiveTap)
-    }
-
-    @MainActor
-    func testWebViewCoordinatorReportsNativeTapAndDragAsInteraction() {
-        let bridge = BibleBridge()
-        let coordinator = WebViewCoordinator(bridge: bridge)
-        let scrollView = UIScrollView()
-        var interactionCount = 0
-        bridge.onNativeUserInteraction = {
-            interactionCount += 1
-        }
-
-        coordinator.handleNativeTap(UITapGestureRecognizer())
-        coordinator.scrollViewWillBeginDragging(scrollView)
-
-        XCTAssertEqual(interactionCount, 2)
-    }
-
-    @MainActor
-    func testBridgeEmitUsesFireAndForgetJavaScript() {
-        let (bridge, recordedScripts) = makeRecordingBridge()
-
-        XCTAssertTrue(bridge.emit(event: "set_config", data: #"{"theme":"light"}"#))
-
-        let script = recordedScripts().first ?? ""
-        XCTAssertTrue(script.contains("void bibleView.emit('set_config'"))
-    }
-
-    /**
-     Verifies raw bridge emits expose whether JavaScript was actually dispatched.
-
-     Detached bridge reporting remains observable so callers can distinguish JavaScript dispatch
-     failure from a queued fire-and-forget emit when they need delivery diagnostics.
-     */
-    @MainActor
-    func testBridgeEmitReportsDetachedDispatchFailure() {
-        let bridge = BibleBridge()
-
-        XCTAssertFalse(bridge.emit(event: "set_config", data: #"{"theme":"light"}"#))
-    }
-
-    /**
-     Verifies bridge test helpers extract the outer emit payload instead of stopping at wrapper-like text.
-
-     - Setup: Records a fire-and-forget bridge emission whose raw payload includes `); } catch`, the same
-       suffix used by `BibleBridge.emit` after the payload argument.
-     - Expected result: Extraction returns the complete payload text through the final wrapper suffix.
-     - Failure meaning: A failure means bridge contract tests can hallucinate malformed payloads when
-       user-facing text happens to resemble the JavaScript error wrapper.
-     */
-    @MainActor
-    func testBridgeEmissionPayloadExtractionIgnoresWrapperSuffixInsidePayloadText() throws {
-        let (bridge, recordedScripts) = makeRecordingBridge()
-
-        bridge.emit(event: "sample_event", data: #"'value before "); } catch value after'"#)
-
-        let payload = try bridgeEmissionPayloadJSON(from: recordedScripts(), event: "sample_event")
-
-        XCTAssertEqual(payload, #"'value before "); } catch value after'"#)
-    }
-
     @MainActor
     func testReaderBridgeModalStateBlocksKeyNavigationAndRequestsClose() {
         let (bridge, recordedScripts) = makeRecordingBridge()

--- a/Sources/BibleView/Tests/BibleViewTests/BibleViewBridgeTestSupport.swift
+++ b/Sources/BibleView/Tests/BibleViewTests/BibleViewBridgeTestSupport.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import BibleView
+
+/**
+ Creates a Bible bridge that records JavaScript evaluations for BibleView bridge tests.
+
+ - Returns: A bridge plus a closure that exposes scripts in emission order for payload assertions.
+ - Side effects: Installs `javaScriptEvaluationObserver` on the returned bridge.
+ - Failure modes: none; callers validate expected emissions with XCTest assertions.
+ */
+func makeRecordingBridge() -> (BibleBridge, () -> [String]) {
+    let bridge = BibleBridge()
+    var evaluatedScripts: [String] = []
+    bridge.javaScriptEvaluationObserver = { script in
+        evaluatedScripts.append(script)
+    }
+    return (bridge, { evaluatedScripts })
+}
+
+/**
+ Extracts the payload argument from a recorded `try { void bibleView.emit(...) } catch` wrapper.
+
+ Production bridge emissions normally pass JSON, but this helper intentionally treats the payload as
+ raw text before callers decide whether to parse it. It finds the wrapper suffix with a backwards
+ search so payload content that resembles `); } catch` does not truncate the extracted contract.
+
+ - Parameters:
+   - scripts: Recorded JavaScript evaluations from `makeRecordingBridge`.
+   - event: Vue event name passed to `bibleView.emit`.
+   - file: XCTest source location used when reporting extraction failures.
+   - line: XCTest source location used when reporting extraction failures.
+ - Returns: The raw payload text between the emit prefix and the outer bridge suffix.
+ - Side effects: none.
+ - Failure modes: Throws XCTest unwrap errors when the event emission, prefix, or suffix is missing.
+ */
+func bridgeEmissionPayloadJSON(
+    from scripts: [String],
+    event: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> String {
+    let prefix = "bibleView.emit('\(event)', "
+    let script = try XCTUnwrap(
+        scripts.first { $0.contains(prefix) },
+        "Expected a \(event) bridge emission",
+        file: file,
+        line: line
+    )
+    let start = try XCTUnwrap(
+        script.range(of: prefix)?.upperBound,
+        "Expected \(event) payload prefix in script: \(script)",
+        file: file,
+        line: line
+    )
+    let end = try XCTUnwrap(
+        script.range(of: "); } catch", options: .backwards, range: start..<script.endIndex)?.lowerBound,
+        "Expected \(event) payload suffix in script: \(script)",
+        file: file,
+        line: line
+    )
+    return String(script[start..<end])
+}

--- a/Sources/BibleView/Tests/BibleViewTests/BridgeIOSTests.swift
+++ b/Sources/BibleView/Tests/BibleViewTests/BridgeIOSTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import BibleView
+
+#if os(iOS)
+import UIKit
+import WebKit
+
+/**
+ BibleView bridge behavior that requires iOS WebKit/UIKit types.
+
+ These tests protect bridge lifecycle, native user-interaction reporting, and JavaScript emission
+ contracts without booting the app host or importing BibleUI. They intentionally live in
+ `BibleViewTests` because the behavior under test is owned by the view bridge layer.
+ */
+final class BridgeIOSTests: XCTestCase {
+    @MainActor
+    func testBridgeBindsWeakWebViewReferenceFromLifecycleCallbacks() {
+        let bridge = BibleBridge()
+        let webView = WKWebView()
+
+        bridge.bindWebView(webView)
+
+        XCTAssertTrue(bridge.webView === webView)
+    }
+
+    @MainActor
+    func testWebViewCoordinatorInstallsPassiveTapRecognizerForNativeFocus() {
+        let bridge = BibleBridge()
+        let coordinator = WebViewCoordinator(bridge: bridge)
+        let webView = UIView()
+
+        coordinator.installSwipeRecognizersIfNeeded(on: webView)
+
+        let passiveTap = webView.gestureRecognizers?
+            .compactMap { $0 as? UITapGestureRecognizer }
+            .first { gesture in
+                !gesture.cancelsTouchesInView && gesture.delegate === coordinator
+            }
+        XCTAssertNotNil(passiveTap)
+    }
+
+    @MainActor
+    func testWebViewCoordinatorReportsNativeTapAndDragAsInteraction() {
+        let bridge = BibleBridge()
+        let coordinator = WebViewCoordinator(bridge: bridge)
+        let scrollView = UIScrollView()
+        var interactionCount = 0
+        bridge.onNativeUserInteraction = {
+            interactionCount += 1
+        }
+
+        coordinator.handleNativeTap(UITapGestureRecognizer())
+        coordinator.scrollViewWillBeginDragging(scrollView)
+
+        XCTAssertEqual(interactionCount, 2)
+    }
+
+    @MainActor
+    func testBridgeEmitUsesFireAndForgetJavaScript() {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+
+        XCTAssertTrue(bridge.emit(event: "set_config", data: #"{"theme":"light"}"#))
+
+        let script = recordedScripts().first ?? ""
+        XCTAssertTrue(script.contains("void bibleView.emit('set_config'"))
+    }
+
+    /**
+     Verifies raw bridge emits expose whether JavaScript was actually dispatched.
+
+     Detached bridge reporting remains observable so callers can distinguish JavaScript dispatch
+     failure from a queued fire-and-forget emit when they need delivery diagnostics.
+     */
+    @MainActor
+    func testBridgeEmitReportsDetachedDispatchFailure() {
+        let bridge = BibleBridge()
+
+        XCTAssertFalse(bridge.emit(event: "set_config", data: #"{"theme":"light"}"#))
+    }
+
+    /**
+     Verifies bridge test helpers extract the outer emit payload instead of stopping at wrapper-like text.
+
+     - Setup: Records a fire-and-forget bridge emission whose raw payload includes `); } catch`, the same
+       suffix used by `BibleBridge.emit` after the payload argument.
+     - Expected result: Extraction returns the complete payload text through the final wrapper suffix.
+     - Failure meaning: A failure means bridge contract tests can hallucinate malformed payloads when
+       user-facing text happens to resemble the JavaScript error wrapper.
+     */
+    @MainActor
+    func testBridgeEmissionPayloadExtractionIgnoresWrapperSuffixInsidePayloadText() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+
+        bridge.emit(event: "sample_event", data: #"'value before "); } catch value after'"#)
+
+        let payload = try bridgeEmissionPayloadJSON(from: recordedScripts(), event: "sample_event")
+
+        XCTAssertEqual(payload, #"'value before "); } catch value after'"#)
+    }
+}
+#endif

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -139,6 +139,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - `AndBibleTests+SettingsIcons` has moved to `BibleUITests` because it exercises BibleUI settings catalogs, text-display editor state, and reader chrome palette contracts without app bootstrap.
 - `AndBibleTests+PassageGrid` has moved to `BibleUITests` because it exercises BibleUI passage chooser layout, palette, progress, and Android source guardrails without app bootstrap.
 - `AndBibleTests+StrongsAndDictionary` has moved to `BibleUITests` because it exercises BibleUI Strong's, dictionary, search, and Android restored-MyBible dictionary contracts without app bootstrap.
+- `AndBibleTests+BridgeIOS` has moved to `BibleUITests` because it exercises iOS WebKit/UIKit bridge lifecycle hooks and BibleUI reader bridge routing without app bootstrap.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -139,7 +139,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 - `AndBibleTests+SettingsIcons` has moved to `BibleUITests` because it exercises BibleUI settings catalogs, text-display editor state, and reader chrome palette contracts without app bootstrap.
 - `AndBibleTests+PassageGrid` has moved to `BibleUITests` because it exercises BibleUI passage chooser layout, palette, progress, and Android source guardrails without app bootstrap.
 - `AndBibleTests+StrongsAndDictionary` has moved to `BibleUITests` because it exercises BibleUI Strong's, dictionary, search, and Android restored-MyBible dictionary contracts without app bootstrap.
-- `AndBibleTests+BridgeIOS` has moved to `BibleUITests` because it exercises iOS WebKit/UIKit bridge lifecycle hooks and BibleUI reader bridge routing without app bootstrap.
+- `AndBibleTests+BridgeIOS` has been split by owning module: WebKit/UIKit bridge lifecycle and emission contracts moved to `BibleViewTests`, while BibleUI reader modal-key routing remains in `BibleUITests`.
 - Batches for the genuinely BibleUI-behavior remainder: ReaderNavigation, Bookmarks/Strongs, Window/Settings, view-model parts of `+AppAndReader`.
 - **Split `+AppAndReader` deliberately**: `sceneConfiguration` test stays app-hosted; `testContentViewDoesNotContainLegacyRootSidebarShell` becomes a repo-standards guardrail or stays app-hosted (decide explicitly - do not move to BibleUITests); the other ~78 funcs go to BibleUITests.
 - Run BibleUITests via `xcodebuild test -scheme BibleUITests -destination 'platform=iOS Simulator,...'` against the **committed package test scheme from Phase 0** (no app host).


### PR DESCRIPTION
## Summary
- Migrates the iOS bridge XCTest coverage out of the app-host `AndBibleTests` bundle.
- Splits the moved coverage by owning module: raw bridge/WebKit behavior goes to `BibleViewTests`, while BibleUI reader routing remains in `BibleUITests`.

## Scope
- Test-only migration for `AndBibleTests+BridgeIOS`.
- Removes the migrated app-host test file from the Xcode project.
- Adds target-local bridge recording helpers for the package test lanes.
- Updates `docs/test-architecture-migration-plan.md` to document the split.

## Contract References
- `docs/test-architecture-migration-plan.md` Phase 3 lowest-owning-module rule.
- Existing iOS bridge contracts for `BibleBridge`, `WebViewCoordinator`, `BibleReaderController`, and `BibleReaderBridgeEventRouter`.
- Adversarial review finding on the initial branch that BibleView-owned tests should not remain in `BibleUITests`; fixed before opening.

## Change Details
- Moved six `BibleBridge` / `WebViewCoordinator` lifecycle and emission tests into `Sources/BibleView/Tests/BibleViewTests/BridgeIOSTests.swift`.
- Kept two reader modal-key and router tests in `Sources/BibleUI/Tests/BibleUITests/BridgeIOSTests.swift`.
- Added narrow package-local bridge test helpers in BibleView and BibleUI test targets.
- Removed the original app-host `AndBibleTests+BridgeIOS.swift` project references.

## Validation Evidence
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleViewTests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bridge-ios-bibleview-target CODE_SIGNING_ALLOWED=NO -only-testing:BibleViewTests/BridgeIOSTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bridge-ios-bibleui-target CODE_SIGNING_ALLOWED=NO -only-testing:BibleUITests/BridgeIOSTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleViewTests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bridge-ios-bibleview-full CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bridge-ios-bibleui-full-split CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/andbible-bridge-ios-app-build-split CODE_SIGNING_ALLOWED=NO -skip-testing:AndBibleUITests`
- `swift package describe --type json`
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_repo_standards.py commits --rev-range test-architecture-phase3-strongs-dictionary..HEAD`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `git diff --check`
- `git diff --cached --check`
- `gitnexus detect_changes scope=staged`
- Adversarial re-review: no blocking findings.

## Risks / Follow-ups
- This PR does not migrate the remaining app-host bridge/progress, reader navigation, remote sync, backup, or AppAndReader tests.
- Local uncommitted instruction-file changes (`CLAUDE.md`, `.claude/`, `AGENTS.md`) were intentionally left out of the commits.
- Existing app-host UI shards are still monitored separately in the lower stack PRs.

## Issue Closure
- Closes: none
- Verified with `gh issue list --repo AndBible/and-bible-ios --search "test architecture migration" --state all`; no matching GitHub issue exists for this slice.