### PR TITLE
test(biblecore): split android database backup tests

### DIFF
--- a/AndBible.xcodeproj/project.pbxproj
+++ b/AndBible.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		7DEA38853208672406B7FCDA /* AndBibleTests+ReaderNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069F1737655720623BBF1459 /* AndBibleTests+ReaderNavigation.swift */; };
 		E9FA86A2D5CC0A4A4E80DA43 /* AndBibleTests+WorkspaceAndRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD8E8244D3217EB4FF6EFDA /* AndBibleTests+WorkspaceAndRepository.swift */; };
 		4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE544E071979CFE6FAA43CFE /* AndBibleTests+Bookmarks.swift */; };
-		A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */; };
 		B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */; };
 		7878413CFC8EEC15FAD39267 /* AndBibleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D5002E961A06DB9393E326 /* AndBibleUITestSupport.swift */; };
 		A2EEBFCC9A28E42778471552 /* AndBibleUITests+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5CED694021FF0C2B594EB6 /* AndBibleUITests+Search.swift */; };
@@ -69,7 +68,6 @@
 		A1B2C3D4E5F60718293A4B5D /* AndBibleUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AndBibleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D4E5F60718293A4B5E /* AndBibleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleUITests.swift; sourceTree = "<group>"; };
 		8174AF1F3D15BAFB4EB66A1E /* AndBible.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AndBible.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+AndroidDatabaseBackup.swift"; sourceTree = "<group>"; };
 		B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AndBibleTests+ExternalDocumentImport.swift"; sourceTree = "<group>"; };
 		AB1FB2406B7E9DD316E296F7 /* AndBibleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleApp.swift; sourceTree = "<group>"; };
 		DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndBibleTests.swift; sourceTree = "<group>"; };
@@ -236,7 +234,6 @@
 			children = (
 				DC344294A2096586A9E7F9C1 /* AndBibleTests.swift */,
 				A279E3BCEE4A2AEC1F495246 /* AndBibleTestSupport.swift */,
-				A15000000000000000000001 /* AndBibleTests+AndroidDatabaseBackup.swift */,
 				B18500000000000000000001 /* AndBibleTests+ExternalDocumentImport.swift */,
 				F7DBD78B5D4D44BEE0FC2737 /* AndBibleTests+AppAndReader.swift */,
 				069F1737655720623BBF1459 /* AndBibleTests+ReaderNavigation.swift */,
@@ -452,7 +449,6 @@
 				E9FA86A2D5CC0A4A4E80DA43 /* AndBibleTests+WorkspaceAndRepository.swift in Sources */,
 				4202BEFA9B7CF9C5DC42E0B9 /* AndBibleTests+Bookmarks.swift in Sources */,
 				D13400000000000000000002 /* AndBibleTests+Downloads.swift in Sources */,
