### PR TITLE
fix(reader): prevent special document swipe navigation

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationDocumentLoader.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationDocumentLoader.swift
@@ -68,7 +68,14 @@ struct BibleReaderAnnotationDocumentLoader {
     /// Reads memorization state for a rendered ordinal range.
     typealias OrdinalProgressProvider = (String, Int, Int) -> [Int]
     /// Updates the compact rendered-content state owned by the controller.
-    typealias RenderedContentStateSetter = (DocumentCategory, String?, String, Int?, String?) -> Void
+    typealias RenderedContentStateSetter = (
+        DocumentCategory,
+        String?,
+        String,
+        Int?,
+        String?,
+        ReaderRenderedDocumentKind
+    ) -> Void
 
     /// Bridge used for Vue event emission.
     private let bridge: BibleBridge
@@ -172,7 +179,7 @@ struct BibleReaderAnnotationDocumentLoader {
             event: "setup_content",
             data: ReaderSetupContentPayload(jumpToOrdinal: jumpToOrdinal)
         )
-        setRenderedContentState(.bible, "My Notes", "My Notes", currentChapter, docId)
+        setRenderedContentState(.bible, "My Notes", "My Notes", currentChapter, docId, .standard)
         incrementMyNotesRevision()
         return true
     }
@@ -243,7 +250,7 @@ struct BibleReaderAnnotationDocumentLoader {
             event: "setup_content",
             data: ReaderSetupContentPayload(jumpToId: bookmarkId?.uuidString)
         )
-        setRenderedContentState(.bible, "StudyPad", label.name, nil, "journal_\(labelId.uuidString)")
+        setRenderedContentState(.bible, "StudyPad", label.name, nil, "journal_\(labelId.uuidString)", .studyPad)
         applyNightModeBackground()
         return true
     }
@@ -276,7 +283,8 @@ struct BibleReaderAnnotationDocumentLoader {
             request.activeModuleName,
             "Memorize",
             request.currentChapter,
-            "memorize:\(request.bookInitials):\(request.startOrdinal)-\(request.endOrdinal)"
+            "memorize:\(request.bookInitials):\(request.startOrdinal)-\(request.endOrdinal)",
+            .memorize
         )
         clearSelection()
         applyNightModeBackground()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -130,6 +130,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     static let emptyRenderedContentState = BibleReaderRenderedContentState.empty.encodedValue
     private static let issueTrackerURLString = "https://github.com/AndBible/and-bible/issues"
     private(set) var renderedContentState: String = BibleReaderController.emptyRenderedContentState
+    private(set) var renderedDocumentKind: ReaderRenderedDocumentKind = .standard
     /// Coordinator for Android-style transient `MultiDocument` state and fake-document identity.
     private var specialDocumentCoordinator = BibleReaderSpecialDocumentCoordinator()
     /// Reader-local My Documents active page state and document payload assembly.
@@ -289,15 +290,22 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         studyPadAccessibilitySnapshot.encodedValue
     }
 
