### PR TITLE
test(ui): migrate element appearance waits to predicates

### DIFF
--- a/Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift
@@ -144,8 +144,8 @@ extension AndBibleUITests {
      *   - file: Source file used for XCTest failure attribution.
      *   - line: Source line used for XCTest failure attribution.
      * - Side effects:
-     *   - repeatedly samples the live XCUI hierarchy until the requested element exists or
-     *     disappears
+     *   - observes the live XCUI hierarchy with an XCTest predicate until the requested element
+     *     exists or disappears
      *   - keeps reader tab-bar controls scoped to `windowTabBar` so negative waits do not snapshot
      *     the full reader hierarchy
      * - Failure modes:
@@ -159,20 +159,22 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let deadline = Date().addingTimeInterval(timeout)
         let resolveElement: () -> XCUIElement? = {
             if self.isWindowTabBarButtonIdentifier(identifier) {
                 return self.resolvedWindowTabBarButton(identifier, in: app)
             }
             return self.resolvedElement(identifier, in: app)
         }
-        repeat {
-            let currentExists = resolveElement() != nil
-            if currentExists == shouldExist {
-                return
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+        let predicate = NSPredicate { _, _ in
+            (resolveElement() != nil) == shouldExist
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        expectation.expectationDescription =
+            "Wait for element '\(identifier)' existence to become \(shouldExist)"
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        if result == .completed {
+            return
+        }
 
         let currentExists = resolveElement() != nil
         XCTAssertEqual(
@@ -193,8 +195,8 @@ extension AndBibleUITests {
      *   - timeout: Maximum number of seconds to wait before giving up.
      * - Returns: `true` when the element appears before the timeout, otherwise `false`.
      * - Side effects:
-     *   - repeatedly re-resolves the live XCUI hierarchy without triggering `waitForExistence`
-     *     debug capture when the element is legitimately absent
+     *   - observes the live XCUI hierarchy with an XCTest predicate without triggering
+     *     `waitForExistence` debug capture when the element is legitimately absent
      * - Failure modes: This helper cannot fail.
      */
     func waitForResolvedElementAppearance(
@@ -202,15 +204,13 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval = 1
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if resolvedElement(identifier, in: app) != nil {
-                return true
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        } while Date() < deadline
-
-        return resolvedElement(identifier, in: app) != nil
+        let predicate = NSPredicate { _, _ in
+            self.resolvedElement(identifier, in: app) != nil
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        expectation.expectationDescription = "Wait for resolved element '\(identifier)' appearance"
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        return result == .completed || resolvedElement(identifier, in: app) != nil
     }
 
 

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -294,6 +294,32 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertIn("XCTWaiter", body)
         self.assertNotIn("RunLoop.current.run", body)
 
+    def test_element_existence_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
+        """Keep lightweight element existence checks on XCTest predicates."""
+        reader_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(reader_source, "waitForElementExistence")
+
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_resolved_element_appearance_wait_uses_xctest_waiter_not_run_loop_polling(
+        self,
+    ) -> None:
+        """Keep optional resolved-element appearance checks on XCTest predicates."""
+        reader_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestReaderSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(reader_source, "waitForResolvedElementAppearance")
+
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
     def test_reader_state_export_includes_window_tab_orders_for_tab_fallback(self) -> None:
         """Expose tab order metadata so tests can tap the real footer without stale queries."""
         source = (


### PR DESCRIPTION
## Summary
- Moves two remaining passive reader UI-test waits from manual run-loop polling to XCTest predicate waiters.
- Adds source guardrails so those helpers do not regress to `RunLoop.current.run` polling.

## Scope
- Test harness only.
- No production app behavior changes.
- No Android parity behavior changes.

## Contract references
- UI-test wait contract: pure observation waits should use semantic hooks or XCTest predicates, not timed run-loop polling.
- GitNexus impact: `waitForElementExistence` LOW risk; `waitForResolvedElementAppearance` LOW risk; compare against `origin/main` LOW risk with no affected execution flows.
- Deferred deliberately: broad helpers such as `requireElement` reported CRITICAL risk and were not changed in this batch.

## Change details
- `waitForElementExistence` now observes resolved existence state through `XCTNSPredicateExpectation`/`XCTWaiter`.
- `waitForResolvedElementAppearance` now observes optional element resolution through `XCTNSPredicateExpectation`/`XCTWaiter`.
- `scripts/test_semantic_wait_guardrails.py` adds focused guardrails for both helpers.

## Validation evidence
- `git diff --check origin/main...HEAD`
- `python3 -m unittest scripts.test_semantic_wait_guardrails`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath .derivedData/HookDrivenTests CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -xctestrun .derivedData/HookDrivenTests/Build/Products/AndBible_iphonesimulator26.5-arm64.xctestrun -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -resultBundlePath .artifacts/hook-driven-reader-appearance-waits.xcresult CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testReadingPlansRouteStartAdvanceDeleteAndImportAffordanceFlow test-without-building`
- GitHub Actions run `28691758786`: Repo Standards, Localization Guardrails, package tests, BibleView JS, Unit Tests, and UI shards 1-4 all passed.

## Risks/follow-ups
- This does not attempt the high-risk generic `requireElement` migration. That should be handled separately with broader UI coverage.

Closes: none
