### PR TITLE
Add first-run Easy Start document setup

### DIFF
--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -33,6 +33,7 @@
 "clear" = "Clear";
 "reset" = "Reset";
 "retry" = "Retry";
+"skip" = "Skip";
 "all" = "All";
 "sort" = "Sort";
 "name" = "Name";
@@ -90,6 +91,11 @@
 "picker_no_general_book_modules" = "No general book modules installed";
 "picker_no_map_modules" = "No map modules installed";
 "download_modules" = "Download Modules";
+"easy_start" = "Easy Start";
+"easy_start_title" = "Easy start";
+"easy_start_message" = "To easily get started, click below to automatically download recommended default documents. Recommended for first time users! You can change these settings later on.";
+"startup_document_setup_prompt" = "Open Downloads to choose Bible modules and other documents. You can change these settings later on.";
+"startup_download_prompt" = "Download Bible modules to start reading.";
 
 /* Toolbar / Actions */
 "toggle_strongs_numbers" = "Toggle Strong's numbers";

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -4,6 +4,8 @@
    General / Shared
    ======================================== */
 "app_name" = "AndBible";
+"app_name_andbible" = "AndBible";
+"app_name_long" = "AndBible: Bible Study";
 "done" = "Done";
 "cancel" = "Cancel";
 "delete" = "Delete";
@@ -91,11 +93,18 @@
 "picker_no_general_book_modules" = "No general book modules installed";
 "picker_no_map_modules" = "No map modules installed";
 "download_modules" = "Download Modules";
+"download" = "Download Documents";
 "easy_start" = "Easy Start";
 "easy_start_title" = "Easy start";
 "easy_start_message" = "To easily get started, click below to automatically download recommended default documents. Recommended for first time users! You can change these settings later on.";
 "startup_document_setup_prompt" = "Open Downloads to choose Bible modules and other documents. You can change these settings later on.";
 "startup_download_prompt" = "Download Bible modules to start reading.";
+"welcome_message" = "Thank you for downloading %@. There are currently no Bibles or documents installed. To continue, please install at least 1 document by downloading from the internet, or by loading from a zip file document.";
+"supported_formats" = "Supported formats for loading documents from a file: %@";
+"format_zip" = "Zip file containing Sword module(s), or documents backup file (*.abmd) created by %@";
+"format_mysword" = "MySword documents (*.mybible)";
+"format_mybible" = "MyBible documents (*.SQLite3)";
+"format_epub" = "EPUB documents (*.epub)";
 
 /* Toolbar / Actions */
 "toggle_strongs_numbers" = "Toggle Strong's numbers";
@@ -201,6 +210,7 @@
 "documents_count %lld" = "%lld documents";
 "download_errors" = "Download errors";
 "install_zip" = "Load Documents From Files";
