### PR TITLE
fix(module-details): align About dialog with Android

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -1012,13 +1012,10 @@ struct BibleReaderModulePicker: View {
      Builds the shared About dialog payload for an installed module.
 
      - Parameter module: Installed module selected from the chooser.
-     - Returns: Details payload compatible with the Downloads About dialog.
+     - Returns: Installed-only details payload compatible with Android's reader-picker About dialog.
      */
     private func moduleDetails(for module: ModuleInfo) -> ModuleBrowserModuleDetails {
-        ModuleBrowserModuleDetails(
-            module: Self.remoteModuleInfo(for: module),
-            installedModule: module
-        )
+        ModuleBrowserModuleDetails(installedModule: module)
     }
 
     /**
@@ -1035,7 +1032,7 @@ struct BibleReaderModulePicker: View {
     ) -> ModuleBrowserRowActionConfirmation {
         ModuleBrowserRowActionConfirmation(
             kind: kind,
-            module: Self.remoteModuleInfo(for: module)
+            installedModule: module
         )
     }
 
@@ -1450,23 +1447,6 @@ struct BibleReaderModulePicker: View {
         default:
             return 7
         }
-    }
-
-    /**
-     Builds a Downloads-compatible remote metadata payload from an installed module snapshot.
-
-     - Parameter module: Installed module metadata.
-     - Returns: Minimal remote row used by the shared About and confirmation presentation helpers.
-     */
-    private static func remoteModuleInfo(for module: ModuleInfo) -> RemoteModuleInfo {
-        RemoteModuleInfo(
-            name: module.name,
-            description: module.description,
-            category: module.category,
-            language: module.language,
-            sourceName: String(localized: "installed", defaultValue: "Installed"),
-            version: module.version
-        )
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -68,7 +68,7 @@ struct BibleReaderModulePicker: View {
     /// Free-text filter applied to module initials, descriptions, category labels, and language.
     @State private var searchText = ""
 
-    /// Details sheet payload for Android's About row action.
+    /// Details dialog payload for Android's About row action.
     @State private var selectedModuleDetails: ModuleBrowserModuleDetails?
 
     /// Confirmation payload for destructive Android document actions.
@@ -175,10 +175,8 @@ struct BibleReaderModulePicker: View {
      */
     var body: some View {
         androidDocumentChooserScreen
-        .sheet(item: $selectedModuleDetails) { details in
-            NavigationStack {
-                ModuleBrowserModuleDetailsView(details: details)
-            }
+        .moduleBrowserModuleDetailsDialog(details: selectedModuleDetails) {
+            selectedModuleDetails = nil
         }
         .alert(
             pendingRowActionConfirmation?.title ?? "",
@@ -793,7 +791,7 @@ struct BibleReaderModulePicker: View {
 
      - Parameter module: Installed module whose details should be shown.
      - Returns: Template info icon matching Android's `aboutButton` column.
-     - Side effects: Sets `selectedModuleDetails`, presenting the shared details sheet.
+     - Side effects: Sets `selectedModuleDetails`, presenting the shared details dialog.
      - Failure modes: Details payload falls back to installed-module metadata when repository source
        metadata is unavailable.
      */
@@ -1011,10 +1009,10 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Builds the shared About sheet payload for an installed module.
+     Builds the shared About dialog payload for an installed module.
 
      - Parameter module: Installed module selected from the chooser.
-     - Returns: Details payload compatible with the Downloads About sheet.
+     - Returns: Details payload compatible with the Downloads About dialog.
      */
     private func moduleDetails(for module: ModuleInfo) -> ModuleBrowserModuleDetails {
         ModuleBrowserModuleDetails(

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
@@ -1,5 +1,6 @@
 // ModuleBrowserRowActionPresentation.swift - Downloads row action presentation helpers
 
+import Foundation
 import SwiftUI
 import SwordKit
 
@@ -134,39 +135,60 @@ struct ModuleBrowserModuleDetailRow: Identifiable, Equatable {
     /**
      Stable field identifiers for the module About dialog.
 
-     Cases are intentionally limited to metadata iOS currently owns. Android-only `BookMetaData`
-     fields such as copyright, history, unlock info text, repository raw properties, and versification
-     are not represented until iOS stores those values honestly.
+     Current rendered cases mirror Android `CommonUtils.showAbout(...)`. The older category/language
+     and install-state cases remain only as regression sentinels in tests so those iOS-only fields are
+     not reintroduced as visible rows.
      */
     enum Kind: String, Equatable {
-        /// SWORD module initials.
-        case initials
+        /// Bad-document warning from Android metadata.
+        case warning
 
-        /// User-facing module name/description.
-        case name
+        /// Main SWORD `About` text.
+        case about
 
-        /// SWORD module category.
-        case category
+        /// SWORD `ShortPromo` text.
+        case shortPromo
 
-        /// Module language display name.
-        case language
+        /// Copyright and distribution license text.
+        case copyright
 
-        /// Remote or installed source label.
-        case source
+        /// Encrypted module unlock information.
+        case unlockInfo
 
-        /// Latest remote catalog version.
+        /// Latest/catalog version row.
         case latestVersion
 
-        /// Installed local module version.
+        /// Installed/local version row.
         case installedVersion
 
-        /// Remote install size when the catalog reports it.
+        /// Version history values.
+        case versionHistory
+
+        /// SWORD versification name.
+        case versification
+
+        /// Android OSIS ID row.
+        case osisId
+
+        /// Android distribution server/repository row.
+        case repository
+
+        /// Deprecated iOS-only module category row.
+        case category
+
+        /// Deprecated iOS-only module language row.
+        case language
+
+        /// Deprecated iOS-only source row.
+        case source
+
+        /// Deprecated iOS-only install-size row.
         case installSize
 
-        /// Local installed-state marker.
+        /// Deprecated iOS-only installed-state row.
         case installedState
 
-        /// Local encrypted module lock state.
+        /// Deprecated iOS-only encrypted lock-state row.
         case encryptionState
     }
 
@@ -179,8 +201,29 @@ struct ModuleBrowserModuleDetailRow: Identifiable, Equatable {
     /// User-visible metadata value.
     let value: String
 
+    /// Android-style message fragment rendered in the About dialog body.
+    let message: String
+
     /// Stable row identity for SwiftUI and tests.
     var id: Kind { kind }
+
+    /**
+     Creates one typed About row and its Android message fragment.
+
+     - Parameters:
+       - kind: Stable metadata field identity.
+       - title: Field label retained for tests and future accessibility affordances.
+       - value: Raw user-visible metadata value.
+       - message: Formatted Android-style message fragment. Defaults to `value`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(kind: Kind, title: String, value: String, message: String? = nil) {
+        self.kind = kind
+        self.title = title
+        self.value = value
+        self.message = message ?? value
+    }
 }
 
 /**
@@ -188,104 +231,330 @@ struct ModuleBrowserModuleDetailRow: Identifiable, Equatable {
 
  Android expands SWORD metadata for the selected row and displays the available details in
  `CommonUtils.showAbout(...)`. iOS currently has a smaller remote/installed metadata model, so this
- payload preserves every available local field while deliberately omitting values iOS does not store.
+ payload preserves every available local field while keeping catalog-only and installed-only metadata
+ separate. Reader-picker About actions must not synthesize a repository row because Android reads the
+ installed document metadata directly.
 
  Side effects:
  - none; this value only drives SwiftUI dialog presentation
 
  Failure modes:
- - missing installed metadata is represented by `nil` and omitted from the dialog
+ - missing remote or installed metadata is represented by `nil` and omitted from the dialog
  - empty optional fields are omitted rather than shown as placeholders
  */
 struct ModuleBrowserModuleDetails: Identifiable {
-    /// Remote catalog row selected from Downloads, or a remote-shaped installed snapshot in picker.
-    let module: RemoteModuleInfo
+    /// Stable dialog identity scoped to the source row that opened the dialog.
+    let id: String
 
-    /// Matching installed module metadata, when the module exists locally.
-    let installedModule: ModuleInfo?
+    /// SWORD module initials used as the fallback heading and OSIS identity.
+    let moduleName: String
 
-    /// Stable dialog identity scoped to the repository row.
-    var id: String { module.id }
+    /// User-facing module description used as Android's `document.name` equivalent when available.
+    let moduleDescription: String
+
+    /// Installed or remote metadata that backs Android About rows.
+    let aboutMetadata: ModuleAboutMetadata
+
+    /// Android row kind used for the primary version line.
+    let primaryVersionKind: ModuleBrowserModuleDetailRow.Kind
+
+    /// Primary version value from the selected document/catalog row.
+    let primaryVersion: String?
+
+    /// Date paired with the primary version, when known.
+    let primaryVersionDate: String?
+
+    /// Secondary installed version shown only for Downloads rows with a matching installed module.
+    let installedVersion: String?
+
+    /// Date paired with the secondary installed version, when known.
+    let installedVersionDate: String?
+
+    /// Android-style dialog heading.
+    var displayName: String {
+        Self.nonEmpty(moduleDescription) ?? moduleName
+    }
+
+    /**
+     Single Android-style About message rendered by the shared dialog.
+
+     Android's `CommonUtils.showAbout(...)` builds one AlertDialog message instead of a form/table.
+     This property keeps that presentation contract visible to tests while `androidAboutRows`
+     preserves typed row identities for semantic parity checks.
+
+     - Returns: Message text with blank-line section separation and adjacent version rows.
+     - Side effects: none.
+     - Failure modes: Empty optional metadata rows are omitted before message assembly.
+     */
+    var androidAboutMessage: String {
+        androidAboutSections(renderingHTML: false)
+            .compactMap(Self.nonEmpty)
+            .joined(separator: "\n\n")
+    }
+
+    /**
+     Android-style About message after Android's final HTML newline conversion.
+
+     Android wraps the document name, bad-document warning, and unlock-info heading in `<b>` tags,
+     appends raw module metadata, then replaces line breaks with `<br>` before displaying the span.
+     This property preserves that presentation contract so links and simple metadata markup render
+     instead of appearing as literal HTML in iOS.
+
+     - Returns: HTML body passed to the Swift attributed-string importer.
+     - Side effects: none.
+     - Failure modes: Empty optional metadata rows are omitted before message assembly.
+     */
+    var androidAboutHTMLMessage: String {
+        androidAboutSections(renderingHTML: true)
+            .compactMap(Self.nonEmpty)
+            .joined(separator: "\n\n")
+            .replacingOccurrences(of: "\n", with: "<br>")
+    }
+
+    /**
+     Attributed About body used by the SwiftUI dialog.
+
+     Android displays the About message through `htmlToSpan(...)`, so iOS imports the same HTML body
+     into an attributed string. If Foundation rejects malformed module metadata HTML, the dialog falls
+     back to the plain Android message rather than dropping the About content.
+
+     - Returns: Attributed message suitable for `Text`.
+     - Side effects: Parses the in-memory HTML string.
+     - Failure modes: Malformed HTML falls back to plain text.
+     */
+    var androidAboutAttributedMessage: AttributedString {
+        Self.attributedHTMLString(from: androidAboutHTMLMessage) ?? AttributedString(androidAboutMessage)
+    }
+
+    /**
+     Builds the ordered About message sections in plain or Android-HTML form.
+
+     - Parameter renderingHTML: Whether section values should include Android's bold wrappers.
+     - Returns: Ordered message sections before blank-line joining and final newline conversion.
+     - Side effects: none.
+     - Failure modes: Empty optional metadata rows are omitted by `androidAboutRows`.
+     */
+    private func androidAboutSections(renderingHTML: Bool) -> [String] {
+        var sections = [displayName]
+        var versionMessages: [String] = []
+
+        if renderingHTML {
+            sections = ["<b>\(displayName)</b>"]
+        }
+
+        func flushVersionMessages() {
+            guard !versionMessages.isEmpty else {
+                return
+            }
+            sections.append(versionMessages.joined(separator: "\n"))
+            versionMessages.removeAll()
+        }
+
+        for row in androidAboutRows {
+            switch row.kind {
+            case .latestVersion, .installedVersion:
+                versionMessages.append(row.message)
+            case .warning:
+                flushVersionMessages()
+                sections.append(renderingHTML ? "<b>\(row.message)</b>" : row.message)
+            case .unlockInfo:
+                flushVersionMessages()
+                sections.append(renderingHTML ? "<b>\(row.title)</b>\n\n\(row.value)" : row.message)
+            default:
+                flushVersionMessages()
+                sections.append(row.message)
+            }
+        }
+        flushVersionMessages()
+        return sections
+    }
+
+    /**
+     Creates a dialog payload for a Downloads catalog row.
+
+     - Parameters:
+       - module: Remote catalog row selected from Downloads.
+       - installedModule: Matching local module metadata, when the module exists locally.
+     - Side effects: none.
+     - Failure modes: Missing installed metadata leaves installed-only rows absent.
+     */
+    init(module: RemoteModuleInfo, installedModule: ModuleInfo?) {
+        id = module.id
+        moduleName = module.name
+        moduleDescription = module.description
+        aboutMetadata = installedModule?.aboutMetadata.withFallbacks(
+            osisId: module.name,
+            repository: module.sourceName
+        ) ?? ModuleAboutMetadata(
+            osisId: module.name,
+            repository: module.sourceName
+        )
+        primaryVersionKind = installedModule == nil ? .installedVersion : .latestVersion
+        primaryVersion = module.version
+        primaryVersionDate = nil
+        installedVersion = installedModule?.version
+        installedVersionDate = installedModule?.aboutMetadata.swordVersionDate
+    }
+
+    /**
+     Creates a dialog payload for a reader-picker installed document.
+
+     Android's reader document picker calls `CommonUtils.showAbout(...)` on the installed document
+     metadata and does not add Downloads-only source/latest/install-size rows. This initializer keeps
+     that boundary explicit so installed modules never gain artificial repository metadata.
+
+     - Parameter installedModule: Installed module selected from the reader document picker.
+     - Side effects: none.
+     - Failure modes: Empty installed metadata fields are omitted by `androidAboutRows`.
+     */
+    init(installedModule: ModuleInfo) {
+        id = installedModule.id
+        moduleName = installedModule.name
+        moduleDescription = installedModule.description
+        aboutMetadata = installedModule.aboutMetadata
+        primaryVersionKind = .latestVersion
+        primaryVersion = installedModule.version
+        primaryVersionDate = installedModule.aboutMetadata.swordVersionDate
+        installedVersion = nil
+        installedVersionDate = nil
+    }
 
     /**
      Android About rows assembled from the metadata iOS can honestly provide.
 
-     - Returns: Ordered dialog rows matching Android's message-first About contract while preserving
-       every available remote and installed iOS field.
+     - Returns: Ordered dialog rows matching Android's message-first About contract.
      - Side effects: none.
      - Failure modes: Empty optional metadata is omitted.
      */
     var androidAboutRows: [ModuleBrowserModuleDetailRow] {
-        var rows: [ModuleBrowserModuleDetailRow] = [
-            row(
-                kind: .initials,
-                title: String(localized: "module_initials", defaultValue: "Initials"),
-                value: module.name
+        var rows: [ModuleBrowserModuleDetailRow] = []
+
+        if aboutMetadata.isBadDocument {
+            let warning = String(
+                localized: "warn_bad_document",
+                defaultValue: "Warning: This document might be (at least partially) bad technical quality."
             )
-        ]
-
-        if let description = Self.nonEmpty(module.description) {
             rows.append(row(
-                kind: .name,
-                title: String(localized: "module_name", defaultValue: "Name"),
-                value: description
-            ))
-        }
-        rows.append(row(
-            kind: .category,
-            title: String(localized: "module_category", defaultValue: "Category"),
-            value: Self.categoryTitle(module.category)
-        ))
-        if let language = Self.nonEmpty(module.language) {
-            rows.append(row(
-                kind: .language,
-                title: String(localized: "module_language", defaultValue: "Language"),
-                value: Self.displayName(for: language)
+                kind: .warning,
+                title: String(localized: "warning", defaultValue: "Warning"),
+                value: warning
             ))
         }
 
-        if let source = Self.nonEmpty(module.sourceName) {
+        if let about = Self.nonEmpty(Self.cleanedAboutText(aboutMetadata.about)) {
             rows.append(row(
-                kind: .source,
-                title: String(localized: "module_source", defaultValue: "Source"),
-                value: source
+                kind: .about,
+                title: String(localized: "about", defaultValue: "About"),
+                value: about
             ))
         }
-        if let latestVersion = Self.nonEmpty(module.version) {
+
+        if let shortPromo = Self.nonEmpty(aboutMetadata.shortPromo) {
             rows.append(row(
-                kind: .latestVersion,
-                title: String(localized: "module_latest_version", defaultValue: "Latest version"),
-                value: latestVersion
+                kind: .shortPromo,
+                title: String(localized: "module_short_promo", defaultValue: "Summary"),
+                value: shortPromo
             ))
         }
-        if let installedVersion = installedModule.flatMap({ Self.nonEmpty($0.version) }) {
+
+        if let copyright = Self.copyrightText(from: aboutMetadata) {
+            rows.append(row(
+                kind: .copyright,
+                title: String(localized: "copyright", defaultValue: "Copyright"),
+                value: copyright,
+                message: Self.formattedAndroidString(
+                    key: "module_about_copyright",
+                    defaultValue: "Copyright: %@",
+                    arguments: [copyright]
+                )
+            ))
+        }
+
+        if let unlockInfo = Self.nonEmpty(aboutMetadata.unlockInfo) {
+            let title = String(localized: "unlock_info", defaultValue: "Encrypted module unlock info")
+            rows.append(row(
+                kind: .unlockInfo,
+                title: title,
+                value: unlockInfo,
+                message: "\(title)\n\n\(unlockInfo)"
+            ))
+        }
+
+        if let primaryVersion = Self.versionParts(primaryVersion, date: primaryVersionDate) {
+            rows.append(row(
+                kind: primaryVersionKind,
+                title: Self.versionTitle(for: primaryVersionKind),
+                value: primaryVersion.value,
+                message: Self.versionMessage(
+                    kind: primaryVersionKind,
+                    version: primaryVersion.version,
+                    date: primaryVersion.date
+                )
+            ))
+        }
+
+        if let installedVersion = Self.versionParts(installedVersion, date: installedVersionDate) {
             rows.append(row(
                 kind: .installedVersion,
-                title: String(localized: "module_installed_version", defaultValue: "Installed version"),
-                value: installedVersion
+                title: Self.versionTitle(for: .installedVersion),
+                value: installedVersion.value,
+                message: Self.versionMessage(
+                    kind: .installedVersion,
+                    version: installedVersion.version,
+                    date: installedVersion.date
+                )
             ))
         }
-        if let installSize = Self.installSizeText(for: module.installSizeBytes) {
+
+        if let history = Self.versionHistoryText(aboutMetadata.history) {
             rows.append(row(
-                kind: .installSize,
-                title: String(localized: "module_install_size", defaultValue: "Install size"),
-                value: installSize
+                kind: .versionHistory,
+                title: String(localized: "module_about_version_history_label", defaultValue: "Version history"),
+                value: history,
+                message: Self.formattedAndroidString(
+                    key: "about_version_history",
+                    defaultValue: "Version history: %@",
+                    arguments: ["\n\(history)"]
+                )
             ))
         }
-        if installedModule != nil {
+
+        if let versification = Self.nonEmpty(aboutMetadata.versification) {
             rows.append(row(
-                kind: .installedState,
-                title: String(localized: "module_installed", defaultValue: "Installed"),
-                value: String(localized: "module_installed", defaultValue: "Installed")
+                kind: .versification,
+                title: String(localized: "module_about_versification_label", defaultValue: "Versification"),
+                value: versification,
+                message: Self.formattedAndroidString(
+                    key: "module_about_versification",
+                    defaultValue: "Versification: %@",
+                    arguments: [versification]
+                )
             ))
         }
-        if let installedModule, installedModule.isEncrypted {
+
+        if let osisId = Self.nonEmpty(aboutMetadata.osisId) {
             rows.append(row(
-                kind: .encryptionState,
-                title: String(localized: "module_encrypted", defaultValue: "Encrypted"),
-                value: installedModule.isUnlocked
-                    ? String(localized: "module_unlocked", defaultValue: "Unlocked")
-                    : String(localized: "module_locked", defaultValue: "Locked")
+                kind: .osisId,
+                title: String(localized: "module_about_osisId_label", defaultValue: "OSIS ID"),
+                value: osisId,
+                message: Self.formattedAndroidString(
+                    key: "module_about_osisId",
+                    defaultValue: "OSIS ID: %@",
+                    arguments: [osisId]
+                )
+            ))
+        }
+
+        if let repository = Self.nonEmpty(aboutMetadata.repository) {
+            rows.append(row(
+                kind: .repository,
+                title: String(localized: "module_about_repository_label", defaultValue: "Distribution server"),
+                value: repository,
+                message: Self.formattedAndroidString(
+                    key: "module_about_repository",
+                    defaultValue: "Distribution server: %@",
+                    arguments: [repository]
+                )
             ))
         }
 
@@ -299,76 +568,210 @@ struct ModuleBrowserModuleDetails: Identifiable {
        - kind: Stable metadata field identity.
        - title: Localized field label.
        - value: User-visible metadata value.
+       - message: Android-style message fragment, or `nil` to use `value`.
      - Returns: Row value consumed by the shared dialog.
      - Side effects: none.
      - Failure modes: none.
      */
-    private func row(kind: ModuleBrowserModuleDetailRow.Kind, title: String, value: String) -> ModuleBrowserModuleDetailRow {
-        ModuleBrowserModuleDetailRow(kind: kind, title: title, value: value)
+    private func row(
+        kind: ModuleBrowserModuleDetailRow.Kind,
+        title: String,
+        value: String,
+        message: String? = nil
+    ) -> ModuleBrowserModuleDetailRow {
+        ModuleBrowserModuleDetailRow(kind: kind, title: title, value: value, message: message)
     }
 
     /**
-     Resolves a module category to the same user-facing buckets used by the Downloads filter.
+     Resolves Android version row parts.
 
-     - Parameter category: SWORD module category.
-     - Returns: Localized category title.
+     - Parameters:
+       - version: Raw SWORD version.
+       - date: Raw SWORD version date.
+     - Returns: Parsed row parts, or `nil` when the version is empty.
      - Side effects: none.
-     - Failure modes: Unknown categories fall back to the raw category value.
+     - Failure modes: Missing dates use Android's `-` placeholder.
      */
-    private static func categoryTitle(_ category: ModuleCategory) -> String {
-        switch category {
-        case .bible:
-            return String(localized: "bibles", defaultValue: "Bibles")
-        case .commentary:
-            return String(localized: "commentaries", defaultValue: "Commentaries")
-        case .dictionary:
-            return String(localized: "dictionaries", defaultValue: "Dictionaries")
-        case .generalBook:
-            return String(localized: "category_books", defaultValue: "Books")
-        case .map:
-            return String(localized: "maps", defaultValue: "Maps")
-        case .addon:
-            return String(localized: "doc_type_addons", defaultValue: "Add-ons")
+    private static func versionParts(_ version: String?, date: String?) -> (
+        version: String,
+        date: String,
+        value: String
+    )? {
+        guard let version = nonEmpty(version) else {
+            return nil
+        }
+        let date = nonEmpty(date) ?? "-"
+        return (version: version, date: date, value: "\(version) (\(date))")
+    }
+
+    /**
+     Resolves Android's localized label for one version row kind.
+
+     - Parameter kind: Version row kind.
+     - Returns: Localized row label.
+     - Side effects: none.
+     - Failure modes: Non-version kinds fall back to latest-version wording.
+     */
+    private static func versionTitle(for kind: ModuleBrowserModuleDetailRow.Kind) -> String {
+        switch kind {
+        case .installedVersion:
+            return String(localized: "module_about_installed_version_label", defaultValue: "Installed version")
         default:
-            return category.rawValue
+            return String(localized: "module_about_latest_version_label", defaultValue: "Latest version")
         }
     }
 
     /**
-     Resolves a language code to localized display text.
+     Formats one Android version line.
 
-     - Parameter languageCode: ISO-style language code from remote or installed metadata.
-     - Returns: Localized language name when available, otherwise the uppercased code.
-     - Side effects: none.
-     - Failure modes: Invalid or unknown codes fall back to uppercased input.
+     - Parameters:
+       - kind: Version row kind controlling latest-versus-installed wording.
+       - version: Version value to interpolate.
+       - date: Version date value to interpolate.
+     - Returns: Localized Android-compatible version line.
+     - Side effects: Reads localized strings from the app bundle.
+     - Failure modes: Android `%s` placeholders are normalized before Swift formatting.
      */
-    private static func displayName(for languageCode: String) -> String {
-        let baseCode = languageCode.components(separatedBy: "-").first ?? languageCode
-        if let name = Locale.current.localizedString(forLanguageCode: baseCode),
-           name.lowercased() != baseCode.lowercased() {
-            if languageCode.contains("-") {
-                let suffix = languageCode.components(separatedBy: "-").dropFirst().joined(separator: "-")
-                return "\(name) (\(suffix))"
-            }
-            return name
+    private static func versionMessage(
+        kind: ModuleBrowserModuleDetailRow.Kind,
+        version: String,
+        date: String
+    ) -> String {
+        switch kind {
+        case .installedVersion:
+            return formattedAndroidString(
+                key: "module_about_installed_version",
+                defaultValue: "Installed version: %1$@ (%2$@)",
+                arguments: [version, date]
+            )
+        default:
+            return formattedAndroidString(
+                key: "module_about_latest_version",
+                defaultValue: "Latest version: %1$@ (%2$@)",
+                arguments: [version, date]
+            )
         }
-        return languageCode.uppercased()
     }
 
     /**
-     Formats the SWORD install-size value shown in Android's download rows.
+     Formats Android string resources with Swift-safe placeholder handling.
 
-     - Parameter bytes: Install-size byte count from remote catalog metadata.
-     - Returns: One-decimal megabyte text, or `nil` when metadata is absent.
+     Android translations use `%s`, `%1$s`, and `%2$s` placeholders. Swift's formatter expects object
+     placeholders (`%@`) for `String` arguments, so this helper normalizes Android string resources
+     before interpolation while preserving the translated wording.
+
+     - Parameters:
+       - key: Android/iOS localization key.
+       - defaultValue: English fallback format.
+       - arguments: Format arguments.
+     - Returns: Interpolated localized text.
+     - Side effects: Reads localized strings from the app bundle.
+     - Failure modes: Missing keys use `defaultValue`.
+     */
+    private static func formattedAndroidString(
+        key: String,
+        defaultValue: String,
+        arguments: [CVarArg]
+    ) -> String {
+        let localizedFormat = Bundle.main.localizedString(forKey: key, value: defaultValue, table: nil)
+        let format = iosStringFormat(fromAndroidFormat: localizedFormat)
+        guard !arguments.isEmpty else {
+            return format
+        }
+        return String(format: format, locale: Locale.current, arguments: arguments)
+    }
+
+    /**
+     Converts Android `%s` string placeholders into Swift object placeholders.
+
+     - Parameter format: Localized Android-format string.
+     - Returns: Swift `String(format:)` compatible format string.
+     - Side effects: none.
+     - Failure modes: Non-string placeholders are left unchanged.
+     */
+    private static func iosStringFormat(fromAndroidFormat format: String) -> String {
+        var normalized = format
+        for index in 1...9 {
+            normalized = normalized.replacingOccurrences(of: "%\(index)$s", with: "%\(index)$@")
+        }
+        return normalized.replacingOccurrences(of: "%s", with: "%@")
+    }
+
+    /**
+     Imports Android-style HTML into a Swift attributed string.
+
+     - Parameter html: HTML message body produced by `androidAboutHTMLMessage`.
+     - Returns: Attributed text when Foundation can parse the HTML, otherwise `nil`.
+     - Side effects: none.
+     - Failure modes: Invalid UTF-8 or malformed HTML returns `nil`.
+     */
+    private static func attributedHTMLString(from html: String) -> AttributedString? {
+        guard let data = html.data(using: .utf8) else {
+            return nil
+        }
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        guard let attributed = try? NSAttributedString(
+            data: data,
+            options: options,
+            documentAttributes: nil
+        ) else {
+            return nil
+        }
+        return AttributedString(attributed)
+    }
+
+    /**
+     Merges copyright fields using Android's `CommonUtils.showAbout(...)` precedence.
+
+     - Parameter metadata: Source-backed About metadata.
+     - Returns: Copyright/distribution text, or `nil` when both fields are empty.
      - Side effects: none.
      - Failure modes: none.
      */
-    private static func installSizeText(for bytes: Int64?) -> String? {
-        guard let bytes else {
+    private static func copyrightText(from metadata: ModuleAboutMetadata) -> String? {
+        var merged = ""
+        if let shortCopyright = nonEmpty(metadata.shortCopyright) {
+            merged += shortCopyright
+        } else if let copyright = nonEmpty(metadata.copyright) {
+            merged += "\n\n\(copyright)"
+        }
+        if let distributionLicense = nonEmpty(metadata.distributionLicense) {
+            merged += "\n\n\(distributionLicense)"
+        }
+        return nonEmpty(merged) == nil ? nil : merged
+    }
+
+    /**
+     Formats JSword version history values in Android display order.
+
+     - Parameter history: Config-order history values.
+     - Returns: Newest-first history text, or `nil` when no values exist.
+     - Side effects: none.
+     - Failure modes: Empty history entries are dropped.
+     */
+    private static func versionHistoryText(_ history: [String]) -> String? {
+        let values = history.compactMap(nonEmpty)
+        guard !values.isEmpty else {
             return nil
         }
-        let megabytes = Double(bytes) / 1_000_000
-        return String(format: "%.1f MB", megabytes)
+        return values.reversed().joined(separator: "\n")
+    }
+
+    /**
+     Applies Android's simple `About` text cleanup before rendering.
+
+     - Parameter value: Raw SWORD About text.
+     - Returns: Text with Android-removed RTF paragraph tokens normalized.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func cleanedAboutText(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\pard", with: "")
+            .replacingOccurrences(of: "\\par", with: "\n")
     }
 
     /**
@@ -450,9 +853,36 @@ struct ModuleBrowserRowActionConfirmation: Identifiable {
      - Failure modes: none.
      */
     init(kind: Kind, module: RemoteModuleInfo) {
+        self.init(kind: kind, moduleName: module.name, moduleDescription: module.description)
+    }
+
+    /**
+     Creates a confirmation payload for an installed reader-picker action.
+
+     - Parameters:
+       - kind: Android-equivalent destructive operation.
+       - installedModule: Installed module that supplied the action.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(kind: Kind, installedModule: ModuleInfo) {
+        self.init(kind: kind, moduleName: installedModule.name, moduleDescription: installedModule.description)
+    }
+
+    /**
+     Creates a confirmation payload from the normalized user-visible module labels.
+
+     - Parameters:
+       - kind: Android-equivalent destructive operation.
+       - moduleName: SWORD module initials used for repository actions.
+       - moduleDescription: User-facing module title used in confirmation copy.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private init(kind: Kind, moduleName: String, moduleDescription: String) {
         self.kind = kind
-        self.moduleName = module.name
-        self.moduleDescription = module.description
+        self.moduleName = moduleName
+        self.moduleDescription = moduleDescription
     }
 
     /**
@@ -517,7 +947,7 @@ struct ModuleBrowserModuleDetailsDialog: View {
     /// Current system color scheme used by the shared Android dialog palette.
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Remote and installed module metadata to display.
+    /// Normalized module metadata to display.
     let details: ModuleBrowserModuleDetails
 
     /// Callback that clears the owning screen's selected details state.
@@ -532,29 +962,18 @@ struct ModuleBrowserModuleDetailsDialog: View {
      */
     var body: some View {
         VStack(spacing: 0) {
-            Text(details.module.name)
-                .font(.headline)
-                .foregroundStyle(dialogPrimaryText)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 22)
-                .padding(.top, 20)
-                .padding(.bottom, 12)
-
-            Divider()
-                .background(dialogSecondaryText.opacity(0.25))
-
             ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
-                    ForEach(details.androidAboutRows) { row in
-                        detailRow(row)
-                    }
-                }
-                .padding(.horizontal, 22)
-                .padding(.vertical, 16)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                Text(details.androidAboutAttributedMessage)
+                    .font(.body)
+                    .foregroundStyle(dialogPrimaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier("moduleDetailsDialogMessage")
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxHeight: 420)
-            .accessibilityIdentifier("moduleDetailsDialogRows")
 
             Divider()
                 .background(dialogSecondaryText.opacity(0.25))
@@ -583,30 +1002,9 @@ struct ModuleBrowserModuleDetailsDialog: View {
         )
         .shadow(color: .black.opacity(0.22), radius: 20, x: 0, y: 12)
         .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
         .accessibilityIdentifier("moduleDetailsDialogScreen")
         .tint(dialogAccent)
-    }
-
-    /**
-     Renders one field/value row in the dialog message.
-
-     - Parameter row: Metadata row assembled from the shared About payload.
-     - Returns: Vertically stacked label and value text.
-     - Side effects: none.
-     - Failure modes: Long values wrap within the dialog width.
-     */
-    private func detailRow(_ row: ModuleBrowserModuleDetailRow) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(row.title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(dialogSecondaryText)
-            Text(row.value)
-                .font(.body)
-                .foregroundStyle(dialogPrimaryText)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityIdentifier("moduleDetailsRow::\(row.kind.rawValue)")
     }
 
     /// Android-dialog background color for the current system appearance.

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift
@@ -118,27 +118,274 @@ struct ModuleBrowserStatusSlotPresentation: Equatable {
 }
 
 /**
- Details payload for Android's Downloads row About action.
+ One visible row in Android's module About dialog.
 
- Android expands SWORD metadata for the selected row and displays its about/copyright/version
- details. iOS currently has a smaller remote catalog model, so the sheet carries the remote row
- plus any installed row snapshot that can supply local version/encryption state.
+ Android assembles a message from the selected module's actual metadata and omits fields that are not
+ available. iOS keeps the same contract as typed rows so tests and both SwiftUI call sites can verify
+ the payload without depending on form or sheet internals.
 
  Side effects:
- - none; this value only drives SwiftUI sheet presentation
+ - none; this value is a pure presentation projection
 
  Failure modes:
- - missing installed metadata is represented by `nil` and omitted from the sheet
+ - none; unavailable metadata is omitted before rows are created
+ */
+struct ModuleBrowserModuleDetailRow: Identifiable, Equatable {
+    /**
+     Stable field identifiers for the module About dialog.
+
+     Cases are intentionally limited to metadata iOS currently owns. Android-only `BookMetaData`
+     fields such as copyright, history, unlock info text, repository raw properties, and versification
+     are not represented until iOS stores those values honestly.
+     */
+    enum Kind: String, Equatable {
+        /// SWORD module initials.
+        case initials
+
+        /// User-facing module name/description.
+        case name
+
+        /// SWORD module category.
+        case category
+
+        /// Module language display name.
+        case language
+
+        /// Remote or installed source label.
+        case source
+
+        /// Latest remote catalog version.
+        case latestVersion
+
+        /// Installed local module version.
+        case installedVersion
+
+        /// Remote install size when the catalog reports it.
+        case installSize
+
+        /// Local installed-state marker.
+        case installedState
+
+        /// Local encrypted module lock state.
+        case encryptionState
+    }
+
+    /// Stable metadata field identity.
+    let kind: Kind
+
+    /// Localized field label rendered by the dialog.
+    let title: String
+
+    /// User-visible metadata value.
+    let value: String
+
+    /// Stable row identity for SwiftUI and tests.
+    var id: Kind { kind }
+}
+
+/**
+ Details payload for Android's module row About action.
+
+ Android expands SWORD metadata for the selected row and displays the available details in
+ `CommonUtils.showAbout(...)`. iOS currently has a smaller remote/installed metadata model, so this
+ payload preserves every available local field while deliberately omitting values iOS does not store.
+
+ Side effects:
+ - none; this value only drives SwiftUI dialog presentation
+
+ Failure modes:
+ - missing installed metadata is represented by `nil` and omitted from the dialog
+ - empty optional fields are omitted rather than shown as placeholders
  */
 struct ModuleBrowserModuleDetails: Identifiable {
-    /// Remote catalog row selected from Downloads.
+    /// Remote catalog row selected from Downloads, or a remote-shaped installed snapshot in picker.
     let module: RemoteModuleInfo
 
     /// Matching installed module metadata, when the module exists locally.
     let installedModule: ModuleInfo?
 
-    /// Stable sheet identity scoped to the repository row.
+    /// Stable dialog identity scoped to the repository row.
     var id: String { module.id }
+
+    /**
+     Android About rows assembled from the metadata iOS can honestly provide.
+
+     - Returns: Ordered dialog rows matching Android's message-first About contract while preserving
+       every available remote and installed iOS field.
+     - Side effects: none.
+     - Failure modes: Empty optional metadata is omitted.
+     */
+    var androidAboutRows: [ModuleBrowserModuleDetailRow] {
+        var rows: [ModuleBrowserModuleDetailRow] = [
+            row(
+                kind: .initials,
+                title: String(localized: "module_initials", defaultValue: "Initials"),
+                value: module.name
+            )
+        ]
+
+        if let description = Self.nonEmpty(module.description) {
+            rows.append(row(
+                kind: .name,
+                title: String(localized: "module_name", defaultValue: "Name"),
+                value: description
+            ))
+        }
+        rows.append(row(
+            kind: .category,
+            title: String(localized: "module_category", defaultValue: "Category"),
+            value: Self.categoryTitle(module.category)
+        ))
+        if let language = Self.nonEmpty(module.language) {
+            rows.append(row(
+                kind: .language,
+                title: String(localized: "module_language", defaultValue: "Language"),
+                value: Self.displayName(for: language)
+            ))
+        }
+
+        if let source = Self.nonEmpty(module.sourceName) {
+            rows.append(row(
+                kind: .source,
+                title: String(localized: "module_source", defaultValue: "Source"),
+                value: source
+            ))
+        }
+        if let latestVersion = Self.nonEmpty(module.version) {
+            rows.append(row(
+                kind: .latestVersion,
+                title: String(localized: "module_latest_version", defaultValue: "Latest version"),
+                value: latestVersion
+            ))
+        }
+        if let installedVersion = installedModule.flatMap({ Self.nonEmpty($0.version) }) {
+            rows.append(row(
+                kind: .installedVersion,
+                title: String(localized: "module_installed_version", defaultValue: "Installed version"),
+                value: installedVersion
+            ))
+        }
+        if let installSize = Self.installSizeText(for: module.installSizeBytes) {
+            rows.append(row(
+                kind: .installSize,
+                title: String(localized: "module_install_size", defaultValue: "Install size"),
+                value: installSize
+            ))
+        }
+        if installedModule != nil {
+            rows.append(row(
+                kind: .installedState,
+                title: String(localized: "module_installed", defaultValue: "Installed"),
+                value: String(localized: "module_installed", defaultValue: "Installed")
+            ))
+        }
+        if let installedModule, installedModule.isEncrypted {
+            rows.append(row(
+                kind: .encryptionState,
+                title: String(localized: "module_encrypted", defaultValue: "Encrypted"),
+                value: installedModule.isUnlocked
+                    ? String(localized: "module_unlocked", defaultValue: "Unlocked")
+                    : String(localized: "module_locked", defaultValue: "Locked")
+            ))
+        }
+
+        return rows
+    }
+
+    /**
+     Creates a typed dialog row.
+
+     - Parameters:
+       - kind: Stable metadata field identity.
+       - title: Localized field label.
+       - value: User-visible metadata value.
+     - Returns: Row value consumed by the shared dialog.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func row(kind: ModuleBrowserModuleDetailRow.Kind, title: String, value: String) -> ModuleBrowserModuleDetailRow {
+        ModuleBrowserModuleDetailRow(kind: kind, title: title, value: value)
+    }
+
+    /**
+     Resolves a module category to the same user-facing buckets used by the Downloads filter.
+
+     - Parameter category: SWORD module category.
+     - Returns: Localized category title.
+     - Side effects: none.
+     - Failure modes: Unknown categories fall back to the raw category value.
+     */
+    private static func categoryTitle(_ category: ModuleCategory) -> String {
+        switch category {
+        case .bible:
+            return String(localized: "bibles", defaultValue: "Bibles")
+        case .commentary:
+            return String(localized: "commentaries", defaultValue: "Commentaries")
+        case .dictionary:
+            return String(localized: "dictionaries", defaultValue: "Dictionaries")
+        case .generalBook:
+            return String(localized: "category_books", defaultValue: "Books")
+        case .map:
+            return String(localized: "maps", defaultValue: "Maps")
+        case .addon:
+            return String(localized: "doc_type_addons", defaultValue: "Add-ons")
+        default:
+            return category.rawValue
+        }
+    }
+
+    /**
+     Resolves a language code to localized display text.
+
+     - Parameter languageCode: ISO-style language code from remote or installed metadata.
+     - Returns: Localized language name when available, otherwise the uppercased code.
+     - Side effects: none.
+     - Failure modes: Invalid or unknown codes fall back to uppercased input.
+     */
+    private static func displayName(for languageCode: String) -> String {
+        let baseCode = languageCode.components(separatedBy: "-").first ?? languageCode
+        if let name = Locale.current.localizedString(forLanguageCode: baseCode),
+           name.lowercased() != baseCode.lowercased() {
+            if languageCode.contains("-") {
+                let suffix = languageCode.components(separatedBy: "-").dropFirst().joined(separator: "-")
+                return "\(name) (\(suffix))"
+            }
+            return name
+        }
+        return languageCode.uppercased()
+    }
+
+    /**
+     Formats the SWORD install-size value shown in Android's download rows.
+
+     - Parameter bytes: Install-size byte count from remote catalog metadata.
+     - Returns: One-decimal megabyte text, or `nil` when metadata is absent.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func installSizeText(for bytes: Int64?) -> String? {
+        guard let bytes else {
+            return nil
+        }
+        let megabytes = Double(bytes) / 1_000_000
+        return String(format: "%.1f MB", megabytes)
+    }
+
+    /**
+     Trims optional catalog text before rendering.
+
+     - Parameter value: Optional raw metadata value.
+     - Returns: Trimmed text, or `nil` when the value is empty.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }
 
 /**
@@ -158,7 +405,7 @@ struct ModuleBrowserRowActionConfirmation: Identifiable {
     /**
      Confirmation operation matching Android's contextual document menu.
 
-     Cases intentionally stay narrow: About is a sheet and Unlock is hidden until iOS has a real
+     Cases intentionally stay narrow: About is a dialog and Unlock is hidden until iOS has a real
      cipher-key coordinator.
      */
     enum Kind {
@@ -250,170 +497,218 @@ struct ModuleBrowserRowActionConfirmation: Identifiable {
 }
 
 /**
- Android-compatible module details sheet for the Downloads About action.
+ Android-compatible module details dialog for Downloads and the reader document picker.
 
- Android loads richer `SwordBookMetaData` before showing About. The iOS catalog currently stores a
- smaller metadata subset, so this sheet presents every available remote and installed field without
- inventing unavailable copyright/unlock content.
+ Android uses `CommonUtils.showAbout(...)`, which shows module metadata in an AppCompat
+ `AlertDialog` with a message body and a single OK action. This SwiftUI surface keeps the same
+ in-place dialog ownership while rendering only the metadata rows iOS can provide honestly.
 
  Data dependencies:
  - a `ModuleBrowserModuleDetails` payload from the selected row
- - SwiftUI dismiss environment for the Done toolbar action
+ - an explicit dismiss closure supplied by the owning screen
 
  Side effects:
- - tapping Done dismisses the sheet
+ - tapping OK invokes `onDismiss`
 
  Failure modes:
- - missing optional metadata rows are omitted
+ - missing optional metadata rows are omitted by `ModuleBrowserModuleDetails.androidAboutRows`
  */
-struct ModuleBrowserModuleDetailsView: View {
-    /// Dismiss action supplied by SwiftUI's sheet environment.
-    @Environment(\.dismiss) private var dismiss
+struct ModuleBrowserModuleDetailsDialog: View {
+    /// Current system color scheme used by the shared Android dialog palette.
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Remote and installed module metadata to display.
     let details: ModuleBrowserModuleDetails
 
-    /**
-     Renders the module details form.
+    /// Callback that clears the owning screen's selected details state.
+    let onDismiss: () -> Void
 
-     - Returns: SwiftUI form with Android About-equivalent metadata fields available on iOS.
-     - Side effects: Done toolbar button dismisses the sheet.
-     - Failure modes: Optional fields with empty values are not rendered.
+    /**
+     Renders the Android-style About dialog.
+
+     - Returns: Centered dialog panel with a scrollable metadata message and OK action.
+     - Side effects: OK invokes `onDismiss`.
+     - Failure modes: Empty row lists render only the module heading and OK action.
      */
     var body: some View {
-        Form {
-            Section {
-                LabeledContent(String(localized: "module_initials", defaultValue: "Initials")) {
-                    Text(details.module.name)
-                }
-                LabeledContent(String(localized: "module_name", defaultValue: "Name")) {
-                    Text(details.module.description)
-                }
-                LabeledContent(String(localized: "module_category", defaultValue: "Category")) {
-                    Text(categoryTitle(details.module.category))
-                }
-                LabeledContent(String(localized: "module_language", defaultValue: "Language")) {
-                    Text(displayName(for: details.module.language))
-                }
-                LabeledContent(String(localized: "module_source", defaultValue: "Source")) {
-                    Text(details.module.sourceName)
-                }
-            }
+        VStack(spacing: 0) {
+            Text(details.module.name)
+                .font(.headline)
+                .foregroundStyle(dialogPrimaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 22)
+                .padding(.top, 20)
+                .padding(.bottom, 12)
 
-            Section(String(localized: "module_versions", defaultValue: "Versions")) {
-                if !details.module.version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    LabeledContent(String(localized: "module_latest_version", defaultValue: "Latest")) {
-                        Text(details.module.version)
-                    }
-                }
-                if let installedModule = details.installedModule,
-                   !installedModule.version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    LabeledContent(String(localized: "module_installed_version", defaultValue: "Installed")) {
-                        Text(installedModule.version)
-                    }
-                }
-                if details.module.version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                   details.installedModule?.version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
-                    Text(String(localized: "module_version_unavailable", defaultValue: "No version metadata available."))
-                        .foregroundStyle(.secondary)
-                }
-            }
+            Divider()
+                .background(dialogSecondaryText.opacity(0.25))
 
-            if let installSize = installSizeText(for: details.module.installSizeBytes) {
-                Section {
-                    LabeledContent(String(localized: "module_install_size", defaultValue: "Install size")) {
-                        Text(installSize)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(details.androidAboutRows) { row in
+                        detailRow(row)
                     }
                 }
+                .padding(.horizontal, 22)
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .frame(maxHeight: 420)
+            .accessibilityIdentifier("moduleDetailsDialogRows")
 
-            if let installedModule = details.installedModule {
-                Section(String(localized: "module_local_state", defaultValue: "Local State")) {
-                    LabeledContent(String(localized: "module_installed", defaultValue: "Installed")) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                    }
-                    if installedModule.isEncrypted {
-                        LabeledContent(String(localized: "module_encrypted", defaultValue: "Encrypted")) {
-                            Text(installedModule.isUnlocked
-                                ? String(localized: "module_unlocked", defaultValue: "Unlocked")
-                                : String(localized: "module_locked", defaultValue: "Locked"))
-                        }
-                    }
+            Divider()
+                .background(dialogSecondaryText.opacity(0.25))
+
+            HStack {
+                Spacer()
+                Button(String(localized: "okay", defaultValue: "OK")) {
+                    onDismiss()
                 }
+                .fontWeight(.semibold)
+                .foregroundStyle(dialogAccent)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+                .accessibilityIdentifier("moduleDetailsOKButton")
             }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
         }
-        .navigationTitle(String(localized: "about"))
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(String(localized: "done", defaultValue: "Done")) {
-                    dismiss()
-                }
-            }
-        }
+        .frame(maxWidth: 430)
+        .background(dialogBackground, in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .strokeBorder(dialogSecondaryText.opacity(0.28), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 20, x: 0, y: 12)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("moduleDetailsDialogScreen")
+        .tint(dialogAccent)
     }
 
     /**
-     Resolves a module category to the same user-facing buckets used by the Downloads filter.
+     Renders one field/value row in the dialog message.
 
-     - Parameter category: SWORD module category.
-     - Returns: Localized category title.
+     - Parameter row: Metadata row assembled from the shared About payload.
+     - Returns: Vertically stacked label and value text.
      - Side effects: none.
-     - Failure modes: Unknown categories fall back to the raw category value.
+     - Failure modes: Long values wrap within the dialog width.
      */
-    private func categoryTitle(_ category: ModuleCategory) -> String {
-        switch category {
-        case .bible:
-            return String(localized: "bibles")
-        case .commentary:
-            return String(localized: "commentaries")
-        case .dictionary:
-            return String(localized: "dictionaries")
-        case .generalBook:
-            return String(localized: "category_books")
-        case .map:
-            return String(localized: "maps", defaultValue: "Maps")
-        case .addon:
-            return String(localized: "doc_type_addons", defaultValue: "Add-ons")
-        default:
-            return category.rawValue
+    private func detailRow(_ row: ModuleBrowserModuleDetailRow) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(row.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(dialogSecondaryText)
+            Text(row.value)
+                .font(.body)
+                .foregroundStyle(dialogPrimaryText)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("moduleDetailsRow::\(row.kind.rawValue)")
     }
 
-    /**
-     Resolves a language code to localized display text.
-
-     - Parameter languageCode: ISO-style language code from remote or installed metadata.
-     - Returns: Localized language name when available, otherwise the uppercased code.
-     - Side effects: none.
-     - Failure modes: Invalid or unknown codes fall back to uppercased input.
-     */
-    private func displayName(for languageCode: String) -> String {
-        let baseCode = languageCode.components(separatedBy: "-").first ?? languageCode
-        if let name = Locale.current.localizedString(forLanguageCode: baseCode),
-           name.lowercased() != baseCode.lowercased() {
-            if languageCode.contains("-") {
-                let suffix = languageCode.components(separatedBy: "-").dropFirst().joined(separator: "-")
-                return "\(name) (\(suffix))"
-            }
-            return name
-        }
-        return languageCode.uppercased()
+    /// Android-dialog background color for the current system appearance.
+    private var dialogBackground: Color {
+        AndroidDialogSurfacePalette.background(for: colorScheme)
     }
 
-    /**
-     Formats the SWORD install-size value shown in Android's download rows.
+    /// Android-dialog primary text color for the current system appearance.
+    private var dialogPrimaryText: Color {
+        AndroidDialogSurfacePalette.primaryText(for: colorScheme)
+    }
 
-     - Parameter bytes: Install-size byte count from remote catalog metadata.
-     - Returns: One-decimal megabyte text, or `nil` when metadata is absent.
-     - Side effects: none.
+    /// Android-dialog secondary text color for the current system appearance.
+    private var dialogSecondaryText: Color {
+        AndroidDialogSurfacePalette.secondaryText(for: colorScheme)
+    }
+
+    /// Android-dialog accent color for the OK action.
+    private var dialogAccent: Color {
+        AndroidDialogSurfacePalette.accent(for: colorScheme)
+    }
+}
+
+/**
+ Full-screen dimmed overlay hosting the module About dialog.
+
+ Android marks the About `AlertDialog` non-cancelable and closes it through the positive button. The
+ dimmer therefore blocks interaction with the underlying screen without dismissing on background tap.
+
+ Side effects:
+ - the nested dialog may invoke `onDismiss`
+
+ Failure modes:
+ - none; missing details are handled by the view modifier before this overlay is created
+ */
+private struct ModuleBrowserModuleDetailsDialogOverlay: View {
+    /// Current system color scheme used for the dimmer opacity.
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// Metadata payload to render in the dialog.
+    let details: ModuleBrowserModuleDetails
+
+    /// Callback that clears the owning screen's selected details state.
+    let onDismiss: () -> Void
+
+    /**
+     Renders the blocking dimmer and centered dialog.
+
+     - Returns: Full-screen overlay with the Android-style module details dialog.
+     - Side effects: OK inside the dialog invokes `onDismiss`.
      - Failure modes: none.
      */
-    private func installSizeText(for bytes: Int64?) -> String? {
-        guard let bytes else {
-            return nil
+    var body: some View {
+        ZStack {
+            Color.black.opacity(colorScheme == .dark ? 0.52 : 0.32)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture {}
+                .accessibilityHidden(true)
+
+            ModuleBrowserModuleDetailsDialog(
+                details: details,
+                onDismiss: onDismiss
+            )
+            .padding(.horizontal, 24)
         }
-        let megabytes = Double(bytes) / 1_000_000
-        return String(format: "%.1f MB", megabytes)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .zIndex(2)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("moduleDetailsDialogOverlay")
+    }
+}
+
+/**
+ Shared presenter for module About details.
+
+ Downloads and the reader document picker both originate from Android document rows and must show the
+ same dialog instead of separate SwiftUI sheets. Keeping the presenter as a `View` extension prevents
+ call-site drift while each owner still controls its selected details state.
+ */
+extension View {
+    /**
+     Presents Android-compatible module About details above the receiving view.
+
+     - Parameters:
+       - details: Currently selected module details, or `nil` when no dialog should be visible.
+       - onDismiss: Callback used to clear the selected details state.
+     - Returns: The receiving view with an optional blocking dialog overlay.
+     - Side effects: OK in the dialog invokes `onDismiss`.
+     - Failure modes: `nil` details produce no overlay.
+     */
+    func moduleBrowserModuleDetailsDialog(
+        details: ModuleBrowserModuleDetails?,
+        onDismiss: @escaping () -> Void
+    ) -> some View {
+        overlay {
+            if let details {
+                ModuleBrowserModuleDetailsDialogOverlay(
+                    details: details,
+                    onDismiss: onDismiss
+                )
+            }
+        }
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -675,10 +675,8 @@ public struct ModuleBrowserView: View {
             allowsMultipleSelection: false,
             onCompletion: handleInstallZipSelection
         )
-        .sheet(item: $selectedModuleDetails) { details in
-            NavigationStack {
-                ModuleBrowserModuleDetailsView(details: details)
-            }
+        .moduleBrowserModuleDetailsDialog(details: selectedModuleDetails) {
+            selectedModuleDetails = nil
         }
         .alert(
             String(localized: "download_errors", defaultValue: "Download errors"),
@@ -1961,7 +1959,8 @@ public struct ModuleBrowserView: View {
        - status: Current Android-equivalent install status.
        - rowActions: Precomputed secondary actions from `ModuleDownloadRowActionPlanner`.
      - Returns: SwiftUI controls for About plus the primary install/update/progress affordance.
-     - Side effects: Produced controls may mutate view state when tapped.
+     - Side effects: Produced controls may mutate view state when tapped, including opening the shared
+       Android-style module details dialog.
      - Failure modes: Action failures are handled by `installModule(_:)`, `cancelInstall(_:)`, or
        the confirmation alert handlers.
      */

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
@@ -347,4 +347,22 @@ final class BibleReaderModulePickerTests: XCTestCase {
         XCTAssertFalse(pickerSource.contains("Section(String(localized: \"document_filter_results"))
     }
 
+    /**
+     Guards reader document-picker About against preserving the shared iOS sheet route.
+
+     Android's `DocumentSelectionBase` row menu invokes `CommonUtils.showAbout(...)` and keeps the user
+     inside the chooser while a dialog is visible. The iOS picker must therefore use the same shared
+     module details dialog presenter as Downloads instead of wrapping `ModuleBrowserModuleDetailsView`
+     in a `NavigationStack` sheet.
+     */
+    func testBibleReaderModulePickerAboutUsesSharedAndroidDialogInsteadOfSheet() throws {
+        let pickerSource = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift"
+        )
+
+        XCTAssertTrue(pickerSource.contains(".moduleBrowserModuleDetailsDialog("))
+        XCTAssertFalse(pickerSource.contains(".sheet(item: $selectedModuleDetails)"))
+        XCTAssertFalse(pickerSource.contains("NavigationStack {\n                ModuleBrowserModuleDetailsView"))
+    }
+
 }

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
@@ -353,7 +353,7 @@ final class BibleReaderModulePickerTests: XCTestCase {
      Android's `DocumentSelectionBase` row menu invokes `CommonUtils.showAbout(...)` and keeps the user
      inside the chooser while a dialog is visible. The iOS picker must therefore use the same shared
      module details dialog presenter as Downloads instead of wrapping `ModuleBrowserModuleDetailsView`
-     in a `NavigationStack` sheet.
+     in a `NavigationStack` sheet or synthesizing Downloads-only metadata for installed documents.
      */
     func testBibleReaderModulePickerAboutUsesSharedAndroidDialogInsteadOfSheet() throws {
         let pickerSource = try BibleUITestSourceLocator.source(
@@ -361,8 +361,10 @@ final class BibleReaderModulePickerTests: XCTestCase {
         )
 
         XCTAssertTrue(pickerSource.contains(".moduleBrowserModuleDetailsDialog("))
+        XCTAssertTrue(pickerSource.contains("ModuleBrowserModuleDetails(installedModule: module)"))
         XCTAssertFalse(pickerSource.contains(".sheet(item: $selectedModuleDetails)"))
         XCTAssertFalse(pickerSource.contains("NavigationStack {\n                ModuleBrowserModuleDetailsView"))
+        XCTAssertFalse(pickerSource.contains("sourceName: String(localized: \"installed\""))
     }
 
 }

--- a/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
@@ -24,8 +24,8 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
 
      Android builds the About dialog from the selected document's real metadata and omits unavailable
      fields. This test covers the iOS payload boundary directly: Downloads and the reader picker both
-     consume `ModuleBrowserModuleDetails`, so every available remote and installed field must be
-     present before SwiftUI renders it.
+     consume `ModuleBrowserModuleDetails`, so SWORD About fields, version rows, repository, and OSIS ID
+     must be present while iOS-only category/language/install-state rows stay absent.
      */
     func testModuleBrowserModuleDetailsRowsPreserveAvailableRemoteAndInstalledMetadata() {
         let details = ModuleBrowserModuleDetails(
@@ -45,43 +45,199 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
                 language: "en",
                 version: "2.0",
                 isEncrypted: true,
-                isUnlocked: false
+                isUnlocked: false,
+                aboutMetadata: ModuleAboutMetadata(
+                    about: "Installed about text",
+                    shortCopyright: "Short copyright",
+                    history: ["1.0 First release", "2.0 Second release"],
+                    versification: "KJVA",
+                    osisId: "KJV",
+                    repository: "CrossWire",
+                    swordVersionDate: "2023-07-19"
+                )
             )
         )
 
         XCTAssertEqual(
             details.androidAboutRows.map(\.kind),
             [
-                .initials,
-                .name,
-                .category,
-                .language,
-                .source,
+                .about,
+                .copyright,
                 .latestVersion,
                 .installedVersion,
-                .installSize,
-                .installedState,
-                .encryptionState
+                .versionHistory,
+                .versification,
+                .osisId,
+                .repository
             ]
         )
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .initials }?.value, "KJV")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .name }?.value, "King James Version")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .category }?.value, "Bibles")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .language }?.value, "English")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .source }?.value, "CrossWire")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .latestVersion }?.value, "2.1")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installedVersion }?.value, "2.0")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installSize }?.value, "2.5 MB")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installedState }?.value, "Installed")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .encryptionState }?.value, "Locked")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .about }?.value, "Installed about text")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .copyright }?.value, "Short copyright")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .latestVersion }?.value, "2.1 (-)")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installedVersion }?.value, "2.0 (2023-07-19)")
+        XCTAssertEqual(
+            details.androidAboutRows.first { $0.kind == .versionHistory }?.value,
+            "2.0 Second release\n1.0 First release"
+        )
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .versification }?.value, "KJVA")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .osisId }?.value, "KJV")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .repository }?.value, "CrossWire")
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .category })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .language })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .installSize })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .installedState })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .encryptionState })
+    }
+
+    /**
+     Verifies the rendered About body follows Android's `CommonUtils.showAbout(...)` message shape.
+
+     Android does not render a form/table for About metadata; it builds one message beginning with the
+     document name, then appends available metadata sections with blank-line separation and adjacent
+     latest/installed version lines. A failure means iOS can have the right fields but still present a
+     materially different About dialog.
+     */
+    func testModuleBrowserModuleDetailsMessageUsesAndroidAboutBodyShape() {
+        let details = ModuleBrowserModuleDetails(
+            module: RemoteModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "2.1"
+            ),
+            installedModule: ModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                version: "2.0",
+                aboutMetadata: ModuleAboutMetadata(
+                    about: "Installed\\par about text",
+                    shortPromo: "Short promo",
+                    shortCopyright: "Short copyright",
+                    distributionLicense: "GPL",
+                    unlockInfo: "Request a key",
+                    history: ["1.0 First release", "2.0 Second release"],
+                    versification: "KJVA",
+                    osisId: "KJV",
+                    repository: "CrossWire",
+                    isBadDocument: true,
+                    swordVersionDate: "2023-07-19"
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            details.androidAboutMessage,
+            """
+            King James Version
+
+            Warning: This document might be (at least partially) bad technical quality.
+
+            Installed
+             about text
+
+            Short promo
+
+            Copyright: Short copyright
+
+            GPL
+
+            Encrypted module unlock info
+
+            Request a key
+
+            Latest version: 2.1 (-)
+            Installed version: 2.0 (2023-07-19)
+
+            Version history:\(" ")
+            2.0 Second release
+            1.0 First release
+
+            Versification: KJVA
+
+            OSIS ID: KJV
+
+            Distribution server: CrossWire
+            """
+        )
+        XCTAssertEqual(
+            details.androidAboutHTMLMessage,
+            "<b>King James Version</b><br><br><b>Warning: This document might be (at least partially) bad technical quality.</b><br><br>Installed<br> about text<br><br>Short promo<br><br>Copyright: Short copyright<br><br>GPL<br><br><b>Encrypted module unlock info</b><br><br>Request a key<br><br>Latest version: 2.1 (-)<br>Installed version: 2.0 (2023-07-19)<br><br>Version history: <br>2.0 Second release<br>1.0 First release<br><br>Versification: KJVA<br><br>OSIS ID: KJV<br><br>Distribution server: CrossWire"
+        )
+    }
+
+    /**
+     Verifies long copyright-only metadata keeps Android's paragraph spacing.
+
+     Android's `CommonUtils.showAbout(...)` prefixes long `Copyright` and `DistributionLicense`
+     fragments with blank paragraphs when `ShortCopyright` is absent. The iOS message assembly must
+     preserve that shape instead of normalizing it into a cleaner iOS-only single-line copyright row.
+     A failure means the dialog text can drift even though the same source-backed metadata fields are
+     present.
+     */
+    func testModuleBrowserModuleDetailsMessagePreservesAndroidCopyrightSpacingWithoutShortCopyright() {
+        let details = ModuleBrowserModuleDetails(
+            module: RemoteModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire"
+            ),
+            installedModule: ModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                aboutMetadata: ModuleAboutMetadata(
+                    copyright: "Long copyright",
+                    distributionLicense: "GPL"
+                )
+            )
+        )
+
+        XCTAssertEqual(
+            details.androidAboutRows.first { $0.kind == .copyright }?.message,
+            """
+            Copyright:\(" ")
+
+            Long copyright
+
+            GPL
+            """
+        )
+    }
+
+    /**
+     Verifies SWORD `History_*` metadata preserves the original config suffix before About rendering.
+
+     JSword projects `History_1.0=value` as `1.0 value`; iOS must avoid lowercasing the raw suffix
+     while keeping config lookup case-insensitive. A failure means version-history rows can drift from
+     Android for non-numeric suffixes even when the dialog assembly is correct.
+     */
+    func testModuleBrowserAboutMetadataPreservesHistorySuffixCase() throws {
+        let config = try XCTUnwrap(SwordModuleConfig.parse("""
+        [TEST]
+        Description=Test Bible
+        Category=Biblical Texts
+        ModDrv=zText
+        Lang=en
+        History_Beta=Beta release
+        History_1.0=First release
+        """))
+
+        XCTAssertEqual(config.moduleInfo.aboutMetadata.history, ["Beta Beta release", "1.0 First release"])
     }
 
     /**
      Verifies unavailable About metadata is omitted instead of rendered as empty iOS-only rows.
 
      Android's About dialog only includes fields backed by actual `BookMetaData` values. The iOS
-     payload must follow the same rule for optional remote metadata so the dialog stays honest when
-     a repository catalog has sparse SWORD fields.
+     payload must follow the same rule for optional metadata so the dialog stays honest when a
+     repository catalog has sparse SWORD fields.
      */
     func testModuleBrowserModuleDetailsRowsOmitUnavailableOptionalMetadata() {
         let details = ModuleBrowserModuleDetails(
@@ -100,12 +256,48 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
         XCTAssertEqual(
             details.androidAboutRows.map(\.kind),
             [
-                .initials,
-                .category
+                .osisId
             ]
         )
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .initials }?.value, "EMPTY")
-        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .category }?.value, "Dictionaries")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .osisId }?.value, "EMPTY")
+    }
+
+    /**
+     Verifies installed document About details do not pass through a fake Downloads catalog row.
+
+     Android reader-picker About uses the installed `BookMetaData` directly and does not invent a
+     repository source or latest-version row. The iOS reader picker must therefore build an installed-only
+     payload; failures here mean installed modules can show artificial metadata or duplicate version rows.
+     */
+    func testModuleBrowserModuleDetailsRowsForInstalledDocumentDoNotInventRemoteMetadata() {
+        let details = ModuleBrowserModuleDetails(
+            installedModule: ModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                version: "2.0",
+                isEncrypted: false,
+                isUnlocked: true
+            )
+        )
+
+        XCTAssertEqual(
+            details.androidAboutRows.map(\.kind),
+            [
+                .latestVersion,
+                .osisId
+            ]
+        )
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .latestVersion }?.value, "2.0 (-)")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .osisId }?.value, "KJV")
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .source })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .installedVersion })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .category })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .language })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .installSize })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .installedState })
+        XCTAssertNil(details.androidAboutRows.first { $0.kind == .encryptionState })
     }
 
     /**
@@ -129,6 +321,12 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
         XCTAssertTrue(detailsSource.contains("AndroidDialogSurfacePalette"))
         XCTAssertTrue(detailsSource.contains("moduleDetailsDialogScreen"))
         XCTAssertTrue(detailsSource.contains("moduleDetailsOKButton"))
+        XCTAssertTrue(detailsSource.contains(".accessibilityAddTraits(.isModal)"))
+        XCTAssertTrue(detailsSource.contains("Text(details.androidAboutAttributedMessage)"))
+        XCTAssertTrue(detailsSource.contains("NSAttributedString.DocumentType.html"))
+        XCTAssertTrue(detailsSource.contains(".onTapGesture {}"))
+        XCTAssertFalse(detailsSource.contains("ForEach(details.androidAboutRows)"))
+        XCTAssertFalse(detailsSource.contains("private func detailRow("))
         XCTAssertFalse(detailsSource.contains("@Environment(\\.dismiss) private var dismiss"))
         XCTAssertFalse(detailsSource.contains("Form {"))
         XCTAssertFalse(detailsSource.contains(".navigationTitle(String(localized: \"about\"))"))

--- a/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
@@ -19,6 +19,122 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
     }
 
     /**
+     Verifies module About metadata remains a shared Android-dialog payload rather than a sheet-local
+     form.
+
+     Android builds the About dialog from the selected document's real metadata and omits unavailable
+     fields. This test covers the iOS payload boundary directly: Downloads and the reader picker both
+     consume `ModuleBrowserModuleDetails`, so every available remote and installed field must be
+     present before SwiftUI renders it.
+     */
+    func testModuleBrowserModuleDetailsRowsPreserveAvailableRemoteAndInstalledMetadata() {
+        let details = ModuleBrowserModuleDetails(
+            module: RemoteModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                sourceName: "CrossWire",
+                version: "2.1",
+                installSizeBytes: 2_500_000
+            ),
+            installedModule: ModuleInfo(
+                name: "KJV",
+                description: "King James Version",
+                category: .bible,
+                language: "en",
+                version: "2.0",
+                isEncrypted: true,
+                isUnlocked: false
+            )
+        )
+
+        XCTAssertEqual(
+            details.androidAboutRows.map(\.kind),
+            [
+                .initials,
+                .name,
+                .category,
+                .language,
+                .source,
+                .latestVersion,
+                .installedVersion,
+                .installSize,
+                .installedState,
+                .encryptionState
+            ]
+        )
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .initials }?.value, "KJV")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .name }?.value, "King James Version")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .category }?.value, "Bibles")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .language }?.value, "English")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .source }?.value, "CrossWire")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .latestVersion }?.value, "2.1")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installedVersion }?.value, "2.0")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installSize }?.value, "2.5 MB")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .installedState }?.value, "Installed")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .encryptionState }?.value, "Locked")
+    }
+
+    /**
+     Verifies unavailable About metadata is omitted instead of rendered as empty iOS-only rows.
+
+     Android's About dialog only includes fields backed by actual `BookMetaData` values. The iOS
+     payload must follow the same rule for optional remote metadata so the dialog stays honest when
+     a repository catalog has sparse SWORD fields.
+     */
+    func testModuleBrowserModuleDetailsRowsOmitUnavailableOptionalMetadata() {
+        let details = ModuleBrowserModuleDetails(
+            module: RemoteModuleInfo(
+                name: "EMPTY",
+                description: "   ",
+                category: .dictionary,
+                language: "",
+                sourceName: "   ",
+                version: "   ",
+                installSizeBytes: nil
+            ),
+            installedModule: nil
+        )
+
+        XCTAssertEqual(
+            details.androidAboutRows.map(\.kind),
+            [
+                .initials,
+                .category
+            ]
+        )
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .initials }?.value, "EMPTY")
+        XCTAssertEqual(details.androidAboutRows.first { $0.kind == .category }?.value, "Dictionaries")
+    }
+
+    /**
+     Guards Downloads row About against regressing to native iOS sheet chrome.
+
+     Android invokes `CommonUtils.showAbout(...)`, which displays a non-cancelable `AlertDialog`
+     message from the row About action. A failure means the Downloads path has drifted back to a
+     SwiftUI sheet or stopped using the shared dialog presenter.
+     */
+    func testModuleBrowserAboutUsesSharedAndroidDialogInsteadOfSheet() throws {
+        let downloadsSource = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift"
+        )
+        let detailsSource = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserRowActionPresentation.swift"
+        )
+
+        XCTAssertTrue(downloadsSource.contains(".moduleBrowserModuleDetailsDialog("))
+        XCTAssertFalse(downloadsSource.contains(".sheet(item: $selectedModuleDetails)"))
+        XCTAssertTrue(detailsSource.contains("struct ModuleBrowserModuleDetailsDialog: View"))
+        XCTAssertTrue(detailsSource.contains("AndroidDialogSurfacePalette"))
+        XCTAssertTrue(detailsSource.contains("moduleDetailsDialogScreen"))
+        XCTAssertTrue(detailsSource.contains("moduleDetailsOKButton"))
+        XCTAssertFalse(detailsSource.contains("@Environment(\\.dismiss) private var dismiss"))
+        XCTAssertFalse(detailsSource.contains("Form {"))
+        XCTAssertFalse(detailsSource.contains(".navigationTitle(String(localized: \"about\"))"))
+    }
+
+    /**
      Verifies destructive Downloads row confirmations use module descriptions instead of initials.
 
      Android confirms removal/index deletion with the visible document name. The iOS row model must

--- a/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleModule.swift
@@ -45,7 +45,11 @@ struct InstalledMyBibleModule: Codable, Sendable {
             description: description,
             category: ModuleCategory(typeString: category),
             language: language,
-            version: version
+            version: version,
+            aboutMetadata: ModuleAboutMetadata(
+                osisId: name,
+                repository: sourceName
+            )
         )
     }
 

--- a/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
@@ -126,6 +126,155 @@ public struct ModuleFeatures: OptionSet, Sendable {
     public static let dailyDevotion = ModuleFeatures(rawValue: 1 << 9)
 }
 
+/**
+ Android-compatible metadata used by module About dialogs.
+
+ Android reloads `SwordBookMetaData` before opening `CommonUtils.showAbout(...)` and reads these
+ optional config fields from the installed document. iOS carries the same values alongside
+ `ModuleInfo` so UI code can render real metadata and omit unavailable fields instead of inventing
+ Downloads-only substitutes.
+
+ Side effects:
+ - none; this is an immutable value type
+
+ Failure modes:
+ - none; missing metadata is represented by empty strings or an empty history array
+ */
+public struct ModuleAboutMetadata: Sendable, Equatable {
+    /// Raw SWORD `About` text.
+    public let about: String
+
+    /// SWORD `ShortPromo` text.
+    public let shortPromo: String
+
+    /// SWORD `ShortCopyright` text.
+    public let shortCopyright: String
+
+    /// SWORD `Copyright` text.
+    public let copyright: String
+
+    /// SWORD `DistributionLicense` text.
+    public let distributionLicense: String
+
+    /// SWORD `UnlockInfo` text for encrypted modules.
+    public let unlockInfo: String
+
+    /// JSword-style `History` values, preserving config order.
+    public let history: [String]
+
+    /// SWORD versification name.
+    public let versification: String
+
+    /// OSIS/module identifier shown by Android About.
+    public let osisId: String
+
+    /// Distribution repository/source name when known.
+    public let repository: String
+
+    /// Whether Android metadata marks this as a bad document.
+    public let isBadDocument: Bool
+
+    /// SWORD `SwordVersionDate` value.
+    public let swordVersionDate: String
+
+    /**
+     Creates an About metadata value.
+
+     - Parameters:
+       - about: Raw SWORD `About` text.
+       - shortPromo: SWORD `ShortPromo` text.
+       - shortCopyright: SWORD `ShortCopyright` text.
+       - copyright: SWORD `Copyright` text.
+       - distributionLicense: SWORD `DistributionLicense` text.
+       - unlockInfo: SWORD `UnlockInfo` text.
+       - history: JSword-style version history values in config order.
+       - versification: SWORD versification name.
+       - osisId: OSIS/module identifier.
+       - repository: Distribution repository/source name.
+       - isBadDocument: Whether Android should show the bad-document warning.
+       - swordVersionDate: SWORD version date value.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public init(
+        about: String = "",
+        shortPromo: String = "",
+        shortCopyright: String = "",
+        copyright: String = "",
+        distributionLicense: String = "",
+        unlockInfo: String = "",
+        history: [String] = [],
+        versification: String = "",
+        osisId: String = "",
+        repository: String = "",
+        isBadDocument: Bool = false,
+        swordVersionDate: String = ""
+    ) {
+        self.about = about
+        self.shortPromo = shortPromo
+        self.shortCopyright = shortCopyright
+        self.copyright = copyright
+        self.distributionLicense = distributionLicense
+        self.unlockInfo = unlockInfo
+        self.history = history
+        self.versification = versification
+        self.osisId = osisId
+        self.repository = repository
+        self.isBadDocument = isBadDocument
+        self.swordVersionDate = swordVersionDate
+    }
+
+    /**
+     Applies honest fallback identifiers to metadata that came from a smaller source.
+
+     Module sidecars and test fixtures can omit OSIS ID or repository while the caller still knows those
+     values from the selected installed or remote row. This method fills only blank values and preserves
+     all source-backed fields.
+
+     - Parameters:
+       - fallbackOsisId: Module initials to use when `osisId` is blank.
+       - fallbackRepository: Repository/source name to use when `repository` is blank.
+     - Returns: Metadata with missing identifier fields filled.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public func withFallbacks(
+        osisId fallbackOsisId: String,
+        repository fallbackRepository: String? = nil
+    ) -> ModuleAboutMetadata {
+        ModuleAboutMetadata(
+            about: about,
+            shortPromo: shortPromo,
+            shortCopyright: shortCopyright,
+            copyright: copyright,
+            distributionLicense: distributionLicense,
+            unlockInfo: unlockInfo,
+            history: history,
+            versification: versification,
+            osisId: Self.nonEmpty(osisId) ?? fallbackOsisId,
+            repository: Self.nonEmpty(repository) ?? Self.nonEmpty(fallbackRepository) ?? "",
+            isBadDocument: isBadDocument,
+            swordVersionDate: swordVersionDate
+        )
+    }
+
+    /**
+     Trims optional metadata text before fallback decisions.
+
+     - Parameter value: Optional raw metadata text.
+     - Returns: Trimmed non-empty text, otherwise `nil`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}
+
 extension ModuleFeatures {
     /**
      Builds a feature set from SWORD/JSword config values.
@@ -245,6 +394,9 @@ public struct ModuleInfo: Sendable, Identifiable {
     /// Module text direction.
     public let isRightToLeft: Bool
 
+    /// Android-compatible module About metadata.
+    public let aboutMetadata: ModuleAboutMetadata
+
     /// Unique identifier (uses module name).
     public var id: String { name }
 
@@ -257,7 +409,8 @@ public struct ModuleInfo: Sendable, Identifiable {
         isEncrypted: Bool = false,
         isUnlocked: Bool = true,
         features: ModuleFeatures = [],
-        isRightToLeft: Bool = false
+        isRightToLeft: Bool = false,
+        aboutMetadata: ModuleAboutMetadata = ModuleAboutMetadata()
     ) {
         self.name = name
         self.description = description
@@ -268,5 +421,6 @@ public struct ModuleInfo: Sendable, Identifiable {
         self.isUnlocked = isUnlocked
         self.features = features
         self.isRightToLeft = isRightToLeft
+        self.aboutMetadata = aboutMetadata.withFallbacks(osisId: name)
     }
 }

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -93,13 +93,14 @@ public final class SwordModule: @unchecked Sendable {
             let language = String(cString: SWModule_getLanguage(handle))
             let modDrvPtr = SWModule_getConfigEntry(handle, "ModDrv")
             let modDrv = modDrvPtr != nil ? String(cString: modDrvPtr!) : ""
+            let config = modulePath.flatMap { SwordModuleConfig.read(name: name, modulePath: $0) }
 
             // Detect features by parsing the .conf file directly from disk.
             // SWORD's flat API getConfigEntry() only returns the FIRST value for
             // multi-value keys (Feature, GlobalOptionFilter), so modules like KJV
             // where StrongsNumbers isn't the first entry are missed. Reading the
             // .conf file catches ALL entries.
-            let features = SwordModule.detectFeatures(
+            let features = config?.features ?? SwordModule.detectFeatures(
                 name: name, handle: handle, modulePath: modulePath
             )
 
@@ -109,6 +110,22 @@ public final class SwordModule: @unchecked Sendable {
             let direction = directionPtr != nil ? String(cString: directionPtr!) : "LtoR"
             let versionPtr = SWModule_getConfigEntry(handle, "Version")
             let versionStr = versionPtr != nil ? String(cString: versionPtr!) : ""
+            func configValue(_ key: String) -> String {
+                guard let value = SWModule_getConfigEntry(handle, key) else { return "" }
+                return String(cString: value)
+            }
+            let aboutMetadata = config?.aboutMetadata ?? ModuleAboutMetadata(
+                about: configValue("About"),
+                shortPromo: configValue("ShortPromo"),
+                shortCopyright: configValue("ShortCopyright"),
+                copyright: configValue("Copyright"),
+                distributionLicense: configValue("DistributionLicense"),
+                unlockInfo: configValue("UnlockInfo"),
+                versification: configValue("Versification"),
+                osisId: name,
+                isBadDocument: SWModule_getConfigEntry(handle, "BadDocument") != nil,
+                swordVersionDate: configValue("SwordVersionDate")
+            )
 
             return ModuleInfo(
                 name: name,
@@ -119,7 +136,8 @@ public final class SwordModule: @unchecked Sendable {
                 isEncrypted: isEncrypted,
                 isUnlocked: !isEncrypted || (cipherKey.map { String(cString: $0) } ?? "").isEmpty == false,
                 features: features,
-                isRightToLeft: direction == "RtoL"
+                isRightToLeft: direction == "RtoL",
+                aboutMetadata: aboutMetadata
             )
         }
     }

--- a/Sources/SwordKit/Sources/SwordKit/SwordModuleConfig.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModuleConfig.swift
@@ -41,6 +41,9 @@ struct SwordModuleConfig: Sendable {
     /// Feature flags collected from repeated `Feature` and `GlobalOptionFilter` lines.
     let features: ModuleFeatures
 
+    /// JSword-compatible version history values collected from `History` and `History_x.y` lines.
+    let history: [String]
+
     /// Case-insensitive config values keyed by lowercased property name.
     let values: [String: [String]]
 
@@ -50,6 +53,24 @@ struct SwordModuleConfig: Sendable {
     /// Category resolved through Android custom-driver and SWORD fallback rules.
     var category: ModuleCategory {
         ModuleCategory(typeString: categoryString, modDrv: modDrv)
+    }
+
+    /// Android `CommonUtils.showAbout(...)` metadata projected from config values.
+    var aboutMetadata: ModuleAboutMetadata {
+        ModuleAboutMetadata(
+            about: Self.firstValue("about", in: values) ?? "",
+            shortPromo: Self.firstValue("shortpromo", in: values) ?? "",
+            shortCopyright: Self.firstValue("shortcopyright", in: values) ?? "",
+            copyright: Self.firstValue("copyright", in: values) ?? "",
+            distributionLicense: Self.firstValue("distributionlicense", in: values) ?? "",
+            unlockInfo: Self.firstValue("unlockinfo", in: values) ?? "",
+            history: history,
+            versification: Self.firstValue("versification", in: values) ?? "",
+            osisId: name,
+            repository: Self.firstValue("repository", in: values) ?? "",
+            isBadDocument: Self.firstValue("baddocument", in: values) != nil,
+            swordVersionDate: Self.firstValue("swordversiondate", in: values) ?? ""
+        )
     }
 
     /// Whether the config belongs to an Android custom book driver that libsword does not expose.
@@ -80,7 +101,8 @@ struct SwordModuleConfig: Sendable {
             language: language,
             version: version,
             features: features,
-            isRightToLeft: direction.caseInsensitiveCompare("RtoL") == .orderedSame
+            isRightToLeft: direction.caseInsensitiveCompare("RtoL") == .orderedSame,
+            aboutMetadata: aboutMetadata
         )
     }
 
@@ -95,6 +117,7 @@ struct SwordModuleConfig: Sendable {
     static func parse(_ content: String) -> SwordModuleConfig? {
         var name = ""
         var values: [String: [String]] = [:]
+        var history: [String] = []
 
         for line in content.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -111,12 +134,19 @@ struct SwordModuleConfig: Sendable {
                 continue
             }
 
-            let key = String(trimmed[..<equalsIndex])
+            let rawKey = String(trimmed[..<equalsIndex])
                 .trimmingCharacters(in: .whitespaces)
-                .lowercased()
+            let key = rawKey.lowercased()
             let value = String(trimmed[trimmed.index(after: equalsIndex)...])
                 .trimmingCharacters(in: .whitespaces)
             values[key, default: []].append(value)
+
+            if key == "history" {
+                history.append(value)
+            } else if key.hasPrefix("history_") {
+                let version = String(rawKey.dropFirst("history_".count))
+                history.append("\(version) \(value)")
+            }
         }
 
         guard !name.isEmpty,
@@ -138,6 +168,7 @@ struct SwordModuleConfig: Sendable {
             features: ModuleFeatures.fromConfigValues(
                 (values["feature"] ?? []) + (values["globaloptionfilter"] ?? [])
             ),
+            history: history,
             values: values,
             content: content
         )

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -28,6 +28,50 @@ final class SwordManagerTests: XCTestCase {
         XCTAssertTrue(info.isUnlocked)
     }
 
+    /**
+     Verifies installed module rows retain Android `CommonUtils.showAbout` metadata from SWORD config.
+
+     JSword reloads `SwordBookMetaData` before opening About and exposes fields such as `About`,
+     copyright, version history, versification, OSIS ID, bad-document state, and version date. iOS must
+     project those config values into `ModuleInfo` so reader-picker and Downloads About dialogs show
+     real metadata instead of iOS-only substitutes.
+     */
+    func testSwordModuleConfigProjectsAndroidAboutMetadataIntoModuleInfo() throws {
+        let config = try XCTUnwrap(SwordModuleConfig.parse("""
+        [TEST]
+        Description=Test Bible
+        Category=Biblical Texts
+        ModDrv=zText
+        Lang=en
+        Version=2.0
+        SwordVersionDate=2024-01-02
+        About=First line\\par Second line
+        ShortPromo=Short promo
+        ShortCopyright=Short copyright
+        Copyright=Long copyright
+        DistributionLicense=GPL
+        UnlockInfo=Request a key
+        History_1.0=First release
+        History_2.0=Second release
+        Versification=KJVA
+        BadDocument=true
+        """))
+
+        let info = config.moduleInfo
+
+        XCTAssertEqual(info.aboutMetadata.about, "First line\\par Second line")
+        XCTAssertEqual(info.aboutMetadata.shortPromo, "Short promo")
+        XCTAssertEqual(info.aboutMetadata.shortCopyright, "Short copyright")
+        XCTAssertEqual(info.aboutMetadata.copyright, "Long copyright")
+        XCTAssertEqual(info.aboutMetadata.distributionLicense, "GPL")
+        XCTAssertEqual(info.aboutMetadata.unlockInfo, "Request a key")
+        XCTAssertEqual(info.aboutMetadata.history, ["1.0 First release", "2.0 Second release"])
+        XCTAssertEqual(info.aboutMetadata.versification, "KJVA")
+        XCTAssertEqual(info.aboutMetadata.osisId, "TEST")
+        XCTAssertTrue(info.aboutMetadata.isBadDocument)
+        XCTAssertEqual(info.aboutMetadata.swordVersionDate, "2024-01-02")
+    }
+
     func testRemoteModuleInfoDefaultsToInstallable() {
         let info = RemoteModuleInfo(
             name: "KJV",


### PR DESCRIPTION
## Summary

Aligns module About details with Android's `CommonUtils.showAbout(...)` contract across Downloads and the reader document picker. The PR now covers real SWORD About metadata, installed-document boundaries, single-message dialog presentation, Android copyright/version-history formatting, and HTML-backed rendering.

## Scope

- Downloads module row About action
- Reader document picker About action
- Shared module About metadata payload and modal presentation
- SWORD config/C API projection into `ModuleInfo`
- Parity tests for metadata rows, message shape, HTML rendering, and source-guarded presentation

## Contract References

- Closes #334
- Android reference: `CommonUtils.showAbout(...)` builds one non-cancelable `AlertDialog` message with a single OK action.
- Android reference: `DocumentSelectionBase.handleAbout(...)` reloads the selected installed `SwordBookMetaData` instead of synthesizing a Downloads row.
- Android reference: About message order is warning, About, ShortPromo, copyright/license, unlock info, version rows, history, versification, OSIS ID, repository.

## Change Details

- Added `ModuleAboutMetadata` to carry Android-compatible About fields through `ModuleInfo`.
- Projected About, copyright/license, unlock info, history, versification, bad-document state, repository, and version date from SWORD config or the SWORD C API fallback.
- Reworked `ModuleBrowserModuleDetails` so Downloads rows use installed metadata when present and reader-picker rows use installed metadata directly without fake remote/source fields.
- Removed visible iOS-only About rows such as category, language, install size, installed state, and encryption state from the Android About payload.
- Replaced sheet/table presentation with the shared Android-style modal dialog body, including consumed background taps, a single OK action, and attributed HTML rendering for bold headings and module links.
- Preserved Android-specific formatting details for adjacent version rows, version-history suffix case, and long-copyright paragraph spacing.
- Added regression coverage for full metadata rows, sparse metadata omission, installed-only reader metadata, Android message body shape, HTML body shape, copyright spacing, history suffix casing, and shared dialog source guards.

## Validation Evidence

- PASS: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F -only-testing:BibleUITests/ModuleBrowserDownloadsTests -only-testing:BibleUITests/BibleReaderModulePickerTests CODE_SIGNING_ALLOWED=NO` (34 tests, 0 failures)
- PASS: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project AndBible.xcodeproj -scheme BibleUITests -configuration Debug -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F CODE_SIGNING_ALLOWED=NO` (395 tests, 0 failures)
- PASS: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project AndBible.xcodeproj -scheme SwordKit -configuration Debug -destination id=0BFFE049-A46B-4BCA-A6B3-281EA931DD7F CODE_SIGNING_ALLOWED=NO`
- PASS: `git diff --cached --check`
- PASS: GitNexus `detect_changes` on the staged worktree diff completed with medium risk, driven by shared `ModuleInfo`/`SwordModule` metadata projection; no high or critical warning.
- Existing unrelated failure: `AndBibleUnitTests` still fails `testMemorizationBridgePersistsInclusiveKJVASpanAcrossChapterIntroOrdinals` and `testMemorizeDocumentPreservesCrossChapterAndroidRange` because the test process reports `SWORD found 0 installed modules` and unwraps no `SwordModule`.

## Risks / Follow-ups

- Remote catalog rows still do not expose `SwordVersionDate` through the current iOS catalog model, so remote latest-version dates fall back to Android's `-` placeholder until that source metadata exists.
- The remaining `AndBibleUnitTests` failures are fixture/setup failures in memorization coverage and are outside this module About parity change.
- No generated files or migration paths are changed.