### PR TITLE
feat(sync): enable Progress remote parity

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Database/MemorizationProgressStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/MemorizationProgressStore.swift
@@ -1,5 +1,6 @@
 // MemorizationProgressStore.swift - Local memorization state persistence
 
+import CryptoKit
 import Foundation
 
 /**
@@ -30,14 +31,56 @@ public struct MemorizationProgressRange: Codable, Equatable, Hashable {
  * be decoded and queried until they are rewritten by normal user actions.
  */
 public struct MemorizedVerseProgress: Codable, Equatable, Hashable {
+    public let id: UUID
     public let bookInitials: String
     public let kjvOrdinal: Int
     public let memorizedAt: Int64
 
-    public init(bookInitials: String = "", kjvOrdinal: Int, memorizedAt: Int64 = 0) {
+    public init(id: UUID? = nil, bookInitials: String = "", kjvOrdinal: Int, memorizedAt: Int64 = 0) {
+        self.id = id ?? Self.stableID(bookInitials: bookInitials, kjvOrdinal: kjvOrdinal)
         self.bookInitials = bookInitials
         self.kjvOrdinal = kjvOrdinal
         self.memorizedAt = memorizedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case bookInitials
+        case kjvOrdinal
+        case memorizedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let bookInitials = try container.decodeIfPresent(String.self, forKey: .bookInitials) ?? ""
+        let kjvOrdinal = try container.decode(Int.self, forKey: .kjvOrdinal)
+        let memorizedAt = try container.decodeIfPresent(Int64.self, forKey: .memorizedAt) ?? 0
+        self.init(
+            id: try container.decodeIfPresent(UUID.self, forKey: .id),
+            bookInitials: bookInitials,
+            kjvOrdinal: kjvOrdinal,
+            memorizedAt: memorizedAt
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(bookInitials, forKey: .bookInitials)
+        try container.encode(kjvOrdinal, forKey: .kjvOrdinal)
+        try container.encode(memorizedAt, forKey: .memorizedAt)
+    }
+
+    private static func stableID(bookInitials: String, kjvOrdinal: Int) -> UUID {
+        let seed = "memorized-verse|\(bookInitials)|\(kjvOrdinal)"
+        let digest = SHA256.hash(data: Data(seed.utf8))
+        let bytes = Array(digest.prefix(16))
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }
 

--- a/Sources/BibleCore/Sources/BibleCore/Database/ReadingProgressStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/ReadingProgressStore.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public enum ReadingProgressSource: String, Codable, Equatable, Hashable {
+public enum ReadingProgressSource: String, Codable, Equatable, Hashable, Sendable {
     case manual = "MANUAL"
     case autoScroll = "AUTO_SCROLL"
     case autoTts = "AUTO_TTS"

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupProgressMapper.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupProgressMapper.swift
@@ -108,6 +108,32 @@ enum AndroidDatabaseBackupProgressMapper {
         return report(for: snapshot, settingsStore: settingsStore)
     }
 
+    /**
+     Replaces local progress stores from an already decoded Android-shaped snapshot.
+
+     Remote patch replay validates sparse Android progress rows into the same in-memory models used
+     by database backup restore. This helper keeps the final JSON rewrite, normalization, and report
+     generation in one place.
+
+     - Parameters:
+       - reading: Final reading-progress snapshot to persist.
+       - memorization: Final memorization-progress snapshot to persist.
+       - settingsStore: Local store backing iOS progress JSON snapshots.
+     - Returns: Counts present after replacement.
+     - Side effects: Rewrites local reading and memorization progress snapshots in `SettingsStore`.
+     - Failure modes: Throws `AndroidDatabaseBackupError.invalidSQLiteDatabase` when JSON encoding fails.
+     */
+    @discardableResult
+    static func replaceLocalSnapshots(
+        reading: ReadingProgressSnapshot,
+        memorization: MemorizationProgressSnapshot,
+        settingsStore: SettingsStore
+    ) throws -> AndroidDatabaseBackupProgressReport {
+        let snapshot = Snapshot(reading: reading, memorization: memorization)
+        try save(snapshot, settingsStore: settingsStore)
+        return report(for: snapshot, settingsStore: settingsStore)
+    }
+
     private static func readSnapshot(from databaseURL: URL) throws -> Snapshot {
         try AndroidDatabaseBackupSQLite.withDatabase(at: databaseURL) { database in
             let fileName = databaseURL.lastPathComponent
@@ -190,7 +216,7 @@ enum AndroidDatabaseBackupProgressMapper {
         fileName: String
     ) throws -> [MemorizedVerseProgress] {
         let statement = try AndroidDatabaseBackupSQLite.prepare(
-            "SELECT kjvOrdinal, memorizedAt FROM MemorizedVerse ORDER BY kjvOrdinal;",
+            "SELECT id, kjvOrdinal, memorizedAt FROM MemorizedVerse ORDER BY kjvOrdinal;",
             on: database,
             fileName: fileName
         )
@@ -206,14 +232,15 @@ enum AndroidDatabaseBackupProgressMapper {
                 throw AndroidDatabaseBackupError.invalidSQLiteDatabase(fileName)
             }
             let ordinal = try validatedKJVAOrdinal(
-                AndroidDatabaseBackupSQLite.int(statement, column: 0),
+                AndroidDatabaseBackupSQLite.int(statement, column: 1),
                 fileName: fileName
             )
             verses.append(
                 MemorizedVerseProgress(
+                    id: try AndroidDatabaseBackupSQLite.uuidFromBlob(statement, column: 0, fileName: fileName),
                     bookInitials: "",
                     kjvOrdinal: ordinal,
-                    memorizedAt: AndroidDatabaseBackupSQLite.int64(statement, column: 1)
+                    memorizedAt: AndroidDatabaseBackupSQLite.int64(statement, column: 2)
                 )
             )
         }
@@ -356,7 +383,7 @@ enum AndroidDatabaseBackupProgressMapper {
             fileName: fileName
         )
         defer { sqlite3_finalize(statement) }
-        AndroidDatabaseBackupSQLite.bindUUIDBlob(UUID(), to: statement, index: 1)
+        AndroidDatabaseBackupSQLite.bindUUIDBlob(verse.id, to: statement, index: 1)
         sqlite3_bind_int(statement, 2, Int32(verse.kjvOrdinal))
         sqlite3_bind_int64(statement, 3, verse.memorizedAt)
         try AndroidDatabaseBackupSQLite.stepDone(statement, fileName: fileName)
@@ -529,6 +556,7 @@ enum AndroidDatabaseBackupProgressMapper {
                 continue
             }
             rowByOrdinal[verse.kjvOrdinal] = MemorizedVerseProgress(
+                id: verse.id,
                 bookInitials: "",
                 kjvOrdinal: verse.kjvOrdinal,
                 memorizedAt: verse.memorizedAt

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
@@ -21,6 +21,9 @@ public enum RemoteSyncInitialBackupRestoreReport: Sendable, Equatable {
 
     /// Successful restore report for the My Documents sync category.
     case myDocuments(RemoteSyncMyDocumentRestoreReport)
+
+    /// Successful restore report for the Progress sync category.
+    case progress(AndroidDatabaseBackupProgressReport)
 }
 
 /**
@@ -74,6 +77,7 @@ public final class RemoteSyncInitialBackupRestoreService {
     private let workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService
     private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
     private let myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService
+    private let progressSnapshotService: RemoteSyncProgressSnapshotService
 
     /**
      Creates a category-level initial-backup restore dispatcher.
@@ -93,6 +97,8 @@ public final class RemoteSyncInitialBackupRestoreService {
          fingerprint baselines after successful remote restores.
        - myDocumentSnapshotService: Snapshot service used to refresh outbound My Documents
          fingerprint baselines after successful remote restores.
+       - progressSnapshotService: Snapshot service used to refresh outbound Progress fingerprint
+         baselines after successful remote restores.
      - Side effects: none.
      - Failure modes: This initializer cannot fail.
      */
@@ -105,7 +111,8 @@ public final class RemoteSyncInitialBackupRestoreService {
         bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService = RemoteSyncBookmarkSnapshotService(),
         workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService = RemoteSyncWorkspaceSnapshotService(),
         readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(),
-        myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService()
+        myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService(),
+        progressSnapshotService: RemoteSyncProgressSnapshotService = RemoteSyncProgressSnapshotService()
     ) {
         self.bookmarkRestoreService = bookmarkRestoreService
         self.readingPlanRestoreService = readingPlanRestoreService
@@ -116,6 +123,7 @@ public final class RemoteSyncInitialBackupRestoreService {
         self.workspaceSnapshotService = workspaceSnapshotService
         self.readingPlanSnapshotService = readingPlanSnapshotService
         self.myDocumentSnapshotService = myDocumentSnapshotService
+        self.progressSnapshotService = progressSnapshotService
     }
 
     /**
@@ -179,7 +187,12 @@ public final class RemoteSyncInitialBackupRestoreService {
             )
             report = .myDocuments(myDocumentReport)
         case .progress:
-            throw RemoteSyncSynchronizationError.unsupportedCategory(category)
+            let progressReport = try AndroidDatabaseBackupProgressMapper.apply(
+                from: stagedBackup.databaseFileURL,
+                mode: .restore,
+                settingsStore: settingsStore
+            )
+            report = .progress(progressReport)
         }
 
         _ = metadataRestoreService.replaceLocalMetadata(
@@ -207,6 +220,8 @@ public final class RemoteSyncInitialBackupRestoreService {
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
+        } else if category == .progress {
+            progressSnapshotService.refreshBaselineFingerprints(settingsStore: settingsStore)
         }
         return report
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -102,9 +102,31 @@ public struct RemoteSyncInitialBackupUploadReport: Sendable, Equatable {
    `ModelContext` and `SettingsStore`
  */
 public final class RemoteSyncInitialBackupUploadService {
+    /**
+     Carries the staged database and any category-specific bookkeeping needed after upload acceptance.
+
+     - Parameters:
+       - databaseURL: Temporary SQLite database that will be archived and uploaded.
+       - workspaceHistoryAliases: Workspace history alias mappings emitted by workspace export.
+       - acceptedBaselineTimestamp: Optional timestamp already written into uploaded baseline rows; callers reuse it
+         for local accepted-baseline state to avoid introducing a newer local patch watermark than the upload contains.
+     - Side effects: none.
+     - Failure modes: This value type cannot fail to initialize.
+     */
     private struct BuiltInitialBackup {
         let databaseURL: URL
         let workspaceHistoryAliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias]
+        let acceptedBaselineTimestamp: Int64?
+
+        init(
+            databaseURL: URL,
+            workspaceHistoryAliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias],
+            acceptedBaselineTimestamp: Int64? = nil
+        ) {
+            self.databaseURL = databaseURL
+            self.workspaceHistoryAliases = workspaceHistoryAliases
+            self.acceptedBaselineTimestamp = acceptedBaselineTimestamp
+        }
     }
 
     private let adapter: (any RemoteSyncAdapting)?
@@ -263,7 +285,8 @@ public final class RemoteSyncInitialBackupUploadService {
             uploadedFile: uploadedFile,
             settingsStore: settingsStore,
             modelContext: modelContext,
-            workspaceHistoryAliases: builtBackup.workspaceHistoryAliases
+            workspaceHistoryAliases: builtBackup.workspaceHistoryAliases,
+            acceptedBaselineTimestamp: builtBackup.acceptedBaselineTimestamp
         )
 
         let patchZeroStatus = RemoteSyncPatchStatus(
@@ -340,6 +363,8 @@ public final class RemoteSyncInitialBackupUploadService {
        - settingsStore: Local-only settings store backing sync bookkeeping.
        - modelContext: SwiftData context used to refresh outbound fingerprints.
        - workspaceHistoryAliases: Synthesized workspace history aliases that should be persisted after a workspace export.
+       - acceptedBaselineTimestamp: Optional timestamp captured while building the uploaded baseline; when supplied,
+         local `LogEntry` rows and `lastPatchWritten` reuse that value instead of taking a second clock sample.
      - Side effects:
        - clears category log-entry and patch-status rows
        - records patch zero with the uploaded archive metadata
@@ -353,7 +378,8 @@ public final class RemoteSyncInitialBackupUploadService {
         uploadedFile: RemoteSyncFile,
         settingsStore: SettingsStore,
         modelContext: ModelContext,
-        workspaceHistoryAliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias]
+        workspaceHistoryAliases: [RemoteSyncWorkspaceFidelityStore.HistoryItemAlias],
+        acceptedBaselineTimestamp: Int64? = nil
     ) {
         let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
         logEntryStore.clearCategory(category)
@@ -371,7 +397,7 @@ public final class RemoteSyncInitialBackupUploadService {
         )
 
         let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
-        let acceptedAt = nowProvider()
+        let acceptedAt = acceptedBaselineTimestamp ?? nowProvider()
         stateStore.setProgressState(
             RemoteSyncProgressState(
                 lastPatchWritten: acceptedAt,
@@ -544,7 +570,8 @@ public final class RemoteSyncInitialBackupUploadService {
      - Parameters:
        - settingsStore: Local-only settings store containing the progress JSON snapshots.
        - schemaVersion: SQLite user-version written into the exported database.
-     - Returns: Temporary SQLite database containing the current Progress baseline.
+     - Returns: Temporary SQLite database containing the current Progress baseline and the timestamp
+       used for its accepted baseline `LogEntry` rows.
      - Side effects: writes one temporary SQLite database beneath the configured temporary directory.
      - Failure modes: rethrows SQLite failures from the Android progress mapper or metadata schema creation.
      */
@@ -553,10 +580,11 @@ public final class RemoteSyncInitialBackupUploadService {
         schemaVersion: Int
     ) throws -> BuiltInitialBackup {
         let databaseURL = temporaryURL(prefix: "remote-sync-progress-initial-", suffix: ".sqlite3")
+        let acceptedBaselineTimestamp = nowProvider()
         let baselineLogEntries = RemoteSyncProgressSnapshotService().acceptedBaselineLogEntries(
             settingsStore: settingsStore,
             sourceDevice: deviceIdentifier,
-            lastUpdated: nowProvider()
+            lastUpdated: acceptedBaselineTimestamp
         )
         do {
             try AndroidDatabaseBackupProgressMapper.writeDatabase(
@@ -606,7 +634,11 @@ public final class RemoteSyncInitialBackupUploadService {
                 try insertLogEntry(entry, in: database)
             }
 
-            return BuiltInitialBackup(databaseURL: databaseURL, workspaceHistoryAliases: [])
+            return BuiltInitialBackup(
+                databaseURL: databaseURL,
+                workspaceHistoryAliases: [],
+                acceptedBaselineTimestamp: acceptedBaselineTimestamp
+            )
         } catch {
             try? fileManager.removeItem(at: databaseURL)
             throw error

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -324,7 +324,10 @@ public final class RemoteSyncInitialBackupUploadService {
                 schemaVersion: schemaVersion
             )
         case .progress:
-            throw RemoteSyncInitialBackupUploadError.unsupportedCategory(category)
+            return try buildProgressInitialBackup(
+                settingsStore: settingsStore,
+                schemaVersion: schemaVersion
+            )
         }
     }
 
@@ -368,9 +371,10 @@ public final class RemoteSyncInitialBackupUploadService {
         )
 
         let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let acceptedAt = nowProvider()
         stateStore.setProgressState(
             RemoteSyncProgressState(
-                lastPatchWritten: nowProvider(),
+                lastPatchWritten: acceptedAt,
                 lastSynchronized: nil,
                 disabledForVersion: nil
             ),
@@ -400,7 +404,16 @@ public final class RemoteSyncInitialBackupUploadService {
                 settingsStore: settingsStore
             )
         case .progress:
-            break
+            let progressSnapshotService = RemoteSyncProgressSnapshotService()
+            logEntryStore.replaceEntries(
+                progressSnapshotService.acceptedBaselineLogEntries(
+                    settingsStore: settingsStore,
+                    sourceDevice: deviceIdentifier,
+                    lastUpdated: acceptedAt
+                ),
+                for: .progress
+            )
+            progressSnapshotService.refreshBaselineFingerprints(settingsStore: settingsStore)
         }
     }
 
@@ -516,6 +529,81 @@ public final class RemoteSyncInitialBackupUploadService {
             }
             for row in snapshot.statusRowsByKey.values.sorted(by: Self.readingPlanStatusSort) {
                 try insertReadingPlanStatusRow(row, in: database)
+            }
+
+            return BuiltInitialBackup(databaseURL: databaseURL, workspaceHistoryAliases: [])
+        } catch {
+            try? fileManager.removeItem(at: databaseURL)
+            throw error
+        }
+    }
+
+    /**
+     Builds one full Android Progress database from the current local reading and memorization state.
+
+     - Parameters:
+       - settingsStore: Local-only settings store containing the progress JSON snapshots.
+       - schemaVersion: SQLite user-version written into the exported database.
+     - Returns: Temporary SQLite database containing the current Progress baseline.
+     - Side effects: writes one temporary SQLite database beneath the configured temporary directory.
+     - Failure modes: rethrows SQLite failures from the Android progress mapper or metadata schema creation.
+     */
+    private func buildProgressInitialBackup(
+        settingsStore: SettingsStore,
+        schemaVersion: Int
+    ) throws -> BuiltInitialBackup {
+        let databaseURL = temporaryURL(prefix: "remote-sync-progress-initial-", suffix: ".sqlite3")
+        let baselineLogEntries = RemoteSyncProgressSnapshotService().acceptedBaselineLogEntries(
+            settingsStore: settingsStore,
+            sourceDevice: deviceIdentifier,
+            lastUpdated: nowProvider()
+        )
+        do {
+            try AndroidDatabaseBackupProgressMapper.writeDatabase(
+                at: databaseURL,
+                settingsStore: settingsStore
+            )
+            var database: OpaquePointer?
+            guard sqlite3_open_v2(databaseURL.path, &database, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+                  let database else {
+                throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+            }
+            defer { sqlite3_close(database) }
+
+            try execute(
+                """
+                PRAGMA user_version = \(schemaVersion);
+                CREATE TABLE LogEntry (
+                    tableName TEXT NOT NULL,
+                    entityId1 BLOB NOT NULL,
+                    entityId2 BLOB NOT NULL DEFAULT '',
+                    type TEXT NOT NULL,
+                    lastUpdated INTEGER NOT NULL DEFAULT 0,
+                    sourceDevice TEXT NOT NULL,
+                    PRIMARY KEY(tableName, entityId1, entityId2)
+                );
+                CREATE TABLE SyncConfiguration (
+                    keyName TEXT NOT NULL,
+                    stringValue TEXT,
+                    longValue INTEGER,
+                    booleanValue INTEGER,
+                    PRIMARY KEY(keyName)
+                );
+                CREATE TABLE SyncStatus (
+                    sourceDevice TEXT NOT NULL,
+                    patchNumber INTEGER NOT NULL,
+                    sizeBytes INTEGER NOT NULL,
+                    appliedDate INTEGER NOT NULL,
+                    PRIMARY KEY(sourceDevice, patchNumber)
+                );
+                CREATE INDEX index_LogEntry_tableName_entityId1 ON LogEntry (tableName, entityId1);
+                CREATE INDEX index_LogEntry_lastUpdated ON LogEntry (lastUpdated);
+                """,
+                in: database
+            )
+
+            for entry in baselineLogEntries {
+                try insertLogEntry(entry, in: database)
             }
 
             return BuiltInitialBackup(databaseURL: databaseURL, workspaceHistoryAliases: [])
@@ -1431,6 +1519,39 @@ public final class RemoteSyncInitialBackupUploadService {
     }
 
     /**
+     Inserts one Android `LogEntry` row into the open initial-backup database.
+
+     - Parameters:
+       - entry: Android sync log entry to insert.
+       - database: Open SQLite database handle.
+     - Side effects: writes one row into the `LogEntry` table.
+     - Failure modes:
+       - throws `RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase` when SQLite rejects prepare, bind, or step work
+     */
+    private func insertLogEntry(_ entry: RemoteSyncLogEntry, in database: OpaquePointer) throws {
+        let sql = """
+        INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+
+        bindText(entry.tableName, to: statement, index: 1)
+        bindSQLiteValue(entry.entityID1, to: statement, index: 2)
+        bindSQLiteValue(entry.entityID2, to: statement, index: 3)
+        bindText(entry.type.rawValue, to: statement, index: 4)
+        sqlite3_bind_int64(statement, 5, entry.lastUpdated)
+        bindText(entry.sourceDevice, to: statement, index: 6)
+
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncInitialBackupUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    /**
      Inserts one Android `ReadingPlan` row into the open initial-backup database.
 
      - Parameters:
@@ -2298,6 +2419,35 @@ public final class RemoteSyncInitialBackupUploadService {
      */
     private func bindText(_ value: String, to statement: OpaquePointer?, index: Int32) {
         sqlite3_bind_text(statement, index, value, -1, remoteSyncInitialBackupUploadSQLiteTransient)
+    }
+
+    /**
+     Binds one Android sync metadata value into a prepared SQLite statement parameter.
+
+     - Parameters:
+       - value: Typed SQLite payload from a preserved or synthesized Android metadata row.
+       - statement: Prepared SQLite statement receiving the bound value.
+       - index: One-based SQLite bind parameter index.
+     - Side effects: mutates the prepared SQLite statement's bound-parameter state.
+     - Failure modes: This helper cannot fail; SQLite binding errors are surfaced by the caller's
+       later `sqlite3_step` check.
+     */
+    private func bindSQLiteValue(_ value: RemoteSyncSQLiteValue, to statement: OpaquePointer?, index: Int32) {
+        switch value.kind {
+        case .null:
+            sqlite3_bind_null(statement, index)
+        case .integer:
+            sqlite3_bind_int64(statement, index, value.integerValue ?? 0)
+        case .real:
+            sqlite3_bind_double(statement, index, value.realValue ?? 0)
+        case .text:
+            sqlite3_bind_text(statement, index, value.textValue ?? "", -1, remoteSyncInitialBackupUploadSQLiteTransient)
+        case .blob:
+            let data = value.blobData ?? Data()
+            _ = data.withUnsafeBytes {
+                sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), remoteSyncInitialBackupUploadSQLiteTransient)
+            }
+        }
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchApplyService.swift
@@ -1,0 +1,496 @@
+// RemoteSyncProgressPatchApplyService.swift - Incremental Android patch replay for Progress
+
+import CLibSword
+import Foundation
+import SQLite3
+
+private let remoteSyncProgressPatchApplySQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+public enum RemoteSyncProgressPatchApplyError: Error, Equatable {
+    case invalidLogEntryIdentifier(table: String)
+    case missingPatchRow(table: String, id: UUID)
+    case invalidSQLiteDatabase
+}
+
+public struct RemoteSyncProgressPatchApplyReport: Sendable, Equatable {
+    public let appliedPatchCount: Int
+    public let appliedLogEntryCount: Int
+    public let skippedLogEntryCount: Int
+    public let readingCount: Int
+    public let memorizedVerseCount: Int
+    public let targetCount: Int
+}
+
+/**
+ Replays sparse Android Progress patch archives into local reading and memorization progress stores.
+ */
+public final class RemoteSyncProgressPatchApplyService {
+    private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
+    private let snapshotService: RemoteSyncProgressSnapshotService
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+
+    public init(
+        metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
+        snapshotService: RemoteSyncProgressSnapshotService = RemoteSyncProgressSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil
+    ) {
+        self.metadataRestoreService = metadataRestoreService
+        self.snapshotService = snapshotService
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+    }
+
+    public func applyPatchArchives(
+        _ stagedArchives: [RemoteSyncStagedPatchArchive],
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncProgressPatchApplyReport {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+        let currentSnapshot = snapshotService.snapshotCurrentState(settingsStore: settingsStore)
+
+        var memorizedRowsByID = Dictionary(
+            uniqueKeysWithValues: currentSnapshot.memorizedVerseRowsByKey.values.map { ($0.id, $0) }
+        )
+        var chapterRowsByID = Dictionary(
+            uniqueKeysWithValues: currentSnapshot.chapterHistoryRowsByKey.values.map { ($0.id, $0) }
+        )
+        var targetRowsByID = Dictionary(
+            uniqueKeysWithValues: currentSnapshot.memorizationTargetRowsByKey.values.map { ($0.id, $0) }
+        )
+        var settingsRow = currentSnapshot.settingsRowsByKey.values.first ??
+            RemoteSyncCurrentProgressSettingsRow(
+                id: RemoteSyncProgressSnapshotService.globalSettingsID,
+                settings: ReadingProgressSettingsSnapshot()
+            )
+        var logEntriesByKey = Dictionary(
+            uniqueKeysWithValues: logEntryStore.entries(for: .progress).map {
+                (logEntryStore.key(for: .progress, entry: $0), $0)
+            }
+        )
+
+        var appliedPatchStatuses: [RemoteSyncPatchStatus] = []
+        var appliedLogEntryCount = 0
+        var skippedLogEntryCount = 0
+
+        for stagedArchive in stagedArchives {
+            let patchDatabaseURL = temporaryDatabaseURL(prefix: "remote-sync-progress-patch-", suffix: ".sqlite3")
+            defer { try? fileManager.removeItem(at: patchDatabaseURL) }
+
+            let archiveData = try Data(contentsOf: stagedArchive.archiveFileURL)
+            let databaseData = try Self.gunzip(archiveData)
+            try databaseData.write(to: patchDatabaseURL, options: .atomic)
+
+            let metadataSnapshot = try metadataRestoreService.readSnapshot(from: patchDatabaseURL)
+            let patchLogEntries = metadataSnapshot.logEntries.filter { Self.progressTableNames.contains($0.tableName) }
+            let filteredLogEntries = patchLogEntries.filter { entry in
+                let key = logEntryStore.key(for: .progress, entry: entry)
+                guard let localEntry = logEntriesByKey[key] else {
+                    return true
+                }
+                return entry.lastUpdated > localEntry.lastUpdated
+            }
+            skippedLogEntryCount += patchLogEntries.count - filteredLogEntries.count
+            guard !filteredLogEntries.isEmpty else {
+                continue
+            }
+
+            try withSQLiteDatabase(at: patchDatabaseURL) { database in
+                try applyMemorizedVerseOperations(
+                    filteredLogEntries.filter { $0.tableName == RemoteSyncProgressSnapshotService.memorizedVerseTable },
+                    database: database,
+                    rowsByID: &memorizedRowsByID,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applyChapterHistoryOperations(
+                    filteredLogEntries.filter { $0.tableName == RemoteSyncProgressSnapshotService.chapterReadHistoryTable },
+                    database: database,
+                    rowsByID: &chapterRowsByID,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applyTargetOperations(
+                    filteredLogEntries.filter { $0.tableName == RemoteSyncProgressSnapshotService.memorizationTargetTable },
+                    database: database,
+                    rowsByID: &targetRowsByID,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+                try applySettingsOperations(
+                    filteredLogEntries.filter { $0.tableName == RemoteSyncProgressSnapshotService.globalSettingsTable },
+                    database: database,
+                    row: &settingsRow,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+            }
+
+            appliedLogEntryCount += filteredLogEntries.count
+            appliedPatchStatuses.append(
+                RemoteSyncPatchStatus(
+                    sourceDevice: stagedArchive.patch.sourceDevice,
+                    patchNumber: stagedArchive.patch.patchNumber,
+                    sizeBytes: stagedArchive.patch.file.size,
+                    appliedDate: stagedArchive.patch.file.timestamp
+                )
+            )
+        }
+
+        let readingSnapshot = ReadingProgressSnapshot(
+            history: chapterRowsByID.values
+                .map {
+                    ReadingProgressHistoryRow(
+                        id: $0.id,
+                        bookInitials: $0.bookInitials,
+                        startOrdinal: 0,
+                        kjvBookOrdinal: $0.kjvBookOrdinal,
+                        chapter: $0.chapter,
+                        cycle: $0.cycle,
+                        readAt: $0.readAt,
+                        source: $0.source
+                    )
+                }
+                .sorted {
+                    if $0.readAt != $1.readAt {
+                        return $0.readAt < $1.readAt
+                    }
+                    return $0.id.uuidString < $1.id.uuidString
+                },
+            settings: settingsRow.settings
+        )
+        let memorizationSnapshot = MemorizationProgressSnapshot(
+            memorizedVerses: memorizedRowsByID.values
+                .map { MemorizedVerseProgress(id: $0.id, bookInitials: "", kjvOrdinal: $0.kjvOrdinal, memorizedAt: $0.memorizedAt) },
+            targetRows: targetRowsByID.values
+                .map {
+                    MemorizationTargetRow(
+                        id: $0.id,
+                        bookInitials: "",
+                        startOrdinal: $0.kjvOrdinalStart,
+                        endOrdinal: $0.kjvOrdinalEnd,
+                        createdAt: $0.createdAt
+                    )
+                }
+        )
+        let report = try AndroidDatabaseBackupProgressMapper.replaceLocalSnapshots(
+            reading: readingSnapshot,
+            memorization: memorizationSnapshot,
+            settingsStore: settingsStore
+        )
+
+        logEntryStore.replaceEntries(logEntriesByKey.values.sorted(by: Self.logEntrySort), for: .progress)
+        patchStatusStore.addStatuses(appliedPatchStatuses, for: .progress)
+        snapshotService.refreshBaselineFingerprints(settingsStore: settingsStore)
+
+        return RemoteSyncProgressPatchApplyReport(
+            appliedPatchCount: appliedPatchStatuses.count,
+            appliedLogEntryCount: appliedLogEntryCount,
+            skippedLogEntryCount: skippedLogEntryCount,
+            readingCount: report.readingCount,
+            memorizedVerseCount: report.memorizedVerseCount,
+            targetCount: report.targetCount
+        )
+    }
+
+    private func applyMemorizedVerseOperations(
+        _ logEntries: [RemoteSyncLogEntry],
+        database: OpaquePointer,
+        rowsByID: inout [UUID: RemoteSyncCurrentProgressMemorizedVerseRow],
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        for entry in logEntries.filter({ $0.type == .upsert }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            guard let row = try fetchMemorizedVerse(id: rowID, from: database) else {
+                throw RemoteSyncProgressPatchApplyError.missingPatchRow(table: entry.tableName, id: rowID)
+            }
+            if let duplicate = rowsByID.first(where: { $0.value.kjvOrdinal == row.kjvOrdinal }) {
+                rowsByID.removeValue(forKey: duplicate.key)
+            }
+            rowsByID[row.id] = row
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+        for entry in logEntries.filter({ $0.type == .delete }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            rowsByID.removeValue(forKey: rowID)
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+    }
+
+    private func applyChapterHistoryOperations(
+        _ logEntries: [RemoteSyncLogEntry],
+        database: OpaquePointer,
+        rowsByID: inout [UUID: RemoteSyncCurrentProgressChapterReadHistoryRow],
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        for entry in logEntries.filter({ $0.type == .upsert }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            guard let row = try fetchChapterHistory(id: rowID, from: database) else {
+                throw RemoteSyncProgressPatchApplyError.missingPatchRow(table: entry.tableName, id: rowID)
+            }
+            rowsByID[row.id] = row
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+        for entry in logEntries.filter({ $0.type == .delete }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            rowsByID.removeValue(forKey: rowID)
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+    }
+
+    private func applyTargetOperations(
+        _ logEntries: [RemoteSyncLogEntry],
+        database: OpaquePointer,
+        rowsByID: inout [UUID: RemoteSyncCurrentProgressMemorizationTargetRow],
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        for entry in logEntries.filter({ $0.type == .upsert }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            guard let row = try fetchTarget(id: rowID, from: database) else {
+                throw RemoteSyncProgressPatchApplyError.missingPatchRow(table: entry.tableName, id: rowID)
+            }
+            rowsByID[row.id] = row
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+        for entry in logEntries.filter({ $0.type == .delete }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            rowsByID.removeValue(forKey: rowID)
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+    }
+
+    private func applySettingsOperations(
+        _ logEntries: [RemoteSyncLogEntry],
+        database: OpaquePointer,
+        row: inout RemoteSyncCurrentProgressSettingsRow,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        for entry in logEntries.filter({ $0.type == .upsert }).sorted(by: Self.logEntrySort) {
+            let rowID = try uuid(from: entry.entityID1, tableName: entry.tableName)
+            guard let fetched = try fetchSettings(id: rowID, from: database) else {
+                throw RemoteSyncProgressPatchApplyError.missingPatchRow(table: entry.tableName, id: rowID)
+            }
+            row = fetched
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+        for entry in logEntries.filter({ $0.type == .delete }).sorted(by: Self.logEntrySort) {
+            row = RemoteSyncCurrentProgressSettingsRow(
+                id: RemoteSyncProgressSnapshotService.globalSettingsID,
+                settings: ReadingProgressSettingsSnapshot()
+            )
+            logEntriesByKey[logEntryStore.key(for: .progress, entry: entry)] = entry
+        }
+    }
+
+    private func fetchMemorizedVerse(
+        id: UUID,
+        from database: OpaquePointer
+    ) throws -> RemoteSyncCurrentProgressMemorizedVerseRow? {
+        let statement = try prepare(
+            "SELECT id, kjvOrdinal, memorizedAt FROM MemorizedVerse WHERE id = ? LIMIT 1;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(id, to: statement, index: 1)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return RemoteSyncCurrentProgressMemorizedVerseRow(
+            id: try uuidFromBlob(statement: statement, column: 0),
+            kjvOrdinal: Int(sqlite3_column_int(statement, 1)),
+            memorizedAt: sqlite3_column_int64(statement, 2)
+        )
+    }
+
+    private func fetchChapterHistory(
+        id: UUID,
+        from database: OpaquePointer
+    ) throws -> RemoteSyncCurrentProgressChapterReadHistoryRow? {
+        let statement = try prepare(
+            """
+            SELECT id, kjvBookOrdinal, chapter, cycle, readAt, bookInitials, source
+            FROM ChapterReadHistory
+            WHERE id = ?
+            LIMIT 1;
+            """,
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(id, to: statement, index: 1)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return RemoteSyncCurrentProgressChapterReadHistoryRow(
+            id: try uuidFromBlob(statement: statement, column: 0),
+            kjvBookOrdinal: Int(sqlite3_column_int(statement, 1)),
+            chapter: Int(sqlite3_column_int(statement, 2)),
+            cycle: Int(sqlite3_column_int(statement, 3)),
+            readAt: sqlite3_column_int64(statement, 4),
+            bookInitials: stringColumn(statement: statement, index: 5),
+            source: ReadingProgressSource(bridgeValue: stringColumn(statement: statement, index: 6))
+        )
+    }
+
+    private func fetchTarget(
+        id: UUID,
+        from database: OpaquePointer
+    ) throws -> RemoteSyncCurrentProgressMemorizationTargetRow? {
+        let statement = try prepare(
+            "SELECT id, kjvOrdinalStart, kjvOrdinalEnd, createdAt FROM MemorizationTarget WHERE id = ? LIMIT 1;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(id, to: statement, index: 1)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return RemoteSyncCurrentProgressMemorizationTargetRow(
+            id: try uuidFromBlob(statement: statement, column: 0),
+            kjvOrdinalStart: Int(sqlite3_column_int(statement, 1)),
+            kjvOrdinalEnd: Int(sqlite3_column_int(statement, 2)),
+            createdAt: sqlite3_column_int64(statement, 3)
+        )
+    }
+
+    private func fetchSettings(
+        id: UUID,
+        from database: OpaquePointer
+    ) throws -> RemoteSyncCurrentProgressSettingsRow? {
+        let statement = try prepare(
+            """
+            SELECT id, autoTrackReading, autoMarkMemorized, memorizeTypeFullWords, memorizeWordVisibility,
+                   memorizeErrorHeatmap, memorizeScrambleHideUsed, memorizeIncludeReference, activeCycle
+            FROM GlobalReadingProgressSettings
+            WHERE id = ?
+            LIMIT 1;
+            """,
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(id, to: statement, index: 1)
+        guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        return RemoteSyncCurrentProgressSettingsRow(
+            id: try uuidFromBlob(statement: statement, column: 0),
+            settings: ReadingProgressSettingsSnapshot(
+                autoTrackReading: sqlite3_column_int(statement, 1) != 0,
+                activeCycle: Int(sqlite3_column_int(statement, 8)),
+                autoMarkMemorized: sqlite3_column_int(statement, 2) != 0,
+                memorizeTypeFullWords: sqlite3_column_int(statement, 3) != 0,
+                memorizeWordVisibility: stringColumn(statement: statement, index: 4),
+                memorizeErrorHeatmap: sqlite3_column_int(statement, 5) != 0,
+                memorizeScrambleHideUsed: sqlite3_column_int(statement, 6) != 0,
+                memorizeIncludeReference: sqlite3_column_int(statement, 7) != 0
+            )
+        )
+    }
+
+    private func uuid(from value: RemoteSyncSQLiteValue, tableName: String) throws -> UUID {
+        switch value.kind {
+        case .blob:
+            guard let data = value.blobData, data.count == 16 else {
+                throw RemoteSyncProgressPatchApplyError.invalidLogEntryIdentifier(table: tableName)
+            }
+            return try uuidFromData(data)
+        case .text:
+            guard let textValue = value.textValue, let uuid = UUID(uuidString: textValue) else {
+                throw RemoteSyncProgressPatchApplyError.invalidLogEntryIdentifier(table: tableName)
+            }
+            return uuid
+        default:
+            throw RemoteSyncProgressPatchApplyError.invalidLogEntryIdentifier(table: tableName)
+        }
+    }
+
+    private func withSQLiteDatabase<T>(at url: URL, body: (OpaquePointer) throws -> T) throws -> T {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let database else {
+            if let database {
+                sqlite3_close(database)
+            }
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(database) }
+        return try body(database)
+    }
+
+    private func prepare(_ sql: String, in database: OpaquePointer) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
+        return statement
+    }
+
+    private func bindUUIDBlob(_ uuid: UUID, to statement: OpaquePointer?, index: Int32) {
+        let data = RemoteSyncProgressSnapshotService.uuidBlob(uuid)
+        _ = data.withUnsafeBytes {
+            sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), remoteSyncProgressPatchApplySQLiteTransient)
+        }
+    }
+
+    private func uuidFromBlob(statement: OpaquePointer?, column: Int32) throws -> UUID {
+        guard let bytes = sqlite3_column_blob(statement, column),
+              sqlite3_column_bytes(statement, column) == 16 else {
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
+        return try uuidFromData(Data(bytes: bytes, count: 16))
+    }
+
+    private func uuidFromData(_ data: Data) throws -> UUID {
+        guard data.count == 16 else {
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
+        let bytes = Array(data)
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    private func stringColumn(statement: OpaquePointer?, index: Int32) -> String {
+        guard let raw = sqlite3_column_text(statement, index) else {
+            return ""
+        }
+        return String(cString: raw)
+    }
+
+    private func temporaryDatabaseURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    private static func gunzip(_ data: Data) throws -> Data {
+        try data.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) -> Data in
+            guard let baseAddress = pointer.baseAddress else {
+                throw RemoteSyncArchiveStagingError.decompressionFailed
+            }
+            var outputLength: UInt = 0
+            guard let output = gunzip_data(
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                UInt(data.count),
+                &outputLength
+            ) else {
+                throw RemoteSyncArchiveStagingError.decompressionFailed
+            }
+            defer { gunzip_free(output) }
+            return Data(bytes: output, count: Int(outputLength))
+        }
+    }
+
+    private static let progressTableNames: Set<String> = [
+        RemoteSyncProgressSnapshotService.memorizedVerseTable,
+        RemoteSyncProgressSnapshotService.chapterReadHistoryTable,
+        RemoteSyncProgressSnapshotService.memorizationTargetTable,
+        RemoteSyncProgressSnapshotService.globalSettingsTable,
+    ]
+
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.lastUpdated != rhs.lastUpdated {
+            return lhs.lastUpdated < rhs.lastUpdated
+        }
+        return "\(lhs.entityID1)-\(lhs.entityID2)" < "\(rhs.entityID1)-\(rhs.entityID2)"
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchApplyService.swift
@@ -25,6 +25,8 @@ public struct RemoteSyncProgressPatchApplyReport: Sendable, Equatable {
  Replays sparse Android Progress patch archives into local reading and memorization progress stores.
  */
 public final class RemoteSyncProgressPatchApplyService {
+    private static let progressOrdinalRange = JSwordKJVAVersification.progressOrdinalRange
+
     private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
     private let snapshotService: RemoteSyncProgressSnapshotService
     private let fileManager: FileManager
@@ -298,9 +300,13 @@ public final class RemoteSyncProgressPatchApplyService {
         defer { sqlite3_finalize(statement) }
         bindUUIDBlob(id, to: statement, index: 1)
         guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        let kjvOrdinal = Int(sqlite3_column_int(statement, 1))
+        guard Self.progressOrdinalRange.contains(kjvOrdinal) else {
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
         return RemoteSyncCurrentProgressMemorizedVerseRow(
             id: try uuidFromBlob(statement: statement, column: 0),
-            kjvOrdinal: Int(sqlite3_column_int(statement, 1)),
+            kjvOrdinal: kjvOrdinal,
             memorizedAt: sqlite3_column_int64(statement, 2)
         )
     }
@@ -343,10 +349,17 @@ public final class RemoteSyncProgressPatchApplyService {
         defer { sqlite3_finalize(statement) }
         bindUUIDBlob(id, to: statement, index: 1)
         guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+        let startOrdinal = Int(sqlite3_column_int(statement, 1))
+        let endOrdinal = Int(sqlite3_column_int(statement, 2))
+        guard Self.progressOrdinalRange.contains(startOrdinal),
+              Self.progressOrdinalRange.contains(endOrdinal),
+              endOrdinal >= startOrdinal else {
+            throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+        }
         return RemoteSyncCurrentProgressMemorizationTargetRow(
             id: try uuidFromBlob(statement: statement, column: 0),
-            kjvOrdinalStart: Int(sqlite3_column_int(statement, 1)),
-            kjvOrdinalEnd: Int(sqlite3_column_int(statement, 2)),
+            kjvOrdinalStart: startOrdinal,
+            kjvOrdinalEnd: endOrdinal,
             createdAt: sqlite3_column_int64(statement, 3)
         )
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressPatchUploadService.swift
@@ -1,0 +1,550 @@
+// RemoteSyncProgressPatchUploadService.swift - Android-shaped outbound progress patch creation
+
+import Foundation
+import SQLite3
+
+private let remoteSyncProgressPatchUploadSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+public enum RemoteSyncProgressPatchUploadError: Error, Equatable {
+    case missingDeviceFolderID
+    case invalidSQLiteDatabase
+}
+
+public struct RemoteSyncProgressPatchUploadReport: Sendable, Equatable {
+    public let uploadedFile: RemoteSyncFile
+    public let patchNumber: Int64
+    public let upsertedMemorizedVerseCount: Int
+    public let upsertedChapterHistoryCount: Int
+    public let upsertedTargetCount: Int
+    public let upsertedSettingsCount: Int
+    public let deletedRowCount: Int
+    public let logEntryCount: Int
+    public let lastUpdated: Int64
+}
+
+/**
+ Creates Android-compatible sparse `progress.sqlite3` patches and uploads them to the device folder.
+ */
+public final class RemoteSyncProgressPatchUploadService {
+    private struct ChangeSet {
+        let memorizedVerseRowsByKey: [String: RemoteSyncCurrentProgressMemorizedVerseRow]
+        let chapterHistoryRowsByKey: [String: RemoteSyncCurrentProgressChapterReadHistoryRow]
+        let targetRowsByKey: [String: RemoteSyncCurrentProgressMemorizationTargetRow]
+        let settingsRowsByKey: [String: RemoteSyncCurrentProgressSettingsRow]
+        let logEntries: [RemoteSyncLogEntry]
+        let updatedEntriesByKey: [String: RemoteSyncLogEntry]
+
+        var deletedRowCount: Int {
+            logEntries.filter { $0.type == .delete }.count
+        }
+    }
+
+    private let adapter: any RemoteSyncAdapting
+    private let snapshotService: RemoteSyncProgressSnapshotService
+    private let fileManager: FileManager
+    private let temporaryDirectory: URL
+    private let nowProvider: () -> Int64
+
+    public init(
+        adapter: any RemoteSyncAdapting,
+        snapshotService: RemoteSyncProgressSnapshotService = RemoteSyncProgressSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil,
+        nowProvider: @escaping () -> Int64 = {
+            Int64(Date().timeIntervalSince1970 * 1000.0)
+        }
+    ) {
+        self.adapter = adapter
+        self.snapshotService = snapshotService
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        self.nowProvider = nowProvider
+    }
+
+    public func uploadPendingPatch(
+        bootstrapState: RemoteSyncBootstrapState,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = 9
+    ) async throws -> RemoteSyncProgressPatchUploadReport? {
+        guard let deviceFolderID = bootstrapState.deviceFolderID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !deviceFolderID.isEmpty else {
+            throw RemoteSyncProgressPatchUploadError.missingDeviceFolderID
+        }
+
+        let sourceDevice = Self.sourceDeviceName(from: deviceFolderID)
+        let timestamp = nowProvider()
+        let snapshot = snapshotService.snapshotCurrentState(settingsStore: settingsStore)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+        let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        let existingEntriesByKey = Dictionary(
+            uniqueKeysWithValues: logEntryStore.entries(for: .progress).map {
+                (logEntryStore.key(for: .progress, entry: $0), $0)
+            }
+        )
+
+        let hadMissingFingerprintBaseline = existingEntriesByKey.contains { key, entry in
+            entry.type != .delete &&
+                snapshot.containsRow(for: key) &&
+                fingerprintStore.fingerprint(
+                    for: .progress,
+                    tableName: entry.tableName,
+                    entityID1: entry.entityID1,
+                    entityID2: entry.entityID2
+                ) == nil
+        }
+
+        let changeSet = buildChangeSet(
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+
+        if changeSet.logEntries.isEmpty {
+            if hadMissingFingerprintBaseline {
+                snapshotService.refreshBaselineFingerprints(settingsStore: settingsStore)
+            }
+            return nil
+        }
+
+        let patchNumber = (patchStatusStore.lastPatchNumber(for: .progress, sourceDevice: sourceDevice) ?? 0) + 1
+        let patchFileName = "\(patchNumber).\(schemaVersion).sqlite3.gz"
+        let databaseURL = temporaryURL(prefix: "remote-sync-progress-upload-", suffix: ".sqlite3")
+        let archiveURL = temporaryURL(prefix: "remote-sync-progress-upload-", suffix: ".sqlite3.gz")
+        defer {
+            try? fileManager.removeItem(at: databaseURL)
+            try? fileManager.removeItem(at: archiveURL)
+        }
+
+        try writePatchDatabase(at: databaseURL, schemaVersion: schemaVersion, changeSet: changeSet)
+        let archiveData = try RemoteSyncArchiveStagingService.gzip(Data(contentsOf: databaseURL))
+        try archiveData.write(to: archiveURL, options: .atomic)
+
+        let uploadedFile = try await adapter.upload(
+            name: patchFileName,
+            fileURL: archiveURL,
+            parentID: deviceFolderID,
+            contentType: NextCloudSyncAdapter.gzipMimeType
+        )
+
+        logEntryStore.replaceEntries(changeSet.updatedEntriesByKey.values.sorted(by: Self.logEntrySort), for: .progress)
+        patchStatusStore.addStatus(
+            RemoteSyncPatchStatus(
+                sourceDevice: sourceDevice,
+                patchNumber: patchNumber,
+                sizeBytes: uploadedFile.size,
+                appliedDate: timestamp
+            ),
+            for: .progress
+        )
+        var progressState = stateStore.progressState(for: .progress)
+        progressState.lastPatchWritten = timestamp
+        stateStore.setProgressState(progressState, for: .progress)
+        snapshotService.refreshBaselineFingerprints(settingsStore: settingsStore)
+
+        return RemoteSyncProgressPatchUploadReport(
+            uploadedFile: uploadedFile,
+            patchNumber: patchNumber,
+            upsertedMemorizedVerseCount: changeSet.memorizedVerseRowsByKey.count,
+            upsertedChapterHistoryCount: changeSet.chapterHistoryRowsByKey.count,
+            upsertedTargetCount: changeSet.targetRowsByKey.count,
+            upsertedSettingsCount: changeSet.settingsRowsByKey.count,
+            deletedRowCount: changeSet.deletedRowCount,
+            logEntryCount: changeSet.logEntries.count,
+            lastUpdated: timestamp
+        )
+    }
+
+    private func buildChangeSet(
+        snapshot: RemoteSyncProgressCurrentSnapshot,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore,
+        timestamp: Int64,
+        sourceDevice: String
+    ) -> ChangeSet {
+        var memorizedVerseRowsByKey: [String: RemoteSyncCurrentProgressMemorizedVerseRow] = [:]
+        var chapterHistoryRowsByKey: [String: RemoteSyncCurrentProgressChapterReadHistoryRow] = [:]
+        var targetRowsByKey: [String: RemoteSyncCurrentProgressMemorizationTargetRow] = [:]
+        var settingsRowsByKey: [String: RemoteSyncCurrentProgressSettingsRow] = [:]
+        var logEntries: [RemoteSyncLogEntry] = []
+        var updatedEntriesByKey = existingEntriesByKey
+
+        appendUpserts(
+            rowsByKey: snapshot.memorizedVerseRowsByKey,
+            tableName: RemoteSyncProgressSnapshotService.memorizedVerseTable,
+            fingerprintsByKey: snapshot.fingerprintsByKey,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice,
+            collectedRows: &memorizedVerseRowsByKey,
+            logEntries: &logEntries,
+            updatedEntriesByKey: &updatedEntriesByKey
+        )
+        appendUpserts(
+            rowsByKey: snapshot.chapterHistoryRowsByKey,
+            tableName: RemoteSyncProgressSnapshotService.chapterReadHistoryTable,
+            fingerprintsByKey: snapshot.fingerprintsByKey,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice,
+            collectedRows: &chapterHistoryRowsByKey,
+            logEntries: &logEntries,
+            updatedEntriesByKey: &updatedEntriesByKey
+        )
+        appendUpserts(
+            rowsByKey: snapshot.memorizationTargetRowsByKey,
+            tableName: RemoteSyncProgressSnapshotService.memorizationTargetTable,
+            fingerprintsByKey: snapshot.fingerprintsByKey,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice,
+            collectedRows: &targetRowsByKey,
+            logEntries: &logEntries,
+            updatedEntriesByKey: &updatedEntriesByKey
+        )
+        appendUpserts(
+            rowsByKey: snapshot.settingsRowsByKey,
+            tableName: RemoteSyncProgressSnapshotService.globalSettingsTable,
+            fingerprintsByKey: snapshot.fingerprintsByKey,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice,
+            collectedRows: &settingsRowsByKey,
+            logEntries: &logEntries,
+            updatedEntriesByKey: &updatedEntriesByKey
+        )
+
+        for (key, entry) in existingEntriesByKey.sorted(by: { $0.key < $1.key }) {
+            guard entry.type != .delete, !snapshot.containsRow(for: key) else {
+                continue
+            }
+            let deleteEntry = RemoteSyncLogEntry(
+                tableName: entry.tableName,
+                entityID1: entry.entityID1,
+                entityID2: entry.entityID2,
+                type: .delete,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            logEntries.append(deleteEntry)
+            updatedEntriesByKey[key] = deleteEntry
+        }
+
+        return ChangeSet(
+            memorizedVerseRowsByKey: memorizedVerseRowsByKey,
+            chapterHistoryRowsByKey: chapterHistoryRowsByKey,
+            targetRowsByKey: targetRowsByKey,
+            settingsRowsByKey: settingsRowsByKey,
+            logEntries: logEntries.sorted(by: Self.logEntrySort),
+            updatedEntriesByKey: updatedEntriesByKey
+        )
+    }
+
+    private func appendUpserts<Row>(
+        rowsByKey: [String: Row],
+        tableName: String,
+        fingerprintsByKey: [String: String],
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore,
+        timestamp: Int64,
+        sourceDevice: String,
+        collectedRows: inout [String: Row],
+        logEntries: inout [RemoteSyncLogEntry],
+        updatedEntriesByKey: inout [String: RemoteSyncLogEntry]
+    ) {
+        for (key, row) in rowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard shouldUploadCurrentRow(
+                key: key,
+                currentFingerprint: fingerprintsByKey[key],
+                existingEntriesByKey: existingEntriesByKey,
+                fingerprintStore: fingerprintStore
+            ) else {
+                continue
+            }
+            let entry = RemoteSyncLogEntry(
+                tableName: tableName,
+                entityID1: Self.entityID1(fromLogKeyEntry: existingEntriesByKey[key], row: row),
+                entityID2: .text(""),
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            collectedRows[key] = row
+            logEntries.append(entry)
+            updatedEntriesByKey[key] = entry
+        }
+    }
+
+    private func shouldUploadCurrentRow(
+        key: String,
+        currentFingerprint: String?,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore
+    ) -> Bool {
+        guard let currentFingerprint else {
+            return false
+        }
+        guard let existingEntry = existingEntriesByKey[key] else {
+            if let existingFingerprint = fingerprintStore.fingerprint(forLogKey: key, category: .progress) {
+                return existingFingerprint != currentFingerprint
+            }
+            return true
+        }
+        if existingEntry.type == .delete {
+            return true
+        }
+        guard let existingFingerprint = fingerprintStore.fingerprint(
+            for: .progress,
+            tableName: existingEntry.tableName,
+            entityID1: existingEntry.entityID1,
+            entityID2: existingEntry.entityID2
+        ) else {
+            return false
+        }
+        return existingFingerprint != currentFingerprint
+    }
+
+    private static func entityID1<Row>(fromLogKeyEntry entry: RemoteSyncLogEntry?, row: Row) -> RemoteSyncSQLiteValue {
+        if let entry {
+            return entry.entityID1
+        }
+        switch row {
+        case let row as RemoteSyncCurrentProgressMemorizedVerseRow:
+            return .blob(RemoteSyncProgressSnapshotService.uuidBlob(row.id))
+        case let row as RemoteSyncCurrentProgressChapterReadHistoryRow:
+            return .blob(RemoteSyncProgressSnapshotService.uuidBlob(row.id))
+        case let row as RemoteSyncCurrentProgressMemorizationTargetRow:
+            return .blob(RemoteSyncProgressSnapshotService.uuidBlob(row.id))
+        case let row as RemoteSyncCurrentProgressSettingsRow:
+            return .blob(RemoteSyncProgressSnapshotService.uuidBlob(row.id))
+        default:
+            return .null()
+        }
+    }
+
+    private func writePatchDatabase(at url: URL, schemaVersion: Int, changeSet: ChangeSet) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK,
+              let database else {
+            throw RemoteSyncProgressPatchUploadError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(database) }
+
+        try execute(progressPatchSchemaSQL(schemaVersion: schemaVersion), in: database)
+        for row in changeSet.memorizedVerseRowsByKey.values.sorted(by: { $0.kjvOrdinal < $1.kjvOrdinal }) {
+            try insertMemorizedVerse(row, in: database)
+        }
+        for row in changeSet.chapterHistoryRowsByKey.values.sorted(by: { $0.readAt < $1.readAt }) {
+            try insertChapterHistory(row, in: database)
+        }
+        for row in changeSet.targetRowsByKey.values.sorted(by: { $0.createdAt > $1.createdAt }) {
+            try insertTarget(row, in: database)
+        }
+        for row in changeSet.settingsRowsByKey.values {
+            try insertSettings(row, in: database)
+        }
+        for entry in changeSet.logEntries {
+            try insertLogEntry(entry, in: database)
+        }
+    }
+
+    private func insertMemorizedVerse(_ row: RemoteSyncCurrentProgressMemorizedVerseRow, in database: OpaquePointer) throws {
+        let statement = try prepare("INSERT INTO MemorizedVerse (id, kjvOrdinal, memorizedAt) VALUES (?, ?, ?);", in: database)
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvOrdinal))
+        sqlite3_bind_int64(statement, 3, row.memorizedAt)
+        try stepDone(statement)
+    }
+
+    private func insertChapterHistory(_ row: RemoteSyncCurrentProgressChapterReadHistoryRow, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            """
+            INSERT INTO ChapterReadHistory (id, kjvBookOrdinal, chapter, cycle, readAt, bookInitials, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?);
+            """,
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvBookOrdinal))
+        sqlite3_bind_int(statement, 3, Int32(row.chapter))
+        sqlite3_bind_int(statement, 4, Int32(row.cycle))
+        sqlite3_bind_int64(statement, 5, row.readAt)
+        bindText(row.bookInitials, to: statement, index: 6)
+        bindText(row.source.rawValue, to: statement, index: 7)
+        try stepDone(statement)
+    }
+
+    private func insertTarget(_ row: RemoteSyncCurrentProgressMemorizationTargetRow, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO MemorizationTarget (id, kjvOrdinalStart, kjvOrdinalEnd, createdAt) VALUES (?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvOrdinalStart))
+        sqlite3_bind_int(statement, 3, Int32(row.kjvOrdinalEnd))
+        sqlite3_bind_int64(statement, 4, row.createdAt)
+        try stepDone(statement)
+    }
+
+    private func insertSettings(_ row: RemoteSyncCurrentProgressSettingsRow, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            """
+            INSERT INTO GlobalReadingProgressSettings (
+                id, autoTrackReading, autoMarkMemorized, memorizeTypeFullWords, memorizeWordVisibility,
+                memorizeErrorHeatmap, memorizeScrambleHideUsed, memorizeIncludeReference, activeCycle
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindUUIDBlob(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, row.autoTrackReading ? 1 : 0)
+        sqlite3_bind_int(statement, 3, row.autoMarkMemorized ? 1 : 0)
+        sqlite3_bind_int(statement, 4, row.memorizeTypeFullWords ? 1 : 0)
+        bindText(row.memorizeWordVisibility, to: statement, index: 5)
+        sqlite3_bind_int(statement, 6, row.memorizeErrorHeatmap ? 1 : 0)
+        sqlite3_bind_int(statement, 7, row.memorizeScrambleHideUsed ? 1 : 0)
+        sqlite3_bind_int(statement, 8, row.memorizeIncludeReference ? 1 : 0)
+        sqlite3_bind_int(statement, 9, Int32(row.activeCycle))
+        try stepDone(statement)
+    }
+
+    private func insertLogEntry(_ entry: RemoteSyncLogEntry, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice) VALUES (?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        bindText(entry.tableName, to: statement, index: 1)
+        Self.bindSQLiteValue(entry.entityID1, to: statement, index: 2)
+        Self.bindSQLiteValue(entry.entityID2, to: statement, index: 3)
+        bindText(entry.type.rawValue, to: statement, index: 4)
+        sqlite3_bind_int64(statement, 5, entry.lastUpdated)
+        bindText(entry.sourceDevice, to: statement, index: 6)
+        try stepDone(statement)
+    }
+
+    private func progressPatchSchemaSQL(schemaVersion: Int) -> String {
+        """
+        PRAGMA user_version = \(schemaVersion);
+        CREATE TABLE MemorizedVerse (
+            id BLOB NOT NULL PRIMARY KEY,
+            kjvOrdinal INTEGER NOT NULL,
+            memorizedAt INTEGER NOT NULL
+        );
+        CREATE UNIQUE INDEX index_MemorizedVerse_kjvOrdinal ON MemorizedVerse (kjvOrdinal);
+        CREATE TABLE MemorizationTarget (
+            id BLOB NOT NULL PRIMARY KEY,
+            kjvOrdinalStart INTEGER NOT NULL,
+            kjvOrdinalEnd INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL
+        );
+        CREATE TABLE ChapterReadHistory (
+            id BLOB NOT NULL PRIMARY KEY,
+            kjvBookOrdinal INTEGER NOT NULL,
+            chapter INTEGER NOT NULL,
+            cycle INTEGER NOT NULL DEFAULT 1,
+            readAt INTEGER NOT NULL,
+            bookInitials TEXT NOT NULL DEFAULT '',
+            source TEXT NOT NULL DEFAULT 'MANUAL'
+        );
+        CREATE TABLE GlobalReadingProgressSettings (
+            id BLOB NOT NULL PRIMARY KEY,
+            autoTrackReading INTEGER NOT NULL DEFAULT 0,
+            autoMarkMemorized INTEGER NOT NULL DEFAULT 1,
+            memorizeTypeFullWords INTEGER NOT NULL DEFAULT 0,
+            memorizeWordVisibility TEXT NOT NULL DEFAULT 'light',
+            memorizeErrorHeatmap INTEGER NOT NULL DEFAULT 1,
+            memorizeScrambleHideUsed INTEGER NOT NULL DEFAULT 0,
+            memorizeIncludeReference INTEGER NOT NULL DEFAULT 1,
+            activeCycle INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE LogEntry (
+            tableName TEXT NOT NULL,
+            entityId1 BLOB,
+            entityId2 BLOB,
+            type TEXT NOT NULL,
+            lastUpdated INTEGER NOT NULL,
+            sourceDevice TEXT NOT NULL
+        );
+        """
+    }
+
+    private func prepare(_ sql: String, in database: OpaquePointer) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+            throw RemoteSyncProgressPatchUploadError.invalidSQLiteDatabase
+        }
+        return statement
+    }
+
+    private func execute(_ sql: String, in database: OpaquePointer) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncProgressPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func stepDone(_ statement: OpaquePointer?) throws {
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncProgressPatchUploadError.invalidSQLiteDatabase
+        }
+    }
+
+    private func bindUUIDBlob(_ uuid: UUID, to statement: OpaquePointer?, index: Int32) {
+        let data = RemoteSyncProgressSnapshotService.uuidBlob(uuid)
+        _ = data.withUnsafeBytes {
+            sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), remoteSyncProgressPatchUploadSQLiteTransient)
+        }
+    }
+
+    private func bindText(_ value: String, to statement: OpaquePointer?, index: Int32) {
+        sqlite3_bind_text(statement, index, value, -1, remoteSyncProgressPatchUploadSQLiteTransient)
+    }
+
+    private static func bindSQLiteValue(_ value: RemoteSyncSQLiteValue, to statement: OpaquePointer?, index: Int32) {
+        switch value.kind {
+        case .null:
+            sqlite3_bind_null(statement, index)
+        case .integer:
+            sqlite3_bind_int64(statement, index, value.integerValue ?? 0)
+        case .real:
+            sqlite3_bind_double(statement, index, value.realValue ?? 0)
+        case .text:
+            sqlite3_bind_text(statement, index, value.textValue ?? "", -1, remoteSyncProgressPatchUploadSQLiteTransient)
+        case .blob:
+            let data = value.blobData ?? Data()
+            _ = data.withUnsafeBytes {
+                sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), remoteSyncProgressPatchUploadSQLiteTransient)
+            }
+        }
+    }
+
+    private func temporaryURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    private static func sourceDeviceName(from deviceFolderID: String) -> String {
+        let trimmed = deviceFolderID.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmed.split(separator: "/").last.map(String.init) ?? deviceFolderID
+    }
+
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.lastUpdated != rhs.lastUpdated {
+            return lhs.lastUpdated < rhs.lastUpdated
+        }
+        return "\(lhs.entityID1)-\(lhs.entityID2)" < "\(rhs.entityID1)-\(rhs.entityID2)"
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncProgressSnapshotService.swift
@@ -1,0 +1,518 @@
+// RemoteSyncProgressSnapshotService.swift - Android-shaped local progress snapshots for remote sync
+
+import CryptoKit
+import Foundation
+
+/**
+ Current local representation of one Android `MemorizedVerse` row.
+ */
+public struct RemoteSyncCurrentProgressMemorizedVerseRow: Sendable, Equatable, Codable {
+    public let id: UUID
+    public let kjvOrdinal: Int
+    public let memorizedAt: Int64
+
+    public init(id: UUID, kjvOrdinal: Int, memorizedAt: Int64) {
+        self.id = id
+        self.kjvOrdinal = kjvOrdinal
+        self.memorizedAt = memorizedAt
+    }
+}
+
+/**
+ Current local representation of one Android `ChapterReadHistory` row.
+ */
+public struct RemoteSyncCurrentProgressChapterReadHistoryRow: Sendable, Equatable, Codable {
+    public let id: UUID
+    public let kjvBookOrdinal: Int
+    public let chapter: Int
+    public let cycle: Int
+    public let readAt: Int64
+    public let bookInitials: String
+    public let source: ReadingProgressSource
+
+    public init(
+        id: UUID,
+        kjvBookOrdinal: Int,
+        chapter: Int,
+        cycle: Int,
+        readAt: Int64,
+        bookInitials: String,
+        source: ReadingProgressSource
+    ) {
+        self.id = id
+        self.kjvBookOrdinal = kjvBookOrdinal
+        self.chapter = chapter
+        self.cycle = cycle
+        self.readAt = readAt
+        self.bookInitials = bookInitials
+        self.source = source
+    }
+}
+
+/**
+ Current local representation of one Android `MemorizationTarget` row.
+ */
+public struct RemoteSyncCurrentProgressMemorizationTargetRow: Sendable, Equatable, Codable {
+    public let id: UUID
+    public let kjvOrdinalStart: Int
+    public let kjvOrdinalEnd: Int
+    public let createdAt: Int64
+
+    public init(id: UUID, kjvOrdinalStart: Int, kjvOrdinalEnd: Int, createdAt: Int64) {
+        self.id = id
+        self.kjvOrdinalStart = kjvOrdinalStart
+        self.kjvOrdinalEnd = kjvOrdinalEnd
+        self.createdAt = createdAt
+    }
+}
+
+/**
+ Current local representation of Android's singleton `GlobalReadingProgressSettings` row.
+ */
+public struct RemoteSyncCurrentProgressSettingsRow: Sendable, Equatable, Codable {
+    public let id: UUID
+    public let autoTrackReading: Bool
+    public let autoMarkMemorized: Bool
+    public let memorizeTypeFullWords: Bool
+    public let memorizeWordVisibility: String
+    public let memorizeErrorHeatmap: Bool
+    public let memorizeScrambleHideUsed: Bool
+    public let memorizeIncludeReference: Bool
+    public let activeCycle: Int
+
+    public init(id: UUID, settings: ReadingProgressSettingsSnapshot) {
+        self.id = id
+        self.autoTrackReading = settings.autoTrackReading
+        self.autoMarkMemorized = settings.autoMarkMemorized
+        self.memorizeTypeFullWords = settings.memorizeTypeFullWords
+        self.memorizeWordVisibility = settings.memorizeWordVisibility
+        self.memorizeErrorHeatmap = settings.memorizeErrorHeatmap
+        self.memorizeScrambleHideUsed = settings.memorizeScrambleHideUsed
+        self.memorizeIncludeReference = settings.memorizeIncludeReference
+        self.activeCycle = settings.activeCycle
+    }
+
+    public var settings: ReadingProgressSettingsSnapshot {
+        ReadingProgressSettingsSnapshot(
+            autoTrackReading: autoTrackReading,
+            activeCycle: activeCycle,
+            autoMarkMemorized: autoMarkMemorized,
+            memorizeTypeFullWords: memorizeTypeFullWords,
+            memorizeWordVisibility: memorizeWordVisibility,
+            memorizeErrorHeatmap: memorizeErrorHeatmap,
+            memorizeScrambleHideUsed: memorizeScrambleHideUsed,
+            memorizeIncludeReference: memorizeIncludeReference
+        )
+    }
+}
+
+/**
+ Snapshot of local reading and memorization progress expressed as Android progress rows.
+ */
+public struct RemoteSyncProgressCurrentSnapshot: Sendable, Equatable {
+    public let memorizedVerseRowsByKey: [String: RemoteSyncCurrentProgressMemorizedVerseRow]
+    public let chapterHistoryRowsByKey: [String: RemoteSyncCurrentProgressChapterReadHistoryRow]
+    public let memorizationTargetRowsByKey: [String: RemoteSyncCurrentProgressMemorizationTargetRow]
+    public let settingsRowsByKey: [String: RemoteSyncCurrentProgressSettingsRow]
+    public let fingerprintsByKey: [String: String]
+
+    public init(
+        memorizedVerseRowsByKey: [String: RemoteSyncCurrentProgressMemorizedVerseRow],
+        chapterHistoryRowsByKey: [String: RemoteSyncCurrentProgressChapterReadHistoryRow],
+        memorizationTargetRowsByKey: [String: RemoteSyncCurrentProgressMemorizationTargetRow],
+        settingsRowsByKey: [String: RemoteSyncCurrentProgressSettingsRow],
+        fingerprintsByKey: [String: String]
+    ) {
+        self.memorizedVerseRowsByKey = memorizedVerseRowsByKey
+        self.chapterHistoryRowsByKey = chapterHistoryRowsByKey
+        self.memorizationTargetRowsByKey = memorizationTargetRowsByKey
+        self.settingsRowsByKey = settingsRowsByKey
+        self.fingerprintsByKey = fingerprintsByKey
+    }
+
+    public func containsRow(for key: String) -> Bool {
+        memorizedVerseRowsByKey[key] != nil ||
+            chapterHistoryRowsByKey[key] != nil ||
+            memorizationTargetRowsByKey[key] != nil ||
+            settingsRowsByKey[key] != nil
+    }
+}
+
+/**
+ Projects local progress JSON snapshots into Android's `progress.sqlite3` row model.
+
+ Android sync treats Progress as a normal database with UUID-keyed rows in
+ `MemorizedVerse`, `ChapterReadHistory`, `MemorizationTarget`, and
+ `GlobalReadingProgressSettings`. iOS stores the same user-facing state in JSON-backed stores, so
+ this service provides the Android-shaped row projection and content fingerprints needed by remote
+ patch upload and baseline refresh.
+ */
+public final class RemoteSyncProgressSnapshotService {
+    public static let memorizedVerseTable = "MemorizedVerse"
+    public static let chapterReadHistoryTable = "ChapterReadHistory"
+    public static let memorizationTargetTable = "MemorizationTarget"
+    public static let globalSettingsTable = "GlobalReadingProgressSettings"
+    public static let globalSettingsID = UUID(uuidString: "b2000000-0000-0000-0000-000000000001")!
+
+    private static let progressOrdinalRange = JSwordKJVAVersification.progressOrdinalRange
+
+    public init() {}
+
+    /**
+     Projects current local progress into Android-shaped rows and row fingerprints.
+
+     - Parameter settingsStore: Local-only settings store containing progress JSON payloads.
+     - Returns: Current Android progress rows keyed by Android `LogEntry` identity.
+     - Side effects: reads local progress snapshots.
+     - Failure modes: malformed local JSON is treated as the stores' default empty snapshots.
+     */
+    public func snapshotCurrentState(settingsStore: SettingsStore) -> RemoteSyncProgressCurrentSnapshot {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let readingSnapshot = ReadingProgressStore(settingsStore: settingsStore).snapshot()
+        let memorizationSnapshot = MemorizationProgressStore(settingsStore: settingsStore).snapshot()
+
+        var memorizedVerseRowsByKey: [String: RemoteSyncCurrentProgressMemorizedVerseRow] = [:]
+        var chapterHistoryRowsByKey: [String: RemoteSyncCurrentProgressChapterReadHistoryRow] = [:]
+        var memorizationTargetRowsByKey: [String: RemoteSyncCurrentProgressMemorizationTargetRow] = [:]
+        var settingsRowsByKey: [String: RemoteSyncCurrentProgressSettingsRow] = [:]
+        var fingerprintsByKey: [String: String] = [:]
+
+        for row in Self.exportableMemorizedVerses(in: memorizationSnapshot.memorizedVerses) {
+            let key = key(for: Self.memorizedVerseTable, id: row.id, logEntryStore: logEntryStore)
+            memorizedVerseRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        for row in Self.exportableChapterHistory(in: readingSnapshot.history) {
+            let key = key(for: Self.chapterReadHistoryTable, id: row.id, logEntryStore: logEntryStore)
+            chapterHistoryRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        for row in Self.exportableTargets(in: memorizationSnapshot.targetRows) {
+            let key = key(for: Self.memorizationTargetTable, id: row.id, logEntryStore: logEntryStore)
+            memorizationTargetRowsByKey[key] = row
+            fingerprintsByKey[key] = Self.fingerprintHex(for: row)
+        }
+
+        let settingsRow = RemoteSyncCurrentProgressSettingsRow(
+            id: Self.globalSettingsID,
+            settings: readingSnapshot.settings
+        )
+        let settingsKey = key(for: Self.globalSettingsTable, id: settingsRow.id, logEntryStore: logEntryStore)
+        settingsRowsByKey[settingsKey] = settingsRow
+        fingerprintsByKey[settingsKey] = Self.fingerprintHex(for: settingsRow)
+
+        return RemoteSyncProgressCurrentSnapshot(
+            memorizedVerseRowsByKey: memorizedVerseRowsByKey,
+            chapterHistoryRowsByKey: chapterHistoryRowsByKey,
+            memorizationTargetRowsByKey: memorizationTargetRowsByKey,
+            settingsRowsByKey: settingsRowsByKey,
+            fingerprintsByKey: fingerprintsByKey
+        )
+    }
+
+    /**
+     Replaces stored Progress row fingerprints with the current local Android-shaped snapshot.
+
+     - Parameter settingsStore: Local-only settings store backing progress and fingerprint rows.
+     - Side effects: clears and rewrites `.progress` row fingerprints.
+     - Failure modes: underlying settings persistence is best-effort and swallows save failures.
+     */
+    public func refreshBaselineFingerprints(settingsStore: SettingsStore) {
+        let snapshot = snapshotCurrentState(settingsStore: settingsStore)
+        let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        fingerprintStore.clearCategory(.progress)
+
+        for row in snapshot.memorizedVerseRowsByKey.values {
+            setFingerprint(
+                snapshot.fingerprintsByKey,
+                tableName: Self.memorizedVerseTable,
+                id: row.id,
+                logEntryStore: logEntryStore,
+                fingerprintStore: fingerprintStore
+            )
+        }
+        for row in snapshot.chapterHistoryRowsByKey.values {
+            setFingerprint(
+                snapshot.fingerprintsByKey,
+                tableName: Self.chapterReadHistoryTable,
+                id: row.id,
+                logEntryStore: logEntryStore,
+                fingerprintStore: fingerprintStore
+            )
+        }
+        for row in snapshot.memorizationTargetRowsByKey.values {
+            setFingerprint(
+                snapshot.fingerprintsByKey,
+                tableName: Self.memorizationTargetTable,
+                id: row.id,
+                logEntryStore: logEntryStore,
+                fingerprintStore: fingerprintStore
+            )
+        }
+        for row in snapshot.settingsRowsByKey.values {
+            setFingerprint(
+                snapshot.fingerprintsByKey,
+                tableName: Self.globalSettingsTable,
+                id: row.id,
+                logEntryStore: logEntryStore,
+                fingerprintStore: fingerprintStore
+            )
+        }
+    }
+
+    /**
+     Builds Android `LogEntry` rows that describe the accepted current Progress baseline.
+
+     Initial backups are full snapshots, but later sparse DELETE patches still need a remembered
+     key set for rows that existed in that baseline. Android carries that through `LogEntry`; iOS
+     mirrors it here so deleting a row after an iOS-created Progress baseline emits a DELETE patch.
+
+     - Parameters:
+       - settingsStore: Local-only settings store containing the progress JSON payloads.
+       - sourceDevice: Android source-device name to record on the baseline entries.
+       - lastUpdated: Millisecond timestamp assigned to each baseline entry.
+     - Returns: Android-compatible upsert `LogEntry` rows for every current Progress row.
+     - Side effects: reads local progress snapshots.
+     - Failure modes: malformed local JSON is treated as the stores' default empty snapshots.
+     */
+    public func acceptedBaselineLogEntries(
+        settingsStore: SettingsStore,
+        sourceDevice: String,
+        lastUpdated: Int64
+    ) -> [RemoteSyncLogEntry] {
+        let snapshot = snapshotCurrentState(settingsStore: settingsStore)
+        var entries: [RemoteSyncLogEntry] = []
+        entries += snapshot.memorizedVerseRowsByKey.values.map {
+            baselineLogEntry(
+                tableName: Self.memorizedVerseTable,
+                id: $0.id,
+                sourceDevice: sourceDevice,
+                lastUpdated: lastUpdated
+            )
+        }
+        entries += snapshot.chapterHistoryRowsByKey.values.map {
+            baselineLogEntry(
+                tableName: Self.chapterReadHistoryTable,
+                id: $0.id,
+                sourceDevice: sourceDevice,
+                lastUpdated: lastUpdated
+            )
+        }
+        entries += snapshot.memorizationTargetRowsByKey.values.map {
+            baselineLogEntry(
+                tableName: Self.memorizationTargetTable,
+                id: $0.id,
+                sourceDevice: sourceDevice,
+                lastUpdated: lastUpdated
+            )
+        }
+        entries += snapshot.settingsRowsByKey.values.map {
+            baselineLogEntry(
+                tableName: Self.globalSettingsTable,
+                id: $0.id,
+                sourceDevice: sourceDevice,
+                lastUpdated: lastUpdated
+            )
+        }
+        return entries.sorted(by: Self.logEntrySort)
+    }
+
+    private func key(
+        for tableName: String,
+        id: UUID,
+        logEntryStore: RemoteSyncLogEntryStore
+    ) -> String {
+        logEntryStore.key(
+            for: .progress,
+            tableName: tableName,
+            entityID1: .blob(Self.uuidBlob(id)),
+            entityID2: .text("")
+        )
+    }
+
+    private func setFingerprint(
+        _ fingerprintsByKey: [String: String],
+        tableName: String,
+        id: UUID,
+        logEntryStore: RemoteSyncLogEntryStore,
+        fingerprintStore: RemoteSyncRowFingerprintStore
+    ) {
+        let key = logEntryStore.key(
+            for: .progress,
+            tableName: tableName,
+            entityID1: .blob(Self.uuidBlob(id)),
+            entityID2: .text("")
+        )
+        guard let fingerprint = fingerprintsByKey[key] else { return }
+        fingerprintStore.setFingerprint(
+            fingerprint,
+            for: .progress,
+            tableName: tableName,
+            entityID1: .blob(Self.uuidBlob(id)),
+            entityID2: .text("")
+        )
+    }
+
+    private func baselineLogEntry(
+        tableName: String,
+        id: UUID,
+        sourceDevice: String,
+        lastUpdated: Int64
+    ) -> RemoteSyncLogEntry {
+        RemoteSyncLogEntry(
+            tableName: tableName,
+            entityID1: .blob(Self.uuidBlob(id)),
+            entityID2: .text(""),
+            type: .upsert,
+            lastUpdated: lastUpdated,
+            sourceDevice: sourceDevice
+        )
+    }
+
+    private static func exportableMemorizedVerses(
+        in verses: [MemorizedVerseProgress]
+    ) -> [RemoteSyncCurrentProgressMemorizedVerseRow] {
+        var rowsByOrdinal: [Int: MemorizedVerseProgress] = [:]
+        for verse in verses where progressOrdinalRange.contains(verse.kjvOrdinal) {
+            guard let existing = rowsByOrdinal[verse.kjvOrdinal] else {
+                rowsByOrdinal[verse.kjvOrdinal] = verse
+                continue
+            }
+            if existing.memorizedAt < verse.memorizedAt ||
+                (existing.memorizedAt == verse.memorizedAt && existing.id.uuidString > verse.id.uuidString) {
+                rowsByOrdinal[verse.kjvOrdinal] = verse
+            }
+        }
+        return rowsByOrdinal.values
+            .map {
+                RemoteSyncCurrentProgressMemorizedVerseRow(
+                    id: $0.id,
+                    kjvOrdinal: $0.kjvOrdinal,
+                    memorizedAt: $0.memorizedAt
+                )
+            }
+            .sorted { $0.kjvOrdinal < $1.kjvOrdinal }
+    }
+
+    private static func exportableChapterHistory(
+        in rows: [ReadingProgressHistoryRow]
+    ) -> [RemoteSyncCurrentProgressChapterReadHistoryRow] {
+        rows
+            .filter { $0.kjvBookOrdinal > 0 && $0.chapter > 0 && $0.cycle > 0 }
+            .map {
+                RemoteSyncCurrentProgressChapterReadHistoryRow(
+                    id: $0.id,
+                    kjvBookOrdinal: $0.kjvBookOrdinal,
+                    chapter: $0.chapter,
+                    cycle: $0.cycle,
+                    readAt: $0.readAt,
+                    bookInitials: $0.bookInitials,
+                    source: $0.source
+                )
+            }
+            .sorted {
+                if $0.readAt != $1.readAt {
+                    return $0.readAt < $1.readAt
+                }
+                return $0.id.uuidString < $1.id.uuidString
+            }
+    }
+
+    private static func exportableTargets(
+        in rows: [MemorizationTargetRow]
+    ) -> [RemoteSyncCurrentProgressMemorizationTargetRow] {
+        rows
+            .filter {
+                progressOrdinalRange.contains($0.startOrdinal) &&
+                    progressOrdinalRange.contains($0.endOrdinal) &&
+                    $0.endOrdinal >= $0.startOrdinal
+            }
+            .map {
+                RemoteSyncCurrentProgressMemorizationTargetRow(
+                    id: $0.id,
+                    kjvOrdinalStart: $0.startOrdinal,
+                    kjvOrdinalEnd: $0.endOrdinal,
+                    createdAt: $0.createdAt
+                )
+            }
+            .sorted {
+                if $0.createdAt != $1.createdAt {
+                    return $0.createdAt > $1.createdAt
+                }
+                return $0.id.uuidString < $1.id.uuidString
+            }
+    }
+
+    static func fingerprintHex(for value: RemoteSyncCurrentProgressMemorizedVerseRow) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                String(value.kjvOrdinal),
+                String(value.memorizedAt),
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncCurrentProgressChapterReadHistoryRow) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                String(value.kjvBookOrdinal),
+                String(value.chapter),
+                String(value.cycle),
+                String(value.readAt),
+                value.bookInitials,
+                value.source.rawValue,
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncCurrentProgressMemorizationTargetRow) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                String(value.kjvOrdinalStart),
+                String(value.kjvOrdinalEnd),
+                String(value.createdAt),
+            ].joined(separator: "|")
+        )
+    }
+
+    static func fingerprintHex(for value: RemoteSyncCurrentProgressSettingsRow) -> String {
+        fingerprintHex(
+            canonicalValue: [
+                value.id.uuidString.lowercased(),
+                value.autoTrackReading ? "1" : "0",
+                value.autoMarkMemorized ? "1" : "0",
+                value.memorizeTypeFullWords ? "1" : "0",
+                value.memorizeWordVisibility,
+                value.memorizeErrorHeatmap ? "1" : "0",
+                value.memorizeScrambleHideUsed ? "1" : "0",
+                value.memorizeIncludeReference ? "1" : "0",
+                String(value.activeCycle),
+            ].joined(separator: "|")
+        )
+    }
+
+    private static func fingerprintHex(canonicalValue: String) -> String {
+        let digest = SHA256.hash(data: Data(canonicalValue.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func uuidBlob(_ uuid: UUID) -> Data {
+        withUnsafeBytes(of: uuid.uuid) { Data($0) }
+    }
+
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.lastUpdated != rhs.lastUpdated {
+            return lhs.lastUpdated < rhs.lastUpdated
+        }
+        return "\(lhs.entityID1)-\(lhs.entityID2)" < "\(rhs.entityID1)-\(rhs.entityID2)"
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
@@ -33,7 +33,7 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
      syncable, so visible settings rows are curated separately by the UI presentation layer.
      */
     public static var activeSyncCases: [RemoteSyncCategory] {
-        [.bookmarks, .workspaces, .readingPlans, .myDocuments]
+        [.bookmarks, .workspaces, .readingPlans, .myDocuments, .progress]
     }
 
     /// Highest Android SQLite schema version iOS can currently read and write for this category.

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -37,6 +37,9 @@ public enum RemoteSyncCategoryPatchReplayReport: Sendable, Equatable {
 
     /// My Documents-category patch replay summary.
     case myDocuments(RemoteSyncMyDocumentPatchApplyReport)
+
+    /// Progress-category patch replay summary.
+    case progress(RemoteSyncProgressPatchApplyReport)
 }
 
 /**
@@ -57,6 +60,9 @@ public enum RemoteSyncCategoryPatchUploadReport: Sendable, Equatable {
 
     /// My Documents-category outbound patch upload summary.
     case myDocuments(RemoteSyncMyDocumentPatchUploadReport)
+
+    /// Progress-category outbound patch upload summary.
+    case progress(RemoteSyncProgressPatchUploadReport)
 }
 
 /**
@@ -212,6 +218,8 @@ public final class RemoteSyncSynchronizationService {
     private let workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService
     private let myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService
     private let myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService
+    private let progressPatchApplyService: RemoteSyncProgressPatchApplyService
+    private let progressPatchUploadService: RemoteSyncProgressPatchUploadService
     private let fileManager: FileManager
     private let temporaryDirectory: URL?
     private let nowProvider: () -> Int64
@@ -233,6 +241,8 @@ public final class RemoteSyncSynchronizationService {
        - workspacePatchUploadService: Workspace outbound patch upload service.
        - myDocumentPatchApplyService: My Documents patch replay service.
        - myDocumentPatchUploadService: My Documents outbound patch upload service.
+       - progressPatchApplyService: Progress patch replay service.
+       - progressPatchUploadService: Progress outbound patch upload service.
        - fileManager: File manager used for staging cleanup.
        - temporaryDirectory: Optional staging directory override.
        - nowProvider: Millisecond clock used for Android-aligned sync progress timestamps.
@@ -253,6 +263,8 @@ public final class RemoteSyncSynchronizationService {
         workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService? = nil,
         myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService = RemoteSyncMyDocumentPatchApplyService(),
         myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService? = nil,
+        progressPatchApplyService: RemoteSyncProgressPatchApplyService = RemoteSyncProgressPatchApplyService(),
+        progressPatchUploadService: RemoteSyncProgressPatchUploadService? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL? = nil,
         nowProvider: @escaping () -> Int64 = {
@@ -290,6 +302,12 @@ public final class RemoteSyncSynchronizationService {
         self.myDocumentPatchApplyService = myDocumentPatchApplyService
         self.myDocumentPatchUploadService = myDocumentPatchUploadService
             ?? RemoteSyncMyDocumentPatchUploadService(
+                adapter: adapter,
+                nowProvider: nowProvider
+            )
+        self.progressPatchApplyService = progressPatchApplyService
+        self.progressPatchUploadService = progressPatchUploadService
+            ?? RemoteSyncProgressPatchUploadService(
                 adapter: adapter,
                 nowProvider: nowProvider
             )
@@ -708,7 +726,12 @@ public final class RemoteSyncSynchronizationService {
                 )
             )
         case .progress:
-            throw RemoteSyncSynchronizationError.unsupportedCategory(category)
+            return .progress(
+                try progressPatchApplyService.applyPatchArchives(
+                    stagedArchives,
+                    settingsStore: settingsStore
+                )
+            )
         }
     }
 
@@ -773,6 +796,12 @@ public final class RemoteSyncSynchronizationService {
             }
             return nil
         case .progress:
+            if let report = try await progressPatchUploadService.uploadPendingPatch(
+                bootstrapState: bootstrapState,
+                settingsStore: settingsStore
+            ) {
+                return .progress(report)
+            }
             return nil
         }
     }

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
@@ -1462,6 +1462,7 @@ final class AndroidDatabaseBackupTests: XCTestCase {
         XCTAssertEqual(readingSnapshot.settings.activeCycle, 3)
         XCTAssertTrue(readingSnapshot.settings.autoTrackReading)
         XCTAssertFalse(readingSnapshot.settings.autoMarkMemorized)
+        XCTAssertEqual(memorizationStore.snapshot().memorizedVerses.map(\.id), [memorizedID])
         XCTAssertEqual(memorizationStore.memorizedOrdinals(bookInitials: "ESV", startOrdinal: 15, endOrdinal: 15), [15])
         XCTAssertEqual(memorizationStore.memorizedOrdinals(bookInitials: "KJV", startOrdinal: 15, endOrdinal: 15), [15])
         XCTAssertEqual(memorizationStore.targetOrdinals(bookInitials: "FinRK", startOrdinal: 20, endOrdinal: 22), [20, 21, 22])

--- a/Sources/BibleCore/Tests/BibleCoreTests/ProgressStoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/ProgressStoreTests.swift
@@ -136,4 +136,47 @@ final class ProgressStoreTests: XCTestCase {
         XCTAssertFalse(store.applySettingsBundle(json: #"{"autoMarkMemorized":null}"#))
         XCTAssertEqual(store.snapshot().settings, updated)
     }
+
+    /**
+     Verifies memorized-verse rows preserve Android row identity while still decoding legacy JSON.
+
+     Android sync keys `MemorizedVerse` mutations by row UUID, not by KJVA ordinal alone. Existing
+     iOS JSON did not have an `id` field, so those rows need deterministic identities rather than a
+     new random UUID each time the snapshot is decoded.
+
+     Failure means iOS remote progress sync could emit unstable Android `LogEntry` keys or lose the
+     UUID Android wrote for an imported memorized verse.
+     */
+    func testMemorizedVerseProgressPreservesAndroidIdentityAndStabilizesLegacyRows() throws {
+        let importedID = UUID(uuidString: "15000000-0000-0000-0000-000000000901")!
+        let settingsStore = try makeInMemorySettingsStore()
+        settingsStore.setString(
+            MemorizationProgressStore.settingsKey,
+            value: """
+            {
+              "memorizedVerses": [
+                {
+                  "id": "\(importedID.uuidString)",
+                  "bookInitials": "",
+                  "kjvOrdinal": 15,
+                  "memorizedAt": 1700000100
+                },
+                {
+                  "bookInitials": "ESV",
+                  "kjvOrdinal": 16,
+                  "memorizedAt": 1700000200
+                }
+              ],
+              "targetRows": []
+            }
+            """
+        )
+
+        let firstSnapshot = MemorizationProgressStore(settingsStore: settingsStore).snapshot()
+        let secondSnapshot = MemorizationProgressStore(settingsStore: settingsStore).snapshot()
+
+        XCTAssertEqual(firstSnapshot.memorizedVerses[0].id, importedID)
+        XCTAssertEqual(firstSnapshot.memorizedVerses[1].id, secondSnapshot.memorizedVerses[1].id)
+        XCTAssertEqual(Set(firstSnapshot.memorizedVerses.map(\.kjvOrdinal)), [15, 16])
+    }
 }

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
@@ -1,0 +1,525 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import BibleCore
+
+private let progressSyncTestSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+final class RemoteSyncProgressTests: XCTestCase {
+    func testProgressPatchUploadWritesSparseAndroidPatchAndRefreshesBaseline() async throws {
+        let settingsStore = try makeInMemorySettingsStore()
+        let memorizedID = UUID(uuidString: "15000000-0000-0000-0000-000000001001")!
+        let historyID = UUID(uuidString: "15000000-0000-0000-0000-000000001002")!
+        let targetID = UUID(uuidString: "15000000-0000-0000-0000-000000001003")!
+        seedProgress(
+            settingsStore: settingsStore,
+            memorizedVerses: [
+                .init(id: memorizedID, kjvOrdinal: 15, memorizedAt: 1_700_000_100),
+            ],
+            chapterHistory: [
+                .init(
+                    id: historyID,
+                    kjvBookOrdinal: 1,
+                    chapter: 1,
+                    cycle: 2,
+                    readAt: 1_700_000_200,
+                    bookInitials: "",
+                    source: .manual
+                ),
+            ],
+            targets: [
+                .init(id: targetID, kjvOrdinalStart: 20, kjvOrdinalEnd: 22, createdAt: 1_700_000_300),
+            ],
+            settings: ReadingProgressSettingsSnapshot(autoTrackReading: true, activeCycle: 2)
+        )
+        let adapter = RemoteSyncMockAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "/progress/device-ios/1.9.sqlite3.gz",
+                name: "1.9.sqlite3.gz",
+                size: 0,
+                timestamp: 2_000,
+                parentID: "/progress/device-ios",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let service = RemoteSyncProgressPatchUploadService(
+            adapter: adapter,
+            nowProvider: { 1_800_000_000 }
+        )
+
+        let report = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/progress/device-ios"),
+            settingsStore: settingsStore
+        )
+
+        let uploadReport = try XCTUnwrap(report)
+        XCTAssertEqual(uploadReport.patchNumber, 1)
+        XCTAssertEqual(uploadReport.upsertedMemorizedVerseCount, 1)
+        XCTAssertEqual(uploadReport.upsertedChapterHistoryCount, 1)
+        XCTAssertEqual(uploadReport.upsertedTargetCount, 1)
+        XCTAssertEqual(uploadReport.upsertedSettingsCount, 1)
+        XCTAssertEqual(uploadReport.deletedRowCount, 0)
+        XCTAssertEqual(uploadReport.logEntryCount, 4)
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploaded = try XCTUnwrap(uploadedFiles.first)
+        XCTAssertEqual(uploaded.name, "1.9.sqlite3.gz")
+        XCTAssertEqual(uploaded.parentID, "/progress/device-ios")
+        let patchDatabaseURL = try materializeProgressArchive(uploaded.data)
+        defer { try? FileManager.default.removeItem(at: patchDatabaseURL) }
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM MemorizedVerse WHERE id = x'\(hex(memorizedID))';", at: patchDatabaseURL), 1)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM ChapterReadHistory WHERE id = x'\(hex(historyID))';", at: patchDatabaseURL), 1)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM MemorizationTarget WHERE id = x'\(hex(targetID))';", at: patchDatabaseURL), 1)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM GlobalReadingProgressSettings;", at: patchDatabaseURL), 1)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM LogEntry;", at: patchDatabaseURL), 4)
+
+        let secondReport = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/progress/device-ios"),
+            settingsStore: settingsStore
+        )
+        XCTAssertNil(secondReport)
+        let uploadedFilesAfterSecondRun = await adapter.uploadedFilesSnapshot()
+        XCTAssertEqual(uploadedFilesAfterSecondRun.count, 1)
+
+        seedProgress(
+            settingsStore: settingsStore,
+            memorizedVerses: [],
+            chapterHistory: [],
+            targets: [],
+            settings: ReadingProgressSettingsSnapshot(autoTrackReading: true, activeCycle: 2)
+        )
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "/progress/device-ios/2.9.sqlite3.gz",
+                name: "2.9.sqlite3.gz",
+                size: 0,
+                timestamp: 3_000,
+                parentID: "/progress/device-ios",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+
+        let deleteReport = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(deviceFolderID: "/progress/device-ios"),
+            settingsStore: settingsStore
+        )
+
+        let deleteUploadReport = try XCTUnwrap(deleteReport)
+        XCTAssertEqual(deleteUploadReport.patchNumber, 2)
+        XCTAssertEqual(deleteUploadReport.upsertedMemorizedVerseCount, 0)
+        XCTAssertEqual(deleteUploadReport.upsertedChapterHistoryCount, 0)
+        XCTAssertEqual(deleteUploadReport.upsertedTargetCount, 0)
+        XCTAssertEqual(deleteUploadReport.upsertedSettingsCount, 0)
+        XCTAssertEqual(deleteUploadReport.deletedRowCount, 3)
+        XCTAssertEqual(deleteUploadReport.logEntryCount, 3)
+
+        let uploadedFilesAfterDelete = await adapter.uploadedFilesSnapshot()
+        XCTAssertEqual(uploadedFilesAfterDelete.count, 2)
+        let deleteUpload = try XCTUnwrap(uploadedFilesAfterDelete.last)
+        XCTAssertEqual(deleteUpload.name, "2.9.sqlite3.gz")
+        let deletePatchDatabaseURL = try materializeProgressArchive(deleteUpload.data)
+        defer { try? FileManager.default.removeItem(at: deletePatchDatabaseURL) }
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM MemorizedVerse;", at: deletePatchDatabaseURL), 0)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM ChapterReadHistory;", at: deletePatchDatabaseURL), 0)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM MemorizationTarget;", at: deletePatchDatabaseURL), 0)
+        XCTAssertEqual(try progressSQLiteInteger("SELECT COUNT(*) FROM LogEntry WHERE type = 'DELETE';", at: deletePatchDatabaseURL), 3)
+    }
+
+    func testProgressPatchApplyReplaysNewerRowsAndDeletesByAndroidLogEntry() throws {
+        let settingsStore = try makeInMemorySettingsStore()
+        let deletedID = UUID(uuidString: "15000000-0000-0000-0000-000000002001")!
+        let insertedID = UUID(uuidString: "15000000-0000-0000-0000-000000002002")!
+        let historyID = UUID(uuidString: "15000000-0000-0000-0000-000000002003")!
+        seedProgress(
+            settingsStore: settingsStore,
+            memorizedVerses: [
+                .init(id: deletedID, kjvOrdinal: 15, memorizedAt: 100),
+            ],
+            chapterHistory: [],
+            targets: [],
+            settings: ReadingProgressSettingsSnapshot()
+        )
+        let patchDatabaseURL = try makeProgressPatchDatabase(
+            memorizedVerses: [
+                .init(id: insertedID, kjvOrdinal: 16, memorizedAt: 300),
+            ],
+            chapterHistory: [
+                .init(
+                    id: historyID,
+                    kjvBookOrdinal: 1,
+                    chapter: 2,
+                    cycle: 1,
+                    readAt: 400,
+                    bookInitials: "",
+                    source: .autoTts
+                ),
+            ],
+            targets: [],
+            settings: ReadingProgressSettingsSnapshot(autoTrackReading: true, activeCycle: 4),
+            logEntries: [
+                .init(
+                    tableName: RemoteSyncProgressSnapshotService.memorizedVerseTable,
+                    entityID1: .blob(RemoteSyncProgressSnapshotService.uuidBlob(deletedID)),
+                    entityID2: .text(""),
+                    type: .delete,
+                    lastUpdated: 500,
+                    sourceDevice: "android"
+                ),
+                .init(
+                    tableName: RemoteSyncProgressSnapshotService.memorizedVerseTable,
+                    entityID1: .blob(RemoteSyncProgressSnapshotService.uuidBlob(insertedID)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 501,
+                    sourceDevice: "android"
+                ),
+                .init(
+                    tableName: RemoteSyncProgressSnapshotService.chapterReadHistoryTable,
+                    entityID1: .blob(RemoteSyncProgressSnapshotService.uuidBlob(historyID)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 502,
+                    sourceDevice: "android"
+                ),
+                .init(
+                    tableName: RemoteSyncProgressSnapshotService.globalSettingsTable,
+                    entityID1: .blob(RemoteSyncProgressSnapshotService.uuidBlob(RemoteSyncProgressSnapshotService.globalSettingsID)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 503,
+                    sourceDevice: "android"
+                ),
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: patchDatabaseURL) }
+        let stagedArchive = try makeProgressPatchArchive(
+            patchDatabaseURL: patchDatabaseURL,
+            sourceDevice: "android",
+            patchNumber: 1,
+            fileTimestamp: 900
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        let report = try RemoteSyncProgressPatchApplyService().applyPatchArchives(
+            [stagedArchive],
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedPatchCount, 1)
+        XCTAssertEqual(report.appliedLogEntryCount, 4)
+        XCTAssertEqual(report.skippedLogEntryCount, 0)
+        XCTAssertEqual(report.readingCount, 1)
+        XCTAssertEqual(report.memorizedVerseCount, 1)
+        XCTAssertEqual(report.targetCount, 0)
+        let memorizationSnapshot = MemorizationProgressStore(settingsStore: settingsStore).snapshot()
+        XCTAssertEqual(memorizationSnapshot.memorizedVerses.map(\.id), [insertedID])
+        XCTAssertEqual(memorizationSnapshot.memorizedVerses.map(\.kjvOrdinal), [16])
+        let readingSnapshot = ReadingProgressStore(settingsStore: settingsStore).snapshot()
+        XCTAssertEqual(readingSnapshot.history.map(\.id), [historyID])
+        XCTAssertEqual(readingSnapshot.history.first?.source, .autoTts)
+        XCTAssertTrue(readingSnapshot.settings.autoTrackReading)
+        XCTAssertEqual(readingSnapshot.settings.activeCycle, 4)
+        XCTAssertEqual(RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .progress).map(\.patchNumber), [1])
+        XCTAssertEqual(RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .progress).count, 4)
+    }
+}
+
+private struct ProgressMemorizedVerseFixture {
+    let id: UUID
+    let kjvOrdinal: Int
+    let memorizedAt: Int64
+}
+
+private struct ProgressChapterReadHistoryFixture {
+    let id: UUID
+    let kjvBookOrdinal: Int
+    let chapter: Int
+    let cycle: Int
+    let readAt: Int64
+    let bookInitials: String
+    let source: ReadingProgressSource
+}
+
+private struct ProgressTargetFixture {
+    let id: UUID
+    let kjvOrdinalStart: Int
+    let kjvOrdinalEnd: Int
+    let createdAt: Int64
+}
+
+private func seedProgress(
+    settingsStore: SettingsStore,
+    memorizedVerses: [ProgressMemorizedVerseFixture],
+    chapterHistory: [ProgressChapterReadHistoryFixture],
+    targets: [ProgressTargetFixture],
+    settings: ReadingProgressSettingsSnapshot
+) {
+    let readingSnapshot = ReadingProgressSnapshot(
+        history: chapterHistory.map {
+            ReadingProgressHistoryRow(
+                id: $0.id,
+                bookInitials: $0.bookInitials,
+                startOrdinal: 0,
+                kjvBookOrdinal: $0.kjvBookOrdinal,
+                chapter: $0.chapter,
+                cycle: $0.cycle,
+                readAt: $0.readAt,
+                source: $0.source
+            )
+        },
+        settings: settings
+    )
+    let memorizationSnapshot = MemorizationProgressSnapshot(
+        memorizedVerses: memorizedVerses.map {
+            MemorizedVerseProgress(id: $0.id, kjvOrdinal: $0.kjvOrdinal, memorizedAt: $0.memorizedAt)
+        },
+        targetRows: targets.map {
+            MemorizationTargetRow(
+                id: $0.id,
+                startOrdinal: $0.kjvOrdinalStart,
+                endOrdinal: $0.kjvOrdinalEnd,
+                createdAt: $0.createdAt
+            )
+        }
+    )
+    let encoder = JSONEncoder()
+    settingsStore.setString(
+        ReadingProgressStore.settingsKey,
+        value: String(data: try! encoder.encode(readingSnapshot), encoding: .utf8)!
+    )
+    settingsStore.setString(
+        MemorizationProgressStore.settingsKey,
+        value: String(data: try! encoder.encode(memorizationSnapshot), encoding: .utf8)!
+    )
+}
+
+private func makeProgressPatchDatabase(
+    memorizedVerses: [ProgressMemorizedVerseFixture],
+    chapterHistory: [ProgressChapterReadHistoryFixture],
+    targets: [ProgressTargetFixture],
+    settings: ReadingProgressSettingsSnapshot,
+    logEntries: [RemoteSyncLogEntry]
+) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("remote-sync-progress-test-\(UUID().uuidString).sqlite3")
+    var db: OpaquePointer?
+    guard sqlite3_open(url.path, &db) == SQLITE_OK, let db else {
+        throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+
+    XCTAssertEqual(sqlite3_exec(db, progressSchemaSQL, nil, nil, nil), SQLITE_OK)
+    for row in memorizedVerses {
+        let statement = try progressPrepare(
+            "INSERT INTO MemorizedVerse (id, kjvOrdinal, memorizedAt) VALUES (?, ?, ?);",
+            db
+        )
+        bindProgressUUID(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvOrdinal))
+        sqlite3_bind_int64(statement, 3, row.memorizedAt)
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+        sqlite3_finalize(statement)
+    }
+    for row in chapterHistory {
+        let statement = try progressPrepare(
+            """
+            INSERT INTO ChapterReadHistory (id, kjvBookOrdinal, chapter, cycle, readAt, bookInitials, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?);
+            """,
+            db
+        )
+        bindProgressUUID(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvBookOrdinal))
+        sqlite3_bind_int(statement, 3, Int32(row.chapter))
+        sqlite3_bind_int(statement, 4, Int32(row.cycle))
+        sqlite3_bind_int64(statement, 5, row.readAt)
+        sqlite3_bind_text(statement, 6, row.bookInitials, -1, progressSyncTestSQLiteTransient)
+        sqlite3_bind_text(statement, 7, row.source.rawValue, -1, progressSyncTestSQLiteTransient)
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+        sqlite3_finalize(statement)
+    }
+    for row in targets {
+        let statement = try progressPrepare(
+            "INSERT INTO MemorizationTarget (id, kjvOrdinalStart, kjvOrdinalEnd, createdAt) VALUES (?, ?, ?, ?);",
+            db
+        )
+        bindProgressUUID(row.id, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, Int32(row.kjvOrdinalStart))
+        sqlite3_bind_int(statement, 3, Int32(row.kjvOrdinalEnd))
+        sqlite3_bind_int64(statement, 4, row.createdAt)
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+        sqlite3_finalize(statement)
+    }
+    let settingsRow = RemoteSyncCurrentProgressSettingsRow(
+        id: RemoteSyncProgressSnapshotService.globalSettingsID,
+        settings: settings
+    )
+    let settingsStatement = try progressPrepare(
+        """
+        INSERT INTO GlobalReadingProgressSettings (
+            id, autoTrackReading, autoMarkMemorized, memorizeTypeFullWords, memorizeWordVisibility,
+            memorizeErrorHeatmap, memorizeScrambleHideUsed, memorizeIncludeReference, activeCycle
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        db
+    )
+    bindProgressUUID(settingsRow.id, to: settingsStatement, index: 1)
+    sqlite3_bind_int(settingsStatement, 2, settingsRow.autoTrackReading ? 1 : 0)
+    sqlite3_bind_int(settingsStatement, 3, settingsRow.autoMarkMemorized ? 1 : 0)
+    sqlite3_bind_int(settingsStatement, 4, settingsRow.memorizeTypeFullWords ? 1 : 0)
+    sqlite3_bind_text(settingsStatement, 5, settingsRow.memorizeWordVisibility, -1, progressSyncTestSQLiteTransient)
+    sqlite3_bind_int(settingsStatement, 6, settingsRow.memorizeErrorHeatmap ? 1 : 0)
+    sqlite3_bind_int(settingsStatement, 7, settingsRow.memorizeScrambleHideUsed ? 1 : 0)
+    sqlite3_bind_int(settingsStatement, 8, settingsRow.memorizeIncludeReference ? 1 : 0)
+    sqlite3_bind_int(settingsStatement, 9, Int32(settingsRow.activeCycle))
+    XCTAssertEqual(sqlite3_step(settingsStatement), SQLITE_DONE)
+    sqlite3_finalize(settingsStatement)
+
+    for entry in logEntries {
+        let statement = try progressPrepare(
+            "INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice) VALUES (?, ?, ?, ?, ?, ?);",
+            db
+        )
+        sqlite3_bind_text(statement, 1, entry.tableName, -1, progressSyncTestSQLiteTransient)
+        bindProgressSQLiteValue(entry.entityID1, to: statement, index: 2)
+        bindProgressSQLiteValue(entry.entityID2, to: statement, index: 3)
+        sqlite3_bind_text(statement, 4, entry.type.rawValue, -1, progressSyncTestSQLiteTransient)
+        sqlite3_bind_int64(statement, 5, entry.lastUpdated)
+        sqlite3_bind_text(statement, 6, entry.sourceDevice, -1, progressSyncTestSQLiteTransient)
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_DONE)
+        sqlite3_finalize(statement)
+    }
+
+    return url
+}
+
+private func makeProgressPatchArchive(
+    patchDatabaseURL: URL,
+    sourceDevice: String,
+    patchNumber: Int64,
+    fileTimestamp: Int64
+) throws -> RemoteSyncStagedPatchArchive {
+    let archiveData = try RemoteSyncArchiveStagingService.gzip(Data(contentsOf: patchDatabaseURL))
+    let archiveURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("remote-sync-progress-test-\(UUID().uuidString).sqlite3.gz")
+    try archiveData.write(to: archiveURL, options: .atomic)
+    return RemoteSyncStagedPatchArchive(
+        patch: RemoteSyncDiscoveredPatch(
+            sourceDevice: sourceDevice,
+            patchNumber: patchNumber,
+            schemaVersion: 9,
+            file: RemoteSyncFile(
+                id: "/progress/\(sourceDevice)/\(patchNumber).9.sqlite3.gz",
+                name: "\(patchNumber).9.sqlite3.gz",
+                size: Int64(archiveData.count),
+                timestamp: fileTimestamp,
+                parentID: "/progress/\(sourceDevice)",
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        ),
+        archiveFileURL: archiveURL
+    )
+}
+
+private func materializeProgressArchive(_ data: Data) throws -> URL {
+    let databaseURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("remote-sync-progress-upload-\(UUID().uuidString).sqlite3")
+    try gunzipTestData(data).write(to: databaseURL, options: .atomic)
+    return databaseURL
+}
+
+private func progressSQLiteInteger(_ sql: String, at url: URL) throws -> Int {
+    var db: OpaquePointer?
+    guard sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+        throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(db) }
+    let statement = try progressPrepare(sql, db)
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW else {
+        throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+    }
+    return Int(sqlite3_column_int(statement, 0))
+}
+
+private func progressPrepare(_ sql: String, _ database: OpaquePointer) throws -> OpaquePointer {
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK, let statement else {
+        throw RemoteSyncProgressPatchApplyError.invalidSQLiteDatabase
+    }
+    return statement
+}
+
+private func bindProgressUUID(_ uuid: UUID, to statement: OpaquePointer?, index: Int32) {
+    let data = RemoteSyncProgressSnapshotService.uuidBlob(uuid)
+    _ = data.withUnsafeBytes {
+        sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), progressSyncTestSQLiteTransient)
+    }
+}
+
+private func bindProgressSQLiteValue(_ value: RemoteSyncSQLiteValue, to statement: OpaquePointer?, index: Int32) {
+    switch value.kind {
+    case .null:
+        sqlite3_bind_null(statement, index)
+    case .integer:
+        sqlite3_bind_int64(statement, index, value.integerValue ?? 0)
+    case .real:
+        sqlite3_bind_double(statement, index, value.realValue ?? 0)
+    case .text:
+        sqlite3_bind_text(statement, index, value.textValue ?? "", -1, progressSyncTestSQLiteTransient)
+    case .blob:
+        let data = value.blobData ?? Data()
+        _ = data.withUnsafeBytes {
+            sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(data.count), progressSyncTestSQLiteTransient)
+        }
+    }
+}
+
+private func hex(_ uuid: UUID) -> String {
+    RemoteSyncProgressSnapshotService.uuidBlob(uuid).map { String(format: "%02x", $0) }.joined()
+}
+
+private let progressSchemaSQL = """
+CREATE TABLE MemorizedVerse (
+    id BLOB NOT NULL PRIMARY KEY,
+    kjvOrdinal INTEGER NOT NULL,
+    memorizedAt INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX index_MemorizedVerse_kjvOrdinal ON MemorizedVerse (kjvOrdinal);
+CREATE TABLE MemorizationTarget (
+    id BLOB NOT NULL PRIMARY KEY,
+    kjvOrdinalStart INTEGER NOT NULL,
+    kjvOrdinalEnd INTEGER NOT NULL,
+    createdAt INTEGER NOT NULL
+);
+CREATE TABLE ChapterReadHistory (
+    id BLOB NOT NULL PRIMARY KEY,
+    kjvBookOrdinal INTEGER NOT NULL,
+    chapter INTEGER NOT NULL,
+    cycle INTEGER NOT NULL DEFAULT 1,
+    readAt INTEGER NOT NULL,
+    bookInitials TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT 'MANUAL'
+);
+CREATE TABLE GlobalReadingProgressSettings (
+    id BLOB NOT NULL PRIMARY KEY,
+    autoTrackReading INTEGER NOT NULL DEFAULT 0,
+    autoMarkMemorized INTEGER NOT NULL DEFAULT 1,
+    memorizeTypeFullWords INTEGER NOT NULL DEFAULT 0,
+    memorizeWordVisibility TEXT NOT NULL DEFAULT 'light',
+    memorizeErrorHeatmap INTEGER NOT NULL DEFAULT 1,
+    memorizeScrambleHideUsed INTEGER NOT NULL DEFAULT 0,
+    memorizeIncludeReference INTEGER NOT NULL DEFAULT 1,
+    activeCycle INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE LogEntry (
+    tableName TEXT NOT NULL,
+    entityId1 BLOB,
+    entityId2 BLOB,
+    type TEXT NOT NULL,
+    lastUpdated INTEGER NOT NULL,
+    sourceDevice TEXT NOT NULL
+);
+PRAGMA user_version = 9;
+"""

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
@@ -223,6 +223,46 @@ final class RemoteSyncProgressTests: XCTestCase {
         XCTAssertEqual(RemoteSyncPatchStatusStore(settingsStore: settingsStore).statuses(for: .progress).map(\.patchNumber), [1])
         XCTAssertEqual(RemoteSyncLogEntryStore(settingsStore: settingsStore).entries(for: .progress).count, 4)
     }
+
+    func testProgressPatchApplyRejectsInvalidMemorizationTargetOrdinals() throws {
+        let settingsStore = try makeInMemorySettingsStore()
+        let targetID = UUID(uuidString: "15000000-0000-0000-0000-000000003001")!
+        let patchDatabaseURL = try makeProgressPatchDatabase(
+            memorizedVerses: [],
+            chapterHistory: [],
+            targets: [
+                .init(id: targetID, kjvOrdinalStart: 0, kjvOrdinalEnd: 2, createdAt: 700),
+            ],
+            settings: ReadingProgressSettingsSnapshot(),
+            logEntries: [
+                .init(
+                    tableName: RemoteSyncProgressSnapshotService.memorizationTargetTable,
+                    entityID1: .blob(RemoteSyncProgressSnapshotService.uuidBlob(targetID)),
+                    entityID2: .text(""),
+                    type: .upsert,
+                    lastUpdated: 701,
+                    sourceDevice: "android"
+                ),
+            ]
+        )
+        defer { try? FileManager.default.removeItem(at: patchDatabaseURL) }
+        let stagedArchive = try makeProgressPatchArchive(
+            patchDatabaseURL: patchDatabaseURL,
+            sourceDevice: "android",
+            patchNumber: 1,
+            fileTimestamp: 900
+        )
+        defer { try? FileManager.default.removeItem(at: stagedArchive.archiveFileURL) }
+
+        XCTAssertThrowsError(
+            try RemoteSyncProgressPatchApplyService().applyPatchArchives(
+                [stagedArchive],
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(error as? RemoteSyncProgressPatchApplyError, .invalidSQLiteDatabase)
+        }
+    }
 }
 
 private struct ProgressMemorizedVerseFixture {

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncProgressTests.swift
@@ -1,11 +1,96 @@
 import Foundation
 import SQLite3
+import SwiftData
 import XCTest
 @testable import BibleCore
 
 private let progressSyncTestSQLiteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 final class RemoteSyncProgressTests: XCTestCase {
+    /**
+     Protects the Progress initial-backup contract that the uploaded Android `LogEntry` rows and the local accepted
+     baseline share the same timestamp.
+
+     Setup uses a deterministic clock that increments on each read so a second clock sample is observable. The test
+     materializes the uploaded gzip archive, compares uploaded and local Progress log-entry timestamps by Android
+     key, and verifies `lastPatchWritten` uses the same accepted baseline. A failure means patch replay can skip a
+     legitimate remote row because the local baseline was advanced past the uploaded initial backup.
+     */
+    func testProgressInitialBackupUsesSingleAcceptedBaselineTimestamp() async throws {
+        let container = try makeInMemorySettingsContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let memorizedID = UUID(uuidString: "15000000-0000-0000-0000-000000000101")!
+        seedProgress(
+            settingsStore: settingsStore,
+            memorizedVerses: [
+                .init(id: memorizedID, kjvOrdinal: 15, memorizedAt: 1_700_000_100),
+            ],
+            chapterHistory: [],
+            targets: [],
+            settings: ReadingProgressSettingsSnapshot(autoTrackReading: true, activeCycle: 2)
+        )
+
+        let syncFolderID = "/org.andbible.ios-sync-progress"
+        let adapter = RemoteSyncMockAdapter()
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(syncFolderID)/initial.sqlite3.gz",
+                name: "initial.sqlite3.gz",
+                size: 0,
+                timestamp: 2_000,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        var nextTimestamp: Int64 = 1_900
+        let service = RemoteSyncInitialBackupUploadService(
+            adapter: adapter,
+            deviceIdentifier: "ios-device",
+            nowProvider: {
+                defer { nextTimestamp += 1 }
+                return nextTimestamp
+            }
+        )
+
+        _ = try await service.uploadInitialBackup(
+            for: .progress,
+            bootstrapState: RemoteSyncBootstrapState(syncFolderID: syncFolderID),
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: 9
+        )
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploaded = try XCTUnwrap(uploadedFiles.first)
+        let databaseURL = try materializeProgressArchive(uploaded.data)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let uploadedEntries = try RemoteSyncInitialBackupMetadataRestoreService()
+            .readSnapshot(from: databaseURL)
+            .logEntries
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let localEntries = logEntryStore.entries(for: .progress)
+        let uploadedEntriesByKey = Dictionary(
+            uniqueKeysWithValues: uploadedEntries.map {
+                (logEntryStore.key(for: .progress, entry: $0), $0)
+            }
+        )
+        let localEntriesByKey = Dictionary(
+            uniqueKeysWithValues: localEntries.map {
+                (logEntryStore.key(for: .progress, entry: $0), $0)
+            }
+        )
+
+        XCTAssertEqual(Set(localEntriesByKey.keys), Set(uploadedEntriesByKey.keys))
+        for key in uploadedEntriesByKey.keys {
+            let uploadedEntry = try XCTUnwrap(uploadedEntriesByKey[key])
+            let localEntry = try XCTUnwrap(localEntriesByKey[key])
+            XCTAssertEqual(localEntry.lastUpdated, uploadedEntry.lastUpdated)
+        }
+        XCTAssertEqual(RemoteSyncStateStore(settingsStore: settingsStore).progressState(for: .progress).lastPatchWritten, 1_900)
+    }
+
     func testProgressPatchUploadWritesSparseAndroidPatchAndRefreshesBaseline() async throws {
         let settingsStore = try makeInMemorySettingsStore()
         let memorizedID = UUID(uuidString: "15000000-0000-0000-0000-000000001001")!

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
@@ -652,7 +652,7 @@ final class RemoteSyncStateTests: XCTestCase {
     func testRemoteSyncCategoryActiveSyncCasesExposeMyDocuments() {
         XCTAssertEqual(
             RemoteSyncCategory.activeSyncCases,
-            [.bookmarks, .workspaces, .readingPlans, .myDocuments]
+            [.bookmarks, .workspaces, .readingPlans, .myDocuments, .progress]
         )
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentation.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentation.swift
@@ -154,8 +154,6 @@ public enum RemoteSyncCategoryLocalization {
                     defaultValue: "AI prompts and provider configurations"
                 )
             )
-        case .progress:
-            return text(for: .progress)
         }
     }
 }
@@ -227,7 +225,7 @@ enum SyncSettingsPresentation {
         .active(.workspaces),
         .active(.myDocuments),
         .deferred(.aiSettings),
-        .deferred(.progress),
+        .active(.progress),
     ]
 
     /**
@@ -269,8 +267,6 @@ enum SyncSettingsPresentation {
         switch category {
         case .aiSettings:
             return Row(androidKey: "sync_ai")
-        case .progress:
-            return Row(androidKey: "sync_reading_progress")
         }
     }
 }
@@ -278,9 +274,9 @@ enum SyncSettingsPresentation {
 /**
  Android-visible sync categories that iOS intentionally displays as disabled deferred rows.
 
- Android exposes AI Settings and Reading Progress toggles in `sync_settings.xml` and wires both
- through `SyncSettings.kt`. iOS does not yet have those category-specific sync engines, so these
- values preserve the visible parity surface without letting users start unsupported sync streams.
+ Android exposes AI Settings in `sync_settings.xml` and wires it through `SyncSettings.kt`. iOS
+ does not yet have that category-specific sync engine, so this value preserves the visible parity
+ surface without letting users start an unsupported sync stream.
 
  - Returns: Value semantics for visible settings rows and tests.
  - Side effects: none.
@@ -290,9 +286,6 @@ enum SyncSettingsPresentation {
 enum RemoteSyncDeferredCategory: String, CaseIterable, Sendable {
     /// Android `sync_enable_ai_settings`; iOS implementation tracked by issue #74.
     case aiSettings = "ai_settings"
-
-    /// Android `sync_enable_progress`; iOS implementation tracked by issue #73.
-    case progress
 
     /// Stable Android-compatible toggle key reserved for the future category implementation.
     var androidSyncEnabledKey: String {
@@ -304,8 +297,6 @@ enum RemoteSyncDeferredCategory: String, CaseIterable, Sendable {
         switch self {
         case .aiSettings:
             return 74
-        case .progress:
-            return 73
         }
     }
 }

--- a/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
@@ -218,7 +218,7 @@ final class SettingsIconsTests: XCTestCase {
                 .active(.workspaces),
                 .active(.myDocuments),
                 .deferred(.aiSettings),
-                .deferred(.progress),
+                .active(.progress),
             ]
         )
     }
@@ -253,11 +253,11 @@ final class SettingsIconsTests: XCTestCase {
             "icon_robot"
         )
         XCTAssertEqual(
-            SyncSettingsPresentation.deferredCategory(.progress).androidKey,
+            SyncSettingsPresentation.category(.progress).androidKey,
             "sync_reading_progress"
         )
         XCTAssertEqual(
-            SyncSettingsPresentation.deferredCategory(.progress).icon?.androidDrawableName,
+            SyncSettingsPresentation.category(.progress).icon?.androidDrawableName,
             "ic_baseline_check_circle_24"
         )
     }
@@ -274,7 +274,7 @@ final class SettingsIconsTests: XCTestCase {
      Expected result:
      - the title remains "Reading Progress"
      - the content description uses "Memorized verses and chapter reading records"
-     - active and deferred Progress rows share the same Android string contract
+     - the active Progress row uses the same Android string contract surfaced by lifecycle copy
 
      Failure meaning:
      - iOS duplicated category string switches have drifted from Android and may show a row title
@@ -282,21 +282,17 @@ final class SettingsIconsTests: XCTestCase {
      */
     func testSyncSettingsProgressTextUsesAndroidTitleAndContentsKeys() {
         let active = RemoteSyncCategoryLocalization.text(for: .progress)
-        let deferred = RemoteSyncCategoryLocalization.deferredText(for: .progress)
 
         XCTAssertEqual(active.title.key, "progress_sync_title")
         XCTAssertEqual(active.title.defaultValue, "Reading Progress")
         XCTAssertEqual(active.contents.key, "progress_sync_contents")
         XCTAssertEqual(active.contents.defaultValue, "Memorized verses and chapter reading records")
-        XCTAssertEqual(active, deferred)
         XCTAssertNotEqual(active.title.key, active.contents.key)
     }
 
     func testDeferredSyncCategoriesReserveAndroidCompatibleKeysAndTrackingIssues() {
         XCTAssertEqual(RemoteSyncDeferredCategory.aiSettings.androidSyncEnabledKey, "sync_enable_ai_settings")
         XCTAssertEqual(RemoteSyncDeferredCategory.aiSettings.trackingIssueNumber, 74)
-        XCTAssertEqual(RemoteSyncDeferredCategory.progress.androidSyncEnabledKey, "sync_enable_progress")
-        XCTAssertEqual(RemoteSyncDeferredCategory.progress.trackingIssueNumber, 73)
     }
 
     func testTextDisplayIconsComeFromAndroidOptionsMenuItems() {


### PR DESCRIPTION
## Summary

Brings the Android-compatible Progress remote sync category online for iOS while preserving iCloud as the existing platform-specific deviation. Progress now participates in the same remote sync lifecycle as the other implemented Android categories: initial backup restore, initial backup upload, pending patch replay, outbound sparse patch upload, and settings visibility.

## Scope

- Preserves Android row identity for memorized-verse progress rows, including stable deterministic ids for legacy iOS rows.
- Adds Android-shaped Progress snapshot, sparse patch upload, and sparse patch replay services.
- Wires Progress through remote sync active categories, category schema version 9, settings presentation, initial backup restore/upload, and ready-state synchronization.
- Adds regression coverage for Progress patch upserts, no-op baselines, DELETE patches after initial baselines, inbound replay, and invalid KJVA ordinal rejection.

## Contract References

- Android Progress sync category: active `progress.sqlite3` stream with schema version 9.
- Android Progress tables mirrored here: `MemorizedVerse`, `ChapterReadHistory`, `MemorizationTarget`, and `GlobalReadingProgressSettings`.
- Android LogEntry key contract: `entityId1 = id`, `entityId2 = ''` for Progress rows.
- Android settings key parity: `sync_enable_progress`.

## Change Details

- `MemorizedVerseProgress` now carries a persisted UUID so Android-imported rows can round-trip without identity churn.
- Initial Progress uploads now include accepted baseline `LogEntry` rows so later local deletions emit sparse DELETE patches instead of disappearing silently.
- Progress patch upload compares current Android-shaped row fingerprints to the accepted baseline and writes Android-compatible patch archives named `<patchNumber>.9.sqlite3.gz`.
- Progress patch replay filters stale log entries, applies newer upserts/deletes, validates KJVA ordinals, updates local JSON-backed progress stores, records patch status, and refreshes fingerprints.
- The sync settings presentation now treats Progress as an active row rather than a deferred gap.

## Validation Evidence

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --target BibleCore`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --target BibleCoreTests`
- `python3 -m unittest discover -s scripts -p 'test_*.py'` ran 176 tests successfully.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer /usr/bin/xcodebuild build -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination "platform=iOS Simulator,id=49FF5522-5E25-4BC7-B09A-43DF7E82262F" -derivedDataPath .derivedData-progress-sync-parity-73 CODE_SIGNING_ALLOWED=NO` succeeded.
- `swift test --filter RemoteSyncProgressTests` is still blocked before test execution by existing SwiftPM macOS compilation failures in BibleUI around ambiguous `Window` type lookup; the BibleCore test target itself compiles.

## Risks/Follow-ups

- The Progress remote sync path is covered at the service/SQLite contract level, but the SwiftPM package test runner cannot execute the tests until the unrelated BibleUI macOS compile ambiguity is fixed.
- No additional Progress parity gaps were left open in this pass. iCloud remains intentionally separate from Android-compatible remote sync.

## Issue Closure Reference

Closes #73
