### PR TITLE
test(ui): replace brittle hittability polling

### DIFF
--- a/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -50,26 +50,28 @@ extension AndBibleUITests {
      *   - timeout: Maximum number of seconds to poll.
      * - Returns: `true` when XCTest reports the element as hittable before the timeout.
      * - Side effects:
-     *   - repeatedly samples the element while allowing pending UI transitions to settle
+     *   - observes the element through XCTest's predicate waiter while pending UI transitions settle
      * - Failure modes: This helper does not fail directly.
      */
     func waitForElementToBecomeHittable(
         _ element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if isElementHittable(element) {
-                return true
-            }
-            let remaining = deadline.timeIntervalSinceNow
-            if remaining > 0, !element.exists {
-                _ = element.waitForExistence(timeout: min(0.2, remaining))
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+        if isElementHittable(element) {
+            return true
+        }
+        guard timeout > 0 else {
+            return false
+        }
 
-        return isElementHittable(element)
+        let predicate = NSPredicate { [weak self] _, _ in
+            self?.isElementHittable(element) ?? false
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        expectation.expectationDescription =
+            "Wait for element \(element.identifier) to become hittable"
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        return result == .completed || isElementHittable(element)
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
@@ -1191,7 +1191,7 @@ extension AndBibleUITests {
         let settingsForm = requireElement("settingsForm", in: app, timeout: timeout, file: file, line: line)
         let visibleTitle = settingsNavigationTitle(for: identifier)
         let deadline = Date().addingTimeInterval(timeout)
-        func resolvedVisibleControl() -> XCUIElement? {
+        func candidateElements() -> [XCUIElement] {
             var candidates = [
                 settingsForm.links[identifier].firstMatch,
                 settingsForm.buttons[identifier].firstMatch,
@@ -1218,13 +1218,88 @@ extension AndBibleUITests {
                 ], at: 0)
             }
 
-            if let control = candidates.first(where: { $0.exists && waitForElementToBecomeHittable($0, timeout: 0.5) }) {
+            return candidates
+        }
+
+        enum SettingsScrollDirection {
+            case higherRows
+            case lowerRows
+        }
+
+        func firstExistingControl() -> XCUIElement? {
+            candidateElements().first(where: { $0.exists && elementHasUsableFrame($0) })
+        }
+
+        func immediateVisibleControl() -> XCUIElement? {
+            let candidates = candidateElements()
+
+            if let control = candidates.first(where: { isElementHittable($0) }) {
                 return control
             }
             if let control = candidates.first(where: { $0.exists && isElementVisible($0, within: settingsForm) }) {
                 return control
             }
             return nil
+        }
+
+        func resolvedVisibleControl() -> XCUIElement? {
+            immediateVisibleControl()
+        }
+
+        func settingsScrollDirection(toward control: XCUIElement) -> SettingsScrollDirection? {
+            guard elementHasUsableFrame(control), elementHasUsableFrame(settingsForm) else {
+                return nil
+            }
+
+            let verticalInset = min(24, max(0, settingsForm.frame.height * 0.08))
+            let visibleFrame = settingsForm.frame.insetBy(dx: 0, dy: verticalInset)
+            if control.frame.minY >= visibleFrame.maxY {
+                return .lowerRows
+            }
+            if control.frame.maxY <= visibleFrame.minY {
+                return .higherRows
+            }
+            return nil
+        }
+
+        func scrollSettingsForm(toward direction: SettingsScrollDirection) {
+            guard elementHasUsableFrame(settingsForm) else {
+                return
+            }
+
+            let startOffset: CGVector
+            let endOffset: CGVector
+            switch direction {
+            case .higherRows:
+                startOffset = CGVector(dx: 0.5, dy: 0.28)
+                endOffset = CGVector(dx: 0.5, dy: 0.82)
+            case .lowerRows:
+                startOffset = CGVector(dx: 0.5, dy: 0.82)
+                endOffset = CGVector(dx: 0.5, dy: 0.28)
+            }
+            settingsForm.coordinate(withNormalizedOffset: startOffset).press(
+                forDuration: 0.01,
+                thenDragTo: settingsForm.coordinate(withNormalizedOffset: endOffset)
+            )
+        }
+
+        func waitForControlAfterScroll(previousFrame: CGRect?) -> XCUIElement? {
+            let predicate = NSPredicate { _, _ in
+                if immediateVisibleControl() != nil {
+                    return true
+                }
+                guard let previousFrame,
+                      let control = firstExistingControl(),
+                      self.elementHasUsableFrame(control)
+                else {
+                    return false
+                }
+                return abs(control.frame.midY - previousFrame.midY) > 2
+            }
+            let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+            expectation.expectationDescription = "Wait for Settings row reveal after scroll"
+            _ = XCTWaiter().wait(for: [expectation], timeout: 0.6)
+            return resolvedVisibleControl()
         }
 
         if let control = resolvedVisibleControl() {
@@ -1248,8 +1323,13 @@ extension AndBibleUITests {
                 break
             }
 
-            settingsForm.swipeUp()
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            let existingControl = firstExistingControl()
+            let direction = existingControl.flatMap { settingsScrollDirection(toward: $0) } ?? .lowerRows
+            let previousFrame = existingControl?.frame
+            scrollSettingsForm(toward: direction)
+            if let control = waitForControlAfterScroll(previousFrame: previousFrame) {
+                return control
+            }
         } while Date() < deadline
 
         let recoveryDeadline = Date().addingTimeInterval(min(3, max(1, timeout / 4)))
@@ -1261,8 +1341,13 @@ extension AndBibleUITests {
                 break
             }
 
-            settingsForm.swipeDown()
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            let existingControl = firstExistingControl()
+            let direction = existingControl.flatMap { settingsScrollDirection(toward: $0) } ?? .higherRows
+            let previousFrame = existingControl?.frame
+            scrollSettingsForm(toward: direction)
+            if let control = waitForControlAfterScroll(previousFrame: previousFrame) {
+                return control
+            }
         } while Date() < recoveryDeadline
 
         if let control = resolveSettingsNavigationControlViaSearch(

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -122,6 +122,35 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         self.assertIn("XCTWaiter", body)
         self.assertNotIn("RunLoop.current.run", body)
 
+    def test_hittability_wait_uses_xctest_waiter_not_run_loop_polling(self) -> None:
+        """Keep shared hittability waits on XCTest predicates instead of manual sleeps."""
+        interaction_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(interaction_source, "waitForElementToBecomeHittable")
+
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_settings_navigation_reveal_uses_existing_row_frame(self) -> None:
+        """Keep Settings row navigation from timing out on offscreen-but-existing rows."""
+        list_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(list_source, "requireSettingsNavigationControl")
+
+        self.assertIn("firstExistingControl()", body)
+        self.assertIn("settingsScrollDirection(toward:", body)
+        self.assertIn("scrollSettingsForm(toward:", body)
+        self.assertIn("XCTNSPredicateExpectation", body)
+        self.assertIn("XCTWaiter", body)
+        self.assertNotIn("waitForElementToBecomeHittable($0, timeout: 0.5)", body)
+        self.assertNotIn("settingsForm.swipeUp()", body)
+        self.assertNotIn("settingsForm.swipeDown()", body)
+        self.assertNotIn("settings-control-diagnostics", body)
+
     def test_workspace_prompt_button_candidates_prefer_prompt_scope_and_titles(self) -> None:
         """Keep workspace prompt button lookup off expensive app-wide identifier queries first."""
         element_source = (


### PR DESCRIPTION
## Summary
- Replace the shared UI-test hittability polling loop with XCTest predicate waiting.
- Make Settings row navigation reveal offscreen-but-existing rows by using their sampled frames to choose scroll direction.
- Add guardrails to keep these waits from regressing to blind run-loop polling or debug instrumentation.

## Scope
- Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
- Tests/UI/AndBibleUITests/AndBibleUITestListSupport.swift
- scripts/test_semantic_wait_guardrails.py
- Production app behavior is unchanged.

## Contract references
- UI tests should wait on semantic XCTest-observed conditions, using timeouts only as bounded failure protection.
- Settings row navigation must use production accessibility rows and not bypass the app route.
- GitNexus staged detection: low risk, no affected execution flows.

## Change details
- waitForElementToBecomeHittable now uses XCTNSPredicateExpectation and XCTWaiter instead of Date/RunLoop polling.
- requireSettingsNavigationControl now separates visible row resolution from offscreen row discovery.
- Offscreen Settings rows are revealed with deterministic form drags based on row frame position.
- Source guardrails assert the shared wait uses XCTest predicates and the Settings resolver does not regress to blind swipe loops.

## Validation evidence
- python3 -m unittest scripts.test_semantic_wait_guardrails
- python3 -m unittest discover -s scripts -p 'test_*.py'
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiWaitPredicateMore CODE_SIGNING_ALLOWED=NO build-for-testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiWaitPredicateMore -resultBundlePath .artifacts/ui-wait-predicate-more-smoke-fixed.xcresult CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testDownloadsRepositoryManagerOpensFromOverflow -only-testing:AndBibleUITests/AndBibleUITests/testMyDocumentsScreenOpensFromReaderMenuAndOpensPage -only-testing:AndBibleUITests/AndBibleUITests/testSearchOptionControlsMutateVisibleState -only-testing:AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions test-without-building
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -configuration Debug -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiWaitPredicateMore -resultBundlePath .artifacts/ui-wait-predicate-more-settings-fast.xcresult CODE_SIGNING_ALLOWED=NO -only-testing:AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions test-without-building

## Risks/follow-ups
- Remaining UI-test runtime is still dominated by app launch, fixture preparation, and broader Settings readiness probes; this PR only removes one shared run-loop polling pattern and one row-reveal failure mode.
- Unrelated local modifications to AGENTS.md and CLAUDE.md were intentionally left unstaged and are not part of this PR.

Closes: none