-				A15000000000000000000002 /* AndBibleTests+AndroidDatabaseBackup.swift in Sources */,
 				B18500000000000000000002 /* AndBibleTests+ExternalDocumentImport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
@@ -1,12 +1,42 @@
 import XCTest
 import CLibSword
 @testable import BibleCore
-@testable import BibleUI
 @testable import SwordKit
 import SwiftData
 import SQLite3
 
-extension AndBibleTests {
+/// SQLite destructor sentinel used by package fixture writers to make SQLite copy bound bytes/text.
+private let androidDatabaseBackupTestSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/**
+ Package-level Android database backup restore, import, export, and validation tests.
+
+ These tests protect Android `.abdb.zip` behavior through BibleCore services without launching the
+ app-host test bundle. Presentation-only backup copy belongs in `BibleUITests`; this suite owns the
+ archive formats, SQLite schemas, category apply semantics, version gates, and cleanup contracts.
+ */
+final class AndroidDatabaseBackupTests: XCTestCase {
+    private var temporaryPaths: [String] = []
+
+    /**
+     Removes temporary Android backup archives and repository fixtures created by each test.
+
+     The app-host test suite previously shared cleanup state through `AndBibleTests`; after moving
+     this behavior into the package target, the migrated suite owns its file cleanup explicitly so
+     package execution remains isolated and repeatable.
+
+     - Side effects: Deletes paths recorded in `temporaryPaths` and clears the list after each test.
+     - Failure modes: Individual cleanup failures are ignored because failed deletion should not mask
+       the test assertion that already completed.
+     */
+    override func tearDown() {
+        for path in temporaryPaths {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        temporaryPaths.removeAll()
+        super.tearDown()
+    }
+
     /**
      Verifies the iOS JSword KJVA compatibility contract used by Android backup progress rows.
 
@@ -45,15 +75,10 @@ extension AndBibleTests {
      The passage chooser progress bars resolve KJVA ranges for many visible cells. The values must
      still match Android/JSword exactly, but lookup should not repeatedly walk the full KJVA table
      while SwiftUI renders book, chapter, and verse grids.
-     */
+    */
     func testJSwordKJVAVersificationUsesPrecomputedOrdinalIndexForProgressRendering() throws {
-        let testFileURL = URL(fileURLWithPath: #filePath)
-        let repoRoot = testFileURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repoRoot.appendingPathComponent(
-            "Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift"
-        )
+        let relativePath = "Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift"
+        let sourceURL = try repositoryRoot(containing: relativePath).appendingPathComponent(relativePath)
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
         let ordinalFunctionStart = try XCTUnwrap(source.range(of: "public static func verseOrdinal("))
         let ordinalFunctionEnd = try XCTUnwrap(
@@ -304,27 +329,6 @@ extension AndBibleTests {
         XCTAssertNil(wrongTypeArchive.manifest)
         XCTAssertEqual(wrongTypeArchive.sections.map(\.category), [.bookmarks])
         XCTAssertFalse(wrongTypeArchive.sections[0].declaredInManifest)
-    }
-
-    /**
-     Verifies Backup & Restore reset success copy names the category that was reset.
-     *
-     Setup:
-     - reads the BibleUI presentation labels for Android reset categories
-
-     Expected result:
-     - repository reset feedback includes repository wording
-     - repository reset feedback does not claim that only "Database" was reset
-
-     Failure meaning:
-     - the user-visible reset result would be misleading for non-database categories such as
-       Repositories, Application Preferences, My Documents, or Progress.
-     */
-    func testAndroidBackupResetSuccessMessageNamesSelectedCategory() {
-        let message = AndroidBackupResetCategory.repositories.localizedBackupResetSuccessMessage
-
-        XCTAssertTrue(message.localizedCaseInsensitiveContains("repositories"))
-        XCTAssertFalse(message.localizedCaseInsensitiveContains("database has been reset"))
     }
 
     /**
@@ -2506,8 +2510,43 @@ extension AndBibleTests {
         let baseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("android-backup-repositories-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
-        temporarySwordModulePaths.append(baseURL.path)
+        temporaryPaths.append(baseURL.path)
         return baseURL
+    }
+
+    /**
+     Finds the repository root containing a source-controlled path used by source-string guardrails.
+
+     Package tests live several directories below the repository root, and their exact depth changes
+     when app-host tests migrate into package targets. Walking upward keeps the guardrail stable
+     without hard-coding a target-specific number of parent directories.
+
+     - Parameter relativePath: Repo-relative path that must exist under the root.
+     - Parameter filePath: Starting test file path for the upward search.
+     - Returns: Directory URL for the repository root.
+     - Side effects: Performs read-only filesystem existence checks.
+     - Failure modes: Throws when no parent directory contains `relativePath`.
+     */
+    private func repositoryRoot(containing relativePath: String, from filePath: String = #filePath) throws -> URL {
+        var directory = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        while true {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent(relativePath).path) {
+                return directory
+            }
+
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path {
+                throw NSError(
+                    domain: "AndroidDatabaseBackupTests",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Unable to locate repository root containing \(relativePath) from \(filePath)"
+                    ]
+                )
+            }
+            directory = parent
+        }
     }
 
     /**
@@ -2525,6 +2564,47 @@ extension AndBibleTests {
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
         }
+    }
+
+    /**
+     Binds a UUID using Android's 16-byte SQLite blob representation.
+
+     - Parameters:
+       - uuid: UUID value to bind.
+       - statement: SQLite statement receiving the value.
+       - index: One-based parameter index.
+     - Side effects: Mutates the prepared SQLite statement binding state.
+     - Failure modes: This helper cannot fail; SQLite reports binding/step failures later.
+     */
+    private func bindUUIDBlob(_ uuid: UUID, to statement: OpaquePointer?, index: Int32) {
+        let blob = RemoteSyncBookmarkSnapshotService.uuidBlob(uuid)
+        _ = blob.withUnsafeBytes { bytes in
+            sqlite3_bind_blob(
+                statement,
+                index,
+                bytes.baseAddress,
+                Int32(blob.count),
+                androidDatabaseBackupTestSQLiteTransient
+            )
+        }
+    }
+
+    /**
+     Binds optional text into a SQLite fixture statement.
+
+     - Parameters:
+       - value: Optional string to bind, or nil for SQLite NULL.
+       - statement: SQLite statement receiving the value.
+       - index: One-based parameter index.
+     - Side effects: Mutates the prepared SQLite statement binding state.
+     - Failure modes: This helper cannot fail; SQLite reports binding/step failures later.
+     */
+    private func bindOptionalText(_ value: String?, to statement: OpaquePointer?, index: Int32) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        sqlite3_bind_text(statement, index, value, -1, androidDatabaseBackupTestSQLiteTransient)
     }
 
     /**
@@ -3258,7 +3338,7 @@ extension AndBibleTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("android-backup-\(UUID().uuidString)\(suffix)")
         try archiveData.write(to: url)
-        temporarySwordModulePaths.append(url.path)
+        temporaryPaths.append(url.path)
         return url
     }
 
@@ -3283,7 +3363,7 @@ extension AndBibleTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("android-backup-sparse-\(UUID().uuidString).abdb.zip")
         FileManager.default.createFile(atPath: url.path, contents: nil)
-        temporarySwordModulePaths.append(url.path)
+        temporaryPaths.append(url.path)
 
         let handle = try FileHandle(forWritingTo: url)
         defer {

--- a/Sources/BibleUI/Tests/BibleUITests/AndroidDatabaseBackupPresentationTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/AndroidDatabaseBackupPresentationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import BibleCore
+@testable import BibleUI
+
+/**
+ Package-level presentation tests for Android database backup UI copy.
+
+ The database backup service and archive semantics belong in `BibleCoreTests`; this suite protects
+ the BibleUI-only localized strings that the Backup & Restore screen presents around those services.
+ */
+final class AndroidDatabaseBackupPresentationTests: XCTestCase {
+    /**
+     Verifies Backup & Restore reset success copy names the category that was reset.
+
+     Setup:
+     - reads the BibleUI presentation labels for Android reset categories
+
+     Expected result:
+     - repository reset feedback includes repository wording
+     - repository reset feedback does not claim that only "Database" was reset
+
+     Failure meaning:
+     - the user-visible reset result would be misleading for non-database categories such as
+       Repositories, Application Preferences, My Documents, or Progress.
+     */
+    func testAndroidBackupResetSuccessMessageNamesSelectedCategory() {
+        let message = AndroidBackupResetCategory.repositories.localizedBackupResetSuccessMessage
+
+        XCTAssertTrue(message.localizedCaseInsensitiveContains("repositories"))
+        XCTAssertFalse(message.localizedCaseInsensitiveContains("database has been reset"))
+    }
+}

--- a/docs/adr/0003-android-database-backup-restore-parity.md
+++ b/docs/adr/0003-android-database-backup-restore-parity.md
@@ -161,6 +161,7 @@ skipping entries or treating a partial archive as a valid empty backup.
 - [Android database backup service](../../Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift)
 - [Android database backup import sheet](../../Sources/BibleUI/Sources/BibleUI/Settings/AndroidDatabaseBackupImportSheet.swift)
 - [Android Backup & Restore workflow](../../Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift)
-- [Android database backup tests](../../AndBibleTests/AndBibleTests+AndroidDatabaseBackup.swift)
+- [Android database backup core tests](../../Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift)
+- [Android database backup presentation tests](../../Sources/BibleUI/Tests/BibleUITests/AndroidDatabaseBackupPresentationTests.swift)
 - #150
 - #153

--- a/docs/test-architecture-migration-plan.md
+++ b/docs/test-architecture-migration-plan.md
@@ -123,6 +123,7 @@ Blocker: `AndBibleTestSupport.swift` is a 2,233-line `extension AndBibleTests` e
 ### Phase 2 - BibleCore logic tests
 - Move the cleanest BibleCore-only files first, preserving app-host-free package execution after each slice.
   - `AndBibleTests+AndroidModuleBackup` has moved to `BibleCoreTests` as the first Phase 2 slice because it only needed local temporary-file cleanup after leaving `AndBibleTests`.
+  - `AndBibleTests+AndroidDatabaseBackup` has been split by owning module: Android `.abdb.zip` archive, restore/import/export, version-gate, and preserved-database contracts moved to `BibleCoreTests`, while the reset-success presentation copy assertion moved to `BibleUITests`.
   - `RemoteSyncMyDocumentRestoreTests` has moved to `BibleCoreTests` as the second Phase 2 slice because it is already a standalone `XCTestCase`; its direct `CLibSword` import is now an explicit `BibleCoreTests` dependency.
   - `WorkspaceSyncRestoreTests` has moved to `BibleCoreTests` as the third Phase 2 slice after confirming its SQLite/gzip fixture ownership stays local to the package target.
 - Add CI coverage using the chosen Phase 0 mechanism:


### PR DESCRIPTION
## Summary
- Moves Android database backup archive/restore/export coverage from the app-host test bundle into BibleCoreTests.
- Splits the BibleUI-only reset success copy assertion into BibleUITests.
- Updates migration and ADR references to the new test ownership.

## Scope
- In scope: test target migration, package-local fixture cleanup, app-host target membership cleanup, migration docs, ADR related links.
- Out of scope: production backup behavior, Android parity semantics, UI presentation changes, CI workflow changes.

## Contract References
- docs/test-architecture-migration-plan.md Phase 2 BibleCore logic tests.
- docs/adr/0003-android-database-backup-restore-parity.md Android database backup parity boundary.
- BibleCore owns archive formats, SQLite schemas, restore/import/export semantics, version gates, and preserved database contracts.
- BibleUI owns localized presentation copy around those services.

## Change Details
- Converted AndBibleTests+AndroidDatabaseBackup into AndroidDatabaseBackupTests under Sources/BibleCore/Tests/BibleCoreTests.
- Removed the BibleUI import from the core suite and added package-local temporary file cleanup plus SQLite binding support.
- Added AndroidDatabaseBackupPresentationTests under Sources/BibleUI/Tests/BibleUITests for the localized reset message assertion.
- Removed the old app-host test file from the Xcode project and updated docs to point at the new package test locations.

## Validation Evidence
- xcodebuild test -scheme BibleCoreTests -only-testing:BibleCoreTests/AndroidDatabaseBackupTests passed.
- xcodebuild test -scheme BibleCoreTests passed.
- xcodebuild test -scheme BibleUITests -only-testing:BibleUITests/AndroidDatabaseBackupPresentationTests passed.
- xcodebuild test -scheme BibleUITests passed.
- xcodebuild build-for-testing -scheme AndBible passed.
- swift package describe --type json passed.
- python3 scripts/check_repo_standards.py docblocks --all-files passed.
- python3 -m unittest discover -s scripts -p test_*.py passed.
- plutil -lint AndBible.xcodeproj/project.pbxproj passed.
- git diff --cached --check passed.
- GitNexus staged detect_changes reported low risk with no affected execution flows.
- Adversarial review completed; low findings were addressed before opening the PR.

## Risks / Follow-ups
- CI still needs to validate the full matrix on GitHub.
- Existing build warnings are unchanged and outside this test migration slice.

## Issue Closure
Closes: none

Verified no matching open GitHub issue for this test-architecture migration slice before publishing.