### PR TITLE
fix(downloads): keep install row order stable

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -10,8 +10,8 @@ import SwordKit
  Tracks one active or failed Downloads row operation using Android's document-status shape.
 
  Android exposes `BEING_INSTALLED` with a percent and `ERROR_DOWNLOADING` as row states rather
- than a global spinner. iOS keeps the same contract locally: in-progress rows sort first and show
- determinate progress plus cancel, while failed rows remain in the list with a retry action.
+ than a global spinner. iOS keeps the same contract locally: in-progress rows show determinate
+ progress plus cancel, while failed rows remain in the list with a retry action.
 
  Side effects:
  - none; values are immutable snapshots of row state
@@ -87,6 +87,28 @@ struct ModuleBrowserDownloadActivity: Equatable {
     var progressPercent: Int {
         Int((min(max(progressFraction, 0), 1) * 100).rounded(.towardZero))
     }
+}
+
+/**
+ Captures the Android Downloads state used for list ordering.
+
+ Android rebuilds sort order when `DocumentSelectionBase.filterDocuments()` runs, but starting a
+ row install only calls `notifyDataSetChanged()`, which updates that row in place. iOS uses this
+ snapshot to keep row ordering stable during live progress updates while still allowing explicit
+ filter/catalog rebuilds to apply Android's active-download-first sort.
+
+ Side effects:
+ - none; values are immutable ordering inputs
+
+ Failure modes:
+ - none; stale snapshots are intentional until the next filter/catalog rebuild
+ */
+struct ModuleBrowserDownloadSortSnapshot {
+    /// Installed modules used to determine installed/update sort rank.
+    let installedModules: [ModuleInfo]
+
+    /// Row activities used to determine Android `BEING_INSTALLED`/error sort rank.
+    let downloadActivities: [String: ModuleBrowserDownloadActivity]
 }
 
 /**
@@ -305,6 +327,15 @@ public struct ModuleBrowserView: View {
     /// Per-module row activity for Android-style progress, cancel, and retry state.
     @State private var downloadActivities: [String: ModuleBrowserDownloadActivity] = [:]
 
+    /// Whether Downloads has captured Android's current filter/sort inputs for visible row order.
+    @State private var didCaptureDownloadSortSnapshot = false
+
+    /// Installed/activity state used for Android-style row ordering until the next filter rebuild.
+    @State private var downloadSortSnapshot = ModuleBrowserDownloadSortSnapshot(
+        installedModules: [],
+        downloadActivities: [:]
+    )
+
     /// Running install tasks keyed by module initials so row cancel buttons can stop work.
     @State private var installTasks: [String: Task<Void, Never>] = [:]
 
@@ -444,16 +475,51 @@ public struct ModuleBrowserView: View {
 
     /// Available (remote) modules filtered by category, language, and search text.
     private var filteredAvailableModules: [RemoteModuleInfo] {
-        Self.filteredDownloadModules(
+        let sortSnapshot = currentDownloadSortSnapshot
+        return Self.filteredDownloadModules(
             availableModules,
             selectedCategory: selectedCategory,
             selectedLanguage: selectedLanguage,
             searchText: searchText,
-            installedModules: installedModules,
-            downloadActivities: downloadActivities,
+            installedModules: sortSnapshot.installedModules,
+            downloadActivities: sortSnapshot.downloadActivities,
             recommendedDocuments: recommendedDocuments,
             badDocuments: badDocuments
         )
+    }
+
+    /**
+     Current installed/activity state that should influence Downloads row order.
+
+     Android does not rerun `filterDocuments()` when a row begins installing; it updates the row in
+     place. Until iOS has captured a filter/catalog rebuild snapshot, this falls back to live state
+     so previews/tests that exercise the helper without loading state still behave deterministically.
+     */
+    private var currentDownloadSortSnapshot: ModuleBrowserDownloadSortSnapshot {
+        didCaptureDownloadSortSnapshot
+            ? downloadSortSnapshot
+            : Self.downloadListSortSnapshot(
+                installedModules: installedModules,
+                downloadActivities: downloadActivities
+            )
+    }
+
+    /**
+     Captures the state Android would use after rerunning `DocumentSelectionBase.filterDocuments()`.
+
+     Side effects:
+     - updates the Downloads sort snapshot used by `filteredAvailableModules`
+     - marks the snapshot as initialized for this view lifetime
+
+     Failure modes:
+     - none; the snapshot intentionally remains stale during row-only install progress changes
+     */
+    private func captureDownloadListSortSnapshot() {
+        downloadSortSnapshot = Self.downloadListSortSnapshot(
+            installedModules: installedModules,
+            downloadActivities: downloadActivities
+        )
+        didCaptureDownloadSortSnapshot = true
     }
 
     // MARK: - Body
