### PR TITLE
fix(reading-plans): align Android plan parity

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/ReadingPlanService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/ReadingPlanService.swift
@@ -23,9 +23,9 @@ public struct ReadingPlanTemplate: Identifiable, Sendable {
 /**
  Provides built-in reading plan templates and plan lifecycle helpers.
 
- The service has two plan sources:
- - Android-parity `.properties` plans loaded from bundled resources
- - a small set of iOS-specific algorithmic plans
+ The built-in catalog mirrors Android's bundled `.properties` reading-plan assets. Custom imports
+ remain transient templates created from user-selected `.properties` content; Android add-on and
+ user-plan discovery is intentionally tracked separately from this bundled catalog.
 
  Day numbering is intentionally 1-based for plan templates and day rows. The persisted
  `ReadingPlan.currentDay` field is still stored separately and currently starts at `0` when a
@@ -34,8 +34,11 @@ public struct ReadingPlanTemplate: Identifiable, Sendable {
 public final class ReadingPlanService {
 
     /**
-     All available built-in plans. Data-driven plans are loaded from bundled .properties files
-     matching the Android AndBible reading plan format.
+     All bundled Android reading-plan templates available to start in-app.
+
+     The list is limited to plan codes backed by bundled `.properties` files so picker, sync,
+     and restore behavior stays aligned with Android's built-in catalog. Missing resource files
+     are skipped rather than represented by empty placeholder templates.
      */
     public static let availablePlans: [ReadingPlanTemplate] = {
         var plans: [ReadingPlanTemplate] = []
@@ -93,10 +96,6 @@ public final class ReadingPlanService {
                 ))
             }
         }
-
-        // iOS-specific algorithmic plans (no Android equivalent)
-        plans.append(ntIn90Days)
-        plans.append(psalmsProverbs)
 
         return plans
     }()
@@ -158,57 +157,6 @@ public final class ReadingPlanService {
         return readings
     }
 
