### PR TITLE
fix(reader): keep verse taps and link parity stable

### DIFF
--- a/bibleview-js/src/__tests__/ambiguous-selection-bookmark.spec.js
+++ b/bibleview-js/src/__tests__/ambiguous-selection-bookmark.spec.js
@@ -44,7 +44,7 @@ function testBookmark(id = "bookmark-1") {
     };
 }
 
-function mountAmbiguousSelection({bookmarks = [], appSettings = {}} = {}) {
+function mountAmbiguousSelection({bookmarks = [], appSettings = {}, config = {}} = {}) {
     const bookmarkMap = new Map(bookmarks.map(bookmark => [bookmark.id, bookmark]));
 
     return mount(AmbiguousSelection, {
@@ -63,7 +63,10 @@ function mountAmbiguousSelection({bookmarks = [], appSettings = {}} = {}) {
                     ...appSettings,
                 },
                 [calculatedConfigKey]: {},
-                [configKey]: {},
+                [configKey]: {
+                    showBookmarks: true,
+                    ...config,
+                },
                 [globalBookmarksKey]: {
                     bookmarkIdsByOrdinal: new Map(),
                     bookmarkMap,
@@ -247,5 +250,94 @@ describe("AmbiguousSelection bookmark routing", () => {
 
         wrapper.vm.cancelled();
         await handlePromise;
+    });
+
+    /**
+     * Protects Android bookmark visibility parity when bookmark display is disabled.
+     *
+     * Android filters bookmark actions from the ambiguous chooser when `showBookmarks` is false.
+     * A failure means hidden bookmark UI can still leak through the chooser even though the reader
+     * has been configured not to show bookmark affordances.
+     */
+    it("filters bookmark chooser actions when bookmark display is disabled", async () => {
+        const bookmark = testBookmark();
+        const wrapper = mountAmbiguousSelection({
+            bookmarks: [bookmark],
+            config: {
+                showBookmarks: false,
+            },
+        });
+        const event = new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            clientY: 100,
+        });
+
+        addEventFunction(event, null, {
+            bookmarkId: "bookmark-1",
+            hidden: false,
+            priority: EventPriorities.VISIBLE_BOOKMARK,
+        });
+        addEventVerseInfo(event, {
+            bibleBookName: "Genesis",
+            bookInitials: "KJV",
+            chapter: 1,
+            ordinal: 9,
+            osisRef: "Gen.1.9",
+            verse: 9,
+            verseTo: "",
+        });
+
+        const handlePromise = wrapper.vm.handle(event);
+        await Promise.resolve();
+
+        expect(wrapper.text()).toContain("Genesis 1:9");
+        expect(wrapper.find("[data-test='ambiguous-bookmark-button']").exists()).toBe(false);
+
+        wrapper.vm.cancelled();
+        await handlePromise;
+    });
+
+    /**
+     * Protects Android unmanaged-link parity in the reader click classifier.
+     *
+     * Plain rendered links without registered event functions should be left to the browser/native
+     * link path after recording a scroll anchor. The ambiguous-selection handler must not treat
+     * those clicks as background modal-dismiss taps.
+     */
+    it("records a scroll anchor and ignores plain unmanaged link clicks", async () => {
+        const scrollAnchorEvents = [];
+        const backEvents = [];
+        const scrollAnchorListener = args => scrollAnchorEvents.push(args);
+        const backListener = args => backEvents.push(args);
+        eventBus.on("set_scroll_anchor", scrollAnchorListener);
+        eventBus.on("back_clicked", backListener);
+
+        try {
+            const wrapper = mountAmbiguousSelection();
+            const link = document.createElement("a");
+            link.setAttribute("href", "https://example.test");
+            const linkText = document.createElement("span");
+            const textNode = document.createTextNode("Example");
+            linkText.appendChild(textNode);
+            link.appendChild(linkText);
+            document.body.appendChild(link);
+
+            const event = new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                clientY: 100,
+            });
+            Object.defineProperty(event, "target", {value: textNode});
+
+            await wrapper.vm.handle(event);
+
+            expect(scrollAnchorEvents).toEqual([[link]]);
+            expect(backEvents).toEqual([]);
+            expect(wrapper.text()).toBe("");
+        } finally {
+            eventBus.off("set_scroll_anchor", scrollAnchorListener);
+            eventBus.off("back_clicked", backListener);
+        }
     });
 });