+    /// Whether the rendered document allows native horizontal swipes to navigate to another page.
+    var allowsHorizontalDocumentNavigation: Bool {
+        renderedDocumentKind.allowsHorizontalDocumentNavigation
+    }
+
     /// Records the latest content identity that native requested the reader WebView to display.
     private func setRenderedContentState(
         category: DocumentCategory,
         moduleName: String?,
         book: String,
         chapter: Int? = nil,
-        key: String? = nil
+        key: String? = nil,
+        documentKind: ReaderRenderedDocumentKind = .standard
     ) {
         myDocumentCoordinator.clearActivePageUnless(category: category, moduleName: moduleName)
+        renderedDocumentKind = documentKind
         renderedContentState = BibleReaderRenderedContentState(
             category: category,
             moduleName: moduleName,
@@ -5099,13 +5107,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             sendLabels: { [weak self] in
                 self?.sendLabelsToVueJS()
             },
-            setRenderedContentState: { [weak self] category, moduleName, book, chapter, key in
+            setRenderedContentState: { [weak self] category, moduleName, book, chapter, key, documentKind in
                 self?.setRenderedContentState(
                     category: category,
                     moduleName: moduleName,
                     book: book,
                     chapter: chapter,
-                    key: key
+                    key: key,
+                    documentKind: documentKind
                 )
             },
             incrementMyNotesRevision: { [weak self] in

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
@@ -23,6 +23,34 @@ enum ReaderHorizontalSwipeAction: Equatable {
     case none
 }
 
+/// Rendered Vue document kind currently hosted by a native reader pane.
+enum ReaderRenderedDocumentKind: Equatable {
+    /// Standard Bible, commentary, auxiliary, or transient document content.
+    case standard
+
+    /// Android-style StudyPad document rendered inside the shared Vue reader.
+    case studyPad
+
+    /// Android-style Memorize document rendered inside the shared Vue reader.
+    case memorize
+
+    /**
+     Whether native chapter/document swipes may leave this rendered document.
+
+     Android refuses page-next/page-previous gestures for StudyPad and Memorize fake documents.
+     Keeping that gate on the rendered document kind prevents the host gesture recognizer from
+     escaping special Vue documents that manage their own internal interaction.
+     */
+    var allowsHorizontalDocumentNavigation: Bool {
+        switch self {
+        case .standard:
+            return true
+        case .studyPad, .memorize:
+            return false
+        }
+    }
+}
+
 /// Resolves configured Bible-view swipe behavior without touching view or controller state.
 enum ReaderHorizontalSwipePolicy {
     /**
@@ -35,6 +63,8 @@ enum ReaderHorizontalSwipePolicy {
        - hasActiveSelection: Whether the pane currently owns a text selection that should keep
          swipe gestures from navigating away.
        - hasOpenModal: Whether the Vue reader client reports an open modal for the pane.
+       - allowsDocumentNavigation: Whether the current rendered document may be replaced by a
+         horizontal chapter/document navigation action.
      - Returns: The navigation, page-scroll, or no-op action the host should execute.
 
      Side effects:
@@ -48,13 +78,15 @@ enum ReaderHorizontalSwipePolicy {
         modeRawValue: String,
         direction: NativeHorizontalSwipeDirection,
         hasActiveSelection: Bool,
-        hasOpenModal: Bool
+        hasOpenModal: Bool,
+        allowsDocumentNavigation: Bool = true
     ) -> ReaderHorizontalSwipeAction {
         guard !hasOpenModal else { return .none }
         guard !hasActiveSelection else { return .none }
 
         switch BibleSwipeMode(rawValue: modeRawValue) ?? .chapter {
         case .chapter:
+            guard allowsDocumentNavigation else { return .none }
             return direction == .left ? .navigateNextChapter : .navigatePreviousChapter
         case .page:
             return direction == .left ? .scrollPageDown : .scrollPageUp

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInteractionPolicies.swift
@@ -73,6 +73,8 @@ enum ReaderHorizontalSwipePolicy {
      Failure modes:
      - returns `.none` when a selection or Vue modal owns interaction, or when the preference
        explicitly disables horizontal swipe handling.
+     - returns `.none` for chapter-navigation swipes when the current rendered document does not
+       allow horizontal document navigation.
      */
     static func action(
         modeRawValue: String,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -4421,7 +4421,8 @@ public struct BibleReaderView: View {
        emit page-scroll commands into the active web view.
      - Failure modes: Returns without action when the gesture did not originate from the active
        window, no focused controller is registered, an in-page text selection is active, the Vue
-       client reports an open modal, or the configured swipe mode is `.none`.
+       client reports an open modal, the rendered document blocks host page navigation, or the
+       configured swipe mode is `.none`.
      */
     private func handleHorizontalSwipe(from window: Window, direction: NativeHorizontalSwipeDirection) {
         guard windowManager.activeWindow?.id == window.id else { return }
@@ -4430,7 +4431,8 @@ public struct BibleReaderView: View {
             modeRawValue: bibleViewSwipeMode,
             direction: direction,
             hasActiveSelection: ctrl.hasActiveSelection,
-            hasOpenModal: ctrl.webModalIsOpen
+            hasOpenModal: ctrl.webModalIsOpen,
+            allowsDocumentNavigation: ctrl.allowsHorizontalDocumentNavigation
         ) {
         case .navigateNextChapter:
             ctrl.navigateNext()

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -529,6 +529,7 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
             ) as? [String: Any]
         )
         XCTAssertEqual(payload["type"] as? String, "journal")
+        XCTAssertFalse(controller.allowsHorizontalDocumentNavigation)
 
         let labelObject = try XCTUnwrap(payload["label"] as? [String: Any])
         XCTAssertEqual(labelObject["name"] as? String, "Study \"Notes\"")

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -531,6 +531,9 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         XCTAssertEqual(payload["type"] as? String, "journal")
         XCTAssertFalse(controller.allowsHorizontalDocumentNavigation)
 
+        controller.returnFromStudyPad()
+        XCTAssertTrue(controller.allowsHorizontalDocumentNavigation)
+
         let labelObject = try XCTUnwrap(payload["label"] as? [String: Any])
         XCTAssertEqual(labelObject["name"] as? String, "Study \"Notes\"")
         let labelStyle = try XCTUnwrap(labelObject["style"] as? [String: Any])

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderInteractionPolicyTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderInteractionPolicyTests.swift
@@ -121,6 +121,47 @@ final class ReaderInteractionPolicyTests: XCTestCase {
     }
 
     /**
+     Verifies that non-pageable rendered documents cannot be changed by native horizontal swipes.
+
+     Android refuses page-next/page-previous gestures while Memorize owns the reader document.
+     The iOS host must keep the same boundary: chapter-mode swipes are ignored instead of
+     navigating away from Memorize, while page-scroll mode can still operate inside the current
+     document. A failure means the native gesture recognizer can escape a special Vue document.
+     */
+    func testReaderHorizontalSwipePolicyBlocksDocumentNavigationWhenCurrentDocumentCannotPage() {
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "CHAPTER",
+                direction: .left,
+                hasActiveSelection: false,
+                hasOpenModal: false,
+                allowsDocumentNavigation: false
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "CHAPTER",
+                direction: .right,
+                hasActiveSelection: false,
+                hasOpenModal: false,
+                allowsDocumentNavigation: false
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            ReaderHorizontalSwipePolicy.action(
+                modeRawValue: "PAGE",
+                direction: .left,
+                hasActiveSelection: false,
+                hasOpenModal: false,
+                allowsDocumentNavigation: false
+            ),
+            .scrollPageDown
+        )
+    }
+
+    /**
      Verifies auto-fullscreen threshold accumulation across scroll directions.
 
      The policy should accumulate deltas until the Android-parity threshold is crossed, reset after

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderProgressBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderProgressBridgeTests.swift
@@ -99,6 +99,9 @@ final class ReaderProgressBridgeTests: BibleUISwordFixtureTestCase {
         XCTAssertEqual(setupPayload["topOffset"] as? Int, 0)
         XCTAssertEqual(setupPayload["bottomOffset"] as? Int, 0)
         XCTAssertFalse(controller.allowsHorizontalDocumentNavigation)
+
+        controller.loadCurrentContent()
+        XCTAssertTrue(controller.allowsHorizontalDocumentNavigation)
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderProgressBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderProgressBridgeTests.swift
@@ -98,6 +98,7 @@ final class ReaderProgressBridgeTests: BibleUISwordFixtureTestCase {
         XCTAssertTrue(setupPayload["jumpToId"] is NSNull)
         XCTAssertEqual(setupPayload["topOffset"] as? Int, 0)
         XCTAssertEqual(setupPayload["bottomOffset"] as? Int, 0)
+        XCTAssertFalse(controller.allowsHorizontalDocumentNavigation)
     }
 
     /**


### PR DESCRIPTION
## Summary

- Prevent native horizontal chapter swipes from navigating away while special Vue reader documents own interaction.
- Track rendered document kind explicitly in native controller state instead of inferring from title or synthetic keys.
- Mark Memorize and StudyPad fake documents as non-pageable for host document navigation.

## Scope

- Reader horizontal swipe policy and native swipe dispatch.
- Annotation document emission for Memorize and StudyPad.
- BibleUI package tests for policy, Memorize bridge state, and StudyPad bridge state.

## Contract References

- Android parity: `BibleView.isPageNextOkay` and `isPagePreviousOkay` return false for `MemorizeDocument` and `StudyPadDocument`.
- iOS issue: #327.
- Existing rendered-content accessibility token format remains unchanged; this PR adds separate native rendered-document kind state.

## Change Details

- Added `ReaderRenderedDocumentKind` with an `allowsHorizontalDocumentNavigation` gate.
- Stored the rendered document kind on `BibleReaderController` whenever rendered content state updates, defaulting normal content to standard.
- Passed the gate into `ReaderHorizontalSwipePolicy.action` so chapter-mode swipes become no-ops for non-pageable documents.
- Tagged Memorize and StudyPad document emissions as non-pageable when their Vue fake documents are emitted.
- Added regression coverage for the policy and for the real Memorize and StudyPad bridge entry points.

## Validation Evidence

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination 'platform=iOS Simulator,id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F' -derivedDataPath .artifacts/DerivedData-issue327 CODE_SIGNING_ALLOWED=NO`
  - Full `BibleUITests`: 369 tests passed.
- GitNexus `detect_changes` against `main`: medium risk; affected flows are the intended reader destination/content state paths.

## Risks / Follow-ups

- Page-scroll swipe mode still scrolls within the current document; this PR blocks host document navigation, matching the Android page-next/page-previous guard.
- No generated files are included. A local ignored `libsword.xcframework` copy was used only to run tests in the worktree.

## Issue Closure

Closes #327
