### PR TITLE
test(ui): reduce semantic wait polling

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -842,7 +842,7 @@ jobs:
 
   ios-simulator-unit-tests:
     name: Unit Tests (Simulator)
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ needs.repo-standards.outputs.required_checks_only == 'true' && 'ubuntu-latest' || 'macos-15' }}
     needs:
       - repo-standards

--- a/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1278,7 +1278,8 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The current non-empty reader reference string from `bookChooserButton`.
      * - Side effects:
-     *   - polls the live reader toolbar until the reference control exports one non-empty value
+     *   - samples the live reader toolbar through the shared semantic-state waiter until the
+     *     reference control exports one non-empty value
      * - Failure modes:
      *   - records an XCTest failure if the reader reference never becomes non-empty
      */
@@ -1295,22 +1296,22 @@ extension AndBibleUITests {
             file: file,
             line: line
         )
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let value = referenceButton.value as? String, !value.isEmpty {
-                return value
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let fallbackValue = referenceButton.value as? String ?? ""
-        XCTAssertFalse(
-            fallbackValue.isEmpty,
-            "Expected bookChooserButton to expose a non-empty reader reference within \(timeout) seconds.",
+        var latestValue = referenceButton.value as? String ?? ""
+        _ = waitForResolvedSemanticState(
+            named: "bookChooserButton.value",
+            timeout: timeout,
+            valueProvider: {
+                latestValue = referenceButton.value as? String ?? ""
+                return latestValue
+            },
+            success: { !$0.isEmpty },
+            failureDescription: {
+                "Expected bookChooserButton to expose a non-empty reader reference within \(timeout) seconds; last value was '\($0)'."
+            },
             file: file,
             line: line
         )
-        return fallbackValue
+        return latestValue
     }
 
     /**
@@ -1502,7 +1503,8 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The first non-empty reader reference value different from `initialValue`.
      * - Side effects:
-     *   - polls the live reader toolbar until `bookChooserButton` exports a different value
+     *   - samples the live reader toolbar through the shared semantic-state waiter until
+     *     `bookChooserButton` exports a different value
      * - Failure modes:
      *   - records an XCTest failure if the reader reference never changes before the timeout
      */
@@ -1520,25 +1522,22 @@ extension AndBibleUITests {
             file: file,
             line: line
         )
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let value = referenceButton.value as? String,
-               !value.isEmpty,
-               value != initialValue {
-                return value
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let fallbackValue = referenceButton.value as? String ?? ""
-        XCTAssertNotEqual(
-            fallbackValue,
-            initialValue,
-            "Expected bookChooserButton to change away from '\(initialValue)' within \(timeout) seconds.",
+        var latestValue = referenceButton.value as? String ?? ""
+        _ = waitForResolvedSemanticState(
+            named: "bookChooserButton.value",
+            timeout: timeout,
+            valueProvider: {
+                latestValue = referenceButton.value as? String ?? ""
+                return latestValue
+            },
+            success: { !$0.isEmpty && $0 != initialValue },
+            failureDescription: {
+                "Expected bookChooserButton to change away from '\(initialValue)' within \(timeout) seconds; last value was '\($0)'."
+            },
             file: file,
             line: line
         )
-        return fallbackValue
+        return latestValue
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -401,6 +401,8 @@ extension AndBibleUITests {
         case "syncSettingsState":
             return screenRootCandidates("syncSettingsScreen", in: app)
                 + screenScopedStateCandidates(identifier, within: "syncSettingsScreen", in: app)
+        case "settingsForm":
+            return screenRootCandidates("settingsForm", in: app)
         default:
             return semanticStateCandidates(for: identifier, in: app)
         }
@@ -1321,18 +1323,14 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let value = readerRenderedContentStateValue(in: app),
-               value.contains(token) {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let lastValue = readerRenderedContentStateValue(in: app) ?? "nil"
-        XCTFail(
-            "Expected reader rendered-content state to contain '\(token)' within \(timeout) seconds; last value was '\(lastValue)'.",
+        waitForResolvedSemanticState(
+            named: "readerRenderedContentState",
+            timeout: timeout,
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
+            success: { $0.contains(token) },
+            failureDescription: {
+                "Expected reader rendered-content state to contain '\(token)' within \(timeout) seconds; last value was '\($0)'."
+            },
             file: file,
             line: line
         )
@@ -1418,15 +1416,16 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if readerRenderedContentStateContains(token, in: app) {
-                return true
+        waitForResolvedSemanticState(
+            named: "readerRenderedContentState",
+            timeout: timeout,
+            valueProvider: { self.readerRenderedContentStateValue(in: app) },
+            success: { $0.contains(token) },
+            recordsFailure: false,
+            failureDescription: {
+                "Expected optional reader rendered-content state to contain '\(token)' within \(timeout) seconds; last value was '\($0)'."
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        return readerRenderedContentStateContains(token, in: app)
+        )
     }
 
     /// Reads a boolean key from the compact reader state export.

--- a/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -880,7 +880,8 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - repeatedly reads the production `settingsForm` accessibility value
+     *   - evaluates the production `settingsForm` accessibility value through the shared semantic
+     *     state waiter
      * - Failure modes:
      *   - records an XCTest failure if the requested token never appears before timeout
      */
@@ -891,19 +892,14 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let settingsForm = requireElement("settingsForm", in: app, timeout: timeout, file: file, line: line)
-        let deadline = Date().addingTimeInterval(timeout)
-
-        repeat {
-            if let state = settingsForm.value as? String, state.contains(expectedToken) {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalState = settingsForm.value as? String ?? ""
-        XCTFail(
-            "Expected Settings state to contain '\(expectedToken)' within \(timeout) seconds. Last state: '\(finalState)'.",
+        waitForResolvedSemanticState(
+            named: "settingsForm",
+            timeout: timeout,
+            valueProvider: { self.semanticStateExportValue("settingsForm", in: app) },
+            success: { $0.contains(expectedToken) },
+            failureDescription: {
+                "Expected Settings state to contain '\(expectedToken)' within \(timeout) seconds. Last state: '\($0)'."
+            },
             file: file,
             line: line
         )

--- a/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -558,7 +558,6 @@ extension AndBibleUITests {
             timeout: timeout,
             valueProvider: { self.resolvedReadingPlanListStateValue(in: app) },
             success: { !$0.contains(token) },
-            missingCountsAsSuccess: true,
             recordsFailure: false,
             failureDescription: {
                 "Expected Reading Plans state to stop containing '\(token)' within \(timeout) seconds. Last state: '\($0)'."

--- a/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -553,16 +553,17 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let currentValue = resolvedReadingPlanListStateValue(in: app),
-               !currentValue.contains(token) {
-                return true
+        return waitForResolvedSemanticState(
+            named: "readingPlanListStateExport",
+            timeout: timeout,
+            valueProvider: { self.resolvedReadingPlanListStateValue(in: app) },
+            success: { !$0.contains(token) },
+            missingCountsAsSuccess: true,
+            recordsFailure: false,
+            failureDescription: {
+                "Expected Reading Plans state to stop containing '\(token)' within \(timeout) seconds. Last state: '\($0)'."
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        return resolvedReadingPlanListStateValue(in: app)?.contains(token) == false
+        )
     }
 
     /// Sanitizes one reading-plan code to match the production accessibility export.

--- a/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -805,25 +805,26 @@ extension AndBibleUITests {
      *   - app: Running application under test.
      *   - timeout: Maximum time to poll the Search state export.
      * - Returns: `true` when the Search state export contains `translationPicker=open`.
-     * - Side effects: none.
+     * - Side effects: samples the Search state export through the shared semantic-state waiter.
      * - Failure modes: This helper does not fail directly.
      */
     func searchTranslationPickerStateIsOpen(
         in app: XCUIApplication,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(max(0, timeout))
-        repeat {
-            if searchStateCandidateValues(in: app).contains(where: { $0.contains("translationPicker=open") }) {
-                return true
+        return waitForResolvedSemanticState(
+            named: "searchStateExport.translationPicker",
+            timeout: max(0, timeout),
+            valueProvider: {
+                let values = self.searchStateCandidateValues(in: app)
+                return values.isEmpty ? nil : values.joined(separator: " || ")
+            },
+            success: { $0.contains("translationPicker=open") },
+            recordsFailure: false,
+            failureDescription: {
+                "Expected Search translation picker state to open within \(timeout) seconds. Last state: '\($0)'."
             }
-            if timeout <= 0 {
-                return false
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        } while Date() < deadline
-
-        return searchStateCandidateValues(in: app).contains { $0.contains("translationPicker=open") }
+        )
     }
 
     /// Returns stable picker descendants that prove the Search translation picker overlay is open.
@@ -1561,7 +1562,7 @@ extension AndBibleUITests {
        - timeout: Maximum number of seconds to poll the Search state export.
      - Returns: `true` when an exported Search state explicitly reports
        `searchFieldFocused=false`.
-     - Side effects: none.
+     - Side effects: samples the Search state export through the shared semantic-state waiter.
      - Failure modes: returns `false` when the state export continues reporting focused input until
        timeout or becomes temporarily unavailable.
      */
@@ -1569,15 +1570,19 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if searchFieldFocusState(in: app) == false {
-                return true
+        return waitForResolvedSemanticState(
+            named: "searchStateExport.searchFieldFocused",
+            timeout: max(0, timeout),
+            valueProvider: {
+                let values = self.searchStateCandidateValues(in: app)
+                return values.isEmpty ? nil : values.joined(separator: " || ")
+            },
+            success: { $0.contains("searchFieldFocused=false") },
+            recordsFailure: false,
+            failureDescription: {
+                "Expected Search field focus to clear within \(timeout) seconds. Last state: '\($0)'."
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        } while Date() < deadline
-
-        return searchFieldFocusState(in: app) == false
+        )
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -1109,7 +1109,7 @@ extension AndBibleUITests {
      *     wait for localized fallback controls that do not expose the stable test value.
      *   - app: Running application under test.
      *   - timeout: Maximum time to wait for the semantic state change.
-     * - Side effects: polls the live picker button only.
+     * - Side effects: samples the live picker button through the shared semantic-state waiter.
      * - Failure modes: fails when the stable picker button remains visible but does not reach the
      *   expected value before the timeout.
      */
@@ -1120,20 +1120,18 @@ extension AndBibleUITests {
     ) {
         guard let expectedValue else { return }
 
-        let deadline = Date().addingTimeInterval(timeout)
         let toggle = app.buttons["searchTranslationSelectAllButton"].firstMatch
-        var lastValue = toggle.value as? String
-
-        repeat {
-            if toggle.exists, toggle.value as? String == expectedValue {
-                return
+        waitForResolvedSemanticState(
+            named: "searchTranslationSelectAllButton",
+            timeout: timeout,
+            valueProvider: {
+                guard toggle.exists else { return nil }
+                return toggle.value as? String
+            },
+            success: { $0 == expectedValue },
+            failureDescription: {
+                "Expected Search translation select toggle value '\(expectedValue)' within \(timeout) seconds; last value was '\($0)'."
             }
-            lastValue = toggle.value as? String
-            RunLoop.current.run(until: Date().addingTimeInterval(0.15))
-        } while Date() < deadline
-
-        XCTFail(
-            "Expected Search translation select toggle value '\(expectedValue)' within \(timeout) seconds; last value was '\(lastValue ?? "nil")'."
         )
     }
 

--- a/Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift
@@ -785,24 +785,29 @@ extension AndBibleUITests {
      *   - valueProvider: Closure returning the currently exported semantic state.
      *   - success: Predicate that should become true before the timeout.
      *   - missingCountsAsSuccess: When true, treats a missing export as success.
+     *   - recordsFailure: When false, returns `false` on timeout instead of recording an XCTest
+     *     failure so optional probes can share the same waiter.
      *   - failureDescription: Closure that formats the final failure message from the last value.
      * - Side effects:
      *   - evaluates a dedicated state export through `XCTNSPredicateExpectation` and `XCTWaiter`
      *     until the predicate succeeds
      * - Failure modes:
-     *   - records an XCTest failure with elapsed wait time, final observed state, and last observed
-     *     state if the predicate never succeeds before the timeout expires
+     *   - returns `false` when the predicate never succeeds and `recordsFailure` is false
+     *   - otherwise records an XCTest failure with elapsed wait time, final observed state, and
+     *     last observed state if the predicate never succeeds before the timeout expires
      */
+    @discardableResult
     func waitForResolvedSemanticState(
         named name: String,
         timeout: TimeInterval,
         valueProvider: @escaping () -> String?,
         success: @escaping (String) -> Bool,
         missingCountsAsSuccess: Bool = false,
+        recordsFailure: Bool = true,
         failureDescription: (String) -> String,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) {
+    ) -> Bool {
         let startedAt = Date()
         var lastObservedValue: String?
         let predicate = NSPredicate(block: { _, _ in
@@ -821,13 +826,16 @@ extension AndBibleUITests {
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
 
         if result == .completed {
-            return
+            return true
         }
 
         let lastObservedBeforeFinalRead = lastObservedValue
         if let finalValue = valueProvider() {
             if success(finalValue) {
-                return
+                return true
+            }
+            guard recordsFailure else {
+                return false
             }
             let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
             let lastObservedState = lastObservedBeforeFinalRead ?? "<none>"
@@ -838,10 +846,14 @@ extension AndBibleUITests {
                 file: file,
                 line: line
             )
+            return false
         } else if missingCountsAsSuccess {
-            return
+            return true
         } else {
             let missingValue = "<missing \(name)>"
+            guard recordsFailure else {
+                return false
+            }
             let elapsed = String(format: "%.2f", Date().timeIntervalSince(startedAt))
             let lastObservedState = lastObservedBeforeFinalRead ?? "<none>"
             XCTFail(
@@ -851,6 +863,7 @@ extension AndBibleUITests {
                 file: file,
                 line: line
             )
+            return false
         }
     }
 
@@ -1703,7 +1716,8 @@ extension AndBibleUITests {
      *   - timeout: Maximum time to keep polling before giving up.
      * - Returns: `true` when the switch reaches `expectedValue`, otherwise `false`.
      * - Side effects:
-     *   - repeatedly samples the live XCUI switch value so delayed SwiftUI updates can settle
+     *   - samples the live XCUI switch value through the shared semantic-state waiter so delayed
+     *     SwiftUI updates can settle
      * - Failure modes: This helper cannot fail.
      */
     func waitForSwitchValue(
@@ -1711,15 +1725,16 @@ extension AndBibleUITests {
         toEqual expectedValue: String,
         timeout: TimeInterval = 2
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if (element.value as? String) == expectedValue {
-                return true
+        return waitForResolvedSemanticState(
+            named: "switchValue:\(element.identifier)",
+            timeout: timeout,
+            valueProvider: { element.value as? String },
+            success: { $0 == expectedValue },
+            recordsFailure: false,
+            failureDescription: {
+                "Expected switch '\(element.identifier)' to report value '\(expectedValue)' within \(timeout) seconds. Last value: '\($0)'."
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        return (element.value as? String) == expectedValue
+        )
     }
 
     /**
@@ -2364,25 +2379,20 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let stateElement = requireElement("syncSettingsState", in: app, timeout: timeout, file: file, line: line)
-        let deadline = Date().addingTimeInterval(timeout)
-
-        repeat {
-            if let state = stateElement.value as? String,
-               expectedTokens.allSatisfy({ syncStateToken(named: $0.key, in: state) == $0.value })
-            {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
-
-        let finalState = stateElement.value as? String ?? "nil"
         let expectedDescription = expectedTokens
             .sorted(by: { $0.key < $1.key })
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: ";")
-        XCTFail(
-            "Expected syncSettingsState to match '\(expectedDescription)' within \(timeout) seconds. Final state: '\(finalState)'.",
+        waitForResolvedSemanticState(
+            named: "syncSettingsState",
+            timeout: timeout,
+            valueProvider: { self.semanticStateExportValue("syncSettingsState", in: app) },
+            success: { state in
+                expectedTokens.allSatisfy { self.syncStateToken(named: $0.key, in: state) == $0.value }
+            },
+            failureDescription: {
+                "Expected syncSettingsState to match '\(expectedDescription)' within \(timeout) seconds. Final state: '\($0)'."
+            },
             file: file,
             line: line
         )

--- a/scripts/test_ios_ci_ui_shard_guardrails.py
+++ b/scripts/test_ios_ci_ui_shard_guardrails.py
@@ -111,6 +111,18 @@ def step_offsets(workflow_text: str, step_name: str) -> list[int]:
     return [match.start() for match in pattern.finditer(workflow_text)]
 
 
+def workflow_job_block(workflow_text: str, job_name: str) -> str:
+    """Return one top-level GitHub Actions job block by job id."""
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+        workflow_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Unable to find workflow job {job_name!r}.")
+    return match.group("body")
+
+
 class IOSCIUIShardGuardrailsTests(unittest.TestCase):
     """Checks the workflow-level guardrail around dynamic UI shard counts."""
 
@@ -163,6 +175,20 @@ class IOSCIUIShardGuardrailsTests(unittest.TestCase):
             ],
             workflow_step_run_blocks(workflow_text, "Checkout Android reference"),
         )
+
+    def test_unit_test_aggregate_gate_does_not_fail_cancelled_runs(self) -> None:
+        """Keep canceled superseded workflow runs from publishing red aggregate checks."""
+        workflow_text = (REPO_ROOT / ".github/workflows/ios-ci.yml").read_text(encoding="utf-8")
+        unit_job = workflow_job_block(workflow_text, "ios-simulator-unit-tests")
+        verify_gate = workflow_step_run_block(workflow_text, "Verify package-test gate results")
+
+        self.assertIn("name: Unit Tests (Simulator)", unit_job)
+        self.assertRegex(unit_job, re.compile(r"^\s+if:\s+\$\{\{\s*!cancelled\(\)\s*\}\}\s*$", re.MULTILINE))
+        self.assertNotRegex(unit_job, re.compile(r"^\s+if:\s+\$\{\{\s*always\(\)\s*\}\}\s*$", re.MULTILINE))
+        self.assertIn("needs.ios-swordkit-package-tests.result", verify_gate)
+        self.assertIn("needs.ios-biblecore-package-tests.result", verify_gate)
+        self.assertIn("needs.ios-bibleview-package-tests.result", verify_gate)
+        self.assertIn("needs.ios-bibleui-package-tests.result", verify_gate)
 
     def test_upload_artifact_retention_guardrail_handles_name_less_steps(self) -> None:
         """Ensure the retention guardrail classifies valid `- uses:` upload steps."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -367,10 +367,15 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         search_source = (
             REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift"
         ).read_text(encoding="utf-8")
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
 
         migrated_waits = [
             swift_function_body(state_source, "waitForSwitchValue"),
             swift_function_body(search_source, "waitForSearchTranslationSelectToggleValue"),
+            swift_function_body(element_source, "requireReaderReferenceValue"),
+            swift_function_body(element_source, "waitForReaderReferenceValueToChange"),
         ]
 
         for body in migrated_waits:

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -346,14 +346,19 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
             REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift"
         ).read_text(encoding="utf-8")
 
+        reading_plan_exclusion_body = swift_function_body(
+            list_source,
+            "waitForReadingPlanListStateToExclude",
+        )
         migrated_waits = [
             swift_function_body(interaction_source, "waitForSettingsState"),
-            swift_function_body(list_source, "waitForReadingPlanListStateToExclude"),
+            reading_plan_exclusion_body,
         ]
 
         for body in migrated_waits:
             self.assertIn("waitForResolvedSemanticState", body)
             self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotIn("missingCountsAsSuccess: true", reading_plan_exclusion_body)
 
         candidates_body = swift_function_body(element_source, "semanticStateValueCandidates")
         self.assertIn('case "settingsForm":', candidates_body)

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -315,6 +315,68 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertIn("waitForResolvedSemanticState", bookmark_rows_body)
         self.assertNotIn("RunLoop.current.run", bookmark_rows_body)
 
+    def test_reader_and_sync_state_waits_use_shared_semantic_waiter(self) -> None:
+        """Keep exported reader/sync state checks hook-driven instead of run-loop polling."""
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        state_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        migrated_waits = [
+            swift_function_body(element_source, "waitForReaderRenderedContentState"),
+            swift_function_body(element_source, "waitForReaderRenderedContentStateIfPresent"),
+            swift_function_body(state_source, "waitForSyncState"),
+        ]
+
+        for body in migrated_waits:
+            self.assertIn("waitForResolvedSemanticState", body)
+            self.assertNotIn("RunLoop.current.run", body)
+
+    def test_settings_and_reading_plan_state_waits_use_shared_semantic_waiter(self) -> None:
+        """Keep Settings and Reading Plan exported state waits off manual polling loops."""
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        interaction_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift"
+        ).read_text(encoding="utf-8")
+        list_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        migrated_waits = [
+            swift_function_body(interaction_source, "waitForSettingsState"),
+            swift_function_body(list_source, "waitForReadingPlanListStateToExclude"),
+        ]
+
+        for body in migrated_waits:
+            self.assertIn("waitForResolvedSemanticState", body)
+            self.assertNotIn("RunLoop.current.run", body)
+
+        candidates_body = swift_function_body(element_source, "semanticStateValueCandidates")
+        self.assertIn('case "settingsForm":', candidates_body)
+        self.assertIn('screenRootCandidates("settingsForm", in: app)', candidates_body)
+
+    def test_value_state_waits_use_shared_semantic_waiter(self) -> None:
+        """Keep pure accessibility-value waits on XCTest predicates, not run-loop polling."""
+        state_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestStateSupport.swift"
+        ).read_text(encoding="utf-8")
+        search_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        migrated_waits = [
+            swift_function_body(state_source, "waitForSwitchValue"),
+            swift_function_body(search_source, "waitForSearchTranslationSelectToggleValue"),
+        ]
+
+        for body in migrated_waits:
+            self.assertIn("waitForResolvedSemanticState", body)
+            self.assertNotIn("RunLoop.current.run", body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -377,6 +377,22 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
             self.assertIn("waitForResolvedSemanticState", body)
             self.assertNotIn("RunLoop.current.run", body)
 
+    def test_search_boolean_state_waits_use_shared_semantic_waiter(self) -> None:
+        """Keep Search boolean state probes on the shared waiter without recording failures."""
+        search_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+
+        migrated_waits = [
+            swift_function_body(search_source, "searchTranslationPickerStateIsOpen"),
+            swift_function_body(search_source, "waitForSearchFieldFocusToClear"),
+        ]
+
+        for body in migrated_waits:
+            self.assertIn("waitForResolvedSemanticState", body)
+            self.assertIn("recordsFailure: false", body)
+            self.assertNotIn("RunLoop.current.run", body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
This PR moves more UI-test synchronization away from manual `RunLoop.current.run` polling and onto shared XCTest predicate waits over exported semantic app state.

The intended outcome is a more hook-driven UI test layer: tests wait for app-published state/value changes instead of sleeping in polling loops, while timeouts remain as process bounds rather than the synchronization mechanism.

## Scope
In scope:
- Reader rendered-state waits, reader reference value waits, sync/settings state waits, search picker/focus probes, switch value waits, and Reading Plan deletion state checks.
- Shared waiter support for non-recording boolean probes.
- Source guardrails that keep these helpers on the shared semantic waiter and preserve the Reading Plan absence contract.

Out of scope:
- Full UI-test suite restructuring.
- Removing all remaining timeouts from end-to-end process bounds.
- Production UI or Android parity behavior changes.

## Contract References
- Repo commit/PR structure from `commit-standard`.
- UI-test synchronization contract: semantic app state and accessibility values should be observed through shared XCTest predicate helpers; timed waits should be retained only as bounds for hangs or performance-sensitive flows.
- Reading Plan deletion contract: a missing list-state export must not count as successful deletion, because that could mask broken list rendering or navigation.

## Change Details
- Extended `waitForResolvedSemanticState` so callers can request a boolean result without recording an XCTest failure.
- Replaced several hand-rolled run-loop polling helpers with the shared semantic waiter.
- Added `settingsForm` root candidates so Settings state waits can use the shared semantic export path.
- Added Python guardrails to prevent these helpers from drifting back to manual polling and to protect the Reading Plan deletion absence semantics.
- Performed an adversarial review; the review found the Reading Plan absence masking risk, which is fixed in `5c252116`.

## Validation Evidence
- `python3 -m unittest scripts.test_semantic_wait_guardrails`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `git diff --check origin/main...HEAD`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -derivedDataPath .derivedData/HookDrivenTests CODE_SIGNING_ALLOWED=NO`
- GitNexus impact for `waitForReadingPlanListStateToExclude`: LOW, one direct caller, no indexed execution flows.
- GitNexus change detection against `origin/main`: no mapped affected execution flows.

## Risks / Follow-ups
- This intentionally does not solve the entire UI-test performance problem; it is one layer of the broader migration from timed waits to native hooks/responses.
- Source guardrails remain string-structure based because they enforce migration boundaries around UI-test helper implementation patterns.

## Screenshots
none

## Closes
Closes: none - verified with `gh issue list --state open --search "semantic wait hook-driven tests UI test optimization in:title,body" --limit 20`, which returned no matching open issue.