### PR TITLE
fix(sync): apply iCloud toggle without restart

### DIFF
--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -133,10 +133,52 @@ private enum PendingRemoteSyncConfirmation: Identifiable, Equatable {
     }
 }
 
+/**
+ Holds the current lifecycle-sync service behind a stable reference for background refresh.
+
+ `BGTaskScheduler` registers its launch handler once, but issue #322 lets the app rebuild the
+ SwiftData stack in-session when iCloud sync is toggled. Keeping this indirection means a later
+ background-refresh launch delegates to the current lifecycle service instead of the instance that
+ existed when the scheduler was first registered.
+ */
+private final class RemoteSyncLifecycleRuntimeReference {
+    /// Current lifecycle service for the active SwiftData container.
+    @MainActor
+    private var service: RemoteSyncLifecycleService?
+
+    /**
+     Replaces the service used by future background-refresh launches.
+     *
+     * - Parameter service: Lifecycle service bound to the current app data stack.
+     * - Side effects: Updates the service reference used by `synchronizeIfNeeded(force:)`.
+     * - Failure modes: none.
+     */
+    @MainActor
+    func update(_ service: RemoteSyncLifecycleService) {
+        self.service = service
+    }
+
+    /**
+     Runs lifecycle synchronization through the current service.
+     *
+     * - Parameter force: Whether throttling should be bypassed.
+     * - Returns: `false` when no service has been installed yet; otherwise the service result.
+     * - Side effects: Delegates to `RemoteSyncLifecycleService`.
+     * - Failure modes: Service failures are handled by the service itself and reported as `false`.
+     */
+    @MainActor
+    func synchronizeIfNeeded(force: Bool) async -> Bool {
+        guard let service else {
+            return false
+        }
+        return await service.synchronizeIfNeeded(force: force)
+    }
+}
+
 @main
 struct AndBibleApp: App {
     /// SwiftData model container for all persisted entities.
-    let modelContainer: ModelContainer
+    @State private var modelContainer: ModelContainer
 
     /// Core services shared across the app.
     @State private var windowManager: WindowManager
@@ -144,6 +186,7 @@ struct AndBibleApp: App {
     @State private var syncService: SyncService
     @State private var searchIndexService = SearchIndexService()
     @State private var remoteSyncLifecycleService: RemoteSyncLifecycleService
+    @State private var contentIdentity = UUID()
     @State private var pendingRemoteAdoption: RemoteSyncBootstrapCandidate?
     @State private var queuedRemoteAdoptions: [RemoteSyncBootstrapCandidate] = []
     @State private var pendingRemoteConfirmation: PendingRemoteSyncConfirmation?
@@ -161,6 +204,7 @@ struct AndBibleApp: App {
     /// Scheduled dismissal for the current external document install-success toast.
     @State private var externalDocumentImportToastWorkItem: DispatchWorkItem?
     private let remoteSyncNetworkMonitor: RemoteSyncNetworkMonitor
+    private let remoteSyncLifecycleRuntimeReference = RemoteSyncLifecycleRuntimeReference()
     #if os(iOS)
     private let remoteSyncBackgroundRefreshCoordinator: RemoteSyncBackgroundRefreshCoordinator
     @UIApplicationDelegateAdaptor(AndBibleApplicationDelegate.self) private var appDelegate
@@ -195,19 +239,9 @@ struct AndBibleApp: App {
         )
     }
 
-    init() {
-        let networkMonitor = RemoteSyncNetworkMonitor()
-        self.remoteSyncNetworkMonitor = networkMonitor
-
-        // Repair any stale migration state before creating the ModelContainer.
-        DataMigration.migrateIfNeeded()
-
-        // Read iCloud sync preference from UserDefaults (before container creation)
-        let requestedICloudEnabled = UserDefaults.standard.bool(forKey: Self.iCloudSyncEnabledKey)
-
-        // -- User data models: keep config name "AndBible" so existing store file is reused.
-        // When iCloud sync is enabled, these models sync via CloudKit. --
-        let cloudModels: [any PersistentModel.Type] = [
+    /// User-data models that live in the CloudKit-capable `AndBible` store.
+    private static var cloudModels: [any PersistentModel.Type] {
+        [
             Workspace.self,
             Window.self,
             PageManager.self,
@@ -228,24 +262,144 @@ struct AndBibleApp: App {
             ReadingPlan.self,
             ReadingPlanDay.self,
         ]
+    }
 
-        // -- Device-local models: never sync, separate store. --
-        let localModels: [any PersistentModel.Type] = [
+    /// Device-local models that are intentionally excluded from CloudKit sync.
+    private static var localModels: [any PersistentModel.Type] {
+        [
             Repository.self,
             Setting.self,
         ]
+    }
 
+    /**
+     Builds the SwiftData model container for the requested iCloud mode.
+
+     This is shared by app startup and live Settings changes so both paths use the same store names,
+     schemas, CloudKit identifier, and startup-recovery behavior.
+
+     - Parameter requestedICloudEnabled: User-requested CloudKit mode.
+     - Returns: Loaded container plus the effective mode after CloudKit recovery, if any.
+     - Side effects:
+       - may clear `icloud_sync_enabled` through `ICloudModelContainerStartupRecovery` if CloudKit
+         startup fails and local fallback succeeds
+     - Failure modes: Re-throws if neither the requested nor fallback container can be created.
+     */
+    private static func loadModelContainer(
+        requestedICloudEnabled: Bool
+    ) throws -> ICloudModelContainerStartupRecovery.Result<ModelContainer> {
+        let cloudModels = Self.cloudModels
+        let localModels = Self.localModels
         let allModels = cloudModels + localModels
         let schema = Schema(allModels)
-
-        // Keep the original config name "AndBible" so SwiftData reuses the existing
-        // "AndBible.store" file. Changing the name would break PersistentIdentifiers.
         let localConfig = ModelConfiguration(
             "LocalStore",
             schema: Schema(localModels),
             isStoredInMemoryOnly: false,
             cloudKitDatabase: .none
         )
+
+        return try ICloudModelContainerStartupRecovery.loadContainer(
+            iCloudEnabled: requestedICloudEnabled,
+            syncEnabledKey: Self.iCloudSyncEnabledKey,
+            loadCloudKitContainer: {
+                let cloudConfig = ModelConfiguration(
+                    "AndBible",
+                    schema: Schema(cloudModels),
+                    isStoredInMemoryOnly: false,
+                    cloudKitDatabase: .private("iCloud.org.andbible.ios")
+                )
+                return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+            },
+            loadLocalContainer: {
+                let cloudConfig = ModelConfiguration(
+                    "AndBible",
+                    schema: Schema(cloudModels),
+                    isStoredInMemoryOnly: false,
+                    cloudKitDatabase: .none
+                )
+                return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
+            }
+        )
+    }
+
+    /**
+     Creates the lifecycle service for the current SwiftData container.
+
+     - Parameters:
+       - container: SwiftData container used for remote-sync model contexts.
+       - windowManager: Window manager that should refresh after workspace sync completes.
+       - networkMonitor: Best-effort network availability source.
+     - Returns: Configured lifecycle service with app-shell callbacks attached.
+     - Side effects: none until the returned service is invoked.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func makeRemoteSyncLifecycleService(
+        modelContainer container: ModelContainer,
+        windowManager: WindowManager,
+        networkMonitor: RemoteSyncNetworkMonitor
+    ) -> RemoteSyncLifecycleService {
+        let remoteSyncLifecycleService = RemoteSyncLifecycleService(
+            modelContainer: container,
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "org.andbible.ios",
+            synchronizationServiceFactory: { remoteSettingsStore in
+                try RemoteSyncSynchronizationServiceFactory(
+                    bundleIdentifier: Bundle.main.bundleIdentifier ?? "org.andbible.ios"
+                )
+                .makeSynchronizationService(using: remoteSettingsStore)
+            },
+            networkAvailableProvider: { [networkMonitor] in
+                networkMonitor.isNetworkAvailable
+            }
+        )
+        remoteSyncLifecycleService.onCategorySynchronized = { report in
+            guard report.category == .workspaces else {
+                return
+            }
+            Self.restoreActiveWorkspace(windowManager: windowManager, modelContainer: container)
+        }
+        return remoteSyncLifecycleService
+    }
+
+    /**
+     Ensures first-launch app data exists for a newly loaded container.
+
+     - Parameters:
+       - container: SwiftData container to prepare.
+       - windowManager: Window manager that receives the active workspace.
+     - Side effects:
+       - creates a default workspace when no workspace exists
+       - seeds Android-compatible default/system labels
+     - Failure modes: Label seeding currently swallows persistence failures through its service.
+     */
+    private static func prepareContainerForUse(
+        _ container: ModelContainer,
+        windowManager: WindowManager
+    ) {
+        let context = ModelContext(container)
+        let workspaceStore = WorkspaceStore(modelContext: context)
+        Self.restoreActiveWorkspace(
+            windowManager: windowManager,
+            modelContainer: container,
+            workspaceStore: workspaceStore,
+            settingsStore: SettingsStore(modelContext: context)
+        )
+
+        let bookmarkStore = BookmarkStore(modelContext: context)
+        let bookmarkService = BookmarkService(store: bookmarkStore)
+        bookmarkService.prepareDefaultLabels()
+        bookmarkService.ensureSystemLabels()
+    }
+
+    init() {
+        let networkMonitor = RemoteSyncNetworkMonitor()
+        self.remoteSyncNetworkMonitor = networkMonitor
+
+        // Repair any stale migration state before creating the ModelContainer.
+        DataMigration.migrateIfNeeded()
+
+        // Read iCloud sync preference from UserDefaults (before container creation)
+        let requestedICloudEnabled = UserDefaults.standard.bool(forKey: Self.iCloudSyncEnabledKey)
 
         // Set up SWORD module directory before creating any SwordManager
         SwordSetup.ensureModulesReady()
@@ -254,27 +408,8 @@ struct AndBibleApp: App {
         let sync = SyncService()
 
         do {
-            let startupResult = try ICloudModelContainerStartupRecovery.loadContainer(
-                iCloudEnabled: requestedICloudEnabled,
-                syncEnabledKey: Self.iCloudSyncEnabledKey,
-                loadCloudKitContainer: {
-                    let cloudConfig = ModelConfiguration(
-                        "AndBible",
-                        schema: Schema(cloudModels),
-                        isStoredInMemoryOnly: false,
-                        cloudKitDatabase: .private("iCloud.org.andbible.ios")
-                    )
-                    return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
-                },
-                loadLocalContainer: {
-                    let cloudConfig = ModelConfiguration(
-                        "AndBible",
-                        schema: Schema(cloudModels),
-                        isStoredInMemoryOnly: false,
-                        cloudKitDatabase: .none
-                    )
-                    return try ModelContainer(for: schema, configurations: [cloudConfig, localConfig])
-                }
+            let startupResult = try Self.loadModelContainer(
+                requestedICloudEnabled: requestedICloudEnabled
             )
             let container = startupResult.container
             sync.setInitialState(enabled: startupResult.effectiveICloudEnabled)
@@ -282,7 +417,7 @@ struct AndBibleApp: App {
             if startupResult.didRecoverFromCloudKitFailure {
                 self._remoteSyncErrorMessage = State(initialValue: Self.iCloudStartupRecoveryMessage)
             }
-            self.modelContainer = container
+            self._modelContainer = State(initialValue: container)
 
             // Initialize services that need ModelContext
             let context = ModelContext(container)
@@ -290,51 +425,25 @@ struct AndBibleApp: App {
             let windowMgr = WindowManager(workspaceStore: workspaceStore)
             self._windowManager = State(initialValue: windowMgr)
 
-            let remoteSyncLifecycleService = RemoteSyncLifecycleService(
+            let remoteSyncLifecycleService = Self.makeRemoteSyncLifecycleService(
                 modelContainer: container,
-                bundleIdentifier: Bundle.main.bundleIdentifier ?? "org.andbible.ios",
-                synchronizationServiceFactory: { remoteSettingsStore in
-                    try RemoteSyncSynchronizationServiceFactory(
-                        bundleIdentifier: Bundle.main.bundleIdentifier ?? "org.andbible.ios"
-                    )
-                    .makeSynchronizationService(using: remoteSettingsStore)
-                },
-                networkAvailableProvider: { [networkMonitor] in
-                    networkMonitor.isNetworkAvailable
-                }
+                windowManager: windowMgr,
+                networkMonitor: networkMonitor
             )
-            remoteSyncLifecycleService.onCategorySynchronized = { report in
-                guard report.category == .workspaces else {
-                    return
-                }
-                Self.restoreActiveWorkspace(windowManager: windowMgr, modelContainer: container)
-            }
             self._remoteSyncLifecycleService = State(initialValue: remoteSyncLifecycleService)
+            self.remoteSyncLifecycleRuntimeReference.update(remoteSyncLifecycleService)
             #if os(iOS)
             let remoteSyncBackgroundRefreshCoordinator = RemoteSyncBackgroundRefreshCoordinator(
                 modelContainer: container,
-                synchronizeIfNeeded: { force in
-                    await remoteSyncLifecycleService.synchronizeIfNeeded(force: force)
+                synchronizeIfNeeded: { [remoteSyncLifecycleRuntimeReference] force in
+                    await remoteSyncLifecycleRuntimeReference.synchronizeIfNeeded(force: force)
                 }
             )
             remoteSyncBackgroundRefreshCoordinator.register()
             self.remoteSyncBackgroundRefreshCoordinator = remoteSyncBackgroundRefreshCoordinator
             #endif
 
-            // Ensure at least one workspace exists
-            Self.restoreActiveWorkspace(
-                windowManager: windowMgr,
-                modelContainer: container,
-                workspaceStore: workspaceStore,
-                settingsStore: SettingsStore(modelContext: context)
-            )
-
-            // Seed default labels on first launch (matches Android)
-            let bookmarkStore = BookmarkStore(modelContext: context)
-            let bookmarkService = BookmarkService(store: bookmarkStore)
-            bookmarkService.prepareDefaultLabels()
-            // Ensure system labels use deterministic UUIDs for CloudKit dedup
-            bookmarkService.ensureSystemLabels()
+            Self.prepareContainerForUse(container, windowManager: windowMgr)
 
             // Start monitoring iCloud account status
             sync.startMonitoring(container: container)
@@ -361,12 +470,14 @@ struct AndBibleApp: App {
                     }
                 } else {
                     ContentView()
+                        .id(contentIdentity)
                         .environment(windowManager)
                         .environment(syncService)
                         .environment(searchIndexService)
                 }
             }
             .task {
+                installICloudModeChangeHandler()
                 configureRemoteSyncLifecycleCallbacks()
                 #if os(iOS)
                 remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
@@ -528,6 +639,72 @@ struct AndBibleApp: App {
             }
         }
         .modelContainer(modelContainer)
+    }
+
+    /**
+     Installs the live iCloud mode-change hook used by Sync Settings.
+
+     `SyncService` is owned by BibleCore and cannot rebuild the app's SwiftData stack directly.
+     The app shell supplies that missing operation here so enabling or disabling iCloud sync can
+     take effect without asking the user to relaunch.
+     *
+     - Side effects: Stores a mode-change callback on the shared `SyncService`.
+     - Failure modes: The callback itself can throw if the requested data stack cannot be loaded.
+     */
+    @MainActor
+    private func installICloudModeChangeHandler() {
+        syncService.setModeChangeHandler { requestedEnabled in
+            try applyICloudRuntimeMode(requestedEnabled)
+        }
+    }
+
+    /**
+     Rebuilds the app runtime for a requested iCloud sync mode.
+
+     - Parameter requestedEnabled: User-requested CloudKit mode from Sync Settings.
+     - Returns: Effective runtime sync mode and the container that should be monitored.
+     - Side effects:
+       - loads a new SwiftData container using the same startup recovery path as app launch
+       - rebuilds `WindowManager` and lifecycle remote-sync services against that container
+       - resets the reader subtree so panes recreate stores/controllers from the new model context
+       - may surface the CloudKit startup recovery message if enabling iCloud falls back to local
+     - Failure modes: Re-throws if the requested/fallback SwiftData container cannot be loaded.
+     */
+    @MainActor
+    private func applyICloudRuntimeMode(_ requestedEnabled: Bool) throws -> SyncModeChangeResult {
+        let startupResult = try Self.loadModelContainer(requestedICloudEnabled: requestedEnabled)
+        let container = startupResult.container
+        let context = ModelContext(container)
+        let workspaceStore = WorkspaceStore(modelContext: context)
+        let windowMgr = WindowManager(workspaceStore: workspaceStore)
+        let lifecycleService = Self.makeRemoteSyncLifecycleService(
+            modelContainer: container,
+            windowManager: windowMgr,
+            networkMonitor: remoteSyncNetworkMonitor
+        )
+        Self.prepareContainerForUse(container, windowManager: windowMgr)
+
+        remoteSyncLifecycleService.stopPeriodicSync()
+        modelContainer = container
+        windowManager = windowMgr
+        remoteSyncLifecycleService = lifecycleService
+        remoteSyncLifecycleRuntimeReference.update(lifecycleService)
+        contentIdentity = UUID()
+        configureRemoteSyncLifecycleCallbacks()
+
+        if startupResult.didRecoverFromCloudKitFailure {
+            remoteSyncErrorMessage = Self.iCloudStartupRecoveryMessage
+        }
+
+        #if os(iOS)
+        remoteSyncBackgroundRefreshCoordinator.updateModelContainer(container)
+        remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
+        #endif
+
+        return SyncModeChangeResult(
+            effectiveEnabled: startupResult.effectiveICloudEnabled,
+            modelContainer: container
+        )
     }
 
     /**

--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -3,6 +3,7 @@
 import SwiftUI
 import SwiftData
 import Darwin
+import Observation
 import BibleCore
 import BibleUI
 import SwordKit
@@ -175,6 +176,91 @@ private final class RemoteSyncLifecycleRuntimeReference {
     }
 }
 
+/**
+ Process-owned presentation state for the app-level Sync Settings route.
+
+ The iCloud toggle can rebuild the SwiftData container while Sync Settings is visible. Keeping the
+ route intent in a stable observable reference, rather than in reader-owned sheet state, lets the
+ window remain open while the data-bound reader subtree refreshes underneath it.
+
+ Side effects:
+ - `present(modelContainer:)` retains the active SwiftData container used by the route's settings
+   store
+ - `dismiss()` releases that captured container after the user explicitly closes Sync Settings
+
+ Failure modes: none; callers choose whether to surface container-loading failures before updating
+ this route state.
+ */
+@MainActor
+@Observable
+private final class SyncSettingsRouteState {
+    /// Shared route state used by every recreated `AndBibleApp` value in the process.
+    static let shared = SyncSettingsRouteState()
+
+    /// Whether Sync Settings should currently be visible above the reader shell.
+    private(set) var isPresented = false
+
+    /// SwiftData container that backs the visible Sync Settings route.
+    private(set) var modelContainer: ModelContainer?
+
+    /**
+     Creates the process-owned route state.
+
+     The initializer is private because the route must survive SwiftUI app-value recreation inside
+     this process. Callers use `shared`.
+     */
+    private init() {}
+
+    /**
+     Opens Sync Settings above the app shell.
+
+     - Parameter modelContainer: Container used by the route's SwiftData environment.
+     - Side effects: Marks the route visible and retains `modelContainer` until dismissal.
+     - Failure modes: none.
+     */
+    func present(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        isPresented = true
+    }
+
+    /**
+     Closes Sync Settings after explicit user dismissal.
+
+     - Side effects: Marks the route hidden and releases the retained settings container.
+     - Failure modes: none.
+     */
+    func dismiss() {
+        isPresented = false
+        modelContainer = nil
+    }
+}
+
+/**
+ Runtime objects prepared for an iCloud sync mode transition.
+
+ Container construction can happen while Sync Settings is open, but rebinding the app shell to the
+ new SwiftData container recreates data-bound reader panes. Holding the prepared runtime lets the
+ app defer that visible shell refresh until the user closes Sync Settings, while `SyncService` can
+ still observe the effective container immediately.
+ */
+@MainActor
+private struct ICloudRuntimeModeChange {
+    /// Effective SwiftData container for the requested iCloud mode.
+    let modelContainer: ModelContainer
+
+    /// Window manager rebuilt against `modelContainer`.
+    let windowManager: WindowManager
+
+    /// Lifecycle sync service rebuilt against `modelContainer`.
+    let remoteSyncLifecycleService: RemoteSyncLifecycleService
+
+    /// Effective iCloud mode after startup recovery and fallback handling.
+    let effectiveICloudEnabled: Bool
+
+    /// Whether CloudKit startup failed and local fallback recovered the app.
+    let didRecoverFromCloudKitFailure: Bool
+}
+
 @main
 struct AndBibleApp: App {
     /// SwiftData model container for all persisted entities.
@@ -187,6 +273,10 @@ struct AndBibleApp: App {
     @State private var searchIndexService = SearchIndexService()
     @State private var remoteSyncLifecycleService: RemoteSyncLifecycleService
     @State private var contentIdentity = UUID()
+    /// App-owned Sync Settings route state that survives live SwiftData runtime replacement.
+    @State private var syncSettingsRouteState = SyncSettingsRouteState.shared
+    /// Prepared iCloud runtime swap waiting for explicit Sync Settings dismissal.
+    @State private var pendingICloudRuntimeModeChange: ICloudRuntimeModeChange?
     @State private var pendingRemoteAdoption: RemoteSyncBootstrapCandidate?
     @State private var queuedRemoteAdoptions: [RemoteSyncBootstrapCandidate] = []
     @State private var pendingRemoteConfirmation: PendingRemoteSyncConfirmation?
@@ -459,23 +549,89 @@ struct AndBibleApp: App {
         }
     }
 
-    var body: some Scene {
-        WindowGroup {
-            Group {
-                if showCalculator && !isUnlocked {
-                    CalculatorView {
-                        withAnimation {
-                            isUnlocked = true
-                        }
-                    }
-                } else {
-                    ContentView()
-                        .id(contentIdentity)
-                        .environment(windowManager)
-                        .environment(syncService)
-                        .environment(searchIndexService)
+    /// Root app content before scene-level lifecycle, alert, and route modifiers are attached.
+    @ViewBuilder
+    private var rootContent: some View {
+        if showCalculator && !isUnlocked {
+            CalculatorView {
+                withAnimation {
+                    isUnlocked = true
                 }
             }
+        } else {
+            ContentView(readerContentIdentity: contentIdentity)
+                .environment(windowManager)
+                .environment(syncService)
+                .environment(searchIndexService)
+                .environment(
+                    \.presentSyncSettings,
+                    SyncSettingsPresentationAction {
+                        syncSettingsRouteState.present(modelContainer: modelContainer)
+                    }
+                )
+        }
+    }
+
+    /// App-owned Sync Settings route content that survives live SwiftData container replacement.
+    private var syncSettingsRouteContent: some View {
+        NavigationStack {
+            SyncSettingsView()
+                .environment(syncService)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(String(localized: "done")) {
+                            dismissSyncSettingsRoute()
+                        }
+                        .accessibilityIdentifier("syncSettingsDoneButton")
+                    }
+                }
+        }
+    }
+
+    /**
+     Dismisses the app-owned Sync Settings route and releases its captured model container.
+
+     - Side effects: Mutates app-level presentation state. Clearing the captured container ensures
+       the next Sync Settings opening uses the app's current SwiftData runtime.
+     - Failure modes: none.
+     */
+    @MainActor
+    private func dismissSyncSettingsRoute() {
+        syncSettingsRouteState.dismiss()
+        activatePendingICloudRuntimeModeChangeIfNeeded()
+    }
+
+    /**
+     Handles scene lifecycle events that affect icons, remote sync, and background refresh.
+
+     - Parameter newPhase: SwiftUI scene phase emitted by the root scene.
+     - Side effects: Starts/stops lifecycle sync, schedules background refresh, and reconciles the
+       alternate app icon when the app becomes active.
+     */
+    private func handleScenePhaseChange(_ newPhase: ScenePhase) {
+        if newPhase == .active {
+            // Reconcile icon state when app becomes active
+            // (setAlternateIconName fails if called before app is fully active)
+            updateAppIcon(discrete: isDiscreteMode)
+            Task {
+                await remoteSyncLifecycleService.sceneDidBecomeActive()
+                #if os(iOS)
+                remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
+                #endif
+            }
+        } else if newPhase == .background {
+            #if os(iOS)
+            remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
+            #endif
+            runRemoteSyncBackgroundPass()
+        } else if newPhase == .inactive {
+            remoteSyncLifecycleService.stopPeriodicSync()
+        }
+    }
+
+    /// Root content with lifecycle and non-alert scene modifiers applied.
+    private var sceneContent: some View {
+        rootContent
             .task {
                 installICloudModeChangeHandler()
                 configureRemoteSyncLifecycleCallbacks()
@@ -484,24 +640,7 @@ struct AndBibleApp: App {
                 #endif
             }
             .onChange(of: scenePhase) { _, newPhase in
-                if newPhase == .active {
-                    // Reconcile icon state when app becomes active
-                    // (setAlternateIconName fails if called before app is fully active)
-                    updateAppIcon(discrete: isDiscreteMode)
-                    Task {
-                        await remoteSyncLifecycleService.sceneDidBecomeActive()
-                        #if os(iOS)
-                        remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
-                        #endif
-                    }
-                } else if newPhase == .background {
-                    #if os(iOS)
-                    remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
-                    #endif
-                    runRemoteSyncBackgroundPass()
-                } else if newPhase == .inactive {
-                    remoteSyncLifecycleService.stopPeriodicSync()
-                }
+                handleScenePhaseChange(newPhase)
             }
             .onChange(of: isDiscreteMode) { _, newValue in
                 updateAppIcon(discrete: newValue)
@@ -516,6 +655,11 @@ struct AndBibleApp: App {
                 handleExternalDocumentURL(url)
             }
             .androidToastFeedback(externalDocumentImportToastMessage, bottomPadding: 96)
+    }
+
+    /// Scene content plus lifecycle remote-sync prompts.
+    private var sceneContentWithRemoteSyncAlerts: some View {
+        sceneContent
             .alert(
                 String(localized: "cloud_sync_title"),
                 isPresented: Binding(
@@ -595,6 +739,11 @@ struct AndBibleApp: App {
             } message: {
                 Text(remoteSyncErrorMessage ?? String(localized: "sync_error"))
             }
+    }
+
+    /// Scene content plus external document import prompts.
+    private var sceneContentWithAlerts: some View {
+        sceneContentWithRemoteSyncAlerts
             .alert(
                 String(localized: "import_from_file", defaultValue: "Import from File"),
                 isPresented: Binding(
@@ -637,8 +786,29 @@ struct AndBibleApp: App {
             } message: {
                 Text(externalDocumentImportMessage ?? "")
             }
+    }
+
+    /// Stable scene presentation host that keeps app-owned routes above data-stack replacement.
+    private var scenePresentationHost: some View {
+        ZStack {
+            sceneContentWithAlerts
+                .modelContainer(modelContainer)
+
+            if syncSettingsRouteState.isPresented {
+                syncSettingsRouteContent
+                    .modelContainer(syncSettingsRouteState.modelContainer ?? modelContainer)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(.systemBackground))
+                    .accessibilityIdentifier("appOwnedSyncSettingsRoute")
+                    .zIndex(1)
+            }
         }
-        .modelContainer(modelContainer)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            scenePresentationHost
+        }
     }
 
     /**
@@ -659,19 +829,18 @@ struct AndBibleApp: App {
     }
 
     /**
-     Rebuilds the app runtime for a requested iCloud sync mode.
+     Builds a complete runtime for a requested iCloud sync mode without rebinding the scene.
 
      - Parameter requestedEnabled: User-requested CloudKit mode from Sync Settings.
-     - Returns: Effective runtime sync mode and the container that should be monitored.
+     - Returns: Prepared runtime objects plus the effective iCloud mode after startup recovery.
      - Side effects:
        - loads a new SwiftData container using the same startup recovery path as app launch
-       - rebuilds `WindowManager` and lifecycle remote-sync services against that container
-       - resets the reader subtree so panes recreate stores/controllers from the new model context
-       - may surface the CloudKit startup recovery message if enabling iCloud falls back to local
+       - seeds required workspace/bookmark data in the prepared container
+       - may clear the persisted iCloud preference through startup recovery when CloudKit fails
      - Failure modes: Re-throws if the requested/fallback SwiftData container cannot be loaded.
      */
     @MainActor
-    private func applyICloudRuntimeMode(_ requestedEnabled: Bool) throws -> SyncModeChangeResult {
+    private func makeICloudRuntimeModeChange(_ requestedEnabled: Bool) throws -> ICloudRuntimeModeChange {
         let startupResult = try Self.loadModelContainer(requestedICloudEnabled: requestedEnabled)
         let container = startupResult.container
         let context = ModelContext(container)
@@ -684,26 +853,88 @@ struct AndBibleApp: App {
         )
         Self.prepareContainerForUse(container, windowManager: windowMgr)
 
+        return ICloudRuntimeModeChange(
+            modelContainer: container,
+            windowManager: windowMgr,
+            remoteSyncLifecycleService: lifecycleService,
+            effectiveICloudEnabled: startupResult.effectiveICloudEnabled,
+            didRecoverFromCloudKitFailure: startupResult.didRecoverFromCloudKitFailure
+        )
+    }
+
+    /**
+     Rebinds the visible app shell to a prepared iCloud runtime.
+
+     - Parameter change: Runtime prepared by `makeICloudRuntimeModeChange(_:)`.
+     - Side effects:
+       - stops sync work tied to the previous runtime
+       - swaps the app's SwiftData container, window manager, lifecycle service, and background
+         refresh coordinator
+       - resets reader panes so they recreate stores/controllers from the new model context
+       - may surface the CloudKit startup recovery message when no Sync Settings route is open
+     - Failure modes: none; container construction already completed before this helper runs.
+     */
+    @MainActor
+    private func activateICloudRuntimeModeChange(_ change: ICloudRuntimeModeChange) {
         remoteSyncLifecycleService.stopPeriodicSync()
-        modelContainer = container
-        windowManager = windowMgr
-        remoteSyncLifecycleService = lifecycleService
-        remoteSyncLifecycleRuntimeReference.update(lifecycleService)
+        modelContainer = change.modelContainer
+        windowManager = change.windowManager
+        remoteSyncLifecycleService = change.remoteSyncLifecycleService
+        remoteSyncLifecycleRuntimeReference.update(change.remoteSyncLifecycleService)
         contentIdentity = UUID()
         configureRemoteSyncLifecycleCallbacks()
 
-        if startupResult.didRecoverFromCloudKitFailure {
+        if change.didRecoverFromCloudKitFailure, !syncSettingsRouteState.isPresented {
             remoteSyncErrorMessage = Self.iCloudStartupRecoveryMessage
         }
 
         #if os(iOS)
-        remoteSyncBackgroundRefreshCoordinator.updateModelContainer(container)
+        remoteSyncBackgroundRefreshCoordinator.updateModelContainer(change.modelContainer)
         remoteSyncBackgroundRefreshCoordinator.scheduleNextRefreshIfNeeded()
         #endif
+    }
 
+    /**
+     Applies any iCloud runtime swap deferred while Sync Settings was visible.
+
+     - Side effects: Mutates app-level runtime state and clears the pending swap after activation.
+     - Failure modes: none; pending changes are already fully constructed.
+     */
+    @MainActor
+    private func activatePendingICloudRuntimeModeChangeIfNeeded() {
+        guard let change = pendingICloudRuntimeModeChange else {
+            return
+        }
+        pendingICloudRuntimeModeChange = nil
+        activateICloudRuntimeModeChange(change)
+    }
+
+    /**
+     Rebuilds the app runtime for a requested iCloud sync mode.
+
+     When Sync Settings is open, the container is loaded immediately and returned to `SyncService`,
+     but the reader/app-shell rebind is deferred until explicit Sync Settings dismissal so the
+     current settings window does not close under the user's finger.
+
+     - Parameter requestedEnabled: User-requested CloudKit mode from Sync Settings.
+     - Returns: Effective runtime sync mode and the container that should be monitored.
+     - Side effects:
+       - loads a new SwiftData container using the same startup recovery path as app launch
+       - either activates the prepared runtime immediately or records it for dismissal-time
+         activation while Sync Settings stays open
+     - Failure modes: Re-throws if the requested/fallback SwiftData container cannot be loaded.
+     */
+    @MainActor
+    private func applyICloudRuntimeMode(_ requestedEnabled: Bool) throws -> SyncModeChangeResult {
+        let change = try makeICloudRuntimeModeChange(requestedEnabled)
+        if syncSettingsRouteState.isPresented {
+            pendingICloudRuntimeModeChange = change
+        } else {
+            activateICloudRuntimeModeChange(change)
+        }
         return SyncModeChangeResult(
-            effectiveEnabled: startupResult.effectiveICloudEnabled,
-            modelContainer: container
+            effectiveEnabled: change.effectiveICloudEnabled,
+            modelContainer: change.modelContainer
         )
     }
 

--- a/AndBible/ContentView.swift
+++ b/AndBible/ContentView.swift
@@ -9,9 +9,23 @@ import BibleUI
  The Android-parity reader drawer is the supported top-level navigation surface.
  */
 struct ContentView: View {
+    /// Identity used to refresh reader panes after the app rebuilds its persistence runtime.
+    let readerContentIdentity: UUID?
+
+    /**
+     Creates the reader-first app shell.
+
+     - Parameter readerContentIdentity: Optional identity propagated to `BibleReaderView` so the
+       pane subtree can recreate controllers after a live data-stack rebuild without tearing down
+       app-owned presentation state such as Settings.
+     */
+    init(readerContentIdentity: UUID? = nil) {
+        self.readerContentIdentity = readerContentIdentity
+    }
+
     var body: some View {
         NavigationStack {
-            BibleReaderView()
+            BibleReaderView(readerContentIdentity: readerContentIdentity)
         }
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
@@ -244,10 +244,15 @@ actor RemoteSyncBackgroundRefreshCompletionState {
    best-effort and must not block the foreground app
  - disabled or incomplete remote-sync configuration cancels pending requests instead of scheduling
  - expired tasks complete with `success = false` and rely on the next schedule attempt
+
+ - Important: The coordinator is main-actor isolated because issue #322 allows its model
+   container to be replaced after startup. All scheduling reads and container rebinding must stay
+   serialized with the app's SwiftData runtime swap.
  */
+@MainActor
 public final class RemoteSyncBackgroundRefreshCoordinator {
     /// Stable app-refresh identifier declared in `Info.plist`.
-    public static let defaultTaskIdentifier = "org.andbible.ios.remote-sync-refresh"
+    public nonisolated static let defaultTaskIdentifier = "org.andbible.ios.remote-sync-refresh"
 
     private var modelContainer: ModelContainer
     private let taskIdentifier: String
@@ -327,7 +332,7 @@ public final class RemoteSyncBackgroundRefreshCoordinator {
                 return
             }
 
-            Task {
+            Task { @MainActor in
                 await self.handle(task: task)
             }
         }
@@ -340,7 +345,7 @@ public final class RemoteSyncBackgroundRefreshCoordinator {
      background-refresh registration itself remains stable, but future scheduling decisions must
      read remote-sync settings from the replacement container instead of the startup container.
      Launched tasks are already routed through the injected `synchronizeIfNeeded` closure.
-     *
+
      - Parameter modelContainer: Replacement container backing current app state.
      - Side effects: Future `scheduleNextRefreshIfNeeded()` calls read settings from this container.
      - Failure modes: none.

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBackgroundRefreshCoordinator.swift
@@ -249,7 +249,7 @@ public final class RemoteSyncBackgroundRefreshCoordinator {
     /// Stable app-refresh identifier declared in `Info.plist`.
     public static let defaultTaskIdentifier = "org.andbible.ios.remote-sync-refresh"
 
-    private let modelContainer: ModelContainer
+    private var modelContainer: ModelContainer
     private let taskIdentifier: String
     private let scheduler: any RemoteSyncBackgroundRefreshScheduling
     private let nowProvider: () -> Date
@@ -331,6 +331,22 @@ public final class RemoteSyncBackgroundRefreshCoordinator {
                 await self.handle(task: task)
             }
         }
+    }
+
+    /**
+     Rebinds scheduling reads to the current app model container.
+
+     Issue #322 allows the app to rebuild its SwiftData stack after a live iCloud sync toggle. The
+     background-refresh registration itself remains stable, but future scheduling decisions must
+     read remote-sync settings from the replacement container instead of the startup container.
+     Launched tasks are already routed through the injected `synchronizeIfNeeded` closure.
+     *
+     - Parameter modelContainer: Replacement container backing current app state.
+     - Side effects: Future `scheduleNextRefreshIfNeeded()` calls read settings from this container.
+     - Failure modes: none.
+     */
+    public func updateModelContainer(_ modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
@@ -28,7 +28,13 @@ public struct SyncModeChangeResult {
     /// Runtime mode that actually became active after the app rebuilt its data stack.
     public let effectiveEnabled: Bool
 
-    /// Container the service should monitor for CloudKit remote-change notifications.
+    /**
+     Container the service should monitor for CloudKit remote-change notifications.
+
+     Return `nil` when `effectiveEnabled` is false, or when a non-app host intentionally accepts
+     state-only behavior. If `effectiveEnabled` is true and this is `nil`, `SyncService` will update
+     visible state but will not restart remote-change monitoring.
+     */
     public let modelContainer: ModelContainer?
 
     /**
@@ -36,7 +42,8 @@ public struct SyncModeChangeResult {
 
      - Parameters:
        - effectiveEnabled: Runtime iCloud mode after the app attempted the change.
-       - modelContainer: Container to monitor when `effectiveEnabled` is true.
+       - modelContainer: Container to monitor when `effectiveEnabled` is true. Passing `nil` leaves
+         remote-change monitoring stopped for this result.
      - Side effects: none.
      - Failure modes: This initializer cannot fail.
      */
@@ -163,9 +170,7 @@ public final class SyncService {
             queue: .main
         ) { [weak self] _ in
             guard let self, !self.requiresRestart else { return }
-            self.lastSyncDate = Date()
-            if case .error = self.state { return }
-            self.state = .idle
+            self.recordRemoteChange()
         }
 
         // Observe iCloud account changes (sign in/out)
@@ -189,6 +194,24 @@ public final class SyncService {
             NotificationCenter.default.removeObserver(obs)
             accountObserver = nil
         }
+    }
+
+    /**
+     Records that the active runtime received a remote-change notification.
+
+     Tests call this directly to validate sync state transitions without constructing a CloudKit
+     container; production reaches the same path from `NSPersistentStoreRemoteChangeNotification`.
+
+     - Parameter date: Timestamp to store as the latest sync event.
+     - Side effects:
+       - updates `lastSyncDate`
+       - returns non-error states to `.idle` after a remote change
+     - Failure modes: none.
+     */
+    func recordRemoteChange(at date: Date = Date()) {
+        lastSyncDate = date
+        if case .error = state { return }
+        state = .idle
     }
 
     // MARK: - Account Status
@@ -234,14 +257,28 @@ public final class SyncService {
         container.fetchUserRecordID { recordID, error in
             guard error == nil, recordID != nil else {
                 DispatchQueue.main.async {
-                    self.accountDescription = String(localized: "icloud_signed_in")
+                    self.recordAccountDescription(String(localized: "icloud_signed_in"))
                 }
                 return
             }
             DispatchQueue.main.async {
-                self.accountDescription = String(localized: "icloud_signed_in")
+                self.recordAccountDescription(String(localized: "icloud_signed_in"))
             }
         }
+    }
+
+    /**
+     Records the user-visible iCloud account description for the active runtime.
+
+     Tests call this directly to validate runtime rollback behavior without depending on CloudKit
+     account APIs. Production reaches the same path after account identity lookup.
+
+     - Parameter description: Display text for the current iCloud account, or `nil` when unavailable.
+     - Side effects: Updates `accountDescription`.
+     - Failure modes: none.
+     */
+    func recordAccountDescription(_ description: String?) {
+        accountDescription = description
     }
 
     // MARK: - Toggle
@@ -281,7 +318,9 @@ public final class SyncService {
             }
         } catch {
             defaults.set(previousMode, forKey: syncEnabledKey)
-            applyRuntimeMode(enabled: previousMode)
+            isEnabled = previousMode
+            activeMode = previousMode
+            requiresRestart = false
             state = .error(error.localizedDescription)
         }
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
@@ -17,6 +17,36 @@ public enum SyncState: Sendable, Equatable {
 }
 
 /**
+ Result produced after a host app applies a requested iCloud sync mode change.
+
+ `SyncService` owns the persisted toggle and public status, but the app shell owns SwiftData
+ container construction. Returning the effective mode keeps CloudKit startup recovery honest: if a
+ requested CloudKit container fails and the app falls back to local storage, the visible toggle
+ returns to disabled instead of requiring a relaunch.
+ */
+public struct SyncModeChangeResult {
+    /// Runtime mode that actually became active after the app rebuilt its data stack.
+    public let effectiveEnabled: Bool
+
+    /// Container the service should monitor for CloudKit remote-change notifications.
+    public let modelContainer: ModelContainer?
+
+    /**
+     Creates one live sync-mode change result.
+
+     - Parameters:
+       - effectiveEnabled: Runtime iCloud mode after the app attempted the change.
+       - modelContainer: Container to monitor when `effectiveEnabled` is true.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(effectiveEnabled: Bool, modelContainer: ModelContainer? = nil) {
+        self.effectiveEnabled = effectiveEnabled
+        self.modelContainer = modelContainer
+    }
+}
+
+/**
  Manages iCloud/CloudKit sync status monitoring.
 
  SwiftData handles actual data sync automatically when configured with
@@ -31,6 +61,9 @@ public enum SyncState: Sendable, Equatable {
  */
 @Observable
 public final class SyncService {
+    /// Host callback that rebuilds SwiftData for a requested iCloud mode.
+    public typealias ModeChangeHandler = @MainActor (_ requestedEnabled: Bool) throws -> SyncModeChangeResult
+
     /// Current sync state.
     public private(set) var state: SyncState = .disabled
 
@@ -39,8 +72,7 @@ public final class SyncService {
 
     /**
      Whether iCloud sync is enabled (persisted in UserDefaults).
-     This reflects the *persisted* preference. The actual CloudKit mode
-     is determined at app startup and cannot change mid-session.
+     This reflects the active runtime mode after any installed mode-change handler completes.
      */
     public private(set) var isEnabled: Bool = false
 
@@ -58,9 +90,27 @@ public final class SyncService {
 
     private var notificationObserver: NSObjectProtocol?
     private var accountObserver: NSObjectProtocol?
+    private let defaults: UserDefaults
+    private let syncEnabledKey: String
+    private var modeChangeHandler: ModeChangeHandler?
 
-    /// Creates an idle sync monitor. Call `setInitialState(enabled:)` during app startup before `startMonitoring(container:)`.
-    public init() {}
+    /**
+     Creates an idle sync monitor. Call `setInitialState(enabled:)` during app startup before
+     `startMonitoring(container:)`.
+
+     - Parameters:
+       - defaults: Preference store that owns the iCloud sync toggle.
+       - syncEnabledKey: Preference key for the iCloud sync toggle.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        defaults: UserDefaults = .standard,
+        syncEnabledKey: String = "icloud_sync_enabled"
+    ) {
+        self.defaults = defaults
+        self.syncEnabledKey = syncEnabledKey
+    }
 
     deinit {
         stopMonitoring()
@@ -73,7 +123,20 @@ public final class SyncService {
     public func setInitialState(enabled: Bool) {
         isEnabled = enabled
         activeMode = enabled
+        requiresRestart = false
         state = enabled ? .idle : .disabled
+    }
+
+    /**
+     Installs the app-shell hook that can rebuild SwiftData for iCloud mode changes.
+
+     Production app startup installs this handler so Settings can apply the toggle immediately.
+     Test hosts and previews may leave it unset; `toggleSync()` then preserves the old explicit
+     restart-required fallback instead of silently pretending a container was rebuilt.
+     */
+    @MainActor
+    public func setModeChangeHandler(_ handler: ModeChangeHandler?) {
+        modeChangeHandler = handler
     }
 
     // MARK: - Monitoring
@@ -181,14 +244,43 @@ public final class SyncService {
     // MARK: - Toggle
 
     /**
-     Toggle sync on/off. Sets `requiresRestart` and moves to `.pendingRestart`
-     state because the ModelContainer must be reconstructed.
+     Toggles iCloud sync.
+
+     When the host app has installed a mode-change handler, this applies the requested mode in the
+     current session by rebuilding the SwiftData stack and restarting monitoring against the new
+     container. Without a handler it preserves the legacy explicit restart-required fallback used
+     by previews and non-app hosts.
      */
+    @MainActor
     public func toggleSync() {
-        isEnabled.toggle()
-        UserDefaults.standard.set(isEnabled, forKey: "icloud_sync_enabled")
-        requiresRestart = true
-        state = .pendingRestart
+        let previousMode = isEnabled
+        let requestedMode = !previousMode
+
+        guard let modeChangeHandler else {
+            isEnabled = requestedMode
+            defaults.set(isEnabled, forKey: syncEnabledKey)
+            requiresRestart = true
+            state = .pendingRestart
+            return
+        }
+
+        defaults.set(requestedMode, forKey: syncEnabledKey)
+        requiresRestart = false
+        state = .syncing
+
+        do {
+            let result = try modeChangeHandler(requestedMode)
+            stopMonitoring()
+            defaults.set(result.effectiveEnabled, forKey: syncEnabledKey)
+            applyRuntimeMode(enabled: result.effectiveEnabled)
+            if result.effectiveEnabled, let modelContainer = result.modelContainer {
+                startMonitoring(container: modelContainer)
+            }
+        } catch {
+            defaults.set(previousMode, forKey: syncEnabledKey)
+            applyRuntimeMode(enabled: previousMode)
+            state = .error(error.localizedDescription)
+        }
     }
 
     /// Reset sync state (for troubleshooting).
@@ -202,5 +294,22 @@ public final class SyncService {
         } else {
             state = .disabled
         }
+    }
+
+    /**
+     Applies an already-rebuilt runtime mode to the service state.
+
+     - Parameter enabled: Effective CloudKit mode after container construction completed.
+     - Side effects: Clears stale account and sync timestamps because they describe the previous
+       container mode.
+     - Failure modes: none.
+     */
+    private func applyRuntimeMode(enabled: Bool) {
+        isEnabled = enabled
+        activeMode = enabled
+        requiresRestart = false
+        accountDescription = nil
+        lastSyncDate = nil
+        state = enabled ? .idle : .disabled
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SyncService.swift
@@ -12,7 +12,7 @@ public enum SyncState: Sendable, Equatable {
     case idle
     case syncing
     case error(String)
-    /// User toggled sync but app hasn't restarted yet to apply the change.
+    /// User toggled sync in a host that cannot rebuild the runtime data stack in-session.
     case pendingRestart
 }
 
@@ -76,15 +76,18 @@ public final class SyncService {
      */
     public private(set) var isEnabled: Bool = false
 
-    /// Whether a restart is required to apply sync changes.
+    /// Whether the current host requires a restart because no live mode-change handler is installed.
     public private(set) var requiresRestart: Bool = false
 
     /// The iCloud account display name, if available.
     public private(set) var accountDescription: String?
 
     /**
-     The sync mode that is actually active for this session
-     (set at startup, does not change until restart).
+     The sync mode that is currently active for this service.
+
+     App startup seeds this value from the loaded SwiftData container. When the production app
+     installs a live mode-change handler, `toggleSync()` updates it after the app shell rebuilds
+     the container; hosts without that handler leave it unchanged and enter `.pendingRestart`.
      */
     private var activeMode: Bool = false
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
@@ -139,12 +139,22 @@ public final class WindowManager {
 
     // MARK: - Workspace Management
 
-    /// Set the active workspace and load its windows.
+    /**
+     Sets the active workspace and loads its windows through this manager's store context.
+
+     - Parameter workspace: Workspace selected by the app, possibly resolved through another
+       `ModelContext`.
+     - Side Effects: Clears registered pane controllers, rebinds the workspace by ID into the
+       manager-owned store when possible, refreshes visible/all window lists, and updates active
+       window fallback.
+     - Failure Modes: If the workspace cannot be resolved through the manager store, the supplied
+       instance is retained and refresh may expose no windows until the store can fetch it.
+     */
     public func setActiveWorkspace(_ workspace: Workspace) {
         // Clear controllers from the previous workspace to prevent stale entries
         controllers.removeAll()
         controllerPendingWindowIds.removeAll()
-        activeWorkspace = workspace
+        activeWorkspace = workspaceStore.workspace(id: workspace.id) ?? workspace
         refreshWindows()
     }
 
@@ -298,8 +308,8 @@ public final class WindowManager {
             workspace.maximizedWindowId = nil
         }
 
-        refreshWindows()
         activeWindow = window
+        refreshWindows()
         return window
     }
 

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncLifecycleTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncLifecycleTests.swift
@@ -1887,6 +1887,57 @@ final class RemoteSyncLifecycleTests: XCTestCase {
         )
     }
 
+    /**
+     Verifies background-refresh scheduling reads from the replacement data stack after a live
+     iCloud mode change.
+
+     Issue #322 rebuilds the SwiftData container in-session. The old container is configured as
+     iCloud-only, which should cancel background refresh, while the replacement container enables
+     NextCloud bookmark sync with a stored interval. A submitted request proves the coordinator
+     no longer reads remote-sync settings from stale startup state.
+     */
+    @MainActor
+    func testRemoteSyncBackgroundRefreshCoordinatorUsesUpdatedContainerForScheduling() throws {
+        let oldContainer = try makeInMemorySettingsContainer()
+        let oldSettingsStore = RemoteSyncSettingsStore(
+            settingsStore: SettingsStore(modelContext: ModelContext(oldContainer)),
+            secretStore: InMemorySecretStore()
+        )
+        oldSettingsStore.selectedBackend = .iCloud
+
+        let replacementContainer = try makeInMemorySettingsContainer()
+        let replacementSettingsStore = RemoteSyncSettingsStore(
+            settingsStore: SettingsStore(modelContext: ModelContext(replacementContainer)),
+            secretStore: InMemorySecretStore()
+        )
+        replacementSettingsStore.selectedBackend = .nextCloud
+        replacementSettingsStore.setSyncEnabled(true, for: .bookmarks)
+        SettingsStore(modelContext: ModelContext(replacementContainer))
+            .setString("gdrive_sync_interval", value: "1800")
+
+        let scheduler = FakeRemoteSyncBackgroundRefreshScheduler()
+        let now = Date(timeIntervalSince1970: 2_000)
+        let coordinator = RemoteSyncBackgroundRefreshCoordinator(
+            modelContainer: oldContainer,
+            scheduler: scheduler,
+            nowProvider: { now },
+            synchronizeIfNeeded: { _ in true }
+        )
+
+        coordinator.updateModelContainer(replacementContainer)
+        coordinator.scheduleNextRefreshIfNeeded()
+
+        XCTAssertEqual(
+            scheduler.submittedRequests,
+            [
+                RemoteSyncBackgroundRefreshRequest(
+                    identifier: RemoteSyncBackgroundRefreshCoordinator.defaultTaskIdentifier,
+                    earliestBeginDate: now.addingTimeInterval(1_800)
+                ),
+            ]
+        )
+    }
+
     @MainActor
     func testRemoteSyncBackgroundRefreshCoordinatorCancelsWhenNoRemoteCategoriesAreEnabled() throws {
         let container = try makeInMemorySettingsContainer()

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
@@ -221,6 +221,106 @@ final class RemoteSyncStateTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: syncEnabledKey))
     }
 
+    /**
+     Verifies iCloud toggle changes can be applied to the live runtime without entering the
+     restart-required state.
+
+     Issue #322 tracks the old behavior where `SyncService` only persisted the requested toggle
+     and pinned the UI to `.pendingRestart`. The app now installs a runtime mode-change applier
+     that rebuilds the SwiftData stack in-session; the service contract is that a successful
+     applier result becomes the active mode immediately and keeps the toggle usable.
+     */
+    @MainActor
+    func testSyncServiceAppliesRuntimeModeChangeWithoutPendingRestart() throws {
+        let defaultsName = "org.andbible.tests.sync-toggle-live.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        let service = SyncService(defaults: defaults, syncEnabledKey: syncEnabledKey)
+        service.setInitialState(enabled: false)
+        var requestedModes: [Bool] = []
+        service.setModeChangeHandler { requestedMode in
+            requestedModes.append(requestedMode)
+            return SyncModeChangeResult(effectiveEnabled: requestedMode)
+        }
+
+        service.toggleSync()
+
+        XCTAssertEqual(requestedModes, [true])
+        XCTAssertTrue(service.isEnabled)
+        XCTAssertFalse(service.requiresRestart)
+        XCTAssertEqual(service.state, .idle)
+        XCTAssertTrue(defaults.bool(forKey: syncEnabledKey))
+    }
+
+    /**
+     Verifies failed live iCloud mode changes do not leave persisted preferences or UI state in an
+     impossible half-applied state.
+
+     The runtime applier is responsible for rebuilding the SwiftData container. When that rebuild
+     throws, the service must restore the previous preference and expose an error instead of
+     requiring a restart or claiming the requested CloudKit mode is active.
+     */
+    @MainActor
+    func testSyncServiceRevertsPreferenceWhenRuntimeModeChangeFails() throws {
+        enum RuntimeModeChangeError: LocalizedError {
+            case rejected
+
+            var errorDescription: String? { "CloudKit runtime rebuild failed" }
+        }
+
+        let defaultsName = "org.andbible.tests.sync-toggle-failure.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        defaults.set(false, forKey: syncEnabledKey)
+        let service = SyncService(defaults: defaults, syncEnabledKey: syncEnabledKey)
+        service.setInitialState(enabled: false)
+        service.setModeChangeHandler { _ in
+            throw RuntimeModeChangeError.rejected
+        }
+
+        service.toggleSync()
+
+        XCTAssertFalse(service.isEnabled)
+        XCTAssertFalse(service.requiresRestart)
+        XCTAssertEqual(service.state, .error("CloudKit runtime rebuild failed"))
+        XCTAssertFalse(defaults.bool(forKey: syncEnabledKey))
+    }
+
+    /**
+     Preserves the restart-required fallback for hosts that do not install a live runtime applier.
+
+     Production app startup should install the handler, but previews or other test hosts may still
+     use `SyncService` directly. Keeping the fallback makes those callers explicit and avoids a
+     silent no-op when no runtime stack can be rebuilt.
+     */
+    @MainActor
+    func testSyncServiceFallsBackToPendingRestartWithoutRuntimeModeHandler() throws {
+        let defaultsName = "org.andbible.tests.sync-toggle-fallback.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        let service = SyncService(defaults: defaults, syncEnabledKey: syncEnabledKey)
+        service.setInitialState(enabled: false)
+
+        service.toggleSync()
+
+        XCTAssertTrue(service.isEnabled)
+        XCTAssertTrue(service.requiresRestart)
+        XCTAssertEqual(service.state, .pendingRestart)
+        XCTAssertTrue(defaults.bool(forKey: syncEnabledKey))
+    }
+
     func testRemoteSyncSettingsStoreDefaultsToICloudWhenBackendMissing() throws {
         let settingsStore = try makeInMemorySettingsStore()
         let secretStore = InMemorySecretStore()

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
@@ -295,6 +295,51 @@ final class RemoteSyncStateTests: XCTestCase {
     }
 
     /**
+     Verifies failed live iCloud mode changes preserve metadata for the still-active runtime.
+
+     The live mode-change handler throws before `SyncService` accepts a replacement SwiftData
+     container. In that path the existing runtime is still current, so rollback should restore the
+     persisted mode and expose an error without clearing timestamps that still describe the active
+     container.
+     */
+    @MainActor
+    func testSyncServicePreservesCurrentRuntimeMetadataWhenModeChangeFails() throws {
+        enum RuntimeModeChangeError: LocalizedError {
+            case rejected
+
+            var errorDescription: String? { "CloudKit runtime rebuild failed" }
+        }
+
+        let defaultsName = "org.andbible.tests.sync-toggle-failure-metadata.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer {
+            defaults.removePersistentDomain(forName: defaultsName)
+        }
+
+        let syncEnabledKey = "icloud_sync_enabled"
+        defaults.set(true, forKey: syncEnabledKey)
+        let service = SyncService(defaults: defaults, syncEnabledKey: syncEnabledKey)
+        service.setInitialState(enabled: true)
+        service.recordAccountDescription("Signed in before failed mode change")
+        let expectedLastSyncDate = Date(timeIntervalSince1970: 1_805_000_000)
+        service.recordRemoteChange(at: expectedLastSyncDate)
+        let lastSyncDateBeforeFailure = try XCTUnwrap(service.lastSyncDate)
+        let accountDescriptionBeforeFailure = try XCTUnwrap(service.accountDescription)
+        service.setModeChangeHandler { _ in
+            throw RuntimeModeChangeError.rejected
+        }
+
+        service.toggleSync()
+
+        XCTAssertTrue(service.isEnabled)
+        XCTAssertFalse(service.requiresRestart)
+        XCTAssertEqual(service.state, .error("CloudKit runtime rebuild failed"))
+        XCTAssertTrue(defaults.bool(forKey: syncEnabledKey))
+        XCTAssertEqual(service.lastSyncDate, lastSyncDateBeforeFailure)
+        XCTAssertEqual(service.accountDescription, accountDescriptionBeforeFailure)
+    }
+
+    /**
      Preserves the restart-required fallback for hosts that do not install a live runtime applier.
 
      Production app startup should install the handler, but previews or other test hosts may still

--- a/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
@@ -320,6 +320,62 @@ final class WorkspaceWindowStoreTests: XCTestCase {
     }
 
     /**
+     Ensures add-window focus never points at a pane missing from the managed window lists.
+
+     The reader footer and semantic state export render from `WindowManager.allWindows`, while pane
+     focus reads `activeWindow`. A failure here means tapping add can produce an active pane that has
+     no corresponding footer tab, which leaves UI automation and users without a stable activation
+     target.
+     */
+    func testWindowManagerAddWindowKeepsActiveWindowInManagedWindowLists() throws {
+        let container = try makeWorkspaceModelContainer()
+        let context = ModelContext(container)
+        let workspaceStore = WorkspaceStore(modelContext: context)
+        let windowManager = WindowManager(workspaceStore: workspaceStore)
+        let workspace = workspaceStore.createWorkspace(name: "Add Window Active List")
+        let firstWindow = try XCTUnwrap(workspaceStore.windows(workspaceId: workspace.id).first)
+        windowManager.setActiveWorkspace(workspace)
+        windowManager.registerController(NSObject(), for: firstWindow.id)
+
+        let secondWindow = try XCTUnwrap(windowManager.addWindow(from: firstWindow))
+
+        XCTAssertEqual(windowManager.activeWindow?.id, secondWindow.id)
+        XCTAssertTrue((workspace.windows ?? []).contains(where: { $0.id == secondWindow.id }))
+        XCTAssertTrue(windowManager.allWindows.contains(where: { $0.id == secondWindow.id }))
+        XCTAssertTrue(windowManager.visibleWindows.contains(where: { $0.id == secondWindow.id }))
+        XCTAssertEqual(windowManager.allWindows.map(\.orderNumber), [0, 1])
+    }
+
+    /**
+     Verifies active workspace selection is rebound into the manager's SwiftData context.
+
+     App startup and fixture setup can resolve `Workspace` objects through a short-lived
+     `ModelContext`, while `WindowManager` owns a long-lived store for later pane mutations.
+     Passing the foreign-context workspace into the manager must not make later add-window actions
+     attach new windows to an object graph the manager cannot save or refresh.
+     */
+    func testWindowManagerRebindsForeignContextWorkspaceBeforeAddingWindow() throws {
+        let container = try makeWorkspaceModelContainer()
+        let seedStore = WorkspaceStore(modelContext: ModelContext(container))
+        let workspace = seedStore.createWorkspace(name: "Foreign Context Workspace")
+        let workspaceID = workspace.id
+
+        let managerStore = WorkspaceStore(modelContext: ModelContext(container))
+        let windowManager = WindowManager(workspaceStore: managerStore)
+        let externalStore = WorkspaceStore(modelContext: ModelContext(container))
+        let externalWorkspace = try XCTUnwrap(externalStore.workspace(id: workspaceID))
+
+        windowManager.setActiveWorkspace(externalWorkspace)
+        let firstWindow = try XCTUnwrap(windowManager.activeWindow)
+        let secondWindow = try XCTUnwrap(windowManager.addWindow(from: firstWindow))
+
+        XCTAssertEqual(windowManager.activeWorkspace?.id, workspaceID)
+        XCTAssertEqual(windowManager.activeWindow?.id, secondWindow.id)
+        XCTAssertEqual(windowManager.allWindows.map(\.orderNumber), [0, 1])
+        XCTAssertTrue(managerStore.windows(workspaceId: workspaceID).contains { $0.id == secondWindow.id })
+    }
+
+    /**
      Ensures new-window creation exits maximized layout before waiting for controller registration.
 
      The setup maximizes the only pane, then adds a sibling pane. The expected result is that the

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -92,6 +92,9 @@ public struct BibleReaderView: View {
     /// Local-only flag recording whether the user entered or skipped first-run document setup.
     private static let firstRunDocumentSetupPromptHandledKey = "startup_document_setup_prompt_handled"
 
+    /// Identity used to recreate data-bound reader panes after the app swaps persistence runtimes.
+    private let readerContentIdentity: UUID?
+
     /// Top-level sheets launched from the reader shell or its global shortcuts.
     enum ReaderSheet: String, Identifiable {
         case history
@@ -230,6 +233,9 @@ public struct BibleReaderView: View {
 
     /// SwiftData context used to persist workspace settings and display-configuration changes.
     @Environment(\.modelContext) private var modelContext
+
+    /// App-owned Sync Settings presenter that can survive runtime data-stack replacement.
+    @Environment(\.presentSyncSettings) private var presentSyncSettings
 
     /// System color scheme used to resolve automatic night-mode behavior.
     @Environment(\.colorScheme) private var colorScheme
@@ -759,7 +765,9 @@ public struct BibleReaderView: View {
      - Note: This initializer performs no work directly. The view resolves its dependencies from
        the SwiftUI environment when rendered.
      */
-    public init() {}
+    public init(readerContentIdentity: UUID? = nil) {
+        self.readerContentIdentity = readerContentIdentity
+    }
 
     /**
      Builds the reader content plus always-on reader overlays.
@@ -935,6 +943,7 @@ public struct BibleReaderView: View {
 
             // Split content — one BibleWindowPane per visible window
             splitContent
+                .id(readerContentIdentity)
 
             // Persistent mini-player when speaking (visible even in fullscreen)
             if speakService.isSpeaking {
@@ -3427,7 +3436,11 @@ public struct BibleReaderView: View {
         case .importExport:
             dismissReaderNavigationDrawerAndPerform { presentReaderModal(.importExport) }
         case .syncSettings:
-            dismissReaderNavigationDrawerAndPerform { presentReaderModal(.syncSettings) }
+            dismissReaderNavigationDrawerAndPerform {
+                if !presentSyncSettings() {
+                    presentReaderModal(.syncSettings)
+                }
+            }
         case .settings:
             dismissReaderNavigationDrawerAndPerform {
                 presentSettings(from: windowManager.activeWindow?.id)

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentationAction.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentationAction.swift
@@ -1,0 +1,52 @@
+// SyncSettingsPresentationAction.swift -- app-owned Sync Settings presentation hook
+
+import SwiftUI
+
+/**
+ Opens the production Sync Settings surface from reader-owned actions.
+
+ The default action is intentionally unhandled so package previews and non-app hosts continue to
+ use the reader-owned fallback presentation. The production app installs a handler above the
+ SwiftData runtime boundary so live iCloud mode changes can prepare or apply the data-stack update
+ without dismissing the open Sync Settings surface.
+ */
+public struct SyncSettingsPresentationAction {
+    /// Optional handler installed by the app shell.
+    private let handler: (() -> Void)?
+
+    /**
+     Creates a Sync Settings presentation action.
+
+     - Parameter handler: Optional app-shell handler that presents Sync Settings.
+     */
+    public init(_ handler: (() -> Void)? = nil) {
+        self.handler = handler
+    }
+
+    /**
+     Runs the app-shell presentation handler when one is installed.
+
+     - Returns: `true` when a handler presented Sync Settings; `false` when callers should fall
+       back to their local presentation.
+     */
+    @discardableResult
+    public func callAsFunction() -> Bool {
+        guard let handler else {
+            return false
+        }
+        handler()
+        return true
+    }
+}
+
+private struct SyncSettingsPresentationActionKey: EnvironmentKey {
+    static let defaultValue = SyncSettingsPresentationAction()
+}
+
+public extension EnvironmentValues {
+    /// App-owned Sync Settings presenter used by reader drawer actions.
+    var presentSyncSettings: SyncSettingsPresentationAction {
+        get { self[SyncSettingsPresentationActionKey.self] }
+        set { self[SyncSettingsPresentationActionKey.self] = newValue }
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -37,9 +37,6 @@ public struct SyncSettingsView: View {
     /// Whether the destructive disable-sync confirmation dialog is presented.
     @State private var showDisableConfirmation = false
 
-    /// Whether the restart-required informational alert is presented.
-    @State private var showRestartAlert = false
-
     /// Currently selected sync backend shown in the backend picker.
     @State private var selectedBackend: RemoteSyncBackend = .iCloud
 
@@ -285,15 +282,9 @@ public struct SyncSettingsView: View {
         ) {
             Button(String(localized: "disable_sync"), role: .destructive) {
                 syncService.toggleSync()
-                showRestartAlert = true
             }
         } message: {
             Text(String(localized: "disable_sync_warning"))
-        }
-        .alert(String(localized: "restart_required"), isPresented: $showRestartAlert) {
-            Button(String(localized: "ok")) {}
-        } message: {
-            Text(String(localized: "restart_to_apply_sync"))
         }
         .alert(
             String(localized: "cloud_sync_title"),
@@ -348,11 +339,13 @@ public struct SyncSettingsView: View {
                 Toggle(isOn: Binding(
                     get: { syncService.isEnabled },
                     set: { newValue in
+                        guard newValue != syncService.isEnabled else {
+                            return
+                        }
                         if !newValue {
                             showDisableConfirmation = true
                         } else {
                             syncService.toggleSync()
-                            showRestartAlert = true
                         }
                     }
                 )) {
@@ -360,10 +353,10 @@ public struct SyncSettingsView: View {
                         SyncSettingsPresentation.backend,
                         title: String(localized: "icloud_sync_enabled"),
                         summary: String(localized: "icloud_sync_description"),
-                        isEnabled: !syncService.requiresRestart
+                        isEnabled: isICloudToggleEnabled
                     )
                 }
-                .disabled(syncService.requiresRestart)
+                .disabled(!isICloudToggleEnabled)
                 .accessibilityIdentifier("syncICloudEnabledToggle")
             } header: {
                 syncSettingsSectionHeader(String(localized: "icloud_sync"))
@@ -416,6 +409,17 @@ public struct SyncSettingsView: View {
                 }
             }
         }
+    }
+
+    /**
+     Returns whether the iCloud toggle should accept another user change.
+
+     Live runtime rebuilds complete synchronously from the settings screen, but the transient
+     `.syncing` state still protects the control from repeated taps while SwiftUI is reconciling
+     the updated data stack.
+     */
+    private var isICloudToggleEnabled: Bool {
+        !syncService.requiresRestart && syncService.state != .syncing
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -24,7 +24,9 @@ import BibleCore
  - editing WebDAV credentials updates local state and can be persisted to SwiftData plus Keychain
  - testing a NextCloud/WebDAV connection builds a transient `WebDAVClient` and performs a network
    request against the configured server
- - toggling iCloud sync calls back into `SyncService` and can persist a restart-required sync mode
+ - toggling iCloud sync calls back into `SyncService`; the production app applies it live, while
+   preview or test hosts without an installed runtime handler can still surface restart-required
+   fallback state
  - disabling iCloud sync first presents a confirmation dialog before mutating the service state
  */
 public struct SyncSettingsView: View {
@@ -786,6 +788,9 @@ public struct SyncSettingsView: View {
         return [
             "backend=\(selectedBackend.rawValue)",
             "enabled=\(enabledToken)",
+            "icloudEnabled=\(syncService.isEnabled)",
+            "restartRequired=\(syncService.requiresRestart)",
+            "icloudState=\(syncStateAccessibilityToken)",
             "visible=\(visibleRemoteCategoryRowsAccessibilityToken)",
             "deferred=\(deferredRemoteCategoryRowsAccessibilityToken)",
             "remoteStatus=\(remoteStatusAccessibilityValue)",
@@ -795,6 +800,33 @@ public struct SyncSettingsView: View {
             "lastConfirmation=\(lastRemoteConfirmationAction ?? "none")",
         ]
         .joined(separator: ";")
+    }
+
+    /**
+     Accessibility-exported token for the CloudKit runtime state shown in the iCloud section.
+
+     UI smoke tests use this token to distinguish the production no-restart path from the fallback
+     `.pendingRestart` state without matching localized status strings or SF Symbol names.
+
+     - Returns: Stable state token for the current `SyncService.state`.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private var syncStateAccessibilityToken: String {
+        switch syncService.state {
+        case .disabled:
+            return "disabled"
+        case .noAccount:
+            return "noAccount"
+        case .idle:
+            return "idle"
+        case .syncing:
+            return "syncing"
+        case .pendingRestart:
+            return "pendingRestart"
+        case .error:
+            return "error"
+        }
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1775,13 +1775,13 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - taps the real add-window control in the reader tab bar
-     *   - waits for the new tab pill to appear, become active, and export the matching
-     *     `readerRenderedContentState` window order before returning
-     *   - retries the add tap once when the expected new tab never materializes
+     *   - waits for the real add-window control to finish any pane-registration disabled state
+     *   - taps the enabled add-window control in the reader tab bar once
+     *   - waits for the expected new tab/window order to appear
+     *   - activates the expected tab through the same tab-tap helper used by multi-window tests
      * - Failure modes:
-     *   - fails if the add control or the expected tab does not appear
-     *   - fails if the new tab appears but never becomes the active rendered window
+     *   - fails if the add control does not appear, never becomes enabled, the expected window
+     *     never materializes, or the expected tab cannot be activated
      */
     func addWindowTab(
         expectingOrder order: Int,
@@ -1791,42 +1791,56 @@ extension AndBibleUITests {
         line: UInt = #line
     ) {
         let identifier = "windowTabButton::\(order)"
-        var sawExpectedTab = false
+        let addButtonIdentifier = "windowTabAddButton"
+        var lastAddButtonValue = "nil"
+        var lastAddButtonEnabled = false
         var lastTabValue = "nil"
         var lastRenderedState = "nil"
 
-        for attempt in 1...2 {
-            tapElementReliably(
-                requireWindowTabBarButton("windowTabAddButton", in: app, timeout: timeout, file: file, line: line),
-                timeout: timeout,
+        _ = requireWindowTabBarButton(addButtonIdentifier, in: app, timeout: timeout, file: file, line: line)
+        let addButtonDeadline = Date().addingTimeInterval(timeout)
+        var tappedAddButton = false
+        repeat {
+            if let addButton = resolvedWindowTabBarButton(addButtonIdentifier, in: app) {
+                lastAddButtonValue = addButton.value.map { "\($0)" } ?? "nil"
+                lastAddButtonEnabled = addButton.isEnabled
+                if addButton.isEnabled && waitForElementToBecomeHittable(addButton, timeout: 0.2) {
+                    addButton.tap()
+                    tappedAddButton = true
+                    break
+                }
+            }
+            lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < addButtonDeadline
+
+        guard tappedAddButton else {
+            XCTFail(
+                "Expected add-window control to become enabled within \(timeout) seconds; last add value was '\(lastAddButtonValue)', enabled=\(lastAddButtonEnabled), and last reader state was '\(lastRenderedState)'.",
                 file: file,
                 line: line
             )
-
-            let deadline = Date().addingTimeInterval(timeout)
-            repeat {
-                if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
-                    sawExpectedTab = true
-                    lastTabValue = tabButton.value.map { "\($0)" } ?? "nil"
-                    lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
-                    if lastTabValue.contains("state=active") && lastRenderedState.contains("windowOrder=\(order)") {
-                        return
-                    }
-                } else {
-                    lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-            } while Date() < deadline
-
-            if sawExpectedTab || attempt == 2 {
-                break
-            }
-
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            return
         }
 
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let tabButton = resolvedWindowTabBarButton(identifier, in: app) {
+                lastTabValue = tabButton.value.map { "\($0)" } ?? "nil"
+                tapWindowTab(order, in: app, timeout: timeout, file: file, line: line)
+                return
+            }
+
+            lastRenderedState = readerRenderedContentStateValue(in: app) ?? "nil"
+            if windowTabOrdersFromReaderState(in: app)?.contains(order) == true {
+                tapWindowTab(order, in: app, timeout: timeout, file: file, line: line)
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
         XCTFail(
-            "Expected added window tab \(order) to become the active rendered window within \(timeout) seconds; last tab value was '\(lastTabValue)' and last reader state was '\(lastRenderedState)'.",
+            "Expected added window tab \(order) to materialize within \(timeout) seconds; last tab value was '\(lastTabValue)' and last reader state was '\(lastRenderedState)'.",
             file: file,
             line: line
         )

--- a/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -15,6 +15,10 @@ extension AndBibleUITests {
 
     /**
      Returns true when one already sampled frame is finite and usable for coordinate taps.
+     *
+     * XCTest can occasionally expose frames whose stored origin and size are finite but whose
+     * derived edges or midpoint overflow. Coordinate helpers synthesize taps from those derived
+     * values, so the guard rejects the entire frame before any caller reaches XCTest's event path.
      */
     func elementFrameIsUsable(_ frame: CGRect) -> Bool {
         return !frame.isNull &&
@@ -22,7 +26,13 @@ extension AndBibleUITests {
             frame.origin.x.isFinite &&
             frame.origin.y.isFinite &&
             frame.width.isFinite &&
-            frame.height.isFinite
+            frame.height.isFinite &&
+            frame.minX.isFinite &&
+            frame.minY.isFinite &&
+            frame.midX.isFinite &&
+            frame.midY.isFinite &&
+            frame.maxX.isFinite &&
+            frame.maxY.isFinite
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -601,11 +601,13 @@ extension AndBibleUITests {
         }
 
         if let controlFrame = snapshotFrame(of: unresolvedElement(controlIdentifier, in: app)) {
+            let offsetX = controlFrame.midX - appSnapshot.frame.minX
+            let offsetY = controlFrame.midY - appSnapshot.frame.minY
+            guard offsetX.isFinite, offsetY.isFinite else {
+                return false
+            }
             app.coordinate(withNormalizedOffset: .zero).withOffset(
-                CGVector(
-                    dx: controlFrame.midX - appSnapshot.frame.minX,
-                    dy: controlFrame.midY - appSnapshot.frame.minY
-                )
+                CGVector(dx: offsetX, dy: offsetY)
             ).tap()
             return true
         }
@@ -618,8 +620,13 @@ extension AndBibleUITests {
             guard tapX.isFinite, tapY.isFinite else {
                 return false
             }
+            let offsetX = tapX - appSnapshot.frame.minX
+            let offsetY = tapY - appSnapshot.frame.minY
+            guard offsetX.isFinite, offsetY.isFinite else {
+                return false
+            }
             app.coordinate(withNormalizedOffset: .zero).withOffset(
-                CGVector(dx: tapX - appSnapshot.frame.minX, dy: tapY - appSnapshot.frame.minY)
+                CGVector(dx: offsetX, dy: offsetY)
             ).tap()
             return true
         }

--- a/Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -1845,6 +1845,83 @@ extension AndBibleUITests {
     }
 
     /**
+     Taps one adopt-versus-create Sync alert choice and waits for the exported Sync state to change.
+     *
+     * - Parameters:
+     *   - title: Visible alert button title to choose.
+     *   - expectedTokens: Sync screen token values expected after the alert action.
+     *   - app: Running application under test.
+     *   - timeout: Maximum time to wait for the action and state transition.
+     *   - file: Source file used for XCTest failure attribution.
+     *   - line: Source line used for XCTest failure attribution.
+     * - Side effects:
+     *   - taps the real native alert button for the visible Sync bootstrap prompt
+     *   - retries only while the same first-prompt button remains visible after XCTest reports a tap
+     * - Failure modes:
+     *   - records an XCTest failure if the alert choice disappears without producing the expected
+     *     state or if the prompt remains visible until timeout
+     */
+    func chooseSyncBootstrapPromptOption(
+        _ title: String,
+        expecting expectedTokens: [String: String],
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastState = resolvedElementSemanticText("syncSettingsState", in: app) ?? "nil"
+
+        func expectedStateIsVisible() -> Bool {
+            guard let state = resolvedElementSemanticText("syncSettingsState", in: app) else {
+                return false
+            }
+            lastState = state
+            return expectedTokens.allSatisfy { syncStateToken(named: $0.key, in: state) == $0.value }
+        }
+
+        XCTAssertTrue(
+            app.alerts.firstMatch.buttons[title].waitForExistence(timeout: min(timeout, 10)),
+            "Expected the adopt-versus-create alert to expose '\(title)'.",
+            file: file,
+            line: line
+        )
+
+        repeat {
+            if expectedStateIsVisible() {
+                return
+            }
+
+            let button = app.alerts.firstMatch.buttons[title].firstMatch
+            if button.exists {
+                tapElementReliably(button, timeout: min(2, max(0.5, deadline.timeIntervalSinceNow)), file: file, line: line)
+            }
+
+            let settleDeadline = Date().addingTimeInterval(min(1.5, max(0.2, deadline.timeIntervalSinceNow)))
+            repeat {
+                if expectedStateIsVisible() {
+                    return
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            } while Date() < settleDeadline
+
+            if !button.exists {
+                break
+            }
+        } while Date() < deadline
+
+        let expectedDescription = expectedTokens
+            .sorted(by: { $0.key < $1.key })
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ";")
+        XCTFail(
+            "Expected alert choice '\(title)' to drive syncSettingsState to '\(expectedDescription)' within \(timeout) seconds. Final state: '\(lastState)'.",
+            file: file,
+            line: line
+        )
+    }
+
+    /**
      Toggles the real justify-text setting and treats the screen-level exported state as the
      authoritative mutation signal.
      *

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -138,14 +138,12 @@ extension AndBibleUITests {
             timeout: 15
         )
 
-        let createFromDeviceButton = app.alerts.firstMatch.buttons["Copy from this device to Cloud"].firstMatch
-        XCTAssertTrue(
-            createFromDeviceButton.waitForExistence(timeout: 10),
-            "Expected the adopt-versus-create alert to expose the create-new choice."
+        chooseSyncBootstrapPromptOption(
+            "Copy from this device to Cloud",
+            expecting: ["pendingConfirmation": "resetCloud:mydocuments"],
+            in: app,
+            timeout: 10
         )
-        tapElementReliably(createFromDeviceButton, timeout: 10)
-
-        waitForSyncState(["pendingConfirmation": "resetCloud:mydocuments"], in: app, timeout: 10)
         tapAlertButton("OK", in: app, timeout: 10)
 
         waitForSyncState(

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -246,17 +246,20 @@ extension AndBibleUITests {
      data stack now." The old path is easy to regress because it is still preserved for previews
      and non-app hosts that do not install a runtime mode-change handler. This smoke test opens the
      real Sync Settings route, taps the iCloud toggle, and asserts the exported state never becomes
-     `restartRequired=true` / `.pendingRestart`. A live runtime rebuild can reset the reader shell
-     and dismiss this route, so the test accepts either an in-place enabled token or a clean return
-     to the reader after the tap. It intentionally does not require a signed-in iCloud account or
-     successful CloudKit adoption; those outcomes are separate service contracts, while this test
-     protects the production wiring to the live applier.
+     `restartRequired=true` / `.pendingRestart`. The live runtime rebuild must keep the settings
+     route open while refreshing data-bound reader panes underneath it. It intentionally does not
+     require a signed-in iCloud account or successful CloudKit adoption; those outcomes are separate
+     service contracts, while this test protects the production wiring to the live applier.
      */
     func testSyncSettingsICloudToggleDoesNotRequireRestart() {
         let app = makeApp()
         app.launch()
 
         _ = openSyncSettingsFromReaderAction(in: app)
+        XCTAssertTrue(
+            app.otherElements["appOwnedSyncSettingsRoute"].waitForExistence(timeout: 2),
+            "The production reader Sync Settings action must use the app-owned route so live runtime rebuilds cannot tear down reader-owned modal state."
+        )
         tapSyncBackend("ICLOUD", in: app)
         waitForSyncState(
             ["backend": "ICLOUD", "restartRequired": "false"],
@@ -266,8 +269,7 @@ extension AndBibleUITests {
 
         let toggle = requireElement("syncICloudEnabledToggle", in: app, timeout: 10)
         let initialState = resolvedElementSemanticText("syncSettingsState", in: app) ?? ""
-        let startedEnabled = syncStateToken(named: "icloudEnabled", in: initialState) == "true"
-        if !startedEnabled {
+        if syncStateToken(named: "icloudEnabled", in: initialState) != "true" {
             tapElementReliably(toggle, timeout: 10)
             RunLoop.current.run(until: Date().addingTimeInterval(1.0))
         }
@@ -285,14 +287,27 @@ extension AndBibleUITests {
                     "pendingRestart",
                     "iCloud toggle must not enter pending-restart fallback. State: '\(state)'."
                 )
-                if startedEnabled || syncStateToken(named: "icloudEnabled", in: state) == "true" {
+                if syncStateToken(named: "icloudState", in: state) != "syncing" {
+                    XCTAssertTrue(
+                        resolvedElement("syncSettingsScreen", in: app) != nil,
+                        "Live iCloud toggle must keep Sync Settings open after applying the runtime mode change. State: '\(state)'."
+                    )
+                    XCTAssertTrue(
+                        app.otherElements["appOwnedSyncSettingsRoute"].exists,
+                        "Live iCloud toggle must remain in the app-owned Sync Settings route after applying the runtime mode change."
+                    )
                     return
                 }
             }
-            if !app.otherElements["syncSettingsScreen"].exists {
-                XCTAssertTrue(
-                    waitForReaderShellReady(in: app, timeout: 1),
-                    "Live iCloud toggle dismissed Sync Settings but did not return to a ready reader shell."
+            if resolvedElement("syncSettingsScreen", in: app) == nil {
+                let lastState = resolvedElementSemanticText("syncSettingsState", in: app) ?? "nil"
+                XCTFail(
+                    """
+                    Live iCloud toggle must keep Sync Settings open while applying the runtime mode change.
+                    Last syncSettingsState: '\(lastState)'.
+                    App state: \(app.state.rawValue).
+                    App debug: \(String(app.debugDescription.prefix(3000)))
+                    """
                 )
                 return
             }
@@ -301,7 +316,7 @@ extension AndBibleUITests {
 
         let finalState = resolvedElementSemanticText("syncSettingsState", in: app) ?? "nil"
         XCTFail(
-            "Expected iCloud toggle to apply without restart-required fallback. Final syncSettingsState: '\(finalState)'."
+            "Expected iCloud toggle to settle without restart-required fallback while keeping Sync Settings open. Final syncSettingsState: '\(finalState)'."
         )
     }
 

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+SettingsAndSync.swift
@@ -241,6 +241,73 @@ extension AndBibleUITests {
     }
 
     /**
+     Verifies the production Sync Settings iCloud toggle uses the live runtime applier instead of
+     the legacy restart-required fallback.
+     *
+     Issue #322 moved iCloud mode changes from "save preference and restart" to "rebuild the app
+     data stack now." The old path is easy to regress because it is still preserved for previews
+     and non-app hosts that do not install a runtime mode-change handler. This smoke test opens the
+     real Sync Settings route, taps the iCloud toggle, and asserts the exported state never becomes
+     `restartRequired=true` / `.pendingRestart`. A live runtime rebuild can reset the reader shell
+     and dismiss this route, so the test accepts either an in-place enabled token or a clean return
+     to the reader after the tap. It intentionally does not require a signed-in iCloud account or
+     successful CloudKit adoption; those outcomes are separate service contracts, while this test
+     protects the production wiring to the live applier.
+     */
+    func testSyncSettingsICloudToggleDoesNotRequireRestart() {
+        let app = makeApp()
+        app.launch()
+
+        _ = openSyncSettingsFromReaderAction(in: app)
+        tapSyncBackend("ICLOUD", in: app)
+        waitForSyncState(
+            ["backend": "ICLOUD", "restartRequired": "false"],
+            in: app,
+            timeout: 10
+        )
+
+        let toggle = requireElement("syncICloudEnabledToggle", in: app, timeout: 10)
+        let initialState = resolvedElementSemanticText("syncSettingsState", in: app) ?? ""
+        let startedEnabled = syncStateToken(named: "icloudEnabled", in: initialState) == "true"
+        if !startedEnabled {
+            tapElementReliably(toggle, timeout: 10)
+            RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        }
+
+        let deadline = Date().addingTimeInterval(30)
+        repeat {
+            if let state = resolvedElementSemanticText("syncSettingsState", in: app) {
+                XCTAssertNotEqual(
+                    syncStateToken(named: "restartRequired", in: state),
+                    "true",
+                    "iCloud toggle must not enter restart-required fallback. State: '\(state)'."
+                )
+                XCTAssertNotEqual(
+                    syncStateToken(named: "icloudState", in: state),
+                    "pendingRestart",
+                    "iCloud toggle must not enter pending-restart fallback. State: '\(state)'."
+                )
+                if startedEnabled || syncStateToken(named: "icloudEnabled", in: state) == "true" {
+                    return
+                }
+            }
+            if !app.otherElements["syncSettingsScreen"].exists {
+                XCTAssertTrue(
+                    waitForReaderShellReady(in: app, timeout: 1),
+                    "Live iCloud toggle dismissed Sync Settings but did not return to a ready reader shell."
+                )
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        } while Date() < deadline
+
+        let finalState = resolvedElementSemanticText("syncSettingsState", in: app) ?? "nil"
+        XCTFail(
+            "Expected iCloud toggle to apply without restart-required fallback. Final syncSettingsState: '\(finalState)'."
+        )
+    }
+
+    /**
      Resolves a Backup & Restore action that may live below the first visible viewport.
      *
      * - Parameters:

--- a/Tests/UI/AndBibleUITests/AndBibleUITests.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests.swift
@@ -110,6 +110,33 @@ final class AndBibleUITests: XCTestCase {
     }
 
     /**
+     Guards shared UI-test coordinate helpers against XCTest frames whose origin and size are finite
+     but whose derived activation point overflows.
+     *
+     * Setup:
+     * - builds a synthetic frame matching the unstable XCTest geometry class observed in CI
+     *
+     * Expected result:
+     * - the frame is rejected before any helper tries to synthesize a tap coordinate from it
+     *
+     * Failure meaning:
+     * - reader chrome and menu helpers can still crash a shard with an infinite tap coordinate
+     *   instead of falling back to another stable surface.
+     *
+     * Side effects: none.
+     */
+    func testElementFrameGuardRejectsOverflowedDerivedCoordinates() {
+        let overflowedMidpointFrame = CGRect(
+            x: CGFloat.greatestFiniteMagnitude,
+            y: 1,
+            width: CGFloat.greatestFiniteMagnitude,
+            height: 44
+        )
+
+        XCTAssertFalse(elementFrameIsUsable(overflowedMidpointFrame))
+    }
+
+    /**
      Protects host-side `xcrun simctl` calls from inheriting simulator/XCTest user-directory values
      or stale command-line-tool selections.
      *

--- a/Tests/UI/Fixtures/ui_test_fixture_manifest.json
+++ b/Tests/UI/Fixtures/ui_test_fixture_manifest.json
@@ -13,6 +13,7 @@
   "AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor": "display-colors-custom",
   "AndBibleUITests/AndBibleUITests/testPaneAllTextOptionsOpensWindowScopeAndWorkspaceParentLink": "baseline",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsCategoryDisableAndBackendSwitchPersistAcrossDirectReopen": "sync-nextcloud-bookmarks-enabled",
+  "AndBibleUITests/AndBibleUITests/testSyncSettingsICloudToggleDoesNotRequireRestart": "sync-nextcloud-bookmarks-enabled",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsMyDocumentsAdoptCreateChoiceSynchronizesFromVisibleWorkflow": "none",
   "AndBibleUITests/AndBibleUITests/testTextEntrySemanticValueCandidatesUnwrapOptionalPlaceholderForms": "none"
 }

--- a/Tests/UI/Fixtures/ui_test_timings.json
+++ b/Tests/UI/Fixtures/ui_test_timings.json
@@ -13,6 +13,7 @@
   "AndBibleUITests/AndBibleUITests/testSettingsBackupRestoreDatabaseWorkflowDestinationAndShareCancel": 133.4,
   "AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions": 127.486,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsCategoryDisableAndBackendSwitchPersistAcrossDirectReopen": 125.0,
+  "AndBibleUITests/AndBibleUITests/testSyncSettingsICloudToggleDoesNotRequireRestart": 125.0,
   "AndBibleUITests/AndBibleUITests/testSyncSettingsMyDocumentsAdoptCreateChoiceSynchronizesFromVisibleWorkflow": 160.0,
   "AndBibleUITests/AndBibleUITests/testTextEntrySemanticValueCandidatesUnwrapOptionalPlaceholderForms": 0.874
 }


### PR DESCRIPTION
## Summary
This PR fixes the iCloud sync toggle flow so enabling or disabling iCloud sync can apply in the current session instead of pinning the user to a restart-required state.

The root issue was architectural: `SyncService` owned the persisted toggle, but only the app shell can rebuild the SwiftData container with or without CloudKit. This change gives the app shell a runtime mode-change hook, rebuilds the app data/runtime services through the same startup path, and keeps the old explicit restart fallback only for non-app hosts that do not install the hook.

## Scope
In scope:
- Apply iCloud sync mode changes without restart when runtime rebuild succeeds.
- Rebuild the SwiftData container, `WindowManager`, remote-sync lifecycle service, and reader subtree after the mode changes.
- Rebind remote-sync background refresh scheduling to the replacement container.
- Roll back the persisted preference and expose an error if the runtime rebuild fails.
- Add focused regression coverage for success, failure, fallback, background-refresh rebinding, and the production Sync Settings route.

Out of scope:
- Changing CloudKit account availability behavior.
- Changing NextCloud/WebDAV remote-sync behavior.
- Reworking SwiftData store schemas or CloudKit container identifiers.
- Adding full manual iCloud account validation in simulator.

## Contract References
- Issue #322
- `commit-standard` PR description contract
- GitNexus impact/change-detection requirements from `AGENTS.md`
- Existing iCloud startup recovery path in `ICloudModelContainerStartupRecovery`

## Change Details
- `SyncService` now supports an app-installed mode-change handler that returns the effective runtime mode after a data-stack rebuild.
- `AndBibleApp` now shares startup container construction with runtime mode switching, rebuilds dependent services, and forces the reader subtree to recreate against the replacement container.
- Background refresh registration remains stable, but scheduling reads are rebound to the current container and launch handling delegates through a stable runtime reference.
- `SyncSettingsView` no longer shows the restart alert for the production app path and disables the iCloud toggle only while a transient mode change is applying or when a fallback host is pending restart.
- `SyncSettingsView` exports stable iCloud enabled, restart-required, and state tokens for UI automation.
- Tests cover live apply without pending restart, rollback on failed rebuild, fallback behavior without a handler, stale-background-refresh-container prevention, and a fixture-backed production-route smoke test for the iCloud toggle.

## Validation Evidence
- `git diff --check`
- `python3 scripts/check_repo_standards.py docblocks --all-files`
- `python3 scripts/check_repo_standards.py source-guards`
- `python3 scripts/test_build_ui_test_shards.py`
- `python3 scripts/test_sync_settings_ui_contract.py`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:BibleCoreTests/RemoteSyncStateTests/testSyncServiceAppliesRuntimeModeChangeWithoutPendingRestart -only-testing:BibleCoreTests/RemoteSyncStateTests/testSyncServiceRevertsPreferenceWhenRuntimeModeChangeFails -only-testing:BibleCoreTests/RemoteSyncStateTests/testSyncServiceFallsBackToPendingRestartWithoutRuntimeModeHandler -only-testing:BibleCoreTests/RemoteSyncLifecycleTests/testRemoteSyncBackgroundRefreshCoordinatorUsesUpdatedContainerForScheduling`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:BibleCoreTests/RemoteSyncLifecycleTests/testRemoteSyncBackgroundRefreshCoordinatorUsesUpdatedContainerForScheduling -only-testing:BibleCoreTests/RemoteSyncLifecycleTests/testRemoteSyncBackgroundRefreshCoordinatorLaunchHandlerRunsThrottledSyncAndCompletesTask -only-testing:BibleCoreTests/RemoteSyncStateTests/testSyncServiceAppliesRuntimeModeChangeWithoutPendingRestart -only-testing:BibleCoreTests/RemoteSyncStateTests/testSyncServiceFallsBackToPendingRestartWithoutRuntimeModeHandler`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:BibleUITests/SettingsIconsTests/testSyncSettingsPresentationUsesAndroidBackedRows`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBibleUnitTests -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -only-testing:AndBibleUITests/AndBibleUITests/testSyncSettingsICloudToggleDoesNotRequireRestart`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project AndBible.xcodeproj -scheme AndBible -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33'`
- `mcp__gitnexus.detect_changes` on the worktree after the follow-up commit: 6 changed files, low risk, no affected execution flows.

## Risks / Follow-ups
- This intentionally touches app runtime wiring because no-restart iCloud changes require replacing the SwiftData container and its dependent services. The focused tests and app build cover the service contract and compile-time wiring; final confidence still benefits from a real signed device or simulator configured for the target iCloud container.
- If SwiftData reports an environment-specific CloudKit container load failure during live toggle, the preference is restored to the previous mode and the user sees an error rather than a half-applied state.

## Screenshots
none

## Closes
Closes #322