@@ -508,6 +574,7 @@ public struct ModuleBrowserView: View {
         .background(ModuleBrowserPalette.background.ignoresSafeArea())
         .onChange(of: searchText) {
             alignFiltersWithAndroidSearchState(searchText)
+            captureDownloadListSortSnapshot()
         }
         .navigationBarBackButtonHidden(true)
         #if os(iOS)
@@ -807,6 +874,7 @@ public struct ModuleBrowserView: View {
         Menu {
             Button(languageFilterTitle(for: "")) {
                 selectedLanguage = ""
+                captureDownloadListSortSnapshot()
             }
             if !availableLanguages.isEmpty {
                 Divider()
@@ -815,6 +883,7 @@ public struct ModuleBrowserView: View {
                 Button(displayName(for: language)) {
                     selectedLanguage = language
                     Self.rememberExplicitSelectedLanguage(language)
+                    captureDownloadListSortSnapshot()
                 }
             }
         } label: {
@@ -865,6 +934,7 @@ public struct ModuleBrowserView: View {
                     selectedLanguage = ""
                     persistSelectedCategory(nil)
                     applyAndroidDefaultLanguageIfNeeded(force: true)
+                    captureDownloadListSortSnapshot()
                 }
                 Divider()
                 ForEach(visibleCategoryFilters, id: \.self) { category in
@@ -873,6 +943,7 @@ public struct ModuleBrowserView: View {
                         selectedLanguage = ""
                         persistSelectedCategory(category)
                         applyAndroidDefaultLanguageIfNeeded(force: true)
+                        captureDownloadListSortSnapshot()
                     }
                 }
             } label: {
@@ -1943,6 +2014,34 @@ public struct ModuleBrowserView: View {
     }
 
     /**
+     Captures Android Downloads ordering inputs for a list/filter rebuild.
+
+     Android's adapter receives row-state updates after a download starts, but the list order is
+     only recomputed when the document filter list is rebuilt. Tests use this helper to preserve
+     that distinction without constructing SwiftUI view state.
+
+     - Parameters:
+       - installedModules: Installed module state at the rebuild boundary.
+       - downloadActivities: Active or failed row activities at the rebuild boundary.
+     - Returns: Immutable sort inputs for `filteredDownloadModules`.
+
+     Side effects:
+     - none
+
+     Failure modes:
+     - none
+     */
+    static func downloadListSortSnapshot(
+        installedModules: [ModuleInfo],
+        downloadActivities: [String: ModuleBrowserDownloadActivity]
+    ) -> ModuleBrowserDownloadSortSnapshot {
+        ModuleBrowserDownloadSortSnapshot(
+            installedModules: installedModules,
+            downloadActivities: downloadActivities
+        )
+    }
+
+    /**
      Filters and sorts remote modules using Android `DocumentSelectionBase.filterDocuments`
      semantics adapted to iOS data models.
 
@@ -2438,6 +2537,7 @@ public struct ModuleBrowserView: View {
             availableModules = deduplicatedModules(from: initialState.cachedModules)
         }
         applyAndroidDefaultLanguageIfNeeded()
+        captureDownloadListSortSnapshot()
         isLoadingInitialState = false
         if defaultDownloadMode.shouldInstallDefaultDocuments {
             startDefaultDownloadFlowIfNeeded()
@@ -2708,6 +2808,7 @@ public struct ModuleBrowserView: View {
                 availableModules = uniqueModules
                 replaceDownloadErrors(with: errors)
                 applyAndroidDefaultLanguageIfNeeded()
+                captureDownloadListSortSnapshot()
                 isRefreshing = false
                 refreshProgress = nil
                 installDefaultDocumentsIfNeeded(

--- a/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
@@ -62,11 +62,12 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
     }
 
     /**
-     Verifies active and failed Downloads activity drives Android-style status ordering.
+     Verifies active and failed Downloads activity drives Android-style status ordering on rebuild.
 
-     Android promotes active installs and update rows while preserving visible failure state. iOS must
-     keep in-progress percentages and failure messages tied to row status instead of flattening those
-     rows into ordinary installable documents.
+     Android promotes active installs and update rows when `filterDocuments()` recomputes the list,
+     while preserving visible failure state. iOS must keep in-progress percentages and failure
+     messages tied to row status instead of flattening those rows into ordinary installable
+     documents.
      */
     func testModuleBrowserDownloadActivityDrivesAndroidProgressAndErrorStatus() {
         let modules = [
@@ -154,12 +155,122 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
     }
 
     /**
+     Verifies Downloads row activity updates do not recompute visible row order.
+
+     Android `DownloadActivity.doDownload` enqueues the document and calls `notifyDataSetChanged()`;
+     it does not rerun `DocumentSelectionBase.filterDocuments()`. That means the tapped row updates
+     progress in place, while a later explicit filter rebuild can still apply Android's
+     active-download-first sort. iOS must keep the same split so live progress state does not make
+     the selected row disappear from the current scroll position.
+     */
+    func testModuleBrowserKeepsDownloadRowOrderStableUntilFilterRebuild() {
+        let modules = [
+            RemoteModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "1.0"
+            ),
+            RemoteModuleInfo(
+                name: "WEB",
+                description: "World English Bible",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "2.0"
+            ),
+            RemoteModuleInfo(
+                name: "REC",
+                description: "Recommended Bible",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "1.0"
+            ),
+            RemoteModuleInfo(
+                name: "WARN",
+                description: "Active warning module",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "1.0"
+            )
+        ]
+        let installed = [
+            ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en", version: "1.0"),
+            ModuleInfo(name: "WEB", description: "World English Bible", category: .bible, language: "en", version: "1.0")
+        ]
+        let recommended = ModuleDownloadConfiguration(
+            bibles: ["en": ["REC::CrossWire"]]
+        )
+
+        let initialSortSnapshot = ModuleBrowserView.downloadListSortSnapshot(
+            installedModules: installed,
+            downloadActivities: [:]
+        )
+        let visibleBeforeInstall = ModuleBrowserView.filteredDownloadModules(
+            modules,
+            selectedCategory: nil,
+            selectedLanguage: "en",
+            searchText: "",
+            installedModules: initialSortSnapshot.installedModules,
+            downloadActivities: initialSortSnapshot.downloadActivities,
+            recommendedDocuments: recommended,
+            badDocuments: nil
+        )
+
+        let liveActivities: [String: ModuleBrowserDownloadActivity] = [
+            "WARN": .inProgress(0.25)
+        ]
+        let visibleAfterRowActivity = ModuleBrowserView.filteredDownloadModules(
+            modules,
+            selectedCategory: nil,
+            selectedLanguage: "en",
+            searchText: "",
+            installedModules: initialSortSnapshot.installedModules,
+            downloadActivities: initialSortSnapshot.downloadActivities,
+            recommendedDocuments: recommended,
+            badDocuments: nil
+        )
+
+        XCTAssertEqual(visibleBeforeInstall.map(\.name), ["WEB", "KJV", "REC", "WARN"])
+        XCTAssertEqual(visibleAfterRowActivity.map(\.name), ["WEB", "KJV", "REC", "WARN"])
+        XCTAssertEqual(
+            ModuleBrowserView.displayStatus(
+                for: modules[3],
+                installedModules: installed,
+                downloadActivities: liveActivities
+            ),
+            .beingInstalled(progressPercent: 25)
+        )
+
+        let rebuiltSortSnapshot = ModuleBrowserView.downloadListSortSnapshot(
+            installedModules: installed,
+            downloadActivities: liveActivities
+        )
+        let visibleAfterFilterRebuild = ModuleBrowserView.filteredDownloadModules(
+            modules,
+            selectedCategory: nil,
+            selectedLanguage: "en",
+            searchText: "",
+            installedModules: rebuiltSortSnapshot.installedModules,
+            downloadActivities: rebuiltSortSnapshot.downloadActivities,
+            recommendedDocuments: recommended,
+            badDocuments: nil
+        )
+
+        XCTAssertEqual(visibleAfterFilterRebuild.map(\.name), ["WARN", "WEB", "KJV", "REC"])
+    }
+
+    /**
      Verifies Downloads filtering and sort order match Android's document browser rules.
 
-     Android keeps active warnings first, then updates, installed rows, recommended rows, copyright
-     placeholder rows, and finally other matching documents while hiding hard-hidden bad documents.
-     iOS must keep that same ordering contract across Bible rows, add-ons, pseudo rows, version
-     comparisons, and install-size formatting without app-host state.
+     Android keeps active warnings first after a filter rebuild, then updates, installed rows,
+     recommended rows, copyright placeholder rows, and finally other matching documents while hiding
+     hard-hidden bad documents. iOS must keep that same ordering contract across Bible rows, add-ons,
+     pseudo rows, version comparisons, and install-size formatting without app-host state.
      */
     func testModuleBrowserFiltersAndSortsAndroidDownloadRows() {
         let modules = [


### PR DESCRIPTION
## Summary
- Keeps the tapped Downloads row in its current visible order while install progress and completion update live.
- Preserves Android's active-download-first ordering when the Downloads list is explicitly rebuilt by initial load, catalog refresh, search, language filter, or document-type filter changes.
- Adds package-level regression coverage for the distinction between row activity updates and filter rebuild ordering.

## Scope
- In scope: Downloads row ordering, install-progress ordering inputs, and ModuleBrowser Downloads tests.
- Out of scope: SWORD install/uninstall plumbing, repository refresh behavior, app-wide test harness restructuring.

## Contract References
- Android `DownloadActivity.doDownload` starts the install and calls `notifyDataSetChanged()` without rerunning `filterDocuments()`, so the row updates in place.
- Android `DocumentSelectionBase.filterDocuments()` recomputes `displayedDocuments` and sorts active installs before updates and other rows when filters/catalogs are rebuilt.
- iOS now separates live row status from the captured sort inputs used for the visible Downloads list.

## Change Details
- Added `ModuleBrowserDownloadSortSnapshot` to capture installed-module and activity state at Android-equivalent list rebuild boundaries.
- Updated `filteredAvailableModules` to sort with the captured snapshot while row rendering still reads live `downloadActivities` and `installedModules`.
- Captured a fresh snapshot after initial load, catalog refresh, search alignment, language filter changes, and document-type filter changes.
- Added `testModuleBrowserKeepsDownloadRowOrderStableUntilFilterRebuild` to lock the row-stability contract.

## Validation Evidence
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ModuleBrowserDownloadsTests` was attempted, but the local package test runner builds `BibleUI` as macOS and fails before this test target on existing iOS-only SwiftUI APIs and `Window` ambiguity.
- GitNexus `detect_changes` on staged changes: low risk, no affected execution flows.

## Risks / Follow-Ups
- Local package tests are still not directly runnable through `swift test`; CI remains the authoritative runner for the added package test.
- The fix intentionally does not scroll to promoted active rows, because Android does not promote them during row-only install updates.

Closes #321
