### PR TITLE
refactor(tests): replace UI polling with XCTest waits

### DIFF
--- a/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -1037,7 +1037,8 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The first matching visible element, or `nil` when none appear before timeout.
      * - Side effects:
-     *   - repeatedly re-queries the live XCUI hierarchy across the provided identifiers
+     *   - observes the live XCUI hierarchy across the provided identifiers with an XCTest
+     *     predicate
      * - Failure modes: This helper does not fail directly.
      */
     func waitForAnyElement(
@@ -1047,15 +1048,38 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> XCUIElement? {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
+        let resolveCurrentMatch: () -> XCUIElement? = {
             for identifier in identifiers {
-                if let candidate = resolvedElement(identifier, in: app) {
+                if let candidate = self.resolvedElement(identifier, in: app) {
                     return candidate
                 }
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+            return nil
+        }
+
+        if let candidate = resolveCurrentMatch() {
+            return candidate
+        }
+        guard timeout > 0 else {
+            return nil
+        }
+
+        var resolvedMatch: XCUIElement?
+        let predicate = NSPredicate { _, _ in
+            if let candidate = resolveCurrentMatch() {
+                resolvedMatch = candidate
+                return true
+            }
+            return false
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        let candidateDescription = identifiers.joined(separator: ", ")
+        expectation.expectationDescription =
+            "Wait for any element in candidates \(candidateDescription)"
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        if result == .completed {
+            return resolvedMatch ?? resolveCurrentMatch()
+        }
 
         return nil
     }

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift
@@ -96,7 +96,8 @@ extension AndBibleUITests {
      *   - line: Source line used for XCTest failure attribution.
      * - Returns: The resolved overflow row once it exposes a usable frame.
      * - Side effects:
-     *   - taps the real Downloads overflow toolbar button until the requested row appears
+     *   - taps the real Downloads overflow toolbar button and waits for the requested row through
+     *     XCTest-backed candidate waits
      * - Failure modes:
      *   - records an XCTest failure when the toolbar button or requested row never becomes visible
      */
@@ -107,24 +108,31 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> XCUIElement {
+        let itemCandidates = [
+            unresolvedElement(itemIdentifier, in: app),
+            app.buttons[itemIdentifier].firstMatch,
+            app.cells[itemIdentifier].firstMatch,
+            app.otherElements[itemIdentifier].firstMatch,
+        ]
         let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let item = resolvedElement(itemIdentifier, in: app),
-               elementHasUsableFrame(item) {
-                return item
-            }
+        if let item = firstVisibleCandidate(from: itemCandidates, waitTimeout: min(1, timeout)) {
+            return item
+        }
 
+        for attempt in 0..<2 {
             let overflowButton = unresolvedElement("moduleBrowserOverflowButton", in: app)
-            if !tapElementIfPossible(overflowButton, timeout: min(1, max(0.1, deadline.timeIntervalSinceNow))) {
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-            }
+            let tapTimeout = min(1, max(0.1, deadline.timeIntervalSinceNow))
+            _ = tapElementIfPossible(overflowButton, timeout: tapTimeout)
 
-            if let item = resolvedElement(itemIdentifier, in: app),
-               elementHasUsableFrame(item) {
+            let remaining = max(0, deadline.timeIntervalSinceNow)
+            guard remaining > 0 else {
+                break
+            }
+            let waitTimeout = attempt == 0 ? min(2, remaining) : remaining
+            if let item = firstVisibleCandidate(from: itemCandidates, waitTimeout: waitTimeout) {
                 return item
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+        }
 
         let item = unresolvedElement(itemIdentifier, in: app)
         XCTAssertTrue(

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -415,6 +415,18 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertNotIn("RunLoop.current.run", surface_body)
         self.assertNotIn("RunLoop.current.run", open_body)
 
+    def test_downloads_overflow_item_wait_uses_xctest_candidate_wait(self) -> None:
+        """Keep Downloads overflow row waits on the shared XCTest-backed candidate helper."""
+        downloads_source = (
+            REPO_ROOT
+            / "Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(downloads_source, "openDownloadsOverflowItem")
+
+        self.assertIn("firstVisibleCandidate", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
     def test_resolved_semantic_wait_failure_reports_elapsed_and_final_state(self) -> None:
         """Keep timeout failures actionable without reintroducing custom polling loops."""
         state_source = (

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -294,6 +294,18 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertIn("XCTWaiter", body)
         self.assertNotIn("RunLoop.current.run", body)
 
+    def test_any_element_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
+        """Keep multi-identifier element waits on XCTest predicates."""
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(element_source, "waitForAnyElement")
+
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
     def test_element_existence_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
         """Keep lightweight element existence checks on XCTest predicates."""
         reader_source = (


### PR DESCRIPTION
Summary
- Moves two UI-test synchronization paths away from manual RunLoop polling and onto XCTest-backed wait helpers.
- Keeps the scope limited to shared test harness behavior; no production code or Android parity behavior changes.

Scope
- Updated waitForAnyElement to use XCTNSPredicateExpectation/XCTWaiter while preserving immediate lookup and nil-on-timeout behavior.
- Updated Downloads overflow row resolution to tap the production overflow control and wait through firstVisibleCandidate instead of sleeping between polls.
- Added semantic wait guardrails for both helpers.

Contract References
- Testing contract: UI readiness waits should rely on XCTest hooks, semantic exports, or native waiters rather than ad hoc run-loop sleeps.
- GitNexus impact: waitForAnyElement LOW risk, 4 direct callers, 0 affected processes; openDownloadsOverflowItem LOW risk, 1 direct caller, 0 affected processes.
- GitNexus compare: LOW risk, 3 changed files, 0 affected execution flows.

Change Details
- Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift: replaced the any-element polling loop with a predicate expectation and explicit candidate description.
- Tests/UI/AndBibleUITests/AndBibleUITests+PlansDownloadsWorkspace.swift: replaced Downloads overflow item polling sleeps with candidate waits around real overflow tap attempts.
- scripts/test_semantic_wait_guardrails.py: added guardrails to prevent these paths from regressing to RunLoop polling.

Validation Evidence
- python3 -m unittest scripts.test_semantic_wait_guardrails
- python3 -m unittest discover -s scripts -p 'test_*.py'
- git diff --check origin/main...HEAD
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -derivedDataPath .derivedData/UiWaitPredicateNext CODE_SIGNING_ALLOWED=NO build-for-testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product UITestFixtureTool
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -xctestrun .derivedData/UiWaitPredicateNext/Build/Products/AndBible_iphonesimulator26.5-arm64.xctestrun -destination id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33 -resultBundlePath .artifacts/ui-wait-predicate-selected-final.xcresult CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testDownloadsRepositoryManagerOpensFromOverflow -only-testing:AndBibleUITests/AndBibleUITests/testMyDocumentsScreenOpensFromReaderMenuAndOpensPage test-without-building

Risks / Follow-ups
- I intentionally did not modify waitForElementToBecomeHittable in this PR. GitNexus rated it HIGH risk with 20 direct callers and 89 impacted UI-test symbols, so that needs a separate, broader verification plan.
- During local verification, testSettingsApplicationShortcutsOpenGlobalTextOptions failed at the existing settingsGlobalTextOptionsLink lookup path. That failure is outside this diff and appears tied to the broader high-risk hittability/settings-row helpers rather than the low-risk helpers changed here.

Closes: none
- Verified with gh issue searches for "UI test wait polling predicate" and "test optimization RunLoop"; no matching open GitHub issue was found for this exact slice.