--- a/bibleview-js/src/__tests__/ambiguous-selection-bookmark.spec.js
+++ b/bibleview-js/src/__tests__/ambiguous-selection-bookmark.spec.js
@@ -16,7 +16,7 @@
  */
 
 import {mount} from "@vue/test-utils";
-import {afterEach, describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import {ref} from "vue";
 import AmbiguousSelection from "@/components/modals/AmbiguousSelection.vue";
 import {useOrdinalHighlight} from "@/composables/ordinal-highlight";
@@ -44,7 +44,7 @@ function testBookmark(id = "bookmark-1") {
     };
 }
 
-function mountAmbiguousSelection({bookmarks = []} = {}) {
+function mountAmbiguousSelection({bookmarks = [], appSettings = {}} = {}) {
     const bookmarkMap = new Map(bookmarks.map(bookmark => [bookmark.id, bookmark]));
 
     return mount(AmbiguousSelection, {
@@ -60,6 +60,7 @@ function mountAmbiguousSelection({bookmarks = []} = {}) {
                     activeSince: -1000,
                     activeWindow: true,
                     limitAmbiguousModalSize: false,
+                    ...appSettings,
                 },
                 [calculatedConfigKey]: {},
                 [configKey]: {},
@@ -106,6 +107,7 @@ function mountAmbiguousSelection({bookmarks = []} = {}) {
 
 afterEach(() => {
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
 });
 
 describe("AmbiguousSelection bookmark routing", () => {
@@ -203,5 +205,47 @@ describe("AmbiguousSelection bookmark routing", () => {
         } finally {
             eventBus.off("bookmark_clicked", listener);
         }
+    });
+
+    /**
+     * Protects shared reader content-tap behavior while a pane is becoming active.
+     *
+     * Android and iOS both route verse clicks through this web handler. A physical tap can focus a
+     * pane and carry verse metadata in the same bubbled event, so the activation debounce must keep
+     * suppressing plain background taps without dropping explicit verse selections. Failure means a
+     * legitimate first tap on verse text can be ignored instead of opening the verse chooser.
+     */
+    it("keeps a verse metadata tap during the activation debounce", async () => {
+        vi.spyOn(performance, "now").mockReturnValue(1000);
+
+        const wrapper = mountAmbiguousSelection({
+            appSettings: {
+                activeSince: 900,
+                activeWindow: true,
+            },
+        });
+        const event = new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            clientY: 100,
+        });
+
+        addEventVerseInfo(event, {
+            bibleBookName: "Genesis",
+            bookInitials: "KJV",
+            chapter: 1,
+            ordinal: 9,
+            osisRef: "Gen.1.9",
+            verse: 9,
+            verseTo: "",
+        });
+
+        const handlePromise = wrapper.vm.handle(event);
+        await Promise.resolve();
+
+        expect(wrapper.text()).toContain("Genesis 1:9");
+
+        wrapper.vm.cancelled();
+        await handlePromise;
     });
 });

--- a/bibleview-js/src/__tests__/link-navigation.spec.js
+++ b/bibleview-js/src/__tests__/link-navigation.spec.js
@@ -15,7 +15,19 @@
  * If not, see http://www.gnu.org/licenses/.
  */
 
+import {mount} from "@vue/test-utils";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {defineComponent} from "vue";
+import AndBibleLink from "@/components/OSIS/AndBibleLink.vue";
+import {useSlotHtmlContent} from "@/composables/slot-html-content";
+import {eventBus} from "@/eventbus";
+import {
+    androidKey,
+    appSettingsKey,
+    calculatedConfigKey,
+    configKey,
+    stringsKey,
+} from "@/types/constants";
 import {handleAnchorNavigation} from "@/utils";
 
 describe("link navigation", () => {
@@ -97,5 +109,85 @@ describe("link navigation", () => {
         expect(handled).toBe(false);
         expect(event.defaultPrevented).toBe(false);
         expect(postMessage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Protects Android link-panel scroll anchoring for sanitized slot HTML links.
+     *
+     * Links rendered from sanitized HTML should record their clicked anchor before routing so the
+     * scroll composable can keep the source link visible if the destination panel changes viewport
+     * height.
+     */
+    it("records a scroll anchor before navigating sanitized slot HTML links", async () => {
+        const scrollAnchorEvents = [];
+        const listener = args => scrollAnchorEvents.push(args);
+        eventBus.on("set_scroll_anchor", listener);
+
+        try {
+            const wrapper = mount(defineComponent({
+                setup() {
+                    return useSlotHtmlContent();
+                },
+                template: `
+                    <div ref="slotContent" @click="handleClick">
+                        <a href="osis://?osis=Gen.1.1"><span>Genesis 1:1</span></a>
+                    </div>
+                `,
+            }));
+            const link = wrapper.find("a").element;
+
+            await wrapper.find("span").trigger("click");
+
+            expect(scrollAnchorEvents).toEqual([[link]]);
+            expect(postMessage).toHaveBeenCalledWith({
+                method: "openExternalLink",
+                args: ["osis://?osis=Gen.1.1"],
+            });
+        } finally {
+            eventBus.off("set_scroll_anchor", listener);
+        }
+    });
+
+    /**
+     * Protects Android link-panel scroll anchoring for OSIS component links.
+     *
+     * Component-managed AndBible links bypass the plain document click handler, so they must record
+     * the clicked element themselves before routing to the native link path.
+     */
+    it("records a scroll anchor before navigating AndBibleLink component clicks", async () => {
+        const scrollAnchorEvents = [];
+        const listener = args => scrollAnchorEvents.push(args);
+        eventBus.on("set_scroll_anchor", listener);
+
+        try {
+            const wrapper = mount(AndBibleLink, {
+                props: {
+                    href: "osis://?osis=Gen.1.1",
+                },
+                global: {
+                    provide: {
+                        [androidKey]: {},
+                        [appSettingsKey]: {},
+                        [calculatedConfigKey]: {},
+                        [configKey]: {},
+                        [stringsKey]: {},
+                    },
+                },
+                slots: {
+                    default: "<span>Genesis 1:1</span>",
+                },
+            });
+            const link = wrapper.find("a").element;
+
+            await wrapper.find("span").trigger("click");
+
+            expect(scrollAnchorEvents).toEqual([[link]]);
+            expect(postMessage).toHaveBeenCalledWith({
+                method: "openExternalLink",
+                args: ["osis://?osis=Gen.1.1"],
+            });
+        } finally {
+            eventBus.off("set_scroll_anchor", listener);
+        }
     });
 });

--- a/bibleview-js/src/__tests__/scroll.spec.js
+++ b/bibleview-js/src/__tests__/scroll.spec.js
@@ -1,8 +1,11 @@
-import {mount} from "@vue/test-utils";
+import {enableAutoUnmount, mount} from "@vue/test-utils";
 import {defineComponent, ref} from "vue";
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 import {resolveScrollToVerseRequest, useScroll} from "@/composables/scroll";
+import {eventBus} from "@/eventbus";
+
+enableAutoUnmount(afterEach);
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -116,5 +119,50 @@ describe("scroll composable", () => {
         wrapper.unmount();
 
         expect(removeListener).toHaveBeenCalledWith("touchstart", touchStartAdd[1]);
+    });
+
+    /**
+     * Protects Android scroll-anchor parity for reader links that open auxiliary panels.
+     *
+     * Android records the clicked link as a temporary scroll anchor, then keeps it visible if a
+     * viewport resize would otherwise push it under the top toolbar or out of view. Failure means
+     * the link-modal path can move the original tap target off-screen after the auxiliary panel
+     * changes available reader height.
+     */
+    it("keeps the emitted scroll anchor visible across resize", async () => {
+        const target = document.createElement("a");
+        target.className = "reference-link";
+        target.textContent = "Genesis 1:1";
+        target.getBoundingClientRect = () => ({top: 10, bottom: 20});
+        document.body.appendChild(target);
+
+        Object.defineProperty(window, "scrollY", {value: 500, configurable: true});
+        Object.defineProperty(window, "innerHeight", {value: 600, configurable: true});
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation(callback => {
+            callback(0);
+            return 1;
+        });
+        const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+        mount(defineComponent({
+            setup() {
+                useScroll(
+                    {},
+                    {disableAnimations: false, topOffset: 0, bottomOffset: 0, imeOpen: false},
+                    ref({topOffset: 100}),
+                    {highlightOrdinal: vi.fn(), resetHighlights: vi.fn()},
+                    ref(Promise.resolve()),
+                    ref(0)
+                );
+            },
+            template: "<div />",
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        eventBus.emit("set_scroll_anchor", [target]);
+        window.dispatchEvent(new Event("resize"));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 243.33333333333334);
     });
 });

--- a/bibleview-js/src/components/OSIS/AndBibleLink.vue
+++ b/bibleview-js/src/components/OSIS/AndBibleLink.vue
@@ -22,10 +22,21 @@
 <script setup lang="ts">
 import {useCommon} from "@/composables";
 import {navigateLink} from "@/utils";
+import {emit} from "@/eventbus";
 
 defineProps<{href: string}>();
 
+/**
+ * Routes an OSIS link through the app navigation bridge after recording its scroll anchor.
+ *
+ * @param event Click event from the rendered anchor.
+ * @param url Internal or external AndBible link target.
+ * @returns Nothing.
+ * @remarks Emits `set_scroll_anchor` for viewport preservation and then delegates navigation to
+ * `navigateLink`, which uses the native iOS bridge when required.
+ */
 function openLink(event: MouseEvent, url: string) {
+    emit("set_scroll_anchor", event.currentTarget as HTMLElement);
     navigateLink(url);
 }
 

--- a/bibleview-js/src/components/modals/AmbiguousSelection.vue
+++ b/bibleview-js/src/components/modals/AmbiguousSelection.vue
@@ -296,11 +296,30 @@ function minusKeyPressed() {
     }
     updateHighlight();
 }
+
+/**
+ * Handles bubbled reader clicks and chooses between direct actions, verse selection, and modal
+ * dismissal.
+ *
+ * The activation debounce still suppresses plain pane-activation taps, but verse or ordinal
+ * metadata marks the event as a content tap and must be processed even when the pane has just
+ * become active.
+ *
+ * @param event Bubbled mouse event that may carry registered callbacks, verse metadata, or ordinal
+ * metadata added by child document components.
+ * @returns A promise that settles after a direct callback runs or the ambiguous selection modal is
+ * dismissed.
+ * @remarks Mutates modal/highlight state and emits reader events. Action mode returns before state
+ * mutation; inactive plain taps return after clearing any existing highlights.
+ */
 async function handle(event: MouseEvent) {
     const isActive = appSettings.activeWindow && (performance.now() - appSettings.activeSince > 250);
     const eventFunctions = getHighestPriorityEventFunctions(event);
     const allEventFunctions = getAllEventFunctions(event);
     const hasParticularClicks = eventFunctions.filter(f => !f.options.hidden).length > 0; // let's not show only "hidden" items
+    const _verseInfo: Nullable<EventVerseInfo> = getEventVerseInfo(event);
+    const _ordinalInfo: Nullable<EventOrdinalInfo> = getEventOrdinalInfo(event);
+    const hasContentSelection = _verseInfo != null || _ordinalInfo != null;
     if (appSettings.actionMode) {
         return;
     }
@@ -309,12 +328,10 @@ async function handle(event: MouseEvent) {
     if (hadHighlights && !showModal.value && !hasParticularClicks) {
         return;
     }
-    if (!isActive && !hasParticularClicks) {
+    if (!isActive && !hasParticularClicks && !hasContentSelection) {
         return;
     }
     emit("back_clicked");
-    const _verseInfo: Nullable<EventVerseInfo> = getEventVerseInfo(event);
-    const _ordinalInfo: Nullable<EventOrdinalInfo> = getEventOrdinalInfo(event);
 
     if (multiSelectionMode.value && multiSelect(_verseInfo, _ordinalInfo)) {
         return;

--- a/bibleview-js/src/components/modals/AmbiguousSelection.vue
+++ b/bibleview-js/src/components/modals/AmbiguousSelection.vue
@@ -121,7 +121,7 @@ const limitAmbiguousModalSize = computed({
     }
 });
 const {bookmarkMap, bookmarkIdsByOrdinal} = inject(globalBookmarksKey)!;
-const {strings} = useCommon();
+const {strings, config} = useCommon();
 const android = inject(androidKey)!;
 const multiSelectionMode = ref(false);
 
@@ -298,12 +298,33 @@ function minusKeyPressed() {
 }
 
 /**
+ * Finds the nearest clicked anchor from a reader click event.
+ *
+ * Reader clicks can originate from nested elements or text nodes inside an anchor. Normalizing to
+ * the anchor keeps downstream scroll-anchor behavior stable.
+ *
+ * @param event Bubbled reader mouse event.
+ * @returns The nearest containing anchor, or null when the click did not come from link content.
+ */
+function closestAnchorFromEvent(event: MouseEvent): HTMLAnchorElement | null {
+    const target = event.target;
+    if (target instanceof Element) {
+        return target.closest("a");
+    }
+    if (target instanceof Node) {
+        return target.parentElement?.closest("a") ?? null;
+    }
+    return null;
+}
+
+/**
  * Handles bubbled reader clicks and chooses between direct actions, verse selection, and modal
  * dismissal.
  *
  * The activation debounce still suppresses plain pane-activation taps, but verse or ordinal
  * metadata marks the event as a content tap and must be processed even when the pane has just
- * become active.
+ * become active. Plain unmanaged links record a scroll anchor and stay on the link path, while
+ * bookmark actions are filtered out of chooser state when bookmark display is disabled.
  *
  * @param event Bubbled mouse event that may carry registered callbacks, verse metadata, or ordinal
  * metadata added by child document components.
@@ -313,14 +334,21 @@ function minusKeyPressed() {
  * mutation; inactive plain taps return after clearing any existing highlights.
  */
 async function handle(event: MouseEvent) {
+    const clickedLink = closestAnchorFromEvent(event);
+    if (clickedLink) {
+        emit("set_scroll_anchor", clickedLink);
+    }
     const isActive = appSettings.activeWindow && (performance.now() - appSettings.activeSince > 250);
     const eventFunctions = getHighestPriorityEventFunctions(event);
-    const allEventFunctions = getAllEventFunctions(event);
+    const allEventFunctions = getAllEventFunctions(event).filter(e => config.showBookmarks || !e.options.bookmarkId);
     const hasParticularClicks = eventFunctions.filter(f => !f.options.hidden).length > 0; // let's not show only "hidden" items
     const _verseInfo: Nullable<EventVerseInfo> = getEventVerseInfo(event);
     const _ordinalInfo: Nullable<EventOrdinalInfo> = getEventOrdinalInfo(event);
     const hasContentSelection = _verseInfo != null || _ordinalInfo != null;
     if (appSettings.actionMode) {
+        return;
+    }
+    if (!hasParticularClicks && clickedLink) {
         return;
     }
     const hadHighlights = hasHighlights.value;

--- a/bibleview-js/src/composables/scroll.ts
+++ b/bibleview-js/src/composables/scroll.ts
@@ -17,7 +17,7 @@
 
 import {computed, nextTick, onScopeDispose, ref, Ref, watch} from "vue";
 import {setupEventBusListener} from "@/eventbus";
-import {isInViewport, setupWindowEventListener} from "@/utils";
+import {isInViewport, setupWindowEventListener, waitNextAnimationFrame} from "@/utils";
 import {AppSettings, CalculatedConfig, Config} from "@/composables/config";
 import {useOrdinalHighlight} from "@/composables/ordinal-highlight";
 import {Nullable} from "@/types/common";
@@ -291,5 +291,62 @@ export function useScroll(
         scrollToId(targetId, options);
     })
     setupEventBusListener("setup_content", setupContent)
+
+    let scrollAnchorElement: HTMLElement | null = null;
+    let scrollAnchorCleanupTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * Clears the temporary link scroll anchor and any scheduled cleanup timer.
+     *
+     * The anchor is local to the current reader document lifetime. It is intentionally short-lived
+     * because it only protects the immediate viewport resize caused by opening a link destination.
+     *
+     * @returns Nothing.
+     * @remarks Mutates module-local anchor state and cancels pending timer work.
+     */
+    function clearScrollAnchor() {
+        scrollAnchorElement = null;
+        if (scrollAnchorCleanupTimeout) {
+            clearTimeout(scrollAnchorCleanupTimeout);
+            scrollAnchorCleanupTimeout = null;
+        }
+    }
+
+    /**
+     * Records a clicked link or its containing ordinal as the temporary scroll anchor.
+     *
+     * Android records the link source before opening link panels so later viewport changes can keep
+     * the tapped content visible. iOS mirrors that contract while preserving its native bridge
+     * navigation path.
+     *
+     * @param element Clicked link or descendant element emitted by the reader click path.
+     * @returns Nothing.
+     * @remarks Mutates module-local anchor state and schedules automatic cleanup after three
+     * seconds.
+     */
+    function setScrollAnchor(element: HTMLElement) {
+        clearScrollAnchor();
+        scrollAnchorElement = (element.closest('.ordinal') as HTMLElement) || element;
+        scrollAnchorCleanupTimeout = setTimeout(clearScrollAnchor, 3000);
+    }
+
+    setupEventBusListener("set_scroll_anchor", setScrollAnchor);
+
+    setupWindowEventListener('resize', async () => {
+        if (!scrollAnchorElement) return;
+        await waitNextAnimationFrame();
+        if (!scrollAnchorElement) return;
+        const rect = scrollAnchorElement.getBoundingClientRect();
+        const viewTop = calculatedConfig.value.topOffset;
+        const viewBottom = window.innerHeight;
+
+        if (rect.bottom < viewTop || rect.top > viewBottom) {
+            const elementTop = rect.top + window.scrollY;
+            const targetY = elementTop - viewTop - (viewBottom - viewTop) / 3;
+            window.scrollTo(0, Math.max(0, targetY));
+        }
+        clearScrollAnchor();
+    });
+
     return {scrollToId, isScrolling, doScrolling, scrollYAtStart, scrollY}
 }

--- a/bibleview-js/src/composables/slot-html-content.ts
+++ b/bibleview-js/src/composables/slot-html-content.ts
@@ -17,6 +17,7 @@
 
 import {onMounted, ref, watch} from "vue";
 import {navigateLink} from "@/utils";
+import {emit} from "@/eventbus";
 
 /**
  * DOMPurify config that allows AndBible custom URI schemes alongside standard ones.
@@ -50,6 +51,17 @@ export function useSlotHtmlContent() {
         }
     });
 
+    /**
+     * Routes clicks from sanitized HTML content through the app link pipeline.
+     *
+     * The clicked anchor is emitted as a scroll anchor before navigation so reader viewport changes
+     * caused by link panels can keep the source content visible.
+     *
+     * @param event Bubbled click event from the rendered slot HTML container.
+     * @returns Nothing.
+     * @remarks Prevents default browser navigation for handled anchors, emits reader scroll-anchor
+     * state, and may route the link through the native bridge via `navigateLink`.
+     */
     function handleClick(event: MouseEvent) {
         const target = event.target as HTMLElement;
         const link = target.closest("a") as HTMLAnchorElement | null;
@@ -57,6 +69,7 @@ export function useSlotHtmlContent() {
             event.preventDefault();
             const href = link.getAttribute("href");
             if (href) {
+                emit("set_scroll_anchor", link);
                 navigateLink(href);
             }
         }

--- a/bibleview-js/src/eventbus.ts
+++ b/bibleview-js/src/eventbus.ts
@@ -51,6 +51,7 @@ type EventTypeNames =
     | "scroll_down"
     | "adjust_loading_count"
     | "export_html"
+    | "set_scroll_anchor"
 
 export const eventBus: Emitter<Record<EventTypeNames, any[]>> = mitt()
 


### PR DESCRIPTION
## Summary
Fixes a reader regression where the first verse tap could be dropped when the same physical tap also activates the reader pane.

This also addresses neighboring Android/iOS parity gaps found while tracing the click path: hidden bookmark actions no longer leak into the ambiguous chooser when bookmark display is disabled, and reader link paths now record a source scroll anchor before opening link/native panels so viewport resize can keep the tapped content visible.

## Scope
In scope:
- `AmbiguousSelection.vue` activation debounce handling for verse and ordinal metadata.
- Ambiguous chooser filtering for bookmark actions when `showBookmarks` is false.
- Scroll-anchor recording for unmanaged reader links, sanitized HTML links, and OSIS component links.
- Resize-time preservation of the tapped link source after link-panel/native navigation changes the viewport.
- Regression coverage for the activation tap, bookmark filtering, unmanaged link classification, link navigation anchoring, and resize anchor behavior.

Out of scope:
- Native iOS gesture-recognizer changes.
- Replacing iOS bridge navigation with Android browser navigation semantics.
- Generated web resource bundle updates in the PR diff.

## Contract References
- GitHub issue #325.
- Shared reader click pipeline: `Verse.vue` adds metadata, `BibleView.vue` bubbles the click, `AmbiguousSelection.vue` chooses the action/modal behavior.
- Link navigation pipeline: sanitized slot HTML and `AndBibleLink.vue` route through `navigateLink` on iOS.
- `docs/config-reference.md` active-window and `activeSince` reader modal behavior.
- Repo commit and PR conventions in `CLAUDE.md` and `.github/PULL_REQUEST_TEMPLATE.md`.

## Change Details
- Reads verse and ordinal metadata before applying the active-pane debounce.
- Allows metadata-bearing content taps through the debounce while preserving suppression for plain inactive taps.
- Filters ambiguous chooser bookmark entries when bookmark display is disabled.
- Records scroll anchors for unmanaged links, sanitized HTML links, and OSIS component links while preserving the iOS native navigation bridge.
- Keeps a temporary clicked-link anchor visible across the immediate resize caused by opening auxiliary link content.
- Documents the touched handler contracts and adds deterministic Vitest regressions.

Adversarial review result: the fix does not special-case native iOS tap handling, does not bypass action mode, does not broaden plain inactive/background taps, and does not replace iOS link routing with Android browser routing. The anchor path was hardened to normalize nested/text click targets back to the actual anchor.

## Validation Evidence
- Red check for #325: `npm run test:unit -- ambiguous-selection-bookmark.spec.js --run` failed before the fix with `expected '' to contain 'Genesis 1:9'`.
- Red checks for neighbor parity: new bookmark/link-anchor/resize tests failed before the parity implementation in `ambiguous-selection-bookmark.spec.js`, `scroll.spec.js`, and `link-navigation.spec.js`.
- Focused green check: `npm run test:unit -- ambiguous-selection-bookmark.spec.js scroll.spec.js link-navigation.spec.js --run` passed, 16 tests.
- `npm run test:ci` passed, 19 test files, 268 passed, 3 skipped. Existing Vue warning noise remains in unrelated specs.
- `npm run lint` passed.
- `npm run type-check` passed.
- `npm run build-debug` passed. Existing Vite warnings remain for language dynamic/static imports and large chunks.
- `git diff --check` passed.
- `python3 scripts/check_repo_standards.py docblocks --all-files` passed.
- `python3 scripts/check_repo_standards.py commits` passed.
- GitNexus pre-edit impacts: LOW risk for `AmbiguousSelection.vue:handle`, `useScroll`, `handleClick`, and `openLink`.
- GitNexus staged detect_changes after parity fixes: LOW risk, 17 changed symbols across 8 files, 0 affected processes.

## Risks / Follow-ups
No known issue-specific follow-up. The changed behavior is limited to reader click classification, bookmark chooser filtering, and temporary link-source anchoring. Existing highlight-clearing behavior still takes precedence when prior highlights are present.

## Screenshots
none

## Closes
Closes #325