-    // MARK: - Algorithmic Plans (iOS-specific)
-
-    private static let ntIn90Days = ReadingPlanTemplate(
-        code: "nt_90",
-        name: "New Testament in 90 Days",
-        description: "Read through the entire New Testament in 90 days.",
-        totalDays: 90,
-        readingsForDay: { day in
-            // 260 NT chapters / 90 days = ~2.9 chapters/day
-            let chaptersPerDay = 3
-            let ntBooks = ntBookChapters
-            let startChapter = (day - 1) * chaptersPerDay
-            var remaining = startChapter
-            var readings: [String] = []
-
-            for _ in 0..<chaptersPerDay {
-                var accumulated = 0
-                for (book, chapters) in ntBooks {
-                    if remaining < accumulated + chapters {
-                        let ch = remaining - accumulated + 1
-                        readings.append("\(book).\(ch)")
-                        break
-                    }
-                    accumulated += chapters
-                }
-                remaining += 1
-            }
-
-            return readings.isEmpty ? "Matt.1" : readings.joined(separator: ",")
-        }
-    )
-
-    private static let psalmsProverbs = ReadingPlanTemplate(
-        code: "psalms_proverbs",
-        name: "Psalms & Proverbs",
-        description: "Read through Psalms and Proverbs in 60 days.",
-        totalDays: 60,
-        readingsForDay: { day in
-            if day <= 30 {
-                // Psalms: 150 chapters / 30 days = 5 per day
-                let start = (day - 1) * 5 + 1
-                let end = min(start + 4, 150)
-                return "Ps.\(start)-Ps.\(end)"
-            } else {
-                // Proverbs: 31 chapters / 30 days = ~1 per day
-                let ch = (day - 31) % 31 + 1
-                return "Prov.\(ch)"
-            }
-        }
-    )
-
     // MARK: - Custom Plan Import
 
     /**
@@ -244,16 +192,19 @@ public final class ReadingPlanService {
        - template: Template defining day count and daily readings.
        - modelContext: Context used to insert the plan and all child day rows.
      - Returns: The newly created persisted plan.
-     - Note: This pre-generates all `ReadingPlanDay` rows up front with 1-based day numbers.
+     - Note: This pre-generates all `ReadingPlanDay` rows up front with 1-based day numbers and
+       stores the start date at the local day boundary to mirror Android's truncated plan date.
      */
     public static func startPlan(
         template: ReadingPlanTemplate,
         modelContext: ModelContext
     ) -> ReadingPlan {
+        let calendar = Calendar.current
+        let startDate = calendar.startOfDay(for: Date())
         let plan = ReadingPlan(
             planCode: template.code,
             planName: template.name,
-            startDate: Date(),
+            startDate: startDate,
             currentDay: 0,
             totalDays: template.totalDays,
             isActive: true
@@ -275,13 +226,102 @@ public final class ReadingPlanService {
     }
 
     /**
-     Calculates which 1-based day the user should be on based on the plan start date.
+     Rebases a plan so the supplied 1-based day number is treated as today's current day.
+
+     - Parameters:
+       - dayNumber: Desired plan day. Values outside the plan range are clamped to `1...totalDays`.
+       - plan: Persisted plan to mutate.
+       - modelContext: SwiftData context used to save the plan and day-row mutations.
+       - now: Clock value used to derive today's date and completion timestamps.
+     - Side effects: Updates `plan.startDate`, `plan.currentDay`, marks all earlier day rows
+       completed, refreshes the active flag, and saves the context on a best-effort basis.
+     - Note: The selected day and later days are not rewritten, matching Android's current-day
+       action which preserves existing status rows outside the prior-day catch-up range.
+     */
+    public static func setCurrentDay(
+        _ dayNumber: Int,
+        for plan: ReadingPlan,
+        modelContext: ModelContext,
+        now: Date = Date()
+    ) {
+        let upperBound = max(plan.totalDays, 1)
+        let clampedDay = min(max(dayNumber, 1), upperBound)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        plan.startDate = calendar.date(byAdding: .day, value: -(clampedDay - 1), to: today) ?? today
+        plan.currentDay = clampedDay
+
+        for day in plan.days ?? [] where day.dayNumber < clampedDay {
+            day.isCompleted = true
+            if day.completedDate == nil {
+                day.completedDate = now
+            }
+        }
+
+        if plan.days?.allSatisfy(\.isCompleted) == true {
+            plan.isActive = false
+        } else {
+            plan.isActive = true
+        }
+        try? modelContext.save()
+    }
+
+    /**
+     Sets a plan's start date and refreshes the persisted current-day pointer.
+
+     - Parameters:
+       - startDate: New date anchor. The date is normalized to the current calendar's start of day
+         and capped at today to match Android's start-date picker.
+       - plan: Persisted plan to mutate.
+       - modelContext: SwiftData context used to save the plan mutation.
+       - now: Clock value used to cap future dates and calculate the resulting current day.
+     - Side effects: Updates `plan.startDate`, recalculates `plan.currentDay`, and saves the
+       context on a best-effort basis.
+     - Note: Day completion statuses are intentionally left untouched so changing the date does not
+       rewrite user-authored reading progress.
+     */
+    public static func setStartDate(
+        _ startDate: Date,
+        for plan: ReadingPlan,
+        modelContext: ModelContext,
+        now: Date = Date()
+    ) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        let requestedStart = calendar.startOfDay(for: startDate)
+        plan.startDate = min(requestedStart, today)
+        plan.currentDay = expectedDay(for: plan, asOf: now)
+        try? modelContext.save()
+    }
+
+    /**
+     Deletes one persisted reading plan and its cascaded day rows.
+
+     - Parameters:
+       - plan: Persisted plan graph to remove.
+       - modelContext: SwiftData context used to delete and save the graph.
+     - Side effects: Deletes the plan from SwiftData, relies on the model relationship cascade to
+       delete `ReadingPlanDay` rows, and saves the context on a best-effort basis.
+     */
+    public static func resetPlan(
+        _ plan: ReadingPlan,
+        modelContext: ModelContext
+    ) {
+        modelContext.delete(plan)
+        try? modelContext.save()
+    }
+
+    /**
+     Calculates which 1-based day the user should be on based on normalized calendar dates.
      - Parameter plan: Persisted reading plan.
+     - Parameter now: Clock value used when comparing the plan start date to today.
      - Returns: Clamped expected day number in the range `1...plan.totalDays`.
      */
-    public static func expectedDay(for plan: ReadingPlan) -> Int {
+    public static func expectedDay(for plan: ReadingPlan, asOf now: Date = Date()) -> Int {
         let calendar = Calendar.current
-        let days = calendar.dateComponents([.day], from: plan.startDate, to: Date()).day ?? 0
+        let startDate = calendar.startOfDay(for: plan.startDate)
+        let today = calendar.startOfDay(for: now)
+        let days = calendar.dateComponents([.day], from: startDate, to: today).day ?? 0
         return min(max(days + 1, 1), plan.totalDays)
     }
 
@@ -295,15 +335,4 @@ public final class ReadingPlanService {
         return plan.totalDays > 0 ? Double(completedDays) / Double(plan.totalDays) : 0
     }
 
-    // MARK: - Bible Reference Helpers
-
-    private static let ntBookChapters: [(String, Int)] = [
-        ("Matt", 28), ("Mark", 16), ("Luke", 24), ("John", 21),
-        ("Acts", 28), ("Rom", 16), ("1Cor", 16), ("2Cor", 13),
-        ("Gal", 6), ("Eph", 6), ("Phil", 4), ("Col", 4),
-        ("1Thess", 5), ("2Thess", 3), ("1Tim", 6), ("2Tim", 4),
-        ("Titus", 3), ("Phlm", 1), ("Heb", 13), ("Jas", 5),
-        ("1Pet", 5), ("2Pet", 3), ("1John", 5), ("2John", 1),
-        ("3John", 1), ("Jude", 1), ("Rev", 22)
-    ]
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncReadingPlanSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncReadingPlanSnapshotService.swift
@@ -125,6 +125,8 @@ public struct RemoteSyncReadingPlanCurrentSnapshot: Sendable, Equatable {
  - preserved Android `remoteStatusID` values are reused when present
  - locally completed days without preserved Android status JSON are synthesized as fully-read
    `chapterReadArray` payloads using the current reading assignment count
+ - non-date-based days before `currentDay` are not synthesized because Android treats them as
+   historic progress derived from the plan row itself
  - synthesized status identifiers are deterministic so later uploads keep stable row keys even
    before Android-origin status metadata exists
 
@@ -418,6 +420,9 @@ public final class RemoteSyncReadingPlanSnapshotService {
         guard day.isCompleted else {
             return nil
         }
+        guard !Self.isImplicitHistoricStatus(plan: plan, day: day) else {
+            return nil
+        }
 
         let readingCount = Self.expectedReadingCount(for: day.readings)
         let payload = SynthesizedReadingStatusPayload(
@@ -462,6 +467,34 @@ public final class RemoteSyncReadingPlanSnapshotService {
     }
 
     /**
+     Checks whether one completed local day is Android-historic progress represented by `currentDay`.
+
+     - Parameters:
+       - plan: Parent reading plan containing Android's persisted current-day pointer.
+       - day: Local day row being considered for synthesized status upload.
+     - Returns: `true` when Android would derive the day as read without a status row.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func isImplicitHistoricStatus(plan: ReadingPlan, day: ReadingPlanDay) -> Bool {
+        !isDateBasedReadings(day.readings) && day.dayNumber < plan.currentDay
+    }
+
+    /**
+     Detects Android's date-prefixed reading-plan assignment format.
+
+     - Parameter readings: Local reading-assignment string for one plan day.
+     - Returns: `true` for strings beginning with Android's `Mon-1;` date prefix.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func isDateBasedReadings(_ readings: String) -> Bool {
+        let regex = try! NSRegularExpression(pattern: #"^[A-Za-z]{3}-\d{1,2};"#)
+        let range = NSRange(readings.startIndex..<readings.endIndex, in: readings)
+        return regex.firstMatch(in: readings, options: [], range: range) != nil
+    }
+
+    /**
      Counts how many logical readings are present in one local plan-day assignment string.
 
      Android date-based plans prefix the actual comma-delimited reading list with a leading
@@ -473,12 +506,8 @@ public final class RemoteSyncReadingPlanSnapshotService {
      - Failure modes: This helper cannot fail.
      */
     private static func expectedReadingCount(for readings: String) -> Int {
-        let regex = try! NSRegularExpression(pattern: #"^[A-Za-z]{3}-\d{1,2};"#)
-        let range = NSRange(readings.startIndex..<readings.endIndex, in: readings)
-
         let readingsPortion: String
-        if regex.firstMatch(in: readings, options: [], range: range) != nil,
-           let separatorIndex = readings.firstIndex(of: ";") {
+        if isDateBasedReadings(readings), let separatorIndex = readings.firstIndex(of: ";") {
             readingsPortion = String(readings[readings.index(after: separatorIndex)...])
         } else {
             readingsPortion = readings

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncLifecycleTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncLifecycleTests.swift
@@ -1273,9 +1273,9 @@ final class RemoteSyncLifecycleTests: XCTestCase {
         let unwrappedReport = try XCTUnwrap(report)
         XCTAssertEqual(unwrappedReport.patchNumber, 1)
         XCTAssertEqual(unwrappedReport.upsertedPlanCount, 1)
-        XCTAssertEqual(unwrappedReport.upsertedStatusCount, 1)
+        XCTAssertEqual(unwrappedReport.upsertedStatusCount, 0)
         XCTAssertEqual(unwrappedReport.deletedRowCount, 0)
-        XCTAssertEqual(unwrappedReport.logEntryCount, 2)
+        XCTAssertEqual(unwrappedReport.logEntryCount, 1)
         XCTAssertEqual(unwrappedReport.lastUpdated, 2_000)
 
         let events = await adapter.eventsSnapshot()
@@ -1304,10 +1304,9 @@ final class RemoteSyncLifecycleTests: XCTestCase {
         let patchSnapshot = try restoreService.readSnapshot(from: databaseURL)
         XCTAssertEqual(patchSnapshot.plans.count, 1)
         XCTAssertEqual(patchSnapshot.plans[0].currentDay, 2)
-        XCTAssertEqual(patchSnapshot.plans[0].statuses.count, 1)
-        XCTAssertEqual(patchSnapshot.plans[0].statuses[0].dayNumber, 1)
-        XCTAssertEqual(metadataSnapshot.logEntries.map(\.type), [.upsert, .upsert])
-        XCTAssertEqual(Set(metadataSnapshot.logEntries.map(\.tableName)), ["ReadingPlan", "ReadingPlanStatus"])
+        XCTAssertTrue(patchSnapshot.plans[0].statuses.isEmpty)
+        XCTAssertEqual(metadataSnapshot.logEntries.map(\.type), [.upsert])
+        XCTAssertEqual(Set(metadataSnapshot.logEntries.map(\.tableName)), ["ReadingPlan"])
         XCTAssertEqual(Set(metadataSnapshot.logEntries.map(\.sourceDevice)), ["ios-device"])
 
         XCTAssertEqual(
@@ -1322,22 +1321,13 @@ final class RemoteSyncLifecycleTests: XCTestCase {
             ]
         )
         XCTAssertEqual(stateStore.progressState(for: .readingPlans).lastPatchWritten, 2_000)
-        XCTAssertEqual(logEntryStore.entries(for: .readingPlans).count, 2)
+        XCTAssertEqual(logEntryStore.entries(for: .readingPlans).count, 1)
 
-        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
         let currentSnapshot = snapshotService.snapshotCurrentState(
             modelContext: modelContext,
             settingsStore: settingsStore
         )
-        let currentStatusKey = try XCTUnwrap(currentSnapshot.statusRowsByKey.keys.first)
-        XCTAssertEqual(currentSnapshot.statusRowsByKey.count, 1)
-        XCTAssertEqual(
-            fingerprintStore.fingerprint(
-                forLogKey: currentStatusKey,
-                category: .readingPlans
-            ),
-            currentSnapshot.fingerprintsByKey[currentStatusKey]
-        )
+        XCTAssertTrue(currentSnapshot.statusRowsByKey.isEmpty)
 
         let secondReport = try await service.uploadPendingPatch(
             bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/org.andbible.ios-sync-readingplans/ios-device"),

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncReadingPlanTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncReadingPlanTests.swift
@@ -117,38 +117,69 @@ final class RemoteSyncReadingPlanTests: XCTestCase {
         XCTAssertEqual(template.readingsForDay(6), "Rev.21-Rev.22")
     }
 
-    func testReadingPlanAlgorithmicPlanLifecycleRemainsAdditive() throws {
+    /**
+     Protects Android built-in catalog parity for bundled reading plans.
+
+     Android's `ReadingPlanTextFileDao` exposes the bundled `.properties` assets as the default
+     catalog, while add-on and user-file discovery is tracked separately in issue #338. The iOS
+     catalog must therefore contain exactly the same bundled plan codes and must not retain
+     iOS-only algorithmic templates. A failure means the visible picker and remote-sync restore
+     support have drifted from Android's built-in definition set.
+     */
+    func testReadingPlanCatalogMatchesAndroidBundledAssets() throws {
+        let planCodes = ReadingPlanService.availablePlans.map(\.code)
+
+        XCTAssertEqual(
+            Set(planCodes),
+            Set([
+                "y1ot1nt1_OTthenNT",
+                "y1ot1nt1_OTandNT",
+                "y1ot1nt1_chronological",
+                "y1ot1nt2_mcheyne",
+                "y1ot6nt4_profHorner",
+                "y1ntpspr",
+                "y2ot1ntps2",
+            ])
+        )
+        XCTAssertEqual(planCodes.count, 7)
+        XCTAssertFalse(planCodes.contains("nt_90"))
+        XCTAssertFalse(planCodes.contains("psalms_proverbs"))
+    }
+
+    /**
+     Verifies starting an Android-backed built-in template still materializes every day row.
+
+     The setup uses the same bundled plan code Android starts from `ReadingPlanSelectorList`.
+     The expected result proves removing iOS-only templates does not regress persisted lifecycle
+     behavior for the supported Android plan catalog. A failure means catalog parity was achieved
+     by losing the start-plan graph that list, daily-reading, and sync flows depend on.
+     */
+    func testReadingPlanAndroidTemplateLifecycleUsesBundledProperties() throws {
         let androidTemplate = try XCTUnwrap(
             ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
         )
-        let algorithmicTemplate = try XCTUnwrap(
-            ReadingPlanService.availablePlans.first(where: { $0.code == "nt_90" })
-        )
 
         XCTAssertEqual(androidTemplate.readingsForDay(1), "Gen.1-Gen.4")
-        XCTAssertEqual(algorithmicTemplate.name, "New Testament in 90 Days")
-        XCTAssertEqual(algorithmicTemplate.totalDays, 90)
-        XCTAssertEqual(algorithmicTemplate.readingsForDay(1), "Matt.1,Matt.2,Matt.3")
 
         let container = try makeReadingPlanRestoreModelContainer()
         let modelContext = ModelContext(container)
         let plan = ReadingPlanService.startPlan(
-            template: algorithmicTemplate,
+            template: androidTemplate,
             modelContext: modelContext
         )
 
-        XCTAssertEqual(plan.planCode, "nt_90")
-        XCTAssertEqual(plan.planName, "New Testament in 90 Days")
+        XCTAssertEqual(plan.planCode, "y1ot1nt1_OTthenNT")
+        XCTAssertEqual(plan.planName, "1-Year through Bible")
         XCTAssertEqual(plan.currentDay, 0)
-        XCTAssertEqual(plan.totalDays, 90)
+        XCTAssertEqual(plan.totalDays, 365)
         XCTAssertTrue(plan.isActive)
         XCTAssertEqual(ReadingPlanService.expectedDay(for: plan), 1)
 
         let days = (plan.days ?? []).sorted { $0.dayNumber < $1.dayNumber }
-        XCTAssertEqual(days.count, 90)
+        XCTAssertEqual(days.count, 365)
         XCTAssertEqual(Array(days.prefix(3).map(\.dayNumber)), [1, 2, 3])
-        XCTAssertEqual(days.first?.readings, "Matt.1,Matt.2,Matt.3")
-        XCTAssertEqual(days.last?.dayNumber, 90)
+        XCTAssertEqual(days.first?.readings, "Gen.1-Gen.4")
+        XCTAssertEqual(days.last?.dayNumber, 365)
         XCTAssertFalse(days[0].isCompleted)
 
         days[0].isCompleted = true
@@ -156,9 +187,169 @@ final class RemoteSyncReadingPlanTests: XCTestCase {
 
         XCTAssertEqual(
             ReadingPlanService.completionPercentage(for: plan),
-            1.0 / 90.0,
+            1.0 / 365.0,
             accuracy: 0.0001
         )
+    }
+
+    /**
+     Verifies new plans store Android's calendar-day start anchor instead of the current timestamp.
+
+     Android starts a plan with `CommonUtils.truncatedDate`, so day progression advances on the next
+     calendar day rather than 24 hours after the user tapped Start. A failure means a plan started
+     later in the day can remain on day 1 past midnight, creating iOS-only reading-plan drift.
+     */
+    func testReadingPlanStartPlanUsesAndroidTruncatedStartDate() throws {
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+        let calendar = Calendar.current
+
+        XCTAssertEqual(plan.startDate, calendar.startOfDay(for: plan.startDate))
+    }
+
+    /**
+     Verifies expected-day calculation advances at the next calendar day boundary.
+
+     Existing local plans can already have timestamped start dates from the older iOS-only behavior.
+     Matching Android requires deriving elapsed days from normalized calendar dates, not from the
+     exact elapsed seconds between two timestamps.
+     */
+    func testReadingPlanExpectedDayUsesCalendarDayBoundary() throws {
+        let calendar = Calendar.current
+        let startDate = try XCTUnwrap(
+            calendar.date(from: DateComponents(year: 2026, month: 2, day: 3, hour: 22, minute: 15))
+        )
+        let nextMorning = try XCTUnwrap(
+            calendar.date(from: DateComponents(year: 2026, month: 2, day: 4, hour: 0, minute: 30))
+        )
+        let plan = ReadingPlan(
+            planCode: "y1ot1nt1_OTthenNT",
+            planName: "1-Year through Bible",
+            startDate: startDate,
+            currentDay: 1,
+            totalDays: 365,
+            isActive: true
+        )
+
+        XCTAssertEqual(ReadingPlanService.expectedDay(for: plan, asOf: nextMorning), 2)
+    }
+
+    /**
+     Verifies Android's current-day action can rebase a plan and mark previous days complete.
+
+     Android's `DailyReading.setCurrentDay` makes the selected day today's plan day and marks prior
+     days read. This test fixes the clock so the start-date mutation is deterministic, then checks
+     that earlier rows are complete while the selected and future days remain open. A failure means
+     iOS exposes the daily-reading control without preserving Android's persisted status contract.
+     */
+    func testReadingPlanSetCurrentDayMirrorsAndroidStatusAndStartDateMutation() throws {
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        let expectedStart = try XCTUnwrap(calendar.date(byAdding: .day, value: -4, to: today))
+
+        ReadingPlanService.setCurrentDay(5, for: plan, modelContext: modelContext, now: now)
+
+        XCTAssertEqual(plan.currentDay, 5)
+        XCTAssertEqual(plan.startDate, expectedStart)
+        let days = (plan.days ?? []).sorted { $0.dayNumber < $1.dayNumber }
+        XCTAssertTrue(days[0].isCompleted)
+        XCTAssertTrue(days[3].isCompleted)
+        XCTAssertNotNil(days[0].completedDate)
+        XCTAssertFalse(days[4].isCompleted)
+        XCTAssertNil(days[4].completedDate)
+        XCTAssertFalse(days[5].isCompleted)
+    }
+
+    /**
+     Verifies Android's start-date action updates the persisted plan anchor without rewriting statuses.
+
+     Android lets the user choose a new plan start date from Daily Reading while preserving existing
+     read/unread day statuses. The setup marks one row complete before rebasing the date; the expected
+     result proves the start anchor and current-day pointer update while completion state remains
+     user-authored. A failure means iOS start-date parity is corrupting progress history.
+     */
+    func testReadingPlanSetStartDateRebasesCurrentDayWithoutChangingStatuses() throws {
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        let newStartDate = try XCTUnwrap(calendar.date(byAdding: .day, value: -2, to: today))
+        let days = (plan.days ?? []).sorted { $0.dayNumber < $1.dayNumber }
+        days[0].isCompleted = true
+        days[0].completedDate = today
+        try modelContext.save()
+
+        ReadingPlanService.setStartDate(newStartDate, for: plan, modelContext: modelContext, now: now)
+
+        XCTAssertEqual(plan.startDate, newStartDate)
+        XCTAssertEqual(plan.currentDay, 3)
+        XCTAssertTrue(days[0].isCompleted)
+        XCTAssertFalse(days[1].isCompleted)
+        XCTAssertFalse(days[2].isCompleted)
+    }
+
+    /**
+     Verifies Android's start-date maximum date is enforced below the UI layer.
+
+     Android's date picker rejects future start dates by setting `maxDate` to today. The iOS service
+     helper also clamps future inputs so backup, tests, or future non-picker call sites cannot create
+     a current-plan state Android would not allow. A failure means the SwiftUI picker may look correct
+     while programmatic plan mutation still preserves an iOS-only future-date behavior.
+     */
+    func testReadingPlanSetStartDateCapsFutureDateAtToday() throws {
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        let futureStartDate = try XCTUnwrap(calendar.date(byAdding: .day, value: 3, to: today))
+
+        ReadingPlanService.setStartDate(futureStartDate, for: plan, modelContext: modelContext, now: now)
+
+        XCTAssertEqual(plan.startDate, today)
+        XCTAssertEqual(plan.currentDay, 1)
+    }
+
+    /**
+     Verifies reset deletes the selected reading plan graph, matching Android's current-plan reset.
+
+     Android clears the current plan's stored plan info and day statuses. In iOS the equivalent
+     persisted unit is the `ReadingPlan` plus cascaded `ReadingPlanDay` rows, so the service should
+     delete the graph and save. A failure means Daily Reading can appear reset while stale plan/day
+     rows remain available to list, sync, or restore flows.
+     */
+    func testReadingPlanResetDeletesPlanGraph() throws {
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+
+        ReadingPlanService.resetPlan(plan, modelContext: modelContext)
+
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<ReadingPlan>()).isEmpty)
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<ReadingPlanDay>()).isEmpty)
     }
 
     func testRemoteSyncReadingPlanRestoreReadsAndroidSnapshot() throws {
@@ -257,6 +448,36 @@ final class RemoteSyncReadingPlanTests: XCTestCase {
             statusStore.status(planCode: "y1ot1nt1_OTthenNT", dayNumber: 3),
             #"{"chapterReadArray":[{"readingNumber":1,"isRead":false}]}"#
         )
+    }
+
+    /**
+     Verifies Android-historic reading-plan days remain implicit when uploading local snapshots.
+
+     For non-date-based plans, Android derives completed days before `currentDay` from the plan row
+     itself and does not need `ReadingPlanStatus` rows for those historic days. iOS still marks those
+     local rows complete for UI progress, but snapshot upload must not turn that local projection into
+     extra Android status rows.
+     */
+    func testReadingPlanSnapshotDoesNotSynthesizeHistoricNonDateStatuses() throws {
+        let container = try makeReadingPlanRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let template = try XCTUnwrap(
+            ReadingPlanService.availablePlans.first(where: { $0.code == "y1ot1nt1_OTthenNT" })
+        )
+        let plan = ReadingPlanService.startPlan(template: template, modelContext: modelContext)
+        plan.currentDay = 3
+        let days = (plan.days ?? []).sorted { $0.dayNumber < $1.dayNumber }
+        days[0].isCompleted = true
+        days[1].isCompleted = true
+        try modelContext.save()
+
+        let snapshot = RemoteSyncReadingPlanSnapshotService().snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertTrue(snapshot.statusRowsByKey.isEmpty)
     }
 
     func testRemoteSyncReadingPlanRestoreRejectsUnknownPlanDefinitionsWithoutMutation() throws {
@@ -898,8 +1119,7 @@ final class RemoteSyncReadingPlanTests: XCTestCase {
         XCTAssertEqual(snapshot.plans.count, 1)
         XCTAssertEqual(snapshot.plans[0].planCode, "y1ot1nt1_OTthenNT")
         XCTAssertEqual(snapshot.plans[0].currentDay, 2)
-        XCTAssertEqual(snapshot.plans[0].statuses.count, 1)
-        XCTAssertEqual(snapshot.plans[0].statuses[0].dayNumber, 1)
+        XCTAssertTrue(snapshot.plans[0].statuses.isEmpty)
     }
 
 }

--- a/Sources/BibleUI/Sources/BibleUI/ReadingPlans/DailyReadingView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/ReadingPlans/DailyReadingView.swift
@@ -17,6 +17,7 @@ import BibleCore
  Side effects:
  - `onAppear` loads the plan and derives the initial selected day index
  - marking or unmarking a day mutates SwiftData and may advance the selected day or reactivate the plan
+ - toolbar actions can rebase the start date, set the selected day as current, or reset the plan
  - plan completion status is recalculated after each completion change
  */
 public struct DailyReadingView: View {
@@ -26,6 +27,9 @@ public struct DailyReadingView: View {
     /// SwiftData context used to load and persist plan progress.
     @Environment(\.modelContext) private var modelContext
 
+    /// Dismiss action used after resetting the current plan graph.
+    @Environment(\.dismiss) private var dismiss
+
     /// Loaded reading plan, or `nil` while the view is still hydrating.
     @State private var plan: ReadingPlan?
 
@@ -34,6 +38,15 @@ public struct DailyReadingView: View {
 
     /// Reading plan days sorted by ascending day number.
     @State private var sortedDays: [ReadingPlanDay] = []
+
+    /// Whether the start-date picker sheet is currently presented.
+    @State private var showStartDatePicker = false
+
+    /// Draft start date edited in the start-date picker before it is saved.
+    @State private var draftStartDate = Date()
+
+    /// Whether the destructive reset confirmation is currently presented.
+    @State private var showResetConfirmation = false
 
     /**
      Creates the daily reading screen for one persisted plan.
@@ -83,9 +96,108 @@ public struct DailyReadingView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                dailyReadingActionsMenu
+            }
+        }
+        .sheet(isPresented: $showStartDatePicker) {
+            startDatePickerSheet
+        }
+        .confirmationDialog(
+            String(localized: "reading_plan_reset_title", defaultValue: "Reset Reading Plan?"),
+            isPresented: $showResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "reset", defaultValue: "Reset"), role: .destructive) {
+                resetCurrentPlan()
+            }
+            Button(String(localized: "cancel"), role: .cancel) {}
+        } message: {
+            Text(String(
+                localized: "reading_plan_reset_message",
+                defaultValue: "This removes the plan and its reading progress."
+            ))
+        }
         .onAppear {
             loadPlan()
         }
+    }
+
+    /// Android-parity current-plan actions exposed from the daily-reading toolbar.
+    private var dailyReadingActionsMenu: some View {
+        Menu {
+            Button {
+                setSelectedDayAsCurrent()
+            } label: {
+                SwiftUI.Label(
+                    String(localized: "reading_plan_set_current_day", defaultValue: "Set Current Day"),
+                    systemImage: "calendar.badge.clock"
+                )
+            }
+            .disabled(plan == nil || currentDay == nil)
+            .accessibilityIdentifier("dailyReadingSetCurrentDayButton")
+
+            Button {
+                presentStartDatePicker()
+            } label: {
+                SwiftUI.Label(
+                    String(localized: "reading_plan_set_start_date", defaultValue: "Set Start Date"),
+                    systemImage: "calendar"
+                )
+            }
+            .disabled(plan == nil)
+            .accessibilityIdentifier("dailyReadingSetStartDateButton")
+
+            Button(role: .destructive) {
+                showResetConfirmation = true
+            } label: {
+                SwiftUI.Label(
+                    String(localized: "reading_plan_reset", defaultValue: "Reset"),
+                    systemImage: "arrow.counterclockwise"
+                )
+            }
+            .disabled(plan == nil)
+            .accessibilityIdentifier("dailyReadingResetPlanButton")
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .accessibilityIdentifier("dailyReadingActionsMenuButton")
+    }
+
+    /// Modal date picker for Android's set-start-date action.
+    private var startDatePickerSheet: some View {
+        NavigationStack {
+            Form {
+                DatePicker(
+                    String(localized: "reading_plan_start_date", defaultValue: "Start Date"),
+                    selection: $draftStartDate,
+                    in: ...Date(),
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.graphical)
+                .accessibilityIdentifier("dailyReadingStartDatePicker")
+            }
+            .navigationTitle(String(localized: "reading_plan_set_start_date", defaultValue: "Set Start Date"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "cancel")) {
+                        showStartDatePicker = false
+                    }
+                    .accessibilityIdentifier("dailyReadingStartDateCancelButton")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(String(localized: "done")) {
+                        applyDraftStartDate()
+                    }
+                    .accessibilityIdentifier("dailyReadingStartDateDoneButton")
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
     }
 
     /**
@@ -287,6 +399,71 @@ public struct DailyReadingView: View {
             let expected = ReadingPlanService.expectedDay(for: plan) - 1
             currentDayIndex = min(max(expected, 0), max(sortedDays.count - 1, 0))
         }
+    }
+
+    /**
+     Applies Android's "set current day" action to the currently selected day.
+
+     Side effects:
+     - mutates the loaded plan through `ReadingPlanService`
+     - reloads local view state from SwiftData after saving
+     */
+    private func setSelectedDayAsCurrent() {
+        guard let plan, let currentDay else { return }
+        ReadingPlanService.setCurrentDay(
+            currentDay.dayNumber,
+            for: plan,
+            modelContext: modelContext
+        )
+        loadPlan()
+    }
+
+    /**
+     Opens the start-date picker initialized with the loaded plan's current start date.
+
+     Side effects:
+     - mutates `draftStartDate`
+     - presents the start-date sheet
+     */
+    private func presentStartDatePicker() {
+        guard let plan else { return }
+        draftStartDate = plan.startDate
+        showStartDatePicker = true
+    }
+
+    /**
+     Persists the draft start date and reloads daily-reading state.
+
+     Side effects:
+     - updates the loaded plan through `ReadingPlanService`
+     - dismisses the picker sheet
+     - reloads local view state from SwiftData after saving
+     */
+    private func applyDraftStartDate() {
+        guard let plan else { return }
+        ReadingPlanService.setStartDate(
+            draftStartDate,
+            for: plan,
+            modelContext: modelContext
+        )
+        showStartDatePicker = false
+        loadPlan()
+    }
+
+    /**
+     Deletes the current plan graph and returns to the reading-plan list.
+
+     Side effects:
+     - deletes the loaded plan through `ReadingPlanService`
+     - clears local view state
+     - dismisses the navigation destination after saving
+     */
+    private func resetCurrentPlan() {
+        guard let plan else { return }
+        ReadingPlanService.resetPlan(plan, modelContext: modelContext)
+        self.plan = nil
+        sortedDays = []
+        dismiss()
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/ReadingPlans/ReadingPlanListView.swift
@@ -21,6 +21,20 @@ import UniformTypeIdentifiers
  - presenting the available-plan sheet can also import a custom plan file
  */
 public struct ReadingPlanListView: View {
+    /// Destinations owned by the reading-plan list while it remains inside the reader stack.
+    private enum ReadingPlanListRoute: Identifiable, Hashable {
+        /// Daily-reading view for a plan that was just started from the selector.
+        case dailyReading(UUID)
+
+        /// Stable route identity used by SwiftUI's item-based navigation destination.
+        var id: String {
+            switch self {
+            case .dailyReading(let planID):
+                return "dailyReading::\(planID.uuidString)"
+            }
+        }
+    }
+
     /// SwiftData context used to create and delete plans.
     @Environment(\.modelContext) private var modelContext
 
@@ -29,6 +43,12 @@ public struct ReadingPlanListView: View {
 
     /// Whether the available-plan picker sheet is presented.
     @State private var showAvailablePlans = false
+
+    /// Route pushed after a new plan is created from the available-plan selector.
+    @State private var activeReadingPlanRoute: ReadingPlanListRoute?
+
+    /// New plan identifier waiting for the selector sheet to dismiss before navigation.
+    @State private var pendingStartedPlanID: UUID?
 
     /**
      Creates the reading-plan list screen.
@@ -53,11 +73,7 @@ public struct ReadingPlanListView: View {
     public var body: some View {
         Group {
             if plans.isEmpty {
-                ContentUnavailableView(
-                    String(localized: "reading_plan_no_plans"),
-                    systemImage: "calendar",
-                    description: Text(String(localized: "reading_plan_no_plans_description"))
-                )
+                emptyState
                 .accessibilityIdentifier("readingPlanListScreen")
                 .accessibilityValue(readingPlanListAccessibilityValue)
             } else {
@@ -76,22 +92,77 @@ public struct ReadingPlanListView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button(String(localized: "reading_plan_start"), systemImage: "plus") {
-                    showAvailablePlans = true
+                    presentAvailablePlans()
                 }
                 .accessibilityIdentifier("readingPlanStartButton")
             }
         }
+        .navigationDestination(item: $activeReadingPlanRoute) { route in
+            readingPlanListDestination(route)
+        }
         .sheet(isPresented: $showAvailablePlans) {
             NavigationStack {
                 AvailablePlansView { template in
-                    let _ = ReadingPlanService.startPlan(
+                    let plan = ReadingPlanService.startPlan(
                         template: template,
                         modelContext: modelContext
                     )
+                    pendingStartedPlanID = plan.id
                     showAvailablePlans = false
                 }
             }
             .presentationDetents([.large])
+        }
+        .onChange(of: showAvailablePlans) { _, isPresented in
+            guard !isPresented else { return }
+            navigateToPendingStartedPlan()
+        }
+    }
+
+    /// Empty reading-plan state with the same start affordance Android exposes from the selector path.
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            ContentUnavailableView(
+                String(localized: "reading_plan_no_plans"),
+                systemImage: "calendar",
+                description: Text(String(localized: "reading_plan_no_plans_description"))
+            )
+
+            Button {
+                presentAvailablePlans()
+            } label: {
+                SwiftUI.Label(String(localized: "reading_plan_start"), systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("readingPlanStartButton")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Opens the available-plan selector through one shared state mutation path.
+    private func presentAvailablePlans() {
+        showAvailablePlans = true
+    }
+
+    /**
+     Pushes the just-created plan into Daily Reading after the selector sheet has dismissed.
+
+     Side effects:
+     - clears `pendingStartedPlanID`
+     - sets `activeReadingPlanRoute`, which drives SwiftUI navigation in the parent stack
+     */
+    private func navigateToPendingStartedPlan() {
+        guard let pendingStartedPlanID else { return }
+        self.pendingStartedPlanID = nil
+        activeReadingPlanRoute = .dailyReading(pendingStartedPlanID)
+    }
+
+    /// Builds reading-plan list destinations without adding another modal presentation layer.
+    @ViewBuilder
+    private func readingPlanListDestination(_ route: ReadingPlanListRoute) -> some View {
+        switch route {
+        case .dailyReading(let planID):
+            DailyReadingView(planId: planID)
         }
     }
 

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
@@ -9,19 +9,21 @@ extension AndBibleUITests {
     /**
      Verifies the drawer Reading Plan route can start, advance, delete, and import plans.
      *
-     * Android opens reading plans through app-owned activities, not a platform sheet. Package tests
-     * own algorithmic plan generation, imported-plan parsing, and persistence contracts; this smoke
-     * keeps one visible route through the production reader menu and user controls.
+     * Android opens the selector through `DailyReading`, returns the chosen plan code, and then
+     * immediately shows that plan's daily reading. Package tests own bundled catalog parity, custom
+     * parsing, and persistence details; this smoke keeps one visible route through the production
+     * reader menu and user controls.
      *
      * - Side effects:
      *   - launches the reader shell with empty reading-plan state
      *   - opens Reading Plans from the drawer and verifies Android-style destination chrome
-     *   - starts the first Android-parity built-in template and marks the first day read
+     *   - starts the first Android-parity built-in template and lands on Daily Reading directly
      *   - returns to the plan list, deletes the active plan, then opens the import picker path
      * - Failure modes:
      *   - fails if Reading Plans regresses to sheet presentation
      *   - fails if the list state does not publish the expected active-plan counts
-     *   - fails if the built-in template cannot be started from the picker
+     *   - fails if the built-in catalog diverges from Android's bundled templates
+     *   - fails if the built-in template does not navigate from picker selection to Daily Reading
      *   - fails if the daily reading route cannot advance through the visible controls
      *   - fails if the row-level delete action is missing or does not remove the active plan
      *   - fails if the custom import affordance does not request file-picker presentation
@@ -42,13 +44,14 @@ extension AndBibleUITests {
         waitForReadingPlanListState(containing: "active=0", in: app, timeout: 10)
 
         openAvailableReadingPlans(in: app, timeout: 10)
+        waitForAvailablePlansState(containing: "templates=7", in: app, timeout: 10)
         waitForAvailablePlansState(containing: builtInPlanToken, in: app, timeout: 10)
 
         tapElementReliably(requireElement("readingPlanTemplateButton", in: app, timeout: 15), timeout: 10)
-        waitForReadingPlanListState(containing: "active=1", in: app, timeout: 15)
-        waitForReadingPlanListState(containing: builtInPlanToken, in: app, timeout: 10)
-
-        tapElementReliably(requireElement("readingPlanActivePlanLink", in: app, timeout: 15), timeout: 10)
+        XCTAssertTrue(
+            requireElement("dailyReadingScreen", in: app, timeout: 20).exists,
+            "Choosing a reading-plan template should continue directly to Daily Reading."
+        )
         let currentDay = requireElement("dailyReadingCurrentDayLabel", in: app, timeout: 15)
         XCTAssertEqual(currentDay.value as? String, "1")
 

--- a/bibleview-js/src/__tests__/scroll.spec.js
+++ b/bibleview-js/src/__tests__/scroll.spec.js
@@ -165,4 +165,50 @@ describe("scroll composable", () => {
 
         expect(scrollTo).toHaveBeenCalledWith(0, 243.33333333333334);
     });
+
+    /**
+     * Protects reader document lifecycle cleanup for temporary link scroll anchors.
+     *
+     * Link navigation can clear or replace the reader document before the resize that follows panel
+     * opening. A detached source anchor must not be measured later because that would scroll the new
+     * document based on stale geometry from the old document.
+     */
+    it("ignores a detached scroll anchor after the reader document is cleared", async () => {
+        const target = document.createElement("a");
+        target.className = "reference-link";
+        target.textContent = "Genesis 1:1";
+        target.getBoundingClientRect = () => ({top: 10, bottom: 20});
+        document.body.appendChild(target);
+
+        Object.defineProperty(window, "scrollY", {value: 500, configurable: true});
+        Object.defineProperty(window, "innerHeight", {value: 600, configurable: true});
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation(callback => {
+            callback(0);
+            return 1;
+        });
+        const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+        mount(defineComponent({
+            setup() {
+                useScroll(
+                    {},
+                    {disableAnimations: false, topOffset: 0, bottomOffset: 0, imeOpen: false},
+                    ref({topOffset: 100}),
+                    {highlightOrdinal: vi.fn(), resetHighlights: vi.fn()},
+                    ref(Promise.resolve()),
+                    ref(0)
+                );
+            },
+            template: "<div />",
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        eventBus.emit("set_scroll_anchor", [target]);
+        eventBus.emit("clear_document", []);
+        target.remove();
+        window.dispatchEvent(new Event("resize"));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(scrollTo).not.toHaveBeenCalled();
+    });
 });

--- a/bibleview-js/src/composables/scroll.ts
+++ b/bibleview-js/src/composables/scroll.ts
@@ -290,8 +290,6 @@ export function useScroll(
         const {targetId, options} = resolveScrollToVerseRequest(request);
         scrollToId(targetId, options);
     })
-    setupEventBusListener("setup_content", setupContent)
-
     let scrollAnchorElement: HTMLElement | null = null;
     let scrollAnchorCleanupTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -330,12 +328,21 @@ export function useScroll(
         scrollAnchorCleanupTimeout = setTimeout(clearScrollAnchor, 3000);
     }
 
+    setupEventBusListener("clear_document", clearScrollAnchor);
+    setupEventBusListener("setup_content", async (...args: Parameters<typeof setupContent>) => {
+        clearScrollAnchor();
+        await setupContent(...args);
+    })
     setupEventBusListener("set_scroll_anchor", setScrollAnchor);
 
     setupWindowEventListener('resize', async () => {
         if (!scrollAnchorElement) return;
         await waitNextAnimationFrame();
         if (!scrollAnchorElement) return;
+        if (!scrollAnchorElement.isConnected) {
+            clearScrollAnchor();
+            return;
+        }
         const rect = scrollAnchorElement.getBoundingClientRect();
         const viewTop = calculatedConfig.value.topOffset;
         const viewBottom = window.innerHeight;


### PR DESCRIPTION
## Summary
Broadens PR #337 into a Reading Plans parity pass while retaining the existing reader scroll-anchor lifecycle fix already on the branch.

The Reading Plans changes align iOS with Android's bundled plan catalog and selector flow, add Android-equivalent current-plan controls, and now include the adversarial-review fixes for calendar-day plan progression and remote-sync status upload semantics.

## Scope
In scope:
- Android bundled Reading Plans catalog parity in `ReadingPlanService`.
- Reading Plans selector flow and empty-state start affordance in `ReadingPlanListView`.
- Daily Reading current-plan controls for set current day, set start date, and reset.
- Start-date bounds matching Android's date picker maximum of today.
- Calendar-day plan start and expected-day progression matching Android's truncated start date behavior.
- Remote-sync snapshot parity for non-date-based historic progress derived from Android `currentDay`.
- Regression coverage for Android catalog size, selector-to-daily navigation, service-level current-plan mutations, day-boundary behavior, and historic-status upload behavior.
- Existing reader scroll-anchor lifecycle cleanup from the earlier commit on this branch.

Out of scope:
- Android add-on and user reading-plan auto-discovery; tracked in #338.
- Changing custom `.properties` import syntax.
- Generated web resource bundle updates.

## Contract References
- Issue #325 and the existing reader scroll-anchor follow-up on this branch.
- Android `ReadingPlanTextFileDao` bundled asset catalog behavior.
- Android `ReadingPlanSelectorList` start-plan result flow.
- Android `DailyReading` current-plan actions: set current day, set start date, reset.
- Android `ReadingPlanRepository.startPlan` use of `CommonUtils.truncatedDate`.
- Android non-date-based historic progress semantics from `ReadingPlanControl.currentPlanDay` and `ReadingPlanStatus`.
- Android `DailyReading` start-date picker `maxDate` behavior.
- Follow-up issue #338 for Android add-on and user reading-plan discovery.
- Repo commit and PR conventions in `CLAUDE.md` and `.github/PULL_REQUEST_TEMPLATE.md`.

## Change Details
- Removed iOS-only algorithmic built-in templates from the built-in catalog and kept custom import as the explicit non-catalog path.
- Added `ReadingPlanService` helpers for setting current day, setting start date, and resetting a plan graph.
- Capped start-date mutation at today in both the service helper and SwiftUI date picker, matching Android's future-date restriction.
- Store newly started plans at the local calendar-day boundary and compute expected day from normalized local calendar dates.
- Preserve Android-origin reading-plan status rows but stop synthesizing status rows for completed non-date-based days before `currentDay`.
- Added a content-level start affordance for empty Reading Plans and programmatic navigation from picker selection to `DailyReadingView`.
- Added Daily Reading toolbar menu actions for set current day, set start date, and reset, all backed by the shared service helpers.
- Updated the UI smoke to assert seven templates and direct selector-to-daily navigation.
- Replaced the algorithmic-plan lifecycle test with Android catalog parity and current-plan persistence tests.
- Preserved the earlier scroll-anchor cleanup behavior in this PR.

## Validation Evidence
- Red check: `swift test --filter RemoteSyncReadingPlanTests/testReadingPlanSetStartDateRebasesCurrentDayWithoutChangingStatuses` failed before implementation because `ReadingPlanService.setCurrentDay`, `setStartDate`, and `resetPlan` did not exist.
- Red check: `testReadingPlanStartPlanUsesAndroidTruncatedStartDate` failed before the review fix because new plans stored the current timestamp instead of local day start.
- Red check: `testReadingPlanExpectedDayUsesCalendarDayBoundary` failed before the review fix because expected day advanced by elapsed seconds instead of calendar days.
- Red check: `testReadingPlanSnapshotDoesNotSynthesizeHistoricNonDateStatuses` failed before the review fix because iOS synthesized Android status rows for historic non-date-based progress.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO` passed, 264 tests, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO -only-testing:BibleCoreTests/RemoteSyncReadingPlanTests` passed, 22 tests, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO -only-testing:BibleCoreTests/RemoteSyncLifecycleTests` passed, 25 tests, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO -only-testing:BibleCoreTests/RemoteSyncReadingPlanTests/testReadingPlanSetStartDateCapsFutureDateAtToday` passed, 1 test, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleCoreTests -configuration Debug -destination 'platform=iOS Simulator,id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO -only-testing:BibleCoreTests/RemoteSyncReadingPlanTests/testReadingPlanSetStartDateRebasesCurrentDayWithoutChangingStatuses` passed, 1 test, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=49FF5522-5E25-4BC7-B09A-43DF7E82262F' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO build` passed after the future-date cap.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer UITEST_DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,id=49FF5522-5E25-4BC7-B09A-43DF7E82262F' -derivedDataPath .derivedData-pr337-ci CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testReadingPlansRouteStartAdvanceDeleteAndImportAffordanceFlow` passed after the future-date cap, 1 test, 0 failures.
- `git diff --check` passed.
- `python3 scripts/check_repo_standards.py docblocks` passed.
- GitNexus impact checks were run before editing `ReadingPlanService`, `RemoteSyncReadingPlanSnapshotService`, `ReadingPlanListView`, `DailyReadingView`, and the touched test methods/classes. `ReadingPlanService` and reading-plan remote-sync tests reported HIGH/CRITICAL by import breadth; edits were constrained to Reading Plans parity and covered by targeted regression tests.
- GitNexus staged `detect_changes` before the latest amend reported medium risk across the four expected review-fix files with one intended affected flow: `ExportAndroidDatabaseBackup -> RemoteSyncReadingPlanSnapshotService`.

Not run:
- Full `swift test`: it compiles the changed BibleCore files, then fails on unrelated BibleUI macOS availability errors such as `TextField.textInputAutocapitalization`, ambiguous `Window`, and unavailable `fullScreenCover`.

## Risks / Follow-ups
- Reading Plans now intentionally stops exposing the iOS-only algorithmic built-ins as built-in templates; this matches Android bundled catalog parity and avoids artificially preserving iOS-only behavior.
- Daily Reading current-plan controls have service-level regression tests in the package test suite, and the new future-date cap is covered in the same simulator package-test lane CI uses.
- Date-based plan status rows are still preserved and synthesized when appropriate; the new upload suppression applies only to non-date-based days before `currentDay`.
- Follow-up #338 tracks Android add-on and user reading-plan discovery, which crosses module/file-system ownership and is intentionally separate from this PR.

## Screenshots
none

## Closes
Closes #325
Refs #338