+"restore_database" = "Restore Database File";
 "refreshing_catalog" = "Refreshing catalog...";
 "no_modules_match_filters" = "No modules match your filters";
 "tap_refresh_to_load" = "Tap Refresh to load available modules";

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -89,6 +89,9 @@ struct ReaderWindowControlsAvoidanceMetrics {
    display updates into active pane controllers
  */
 public struct BibleReaderView: View {
+    /// Local-only flag recording whether the user entered or skipped first-run document setup.
+    private static let firstRunDocumentSetupPromptHandledKey = "startup_document_setup_prompt_handled"
+
     /// Top-level sheets launched from the reader shell or its global shortcuts.
     enum ReaderSheet: String, Identifiable {
         case history
@@ -251,8 +254,8 @@ public struct BibleReaderView: View {
     /// Tracks whether Android Easy Start default downloads are still refreshing or installing.
     @State private var startupDefaultDownloadsInFlight = false
 
-    /// Whether the no-Bible startup prompt should be visible.
-    @State private var showStartupDownloadPrompt = false
+    /// Reason the startup document-setup prompt should be visible.
+    @State private var startupDownloadPromptReason: StartupDocumentSetupPromptPolicy.PromptReason?
 
     /// Guards startup prompt evaluation so it does not reappear repeatedly in one session.
     @State private var didEvaluateStartupDownloadPrompt = false
@@ -846,8 +849,8 @@ public struct BibleReaderView: View {
             readerDestinationContent(destination)
         }
         .confirmationDialog(
-            String(localized: "picker_no_bible_modules"),
-            isPresented: $showStartupDownloadPrompt,
+            startupDownloadPromptTitle,
+            isPresented: startupDownloadPromptPresentedBinding,
             titleVisibility: .visible
         ) {
             startupDownloadPromptActions
@@ -1387,7 +1390,33 @@ public struct BibleReaderView: View {
         }
     }
 
-    /// Buttons shown when startup detects there are no installed Bible modules.
+    /// Presentation binding for the startup setup prompt.
+    private var startupDownloadPromptPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { startupDownloadPromptReason != nil },
+            set: { isPresented in
+                if !isPresented {
+                    dismissStartupDownloadPromptFromSystem()
+                }
+            }
+        )
+    }
+
+    /// Title shown in the startup document-setup prompt.
+    private var startupDownloadPromptTitle: String {
+        switch startupDownloadPromptReason {
+        case .firstRunSetup:
+            if isStartupEasyStartAvailable {
+                String(localized: "easy_start_title", defaultValue: "Easy start")
+            } else {
+                String(localized: "download_modules")
+            }
+        case .noBibleModules, nil:
+            String(localized: "picker_no_bible_modules")
+        }
+    }
+
+    /// Buttons shown when startup needs document setup.
     @ViewBuilder
     private var startupDownloadPromptActions: some View {
         if isStartupEasyStartAvailable {
@@ -1396,19 +1425,50 @@ public struct BibleReaderView: View {
             }
         }
         Button(String(localized: "download_modules")) {
+            markFirstRunDocumentSetupPromptHandled()
+            startupDownloadPromptReason = nil
             presentDownloads(from: windowManager.activeWindow?.id)
         }
-        Button(String(localized: "cancel"), role: .cancel) {}
+        Button(startupDownloadPromptCancelTitle, role: .cancel) {
+            handleStartupDownloadPromptCancelled()
+        }
     }
 
-    /// Message shown in the no-Bible startup prompt.
+    /// Cancel button copy for the current startup document-setup prompt reason.
+    private var startupDownloadPromptCancelTitle: String {
+        if startupDownloadPromptReason == .firstRunSetup {
+            return String(localized: "skip", defaultValue: "Skip")
+        }
+        return String(localized: "cancel")
+    }
+
+    /// Message shown in the startup document-setup prompt.
     private var startupDownloadPromptMessage: some View {
-        Text(
-            String(
-                localized: "startup_download_prompt",
-                defaultValue: "Download Bible modules to start reading."
+        switch startupDownloadPromptReason {
+        case .firstRunSetup:
+            if isStartupEasyStartAvailable {
+                Text(
+                    String(
+                        localized: "easy_start_message",
+                        defaultValue: "To easily get started, click below to automatically download recommended default documents. Recommended for first time users! You can change these settings later on."
+                    )
+                )
+            } else {
+                Text(
+                    String(
+                        localized: "startup_document_setup_prompt",
+                        defaultValue: "Open Downloads to choose Bible modules and other documents. You can change these settings later on."
+                    )
+                )
+            }
+        case .noBibleModules, nil:
+            Text(
+                String(
+                    localized: "startup_download_prompt",
+                    defaultValue: "Download Bible modules to start reading."
+                )
             )
-        )
+        }
     }
 
     /// Strong's mode picker options used by the reader toolbar dialog.
@@ -1758,11 +1818,62 @@ public struct BibleReaderView: View {
      - installation failures are handled inside `ModuleBrowserView`
      */
     private func presentStartupDefaultDownloads() {
-        showStartupDownloadPrompt = false
+        markFirstRunDocumentSetupPromptHandled()
+        startupDownloadPromptReason = nil
         startupDefaultDownloadsInFlight = true
         presentDownloads(
             from: windowManager.activeWindow?.id,
             defaultDownloadMode: .englishStartup
+        )
+    }
+
+    /**
+     Dismisses the startup setup prompt from SwiftUI system cancellation.
+
+     Side effects:
+     - marks first-run setup handled when the user dismisses the non-blocking recommended setup
+     - preserves no-Bible behavior so that a later app launch can still prompt for required setup
+     */
+    private func dismissStartupDownloadPromptFromSystem() {
+        handleStartupDownloadPromptCancelled()
+    }
+
+    /**
+     Handles the startup setup prompt's explicit cancel/skip action.
+
+     Side effects:
+     - persists the first-run setup skip when the prompt is informational
+     - clears the current prompt reason for the active reader session
+     */
+    private func handleStartupDownloadPromptCancelled() {
+        if startupDownloadPromptReason == .firstRunSetup {
+            markFirstRunDocumentSetupPromptHandled()
+        }
+        startupDownloadPromptReason = nil
+    }
+
+    /**
+     Reads the durable first-run setup marker.
+
+     - Returns: `true` when the user has opened Downloads/Easy Start or skipped setup.
+     - Side effects: Reads SwiftData settings through `SettingsStore`.
+     */
+    private func hasHandledFirstRunDocumentSetupPrompt() -> Bool {
+        SettingsStore(modelContext: modelContext).getBool(Self.firstRunDocumentSetupPromptHandledKey)
+    }
+
+    /**
+     Persists that the user has handled first-run document setup.
+
+     Side effects:
+     - writes a local-only SwiftData setting
+     - intentionally does not use `AppPreferenceKey` because Android has no matching global
+       preference; this marker only compensates for iOS shipping a bundled fallback Bible.
+     */
+    private func markFirstRunDocumentSetupPromptHandled() {
+        SettingsStore(modelContext: modelContext).setBool(
+            Self.firstRunDocumentSetupPromptHandledKey,
+            value: true
         )
     }
 
@@ -1878,8 +1989,8 @@ public struct BibleReaderView: View {
         for (_, ctrl) in windowManager.controllers {
             (ctrl as? BibleReaderController)?.refreshInstalledModules()
         }
-        if showStartupDownloadPrompt, !startupHasNoBibleModules() {
-            showStartupDownloadPrompt = false
+        if startupDownloadPromptReason == .noBibleModules, !startupHasNoBibleModules() {
+            startupDownloadPromptReason = nil
         }
     }
 
@@ -2408,16 +2519,16 @@ public struct BibleReaderView: View {
     }
 
     /**
-     Shows the no-Bible startup prompt once when the local module store has no Bible modules.
+     Shows the startup document-setup prompt once when setup requires user attention.
 
      Android `StartupActivity` stops on its first-download layout whenever `SwordDocumentFacade`
-     has no Bibles. iOS is reader-first, so this coordinator presents the equivalent decision as a
-     startup prompt over the reader shell: normal Downloads for every locale, and English Easy
-     Start when Android would expose it.
+     has no Bibles. iOS also ships a bundled fallback Bible, so this coordinator separates that
+     required no-Bible state from a one-time recommended setup path for first-run users.
 
      Side effects:
      - reads installed modules through the focused controller or a temporary `SwordManager`
-     - mutates `didEvaluateStartupDownloadPrompt` and `showStartupDownloadPrompt`
+     - reads the durable first-run setup marker
+     - mutates `didEvaluateStartupDownloadPrompt` and `startupDownloadPromptReason`
 
      Failure modes:
      - if `SwordManager` cannot be created, no prompt is shown and normal reader fallback remains
@@ -2430,7 +2541,10 @@ public struct BibleReaderView: View {
             return
         }
         didEvaluateStartupDownloadPrompt = true
-        showStartupDownloadPrompt = startupHasNoBibleModules()
+        startupDownloadPromptReason = StartupDocumentSetupPromptPolicy.promptReason(
+            hasNoBibleModules: startupHasNoBibleModules(),
+            hasHandledFirstRunSetup: hasHandledFirstRunDocumentSetupPrompt()
+        )
     }
 
     /**
@@ -2442,14 +2556,14 @@ public struct BibleReaderView: View {
 
      Side effects:
      - may reset the startup-prompt guard
-     - may show the startup prompt again
+     - may show the required no-Bible startup prompt again
 
      Failure modes:
      - if module discovery fails, the prompt is not shown
      */
     private func reevaluateStartupDownloadPromptAfterDownloads() {
         guard startupHasNoBibleModules() else {
-            showStartupDownloadPrompt = false
+            startupDownloadPromptReason = nil
             return
         }
         didEvaluateStartupDownloadPrompt = false

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -116,7 +116,11 @@ public struct BibleReaderView: View {
         /// Drawer-owned reading-plan list destination that avoids legacy sheet chrome.
         case readingPlans
         case settings
+        /// Android-style startup setup route used instead of transient iOS dialog chrome.
+        case startupDocumentSetup
         case downloads
+        /// Backup & Restore route opened by startup setup file-import and restore actions.
+        case importExport
         case globalTextOptions
         case workspaceTextOptions = "textOptions"
         case windowTextOptions
@@ -848,15 +852,6 @@ public struct BibleReaderView: View {
         .navigationDestination(item: $activeReaderDestination) { destination in
             readerDestinationContent(destination)
         }
-        .confirmationDialog(
-            startupDownloadPromptTitle,
-            isPresented: startupDownloadPromptPresentedBinding,
-            titleVisibility: .visible
-        ) {
-            startupDownloadPromptActions
-        } message: {
-            startupDownloadPromptMessage
-        }
         .sheet(item: readerSheetModalBinding) { modal in
             readerModalContent(modal)
         }
@@ -1286,6 +1281,29 @@ public struct BibleReaderView: View {
             .overlay(alignment: .topLeading) {
                 readerRenderedContentStateExport
             }
+        case .startupDocumentSetup:
+            if let startupDownloadPromptReason {
+                StartupDocumentSetupView(
+                    presentation: StartupDocumentSetupPresentation(
+                        reason: startupDownloadPromptReason,
+                        isEasyStartAvailable: isStartupEasyStartAvailable
+                    ),
+                    versionText: AndBibleAppVersionMetadata.current().drawerFooterText,
+                    onEasyStart: presentStartupDefaultDownloads,
+                    onDownloadDocuments: presentStartupDownloadDocuments,
+                    onLoadDocumentsFromFiles: presentStartupLoadDocumentsFromFiles,
+                    onRestoreDatabase: presentStartupRestoreDatabase,
+                    onSkip: handleStartupDownloadPromptCancelled
+                )
+                #if os(iOS)
+                .toolbar(.visible, for: .navigationBar)
+                #endif
+                .overlay(alignment: .topLeading) {
+                    readerRenderedContentStateExport
+                }
+            } else {
+                EmptyView()
+            }
         case .downloads:
             ModuleBrowserView(
                 initialSearchText: downloadsInitialSearchText,
@@ -1297,6 +1315,18 @@ public struct BibleReaderView: View {
             .overlay(alignment: .topLeading) {
                 readerRenderedContentStateExport
             }
+        case .importExport:
+            ImportExportView()
+                #if os(iOS)
+                .toolbar(.visible, for: .navigationBar)
+                .navigationBarBackButtonHidden(true)
+                .toolbar {
+                    readerDestinationBackToolbarItem
+                }
+                #endif
+                .overlay(alignment: .topLeading) {
+                    readerRenderedContentStateExport
+                }
         case .globalTextOptions:
             TextDisplaySettingsView(
                 settings: $globalDisplaySettings,
@@ -1387,87 +1417,6 @@ public struct BibleReaderView: View {
             }
             .accessibilityLabel(String(localized: "back", defaultValue: "Back"))
             .accessibilityIdentifier("readerDestinationBackButton")
-        }
-    }
-
-    /// Presentation binding for the startup setup prompt.
-    private var startupDownloadPromptPresentedBinding: Binding<Bool> {
-        Binding(
-            get: { startupDownloadPromptReason != nil },
-            set: { isPresented in
-                if !isPresented {
-                    dismissStartupDownloadPromptFromSystem()
-                }
-            }
-        )
-    }
-
-    /// Title shown in the startup document-setup prompt.
-    private var startupDownloadPromptTitle: String {
-        switch startupDownloadPromptReason {
-        case .firstRunSetup:
-            if isStartupEasyStartAvailable {
-                String(localized: "easy_start_title", defaultValue: "Easy start")
-            } else {
-                String(localized: "download_modules")
-            }
-        case .noBibleModules, nil:
-            String(localized: "picker_no_bible_modules")
-        }
-    }
-
-    /// Buttons shown when startup needs document setup.
-    @ViewBuilder
-    private var startupDownloadPromptActions: some View {
-        if isStartupEasyStartAvailable {
-            Button(String(localized: "easy_start", defaultValue: "Easy Start")) {
-                presentStartupDefaultDownloads()
-            }
-        }
-        Button(String(localized: "download_modules")) {
-            markFirstRunDocumentSetupPromptHandled()
-            startupDownloadPromptReason = nil
-            presentDownloads(from: windowManager.activeWindow?.id)
-        }
-        Button(startupDownloadPromptCancelTitle, role: .cancel) {
-            handleStartupDownloadPromptCancelled()
-        }
-    }
-
-    /// Cancel button copy for the current startup document-setup prompt reason.
-    private var startupDownloadPromptCancelTitle: String {
-        if startupDownloadPromptReason == .firstRunSetup {
-            return String(localized: "skip", defaultValue: "Skip")
-        }
-        return String(localized: "cancel")
-    }
-
-    /// Message shown in the startup document-setup prompt.
-    private var startupDownloadPromptMessage: some View {
-        switch startupDownloadPromptReason {
-        case .firstRunSetup:
-            if isStartupEasyStartAvailable {
-                Text(
-                    String(
-                        localized: "easy_start_message",
-                        defaultValue: "To easily get started, click below to automatically download recommended default documents. Recommended for first time users! You can change these settings later on."
-                    )
-                )
-            } else {
-                Text(
-                    String(
-                        localized: "startup_document_setup_prompt",
-                        defaultValue: "Open Downloads to choose Bible modules and other documents. You can change these settings later on."
-                    )
-                )
-            }
-        case .noBibleModules, nil:
-            Text(
-                String(
-                    localized: "startup_download_prompt",
-                    defaultValue: "Download Bible modules to start reading."
-                )
-            )
         }
     }
 
@@ -1828,14 +1777,58 @@ public struct BibleReaderView: View {
     }
 
     /**
-     Dismisses the startup setup prompt from SwiftUI system cancellation.
+     Opens the standard document download route from startup setup.
 
      Side effects:
-     - marks first-run setup handled when the user dismisses the non-blocking recommended setup
-     - preserves no-Bible behavior so that a later app launch can still prompt for required setup
+     - marks the one-time first-run setup as handled when applicable
+     - presents Downloads on the reader destination stack
      */
-    private func dismissStartupDownloadPromptFromSystem() {
-        handleStartupDownloadPromptCancelled()
+    private func presentStartupDownloadDocuments() {
+        if startupDownloadPromptReason == .firstRunSetup {
+            markFirstRunDocumentSetupPromptHandled()
+            startupDownloadPromptReason = nil
+        }
+        presentDownloads(from: windowManager.activeWindow?.id)
+    }
+
+    /**
+     Opens Backup & Restore so the user can load local document files from startup setup.
+
+     Android launches `InstallZip` directly from this action. iOS keeps the existing import engine
+     behind the Android-aligned Backup & Restore screen so startup does not fork file-import logic.
+
+     Side effects:
+     - marks the one-time first-run setup as handled when applicable
+     - presents Backup & Restore on the reader destination stack
+     */
+    private func presentStartupLoadDocumentsFromFiles() {
+        presentStartupImportExport()
+    }
+
+    /**
+     Opens Backup & Restore so the user can restore a database from startup setup.
+
+     Side effects:
+     - marks the one-time first-run setup as handled when applicable
+     - presents Backup & Restore on the reader destination stack
+     */
+    private func presentStartupRestoreDatabase() {
+        presentStartupImportExport()
+    }
+
+    /**
+     Routes startup import/restore actions through the existing Android-compatible backup surface.
+
+     Side effects:
+     - marks the one-time first-run setup as handled when applicable
+     - pushes `.importExport` as the active reader destination
+     */
+    private func presentStartupImportExport() {
+        if startupDownloadPromptReason == .firstRunSetup {
+            markFirstRunDocumentSetupPromptHandled()
+            startupDownloadPromptReason = nil
+        }
+        presentReaderDestination(.importExport, from: windowManager.activeWindow?.id)
     }
 
     /**
@@ -1850,6 +1843,9 @@ public struct BibleReaderView: View {
             markFirstRunDocumentSetupPromptHandled()
         }
         startupDownloadPromptReason = nil
+        if activeReaderDestination == .startupDocumentSetup {
+            activeReaderDestination = nil
+        }
     }
 
     /**
@@ -1936,9 +1932,37 @@ public struct BibleReaderView: View {
             break
         case .settings:
             reloadBehaviorPreferences()
+        case .startupDocumentSetup:
+            handleStartupDocumentSetupClosed()
         case .downloads:
             handleDownloadsDestinationClosed()
+        case .importExport:
+            handleImportExportDestinationClosed()
         case .globalTextOptions, .workspaceTextOptions, .windowTextOptions, .windowColorSettings:
+            break
+        }
+    }
+
+    /**
+     Handles an unexpected close of the startup setup route.
+
+     The no-Bible setup screen is blocking in Android, so if SwiftUI reports that it was closed
+     without a setup action, iOS immediately re-evaluates startup state. The first-run setup route is
+     optional because iOS can already display the bundled fallback Bible, so closing it marks the
+     prompt handled like Skip.
+
+     Side effects:
+     - may mark first-run setup handled
+     - may re-present startup setup when no Bible is installed
+     */
+    private func handleStartupDocumentSetupClosed() {
+        switch startupDownloadPromptReason {
+        case .firstRunSetup:
+            handleStartupDownloadPromptCancelled()
+        case .noBibleModules:
+            didEvaluateStartupDownloadPrompt = false
+            evaluateStartupDownloadPromptIfNeeded()
+        case nil:
             break
         }
     }
@@ -1972,6 +1996,24 @@ public struct BibleReaderView: View {
     }
 
     /**
+     Refreshes reader module state after the startup import/restore route closes.
+
+     Backup & Restore can install modules or restore Android-compatible backups through existing
+     engines. This mirrors Android's `afterDownload()` check by returning to blocking setup when the
+     user still has no Bible.
+
+     Side effects:
+     - refreshes installed-module snapshots in every open reader controller
+     - may re-show the startup no-Bible route
+     */
+    private func handleImportExportDestinationClosed() {
+        for (_, ctrl) in windowManager.controllers {
+            (ctrl as? BibleReaderController)?.refreshInstalledModules()
+        }
+        reevaluateStartupDownloadPromptAfterDownloads()
+    }
+
+    /**
      Refreshes open reader controllers after the installed SWORD module store changes.
 
      Settings restores, external ZIP opens, and Downloads installs mutate module files outside the
@@ -1991,6 +2033,9 @@ public struct BibleReaderView: View {
         }
         if startupDownloadPromptReason == .noBibleModules, !startupHasNoBibleModules() {
             startupDownloadPromptReason = nil
+            if activeReaderDestination == .startupDocumentSetup {
+                activeReaderDestination = nil
+            }
         }
     }
 
@@ -2541,10 +2586,14 @@ public struct BibleReaderView: View {
             return
         }
         didEvaluateStartupDownloadPrompt = true
-        startupDownloadPromptReason = StartupDocumentSetupPromptPolicy.promptReason(
+        let promptReason = StartupDocumentSetupPromptPolicy.promptReason(
             hasNoBibleModules: startupHasNoBibleModules(),
             hasHandledFirstRunSetup: hasHandledFirstRunDocumentSetupPrompt()
         )
+        startupDownloadPromptReason = promptReason
+        if promptReason != nil {
+            presentReaderDestination(.startupDocumentSetup, from: windowManager.activeWindow?.id)
+        }
     }
 
     /**
@@ -2564,6 +2613,9 @@ public struct BibleReaderView: View {
     private func reevaluateStartupDownloadPromptAfterDownloads() {
         guard startupHasNoBibleModules() else {
             startupDownloadPromptReason = nil
+            if activeReaderDestination == .startupDocumentSetup {
+                activeReaderDestination = nil
+            }
             return
         }
         didEvaluateStartupDownloadPrompt = false

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -261,6 +261,9 @@ public struct BibleReaderView: View {
     /// Reason the startup document-setup prompt should be visible.
     @State private var startupDownloadPromptReason: StartupDocumentSetupPromptPolicy.PromptReason?
 
+    /// Startup restore/import target passed to Backup & Restore for direct Android-style pickers.
+    @State private var startupRestoreImportTarget: RestoreWorkflowTarget?
+
     /// Guards startup prompt evaluation so it does not reappear repeatedly in one session.
     @State private var didEvaluateStartupDownloadPrompt = false
 
@@ -1316,7 +1319,7 @@ public struct BibleReaderView: View {
                 readerRenderedContentStateExport
             }
         case .importExport:
-            ImportExportView()
+            ImportExportView(startupRestoreImportTarget: startupRestoreImportTarget)
                 #if os(iOS)
                 .toolbar(.visible, for: .navigationBar)
                 .navigationBarBackButtonHidden(true)
@@ -1799,35 +1802,37 @@ public struct BibleReaderView: View {
 
      Side effects:
      - marks the one-time first-run setup as handled when applicable
-     - presents Backup & Restore on the reader destination stack
+     - presents Backup & Restore on the reader destination stack with the Documents target
      */
     private func presentStartupLoadDocumentsFromFiles() {
-        presentStartupImportExport()
+        presentStartupImportExport(for: .documents)
     }
 
     /**
-     Opens Backup & Restore so the user can restore a database from startup setup.
+     Opens the database restore picker from startup setup.
 
      Side effects:
      - marks the one-time first-run setup as handled when applicable
-     - presents Backup & Restore on the reader destination stack
+     - presents Backup & Restore on the reader destination stack with the Database target
      */
     private func presentStartupRestoreDatabase() {
-        presentStartupImportExport()
+        presentStartupImportExport(for: .database)
     }
 
     /**
-     Routes startup import/restore actions through the existing Android-compatible backup surface.
+     Routes startup import/restore actions through the existing Android-compatible picker surface.
 
      Side effects:
      - marks the one-time first-run setup as handled when applicable
+     - stores the startup restore/import target for the next Backup & Restore route
      - pushes `.importExport` as the active reader destination
      */
-    private func presentStartupImportExport() {
+    private func presentStartupImportExport(for restoreImportTarget: RestoreWorkflowTarget) {
         if startupDownloadPromptReason == .firstRunSetup {
             markFirstRunDocumentSetupPromptHandled()
             startupDownloadPromptReason = nil
         }
+        startupRestoreImportTarget = restoreImportTarget
         presentReaderDestination(.importExport, from: windowManager.activeWindow?.id)
     }
 
@@ -2007,6 +2012,7 @@ public struct BibleReaderView: View {
      - may re-show the startup no-Bible route
      */
     private func handleImportExportDestinationClosed() {
+        startupRestoreImportTarget = nil
         for (_, ctrl) in windowManager.controllers {
             (ctrl as? BibleReaderController)?.refreshInstalledModules()
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1857,10 +1857,13 @@ public struct BibleReaderView: View {
      Reads the durable first-run setup marker.
 
      - Returns: `true` when the user has opened Downloads/Easy Start or skipped setup.
-     - Side effects: Reads SwiftData settings through `SettingsStore`.
+     - Side effects: Reads SwiftData settings through `SettingsStore` outside UI-test harnesses.
      */
     private func hasHandledFirstRunDocumentSetupPrompt() -> Bool {
-        SettingsStore(modelContext: modelContext).getBool(Self.firstRunDocumentSetupPromptHandledKey)
+        if UITestRuntimeConfiguration.treatsFirstRunDocumentSetupAsHandled {
+            return true
+        }
+        return SettingsStore(modelContext: modelContext).getBool(Self.firstRunDocumentSetupPromptHandledKey)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
@@ -45,3 +45,66 @@ struct StartupDocumentSetupPromptPolicy {
         return nil
     }
 }
+
+/**
+ Android startup setup presentation contract.
+
+ Android's first-download page is a full setup screen, not a transient action sheet. This value
+ keeps the startup action set explicit so the reader can render a route-backed surface while tests
+ assert behavior instead of SwiftUI implementation details.
+
+ Failure modes:
+ - unsupported locales simply omit Easy Start because Android exposes it for English only
+ - first-run setup may be skipped because iOS can already show a bundled fallback Bible
+ - no-Bible setup intentionally cannot be skipped because Android blocks on first-download setup
+ */
+struct StartupDocumentSetupPresentation: Equatable {
+    /// Android first-download action exposed by the startup setup surface.
+    enum Action: Equatable {
+        /// English-only default document download flow.
+        case easyStart
+
+        /// Open the document download screen.
+        case downloadDocuments
+
+        /// Open document loading from local files.
+        case loadDocumentsFromFiles
+
+        /// Open database restore.
+        case restoreDatabase
+
+        /// Skip the non-blocking first-run setup prompt.
+        case skip
+    }
+
+    /// Reason the setup screen is being shown.
+    let reason: StartupDocumentSetupPromptPolicy.PromptReason
+
+    /// Whether Android's English-only Easy Start row should be present.
+    let isEasyStartAvailable: Bool
+
+    /// The startup surface is reader-stack backed to match Android's full setup page.
+    var usesReaderStackSurface: Bool {
+        true
+    }
+
+    /// Skip is allowed only for iOS's non-blocking first-run setup path.
+    var allowsSkip: Bool {
+        reason == .firstRunSetup
+    }
+
+    /// Ordered actions matching Android's first-download layout with iOS's skip extension last.
+    var actions: [Action] {
+        var startupActions: [Action] = []
+        if isEasyStartAvailable {
+            startupActions.append(.easyStart)
+        }
+        startupActions.append(.downloadDocuments)
+        startupActions.append(.restoreDatabase)
+        startupActions.append(.loadDocumentsFromFiles)
+        if allowsSkip {
+            startupActions.append(.skip)
+        }
+        return startupActions
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
@@ -75,6 +75,18 @@ struct StartupDocumentSetupPresentation: Equatable {
 
         /// Skip the non-blocking first-run setup prompt.
         case skip
+
+        /// Startup-specific BackupActivity category target, when the action opens a file picker.
+        var restoreImportTarget: RestoreWorkflowTarget? {
+            switch self {
+            case .restoreDatabase:
+                return .database
+            case .loadDocumentsFromFiles:
+                return .documents
+            case .easyStart, .downloadDocuments, .skip:
+                return nil
+            }
+        }
     }
 
     /// Reason the setup screen is being shown.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupPromptPolicy.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/**
+ Selects the startup document-setup prompt reason independently from SWORD module discovery.
+
+ Android keeps its first-download screen visible until the user has at least one Bible, while iOS
+ also ships a bundled fallback Bible. This policy keeps the no-Bible prompt as the highest-priority
+ blocking state, then separately surfaces the one-time first-run setup path when a fallback Bible is
+ already present.
+
+ Failure modes:
+ - malformed or missing persistence should be normalized by the caller before invoking this policy
+ - unsupported locale decisions are intentionally outside this policy so UI actions can stay
+   Android-parity English-only where default document bundles require English catalog data
+ */
+struct StartupDocumentSetupPromptPolicy {
+    /// Reason the reader should present a startup document-setup prompt.
+    enum PromptReason: Equatable {
+        /// No installed Bible module is available, so reading setup is required.
+        case noBibleModules
+
+        /// A fallback Bible exists, but the user has not seen the recommended setup path.
+        case firstRunSetup
+    }
+
+    /**
+     Resolves which startup prompt, if any, should be presented.
+
+     - Parameters:
+       - hasNoBibleModules: Whether the installed module store currently lacks Bible modules.
+       - hasHandledFirstRunSetup: Whether the user has already entered or skipped first-run setup.
+     - Returns: `.noBibleModules` when reading cannot start from installed modules,
+       `.firstRunSetup` for the one-time recommended setup prompt, or `nil` when no prompt is due.
+     */
+    static func promptReason(
+        hasNoBibleModules: Bool,
+        hasHandledFirstRunSetup: Bool
+    ) -> PromptReason? {
+        if hasNoBibleModules {
+            return .noBibleModules
+        }
+        if !hasHandledFirstRunSetup {
+            return .firstRunSetup
+        }
+        return nil
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/StartupDocumentSetupView.swift
@@ -1,0 +1,226 @@
+import Foundation
+import SwiftUI
+
+/**
+ Android-style startup document setup screen.
+
+ Android renders first-download setup as a scrollable page with welcome text, format guidance, and
+ full-width actions. This SwiftUI view mirrors that structure as a reader-stack destination instead
+ of using iOS action-sheet chrome.
+
+ - Inputs:
+   - presentation: Ordered setup action contract resolved from startup state.
+   - versionText: Optional application version detail shown at the bottom of the setup page.
+   - action closures: Reader-owned routing hooks for each startup action.
+ - Side effects: Invokes the supplied action closure when a button is tapped.
+ - Failure modes: Missing optional version text is simply omitted.
+ */
+struct StartupDocumentSetupView: View {
+    /// Presentation policy and action ordering for the current startup state.
+    let presentation: StartupDocumentSetupPresentation
+
+    /// Optional version text shown in the footer.
+    let versionText: String?
+
+    /// Starts Android Easy Start default downloads.
+    let onEasyStart: () -> Void
+
+    /// Opens the document download screen.
+    let onDownloadDocuments: () -> Void
+
+    /// Opens local document loading.
+    let onLoadDocumentsFromFiles: () -> Void
+
+    /// Opens database restore.
+    let onRestoreDatabase: () -> Void
+
+    /// Skips iOS's non-blocking first-run setup prompt.
+    let onSkip: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                welcomeText
+
+                if presentation.isEasyStartAvailable {
+                    Text(
+                        String(
+                            localized: "easy_start_message",
+                            defaultValue: "To easily get started, click below to automatically download recommended default documents. Recommended for first time users! You can change these settings later on."
+                        )
+                    )
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                }
+
+                VStack(spacing: 10) {
+                    ForEach(presentation.actions, id: \.self) { action in
+                        startupActionButton(for: action)
+                    }
+                }
+
+                Text(supportedFormatsText)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("startupDocumentSetupSupportedFormats")
+
+                Spacer(minLength: 24)
+
+                if let versionText {
+                    Text(versionText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .accessibilityIdentifier("startupDocumentSetupVersionText")
+                }
+            }
+            .padding(15)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color(.systemBackground))
+        .navigationBarBackButtonHidden(true)
+        .accessibilityIdentifier("startupDocumentSetupScreen")
+    }
+
+    /// Logo and app title matching Android's first-download header composition.
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "book.closed.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 64, height: 64)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text(String(localized: "app_name_long", defaultValue: "AndBible: Bible Study"))
+                .font(.system(size: 28, weight: .semibold))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+                .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Welcome or first-run setup message for the current startup reason.
+    private var welcomeText: some View {
+        Text(welcomeMessage)
+            .font(.body)
+            .foregroundStyle(.primary)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityIdentifier("startupDocumentSetupWelcomeText")
+    }
+
+    /// Localized welcome message matching Android's no-Bible copy when setup is required.
+    private var welcomeMessage: String {
+        switch presentation.reason {
+        case .noBibleModules:
+            return String(
+                format: String(
+                    localized: "welcome_message",
+                    defaultValue: "Thank you for downloading %@. There are currently no Bibles or documents installed. To continue, please install at least 1 document by downloading from the internet, or by loading from a zip file document."
+                ),
+                String(localized: "app_name_long", defaultValue: "AndBible: Bible Study")
+            )
+        case .firstRunSetup:
+            return String(
+                localized: "startup_document_setup_prompt",
+                defaultValue: "Open Downloads to choose Bible modules and other documents. You can change these settings later on."
+            )
+        }
+    }
+
+    /// Supported-file text copied from Android's first-download page.
+    private var supportedFormatsText: String {
+        let appName = String(localized: "app_name_andbible", defaultValue: "AndBible")
+        let zip = String(
+            format: String(
+                localized: "format_zip",
+                defaultValue: "Zip file containing Sword module(s), or documents backup file (*.abmd) created by %@"
+            ),
+            appName
+        )
+        let formats = [
+            zip,
+            String(localized: "format_mybible", defaultValue: "MyBible documents (*.SQLite3)"),
+            String(localized: "format_mysword", defaultValue: "MySword documents (*.mybible)"),
+            String(localized: "format_epub", defaultValue: "EPUB documents (*.epub)")
+        ].joined(separator: ", ")
+        return String(
+            format: String(
+                localized: "supported_formats",
+                defaultValue: "Supported formats for loading documents from a file: %@"
+            ),
+            formats
+        )
+    }
+
+    /**
+     Renders a full-width Android startup action button.
+
+     - Parameter action: Startup setup action to render.
+     - Returns: A button with stable accessibility metadata and Android-like full-width sizing.
+     */
+    @ViewBuilder
+    private func startupActionButton(for action: StartupDocumentSetupPresentation.Action) -> some View {
+        Button(action: handler(for: action)) {
+            Text(title(for: action))
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .padding(.vertical, 6)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .accessibilityIdentifier(accessibilityIdentifier(for: action))
+    }
+
+    /// Human-readable title for a startup action.
+    private func title(for action: StartupDocumentSetupPresentation.Action) -> String {
+        switch action {
+        case .easyStart:
+            String(localized: "easy_start_title", defaultValue: "Easy start")
+        case .downloadDocuments:
+            String(localized: "download", defaultValue: "Download Documents")
+        case .loadDocumentsFromFiles:
+            String(localized: "install_zip", defaultValue: "Load Documents From Files")
+        case .restoreDatabase:
+            String(localized: "restore_database", defaultValue: "Restore Database File")
+        case .skip:
+            String(localized: "skip", defaultValue: "Skip")
+        }
+    }
+
+    /// Action closure for a startup setup action.
+    private func handler(for action: StartupDocumentSetupPresentation.Action) -> () -> Void {
+        switch action {
+        case .easyStart:
+            onEasyStart
+        case .downloadDocuments:
+            onDownloadDocuments
+        case .loadDocumentsFromFiles:
+            onLoadDocumentsFromFiles
+        case .restoreDatabase:
+            onRestoreDatabase
+        case .skip:
+            onSkip
+        }
+    }
+
+    /// Stable UI-test identifier for a startup action.
+    private func accessibilityIdentifier(for action: StartupDocumentSetupPresentation.Action) -> String {
+        switch action {
+        case .easyStart:
+            "startupSetupAction.easyStart"
+        case .downloadDocuments:
+            "startupSetupAction.downloadDocuments"
+        case .loadDocumentsFromFiles:
+            "startupSetupAction.loadDocumentsFromFiles"
+        case .restoreDatabase:
+            "startupSetupAction.restoreDatabase"
+        case .skip:
+            "startupSetupAction.skip"
+        }
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -59,6 +59,12 @@ public struct ImportExportView: View {
     /// Controls presentation of the shared restore/import file picker.
     @State private var showRestoreImportPicker = false
 
+    /// Startup setup target that should open its picker as soon as this route appears.
+    private let startupRestoreImportTarget: RestoreWorkflowTarget?
+
+    /// Prevents a startup-triggered restore/import picker from reopening after dismissal.
+    @State private var didPresentStartupRestoreImportPicker = false
+
     /// Restore/import target whose content types and result handler are active for the file picker.
     @State private var restoreImportPickerTarget: RestoreWorkflowTarget?
 
@@ -153,7 +159,24 @@ public struct ImportExportView: View {
 
      - Note: This initializer has no inputs and performs no side effects.
      */
-    public init() {}
+    public init() {
+        self.startupRestoreImportTarget = nil
+    }
+
+    /**
+     Creates the import/export screen for a startup setup action.
+
+     Android's startup Restore Database and Load Documents From Files buttons open their target
+     pickers directly instead of first showing BackupActivity's generic landing screen. This
+     initializer preserves that entry-point intent while reusing the same picker handlers as the
+     normal Backup & Restore screen.
+
+     - Parameter startupRestoreImportTarget: Optional restore/import target to present once after
+       the route appears.
+     */
+    init(startupRestoreImportTarget: RestoreWorkflowTarget?) {
+        self.startupRestoreImportTarget = startupRestoreImportTarget
+    }
 
     /**
      Current presentation snapshot for UI automation and picker routing.
@@ -365,6 +388,9 @@ public struct ImportExportView: View {
         .accessibilityIdentifier("importExportScreen")
         .accessibilityValue(accessibilityState)
         .navigationTitle(String(localized: "backup_and_restore", defaultValue: "Backup & Restore"))
+        .onAppear {
+            presentStartupRestoreImportPickerIfNeeded()
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -502,6 +528,29 @@ public struct ImportExportView: View {
      */
     private func beginRestoreOrImport() {
         restoreImportPickerTarget = restoreTarget.wrappedValue
+        showRestoreImportPicker = true
+    }
+
+    /**
+     Opens the startup-requested restore/import picker once.
+
+     Android startup setup has direct buttons for Database restore and Documents loading. iOS still
+     needs this route in the navigation stack to own SwiftUI's file importer, so this method applies
+     the startup target and presents the existing shared picker exactly once.
+
+     - Side effects: Updates the persisted restore/import radio target, captures the picker target,
+       and presents the file picker.
+     - Failure modes: If another backup workflow is already busy, the startup picker is not opened.
+     */
+    private func presentStartupRestoreImportPickerIfNeeded() {
+        guard !didPresentStartupRestoreImportPicker,
+              let startupRestoreImportTarget,
+              !isBackupWorkflowBusy else {
+            return
+        }
+        didPresentStartupRestoreImportPicker = true
+        restoreTargetRawValue = startupRestoreImportTarget.rawValue
+        restoreImportPickerTarget = startupRestoreImportTarget
         showRestoreImportPicker = true
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Shared/UITestRuntimeConfiguration.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/UITestRuntimeConfiguration.swift
@@ -10,6 +10,8 @@ enum UITestRuntimeConfiguration {
     private static let studyPadCreatedNoteTextArgument = "-UITEST_STUDYPAD_CREATED_NOTE_TEXT"
     private static let remoteSyncBootstrapScenarioEnvironmentKey = "UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"
     private static let remoteSyncBootstrapScenarioArgument = "-UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"
+    private static let firstRunDocumentSetupHandledEnvironmentKey = "UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED"
+    private static let firstRunDocumentSetupHandledArgument = "-UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED"
 
     /// Test-only remote sync bootstrap paths that can replace live backend transport in UI tests.
     enum RemoteSyncBootstrapScenario: String {
@@ -61,6 +63,32 @@ enum UITestRuntimeConfiguration {
             return nil
         }
         return RemoteSyncBootstrapScenario(rawValue: value)
+    }
+
+    /// Whether UI automation should treat the informational first-run setup prompt as handled.
+    static var treatsFirstRunDocumentSetupAsHandled: Bool {
+        isFirstRunDocumentSetupHandled(
+            environment: ProcessInfo.processInfo.environment,
+            arguments: ProcessInfo.processInfo.arguments
+        )
+    }
+
+    /**
+     Resolves the test-only first-run setup marker from a supplied process shape.
+
+     - Parameters:
+       - environment: Process environment to inspect.
+       - arguments: Process arguments to inspect.
+     - Returns: `true` only when the explicit UI-test environment variable or argument is present.
+     */
+    static func isFirstRunDocumentSetupHandled(
+        environment: [String: String],
+        arguments: [String]
+    ) -> Bool {
+        if environment[firstRunDocumentSetupHandledEnvironmentKey] == "1" {
+            return true
+        }
+        return arguments.contains(firstRunDocumentSetupHandledArgument)
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
@@ -56,4 +56,45 @@ final class StartupDocumentSetupPromptPolicyTests: XCTestCase {
             )
         )
     }
+
+    /**
+     English first-run setup exposes Android's setup actions without using a transient dialog.
+
+     Android's first-download surface exposes English-only Easy Start, Download, database restore,
+     and file import actions as a setup screen. iOS keeps the same discoverable action set while
+     adding Skip only for the non-blocking bundled-Bible first-run case.
+     */
+    func testFirstRunEnglishPresentationUsesAndroidSetupActionsWithSkip() {
+        let presentation = StartupDocumentSetupPresentation(
+            reason: .firstRunSetup,
+            isEasyStartAvailable: true
+        )
+
+        XCTAssertEqual(
+            presentation.actions,
+            [.easyStart, .downloadDocuments, .restoreDatabase, .loadDocumentsFromFiles, .skip]
+        )
+        XCTAssertTrue(presentation.allowsSkip)
+        XCTAssertTrue(presentation.usesReaderStackSurface)
+    }
+
+    /**
+     Required no-Bible setup remains blocking while still exposing Android's setup entry points.
+
+     Skip is intentionally absent here because Android keeps users on first-download setup until a
+     readable Bible/document path is installed.
+     */
+    func testNoBiblePresentationUsesBlockingAndroidSetupActionsWithoutSkip() {
+        let presentation = StartupDocumentSetupPresentation(
+            reason: .noBibleModules,
+            isEasyStartAvailable: false
+        )
+
+        XCTAssertEqual(
+            presentation.actions,
+            [.downloadDocuments, .restoreDatabase, .loadDocumentsFromFiles]
+        )
+        XCTAssertFalse(presentation.allowsSkip)
+        XCTAssertTrue(presentation.usesReaderStackSurface)
+    }
 }

--- a/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import BibleUI
+
+/**
+ Verifies the reader startup setup prompt policy independently from the app-host lifecycle.
+
+ These tests protect the Android-parity startup contract: no-Bible setup remains blocking and
+ repeatable, while iOS' bundled fallback Bible does not suppress the one-time recommended setup
+ entry point. Failures mean first-run users can again lose the discoverable Easy Start/Downloads
+ path because module presence and setup completion were conflated.
+ */
+final class StartupDocumentSetupPromptPolicyTests: XCTestCase {
+    /**
+     No-Bible module state must take priority over the informational first-run setup marker.
+
+     Android keeps users on its first-download setup surface while no Bible is installed. iOS mirrors
+     that as a startup prompt even if the user previously skipped the recommended setup message.
+     */
+    func testNoBiblePromptTakesPriorityOverHandledFirstRunSetup() {
+        XCTAssertEqual(
+            StartupDocumentSetupPromptPolicy.promptReason(
+                hasNoBibleModules: true,
+                hasHandledFirstRunSetup: true
+            ),
+            .noBibleModules
+        )
+    }
+
+    /**
+     A bundled fallback Bible must not count as completing first-run setup.
+
+     Fresh iOS installs include KJV so the reader can render immediately, but issue #320 requires a
+     discoverable recommended setup path until the user explicitly enters setup or skips it.
+     */
+    func testFirstRunSetupPromptAppearsWhenBibleExistsButSetupNotHandled() {
+        XCTAssertEqual(
+            StartupDocumentSetupPromptPolicy.promptReason(
+                hasNoBibleModules: false,
+                hasHandledFirstRunSetup: false
+            ),
+            .firstRunSetup
+        )
+    }
+
+    /**
+     The startup setup prompt is suppressed after the user has handled first-run setup.
+
+     This keeps the first-run prompt durable and one-time after the user opens setup/downloads or
+     explicitly skips it, while leaving the no-Bible prompt covered by the priority test above.
+     */
+    func testPromptIsSuppressedWhenBibleExistsAndFirstRunSetupHandled() {
+        XCTAssertNil(
+            StartupDocumentSetupPromptPolicy.promptReason(
+                hasNoBibleModules: false,
+                hasHandledFirstRunSetup: true
+            )
+        )
+    }
+}

--- a/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
@@ -58,6 +58,34 @@ final class StartupDocumentSetupPromptPolicyTests: XCTestCase {
     }
 
     /**
+     UI tests can explicitly keep their existing seeded-reader startup contract.
+
+     The flag is intentionally opt-in and test-namespaced so production launches still show the
+     first-run setup prompt, while hosted route tests that seed reader state do not get blocked by
+     the informational prompt.
+     */
+    func testUITestRuntimeCanTreatFirstRunSetupAsHandledOnlyWhenExplicit() {
+        XCTAssertTrue(
+            UITestRuntimeConfiguration.isFirstRunDocumentSetupHandled(
+                environment: ["UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED": "1"],
+                arguments: []
+            )
+        )
+        XCTAssertTrue(
+            UITestRuntimeConfiguration.isFirstRunDocumentSetupHandled(
+                environment: [:],
+                arguments: ["-UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED"]
+            )
+        )
+        XCTAssertFalse(
+            UITestRuntimeConfiguration.isFirstRunDocumentSetupHandled(
+                environment: ["UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED": "0"],
+                arguments: []
+            )
+        )
+    }
+
+    /**
      English first-run setup exposes Android's setup actions without using a transient dialog.
 
      Android's first-download surface exposes English-only Easy Start, Download, database restore,

--- a/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/StartupDocumentSetupPromptPolicyTests.swift
@@ -97,4 +97,19 @@ final class StartupDocumentSetupPromptPolicyTests: XCTestCase {
         XCTAssertFalse(presentation.allowsSkip)
         XCTAssertTrue(presentation.usesReaderStackSurface)
     }
+
+    /**
+     Startup file actions target the same Android BackupActivity categories as their button labels.
+
+     Android's first-download Restore button opens database restore, while Load Documents From Files
+     opens the document/module loader. Keeping this mapping explicit prevents the iOS startup page
+     from routing both buttons through an indistinct Backup & Restore landing screen.
+     */
+    func testStartupFileActionsResolveSpecificRestoreImportTargets() {
+        XCTAssertEqual(StartupDocumentSetupPresentation.Action.restoreDatabase.restoreImportTarget, .database)
+        XCTAssertEqual(StartupDocumentSetupPresentation.Action.loadDocumentsFromFiles.restoreImportTarget, .documents)
+        XCTAssertNil(StartupDocumentSetupPresentation.Action.downloadDocuments.restoreImportTarget)
+        XCTAssertNil(StartupDocumentSetupPresentation.Action.easyStart.restoreImportTarget)
+        XCTAssertNil(StartupDocumentSetupPresentation.Action.skip.restoreImportTarget)
+    }
 }

--- a/Tests/UI/AndBibleUITests/AndBibleUITestSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestSupport.swift
@@ -18,6 +18,7 @@ extension AndBibleUITests {
      * - Side effects:
      *   - terminates any previously launched app process through CoreSimulator when possible
      *   - assigns a fresh `UITEST_SESSION_ID` and standard locale/accessibility launch flags
+     *   - marks the informational first-run setup prompt handled for fixture-backed reader flows
      *   - prepares the fixture scenario declared for the current test method
      * - Failure modes:
      *   - fixture preparation records XCTest failures when required host-side setup cannot complete
@@ -35,7 +36,9 @@ extension AndBibleUITests {
         trackedApp = app
         app.launchEnvironment["UITEST_SESSION_ID"] = UUID().uuidString
         app.launchEnvironment["UITEST_ENABLE_DETAILED_ACCESSIBILITY_EXPORTS"] = "1"
+        app.launchEnvironment["UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED"] = "1"
         app.launchArguments += ["-UITEST_ENABLE_DETAILED_ACCESSIBILITY_EXPORTS"]
+        app.launchArguments += ["-UITEST_FIRST_RUN_DOCUMENT_SETUP_HANDLED"]
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
         if let remoteSyncBootstrapScenario {
             app.launchEnvironment["UITEST_REMOTE_SYNC_BOOTSTRAP_SCENARIO"] = remoteSyncBootstrapScenario

--- a/scripts/test_reader_modal_ownership_matrix.py
+++ b/scripts/test_reader_modal_ownership_matrix.py
@@ -73,9 +73,17 @@ ROUTE_CLASSIFICATIONS: dict[str, tuple[str, str]] = {
         "Android app-owned",
         "Adapted app-owned route with Settings UI coverage.",
     ),
+    "ReaderDestination.startupDocumentSetup": (
+        "Android app-owned",
+        "Startup setup route matching Android's first-download activity surface.",
+    ),
     "ReaderDestination.downloads": (
         "Android app-owned",
         "Adapted app-owned route.",
+    ),
+    "ReaderDestination.importExport": (
+        "Android app-owned plus iOS system boundary",
+        "Startup setup route may use native iOS file boundaries only at OS handoff points.",
     ),
     "ReaderDestination.globalTextOptions": (
         "Android app-owned",
@@ -144,10 +152,6 @@ ROUTE_CLASSIFICATIONS: dict[str, tuple[str, str]] = {
     "ReaderModal.help": (
         "Android app-owned",
         "Adapted informational route. Vue-scoped help remains bridge-owned when invoked from Vue.",
-    ),
-    "showStartupDownloadPrompt": (
-        "Android app-owned",
-        "Acceptable dialog adaptation if labels, cancel/default behavior, and Downloads handoff remain equivalent.",
     ),
     "showReaderStrongsModeDialog": (
         "Android app-owned",
@@ -273,7 +277,6 @@ class ReaderModalOwnershipMatrixTests(unittest.TestCase):
     def test_standalone_transient_routes_are_classified(self) -> None:
         """State-backed reader presentations outside the enums remain documented."""
         for token in [
-            "showStartupDownloadPrompt",
             "showReaderStrongsModeDialog",
             "shareSheetBinding",
             "crossReferenceSheetBinding",


### PR DESCRIPTION
## Summary

Adds an Android-style first-run document setup route for fresh iOS installs, including direct startup file-picker actions for database restore and document/module loading. Also preserves the existing seeded-reader UI-test startup contract so established reader workflows do not get intercepted by the informational first-run setup route.

## Scope

- Reader startup setup routing in BibleReaderView
- StartupDocumentSetupPromptPolicy presentation/action contract
- StartupDocumentSetupView route-backed setup surface
- Backup & Restore startup entry-point handoff for direct picker presentation
- English-localized startup setup strings
- Focused BibleUI startup policy regression tests
- ADR 0006 reader-route standards classification for the new setup destinations
- UI-test runtime configuration for fixture-backed seeded reader launches

## Contract References

- Android StartupActivity.showFirstLayout renders a full setup screen, not a transient iOS action sheet.
- Android startup order is Easy Start when English, Download Documents, Restore Database File, then Load Documents From Files.
- Android restoreDatabase() opens an ACTION_GET_CONTENT database restore flow directly.
- Android onLoadFromZip() launches InstallZip directly for document/module files.
- Android keeps no-Bible startup setup blocking until a Bible exists.
- iOS-specific constraint: bundled fallback KJV allows reading before setup, so first-run setup can be skipped and persisted locally.
- ADR 0006 requires reader modal/destination routes to be classified by Android ownership and iOS boundary behavior.

## Change Details

- Replaced the startup confirmation dialog with a reader-stack setup destination.
- Added explicit setup prompt reasons for no-Bible blocking setup and first-run recommended setup.
- Preserved Android's English-only Easy Start availability while keeping normal Downloads available to every locale.
- Added typed restore/import targets so Restore Database File opens the database picker and Load Documents From Files opens the documents/module picker.
- Reused the existing ImportExportView picker handlers instead of duplicating backup/import engines.
- Clears one-shot startup picker state when the Backup & Restore route closes.
- Classified the new startup setup reader destinations in the ADR 0006 modal ownership matrix.
- Added an explicit UI-test-only first-run handled flag for fixture-backed reader tests; no-Bible setup still wins through the existing policy priority.

## Validation Evidence

- python3 -m unittest discover -s scripts -p 'test_*.py' passed.
- git diff --check passed.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:BibleUITests/StartupDocumentSetupPromptPolicyTests CODE_SIGNING_ALLOWED=NO passed.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' CODE_SIGNING_ALLOWED=NO passed.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleUITests/AndBibleUITests/testSyncSettingsMyDocumentsAdoptCreateChoiceSynchronizesFromVisibleWorkflow CODE_SIGNING_ALLOWED=NO passed.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor CODE_SIGNING_ALLOWED=NO passed.
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleUITests/AndBibleUITests/testDownloadsRepositoryManagerOpensFromOverflow CODE_SIGNING_ALLOWED=NO passed.
- GitNexus staged detect_changes reported CRITICAL for the runtime route change because the diff touches central reader destination routing and ImportExportView; the direct blast radius was reviewed and import/restore engines remain unchanged.
- GitNexus staged detect_changes reported LOW for the standards matrix follow-up; it only touched ROUTE_CLASSIFICATIONS and affected no indexed app execution flows.
- GitNexus staged detect_changes reported LOW for the seeded UI-test contract follow-up; it touched four files and affected no indexed app execution flows.

## Risks / Follow-ups

Adversarial review notes:

- The main runtime risk is reader startup routing, not the policy helper. No-Bible setup remains required and repeatable until a Bible exists.
- The direct picker handoff intentionally uses the existing Backup & Restore fileImporter because SwiftUI needs an owning route for the picker, but it now opens the Android-equivalent target immediately.
- The first-run handled marker is iOS-specific because Android does not ship the same fallback-Bible startup compensation.
- The UI-test first-run handled flag is test-namespaced and opt-in from the fixture harness; it does not change production launches or no-Bible blocking setup.
- Easy Start remains English-locale gated to avoid broadening beyond Android behavior.
- A local shard-2 representative test was attempted but blocked by the existing fixture-container bootstrap path under this machine's CommandLineTools xcode-select state; CI uses the workflow-selected Xcode path and the startup-prompt failure is covered by the passing focused UI representatives above.
- Full GitHub CI is pending for the latest push.

## Issue Closure

Closes #320
