### PR TITLE
test(ui): centralize state-driven UI waits

### DIFF
--- a/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift
@@ -435,16 +435,32 @@ extension AndBibleUITests {
         _ candidates: [XCUIElement],
         timeout: TimeInterval = 0
     ) -> XCUIElement? {
+        guard !candidates.isEmpty else {
+            return nil
+        }
+
         let boundedTimeout = max(0, timeout)
-        for candidate in candidates {
-            if candidate.exists {
-                return candidate
+        func firstCurrentMatch() -> XCUIElement? {
+            candidates.first(where: { $0.exists })
+        }
+
+        if let candidate = firstCurrentMatch() {
+            return candidate
+        }
+
+        var resolvedCandidate: XCUIElement?
+        let didResolve = waitForUITestCondition(
+            "Wait for first existing element from \(candidates.count) candidates",
+            timeout: boundedTimeout
+        ) {
+            if let candidate = firstCurrentMatch() {
+                resolvedCandidate = candidate
+                return true
             }
-            if boundedTimeout > 0,
-               candidate.waitForExistence(timeout: boundedTimeout)
-            {
-                return candidate
-            }
+            return false
+        }
+        if didResolve {
+            return resolvedCandidate ?? firstCurrentMatch()
         }
         return nil
     }
@@ -1008,13 +1024,20 @@ extension AndBibleUITests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> XCUIElement {
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let element = resolvedElement(identifier, in: app) {
-                return element
+        var resolvedMatch: XCUIElement?
+        let didResolve = waitForUITestCondition(
+            "Wait for element \(identifier)",
+            timeout: timeout
+        ) {
+            if let element = self.resolvedElement(identifier, in: app) {
+                resolvedMatch = element
+                return true
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+            return false
+        }
+        if didResolve {
+            return resolvedMatch ?? resolvedElement(identifier, in: app) ?? unresolvedElement(identifier, in: app)
+        }
 
         let element = unresolvedElement(identifier, in: app)
         XCTAssertTrue(
@@ -1147,13 +1170,24 @@ extension AndBibleUITests {
             app.otherElements.matching(predicate).firstMatch,
         ]
 
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if let element = candidates.first(where: { $0.exists || $0.waitForExistence(timeout: 0.2) }) {
-                return element
+        func currentMatch() -> XCUIElement? {
+            candidates.first(where: { $0.exists })
+        }
+
+        var resolvedMatch: XCUIElement?
+        let didResolve = waitForUITestCondition(
+            "Wait for History row containing \(fragment)",
+            timeout: timeout
+        ) {
+            if let element = currentMatch() {
+                resolvedMatch = element
+                return true
             }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        } while Date() < deadline
+            return false
+        }
+        if didResolve {
+            return resolvedMatch ?? currentMatch() ?? candidates.first ?? app.otherElements["historyRow::missing"].firstMatch
+        }
 
         XCTAssertTrue(
             false,

--- a/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -43,6 +43,40 @@ extension AndBibleUITests {
     }
 
     /**
+     Waits for a UI-test condition through XCTest's predicate waiter.
+
+     - Parameters:
+       - description: Human-readable condition name used in XCTest diagnostics.
+       - timeout: Maximum number of seconds to wait after an initial immediate probe.
+       - condition: Predicate closure that reads current UI state and returns true once ready.
+     - Returns: `true` when the condition succeeds immediately or before the timeout.
+     - Side effects:
+       - samples `condition` through `XCTNSPredicateExpectation` while XCTest waits
+     - Failure modes: This helper does not fail directly.
+     */
+    @discardableResult
+    func waitForUITestCondition(
+        _ description: String,
+        timeout: TimeInterval,
+        condition: @escaping () -> Bool
+    ) -> Bool {
+        if condition() {
+            return true
+        }
+        guard timeout > 0 else {
+            return false
+        }
+
+        let predicate = NSPredicate { _, _ in
+            condition()
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        expectation.expectationDescription = description
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        return result == .completed || condition()
+    }
+
+    /**
      Waits for one live XCUI element to become hittable.
      *
      * - Parameters:
@@ -57,21 +91,12 @@ extension AndBibleUITests {
         _ element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
-        if isElementHittable(element) {
-            return true
-        }
-        guard timeout > 0 else {
-            return false
-        }
-
-        let predicate = NSPredicate { [weak self] _, _ in
+        waitForUITestCondition(
+            "Wait for element \(element.identifier) to become hittable",
+            timeout: timeout
+        ) { [weak self] in
             self?.isElementHittable(element) ?? false
         }
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
-        expectation.expectationDescription =
-            "Wait for element \(element.identifier) to become hittable"
-        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
-        return result == .completed || isElementHittable(element)
     }
 
     /**

--- a/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift
@@ -43,6 +43,28 @@ extension AndBibleUITests {
     }
 
     /**
+     Returns a stable, non-empty element name for XCTest wait diagnostics.
+     *
+     * - Parameter element: UI element whose identifier or label should describe the wait target.
+     * - Returns: the accessibility identifier, visible label, or a generic placeholder.
+     * - Side effects: none
+     * - Failure modes: Falls back to a placeholder when XCTest exposes neither identifier nor label.
+     */
+    func uiTestElementDiagnosticName(_ element: XCUIElement) -> String {
+        let identifier = element.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !identifier.isEmpty {
+            return identifier
+        }
+
+        let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !label.isEmpty {
+            return label
+        }
+
+        return "unidentified UI element"
+    }
+
+    /**
      Waits for a UI-test condition through XCTest's predicate waiter.
 
      - Parameters:
@@ -92,8 +114,8 @@ extension AndBibleUITests {
         timeout: TimeInterval
     ) -> Bool {
         waitForUITestCondition(
-            "Wait for element \(element.identifier) to become hittable",
-            timeout: timeout
+            "Wait for \(uiTestElementDiagnosticName(element)) to become hittable",
+            timeout: max(0, timeout)
         ) { [weak self] in
             self?.isElementHittable(element) ?? false
         }

--- a/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift
@@ -600,13 +600,14 @@ extension AndBibleUITests {
                     && waitForElementToBecomeHittable($0, timeout: 0.5)
             }) {
                 tapElementReliably(identifierElement, timeout: 3)
-                let activationDeadline = min(Date().addingTimeInterval(2), deadline)
-                repeat {
-                    if isExpectedScopeSelected() {
-                        return
-                    }
-                    RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-                } while Date() < activationDeadline
+                let activationTimeout = min(2, max(0, deadline.timeIntervalSinceNow))
+                if waitForUITestCondition(
+                    "Wait for Search scope \(scopeToken.rawValue) activation",
+                    timeout: activationTimeout,
+                    condition: isExpectedScopeSelected
+                ) {
+                    return
+                }
                 continue
             }
 
@@ -707,23 +708,21 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) -> Bool {
-        let deadline = Date().addingTimeInterval(max(0, timeout))
-
-        repeat {
-            if searchTranslationPickerStateIsOpen(in: app, timeout: 0) {
+        waitForUITestCondition(
+            "Wait for Search translation picker to open",
+            timeout: max(0, timeout)
+        ) {
+            if self.searchTranslationPickerStateIsOpen(in: app, timeout: 0) {
                 return true
             }
-            if firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil {
+            if self.firstExistingElement(
+                self.searchTranslationPickerOpenCandidates(in: app),
+                timeout: 0
+            ) != nil {
                 return true
             }
-            if timeout <= 0 {
-                return false
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        } while Date() < deadline
-
-        return searchTranslationPickerStateIsOpen(in: app, timeout: 0)
-            || firstExistingElement(searchTranslationPickerOpenCandidates(in: app), timeout: 0) != nil
+            return false
+        }
     }
 
     /**
@@ -949,28 +948,29 @@ extension AndBibleUITests {
         in app: XCUIApplication,
         timeout: TimeInterval
     ) {
-        let deadline = Date().addingTimeInterval(max(0, timeout))
-
-        repeat {
-            if let row = firstExistingElement(
-                searchTranslationRowCandidates(identifier, moduleName: moduleName, in: app),
-                timeout: 0.1
+        waitForUITestCondition(
+            "Wait for Search translation row \(moduleName) mutation",
+            timeout: max(0, timeout)
+        ) {
+            if let row = self.firstExistingElement(
+                self.searchTranslationRowCandidates(identifier, moduleName: moduleName, in: app),
+                timeout: 0
             ) {
                 if let expectedValue, row.value as? String == expectedValue {
-                    return
+                    return true
                 }
-                if expectedValue == nil, elementHasUsableFrame(row) {
-                    return
+                if expectedValue == nil, self.elementHasUsableFrame(row) {
+                    return true
                 }
             }
 
             if expectedValue == nil,
-               firstExistingElement(searchTranslationPickerListCandidates(in: app), timeout: 0.1) != nil {
-                return
+               self.firstExistingElement(self.searchTranslationPickerListCandidates(in: app), timeout: 0) != nil {
+                return true
             }
 
-            RunLoop.current.run(until: Date().addingTimeInterval(0.15))
-        } while Date() < deadline
+            return false
+        }
     }
 
     /// Returns row candidates for one Search translation picker module.
@@ -1202,13 +1202,11 @@ extension AndBibleUITests {
         }
 
         func waitForExpectedWordModeActivation(until activationDeadline: Date) -> Bool {
-            repeat {
-                if isExpectedWordModeSelected() {
-                    return true
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-            } while Date() < activationDeadline
-            return isExpectedWordModeSelected()
+            waitForUITestCondition(
+                "Wait for Search word mode \(expectedToken) activation",
+                timeout: max(0, activationDeadline.timeIntervalSinceNow),
+                condition: isExpectedWordModeSelected
+            )
         }
 
         repeat {

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -130,8 +130,21 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         body = swift_function_body(interaction_source, "waitForElementToBecomeHittable")
 
         self.assertIn("waitForUITestCondition", body)
+        self.assertIn("uiTestElementDiagnosticName(element)", body)
+        self.assertIn("max(0, timeout)", body)
         self.assertNotIn("RunLoop.current.run", body)
         self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_hittability_wait_diagnostics_fall_back_to_label_or_placeholder(self) -> None:
+        """Keep label-only XCUI elements from producing empty wait diagnostics."""
+        interaction_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(interaction_source, "uiTestElementDiagnosticName")
+
+        self.assertIn("element.identifier", body)
+        self.assertIn("element.label", body)
+        self.assertIn('"unidentified UI element"', body)
 
     def test_shared_condition_wait_uses_xctest_predicate_waiter(self) -> None:
         """Keep reusable UI-test condition waits on XCTest instead of ad hoc polling."""

--- a/scripts/test_semantic_wait_guardrails.py
+++ b/scripts/test_semantic_wait_guardrails.py
@@ -129,8 +129,52 @@ class SemanticWaitGuardrailsTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         body = swift_function_body(interaction_source, "waitForElementToBecomeHittable")
 
+        self.assertIn("waitForUITestCondition", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_shared_condition_wait_uses_xctest_predicate_waiter(self) -> None:
+        """Keep reusable UI-test condition waits on XCTest instead of ad hoc polling."""
+        interaction_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestInteractionSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(interaction_source, "waitForUITestCondition")
+
         self.assertIn("XCTNSPredicateExpectation", body)
         self.assertIn("XCTWaiter", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_first_existing_element_uses_one_bounded_predicate_wait(self) -> None:
+        """Prevent candidate lookup from spending the timeout once per candidate."""
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(element_source, "firstExistingElement")
+
+        self.assertIn("waitForUITestCondition", body)
+        self.assertNotIn("waitForExistence", body)
+        self.assertNotIn("RunLoop.current.run", body)
+
+    def test_require_element_uses_predicate_waiter_not_run_loop_polling(self) -> None:
+        """Keep generic element resolution from manual sleep polling."""
+        element_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestElementSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(element_source, "requireElement")
+
+        self.assertIn("waitForUITestCondition", body)
+        self.assertNotIn("RunLoop.current.run", body)
+        self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
+
+    def test_search_translation_row_mutation_uses_predicate_waiter(self) -> None:
+        """Keep Search picker row-settle waits state-driven after row taps."""
+        search_source = (
+            REPO_ROOT / "Tests/UI/AndBibleUITests/AndBibleUITestSearchSupport.swift"
+        ).read_text(encoding="utf-8")
+        body = swift_function_body(search_source, "waitForSearchTranslationRowMutation")
+
+        self.assertIn("waitForUITestCondition", body)
         self.assertNotIn("RunLoop.current.run", body)
         self.assertNotRegex(body, re.compile(r"\brepeat\s*\{"))
 


### PR DESCRIPTION
## Summary
This PR moves another chunk of UI-test synchronization away from ad hoc polling and toward reusable, XCTest-backed state waits.

It solves the repeated pattern where generic UI helpers and Search picker helpers burned time through manual run-loop sleeps or per-candidate timeout loops. The intended outcome is lower hidden wait amplification and more deterministic UI-test diagnostics without changing production app behavior.

## Scope
In scope:
- Add a shared predicate-backed UI-test condition waiter.
- Refactor generic element resolution and Search option/picker state waits to use bounded state predicates.
- Add script guardrails that keep these helpers from regressing to manual run-loop polling or per-candidate timeout behavior.

Out of scope:
- Production app behavior changes.
- Full UI-suite rewrite.
- Side-effecting tap/reveal loops that need a separate, more careful conversion pass.

## Contract References
- `commit-standard` required commit and PR sections.
- `engineering-guardrails` for root-cause test-harness cleanup rather than longer timeouts.
- GitNexus impact checks for edited UI-test helper symbols.

## Change Details
- `AndBibleUITestInteractionSupport.swift` now has `waitForUITestCondition`, a reusable helper backed by `XCTNSPredicateExpectation` and `XCTWaiter`.
- `waitForElementToBecomeHittable` delegates to the shared helper instead of owning predicate wait logic.
- `firstExistingElement`, `requireElement`, and `requireHistoryRow` use one bounded condition wait instead of manual loops or one timeout per candidate.
- Search scope, word mode, translation picker open-state, and translation row mutation waits now observe exported/element state through the shared helper.
- `scripts/test_semantic_wait_guardrails.py` now asserts these paths do not drift back to `RunLoop.current.run` polling.

## Validation Evidence
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product UITestFixtureTool`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiTestStateWaitOptimization -skipPackagePluginValidation build-for-testing`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiTestStateWaitOptimization -skipPackagePluginValidation test -only-testing:AndBibleUITests/AndBibleUITests/testSearchOptionControlsMutateVisibleState -only-testing:AndBibleUITests/AndBibleUITests/testBookmarkSelectionNavigatesReaderToSeededReference -only-testing:AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project AndBible.xcodeproj -scheme AndBible -destination 'id=C52691F5-C1FB-4DC0-A4A1-00D993F9CD33' -derivedDataPath .derivedData/UiTestStateWaitOptimization -skipPackagePluginValidation test -only-testing:AndBibleUITests/AndBibleUITests/testSearchOptionControlsMutateVisibleState`
- GitNexus `detect_changes` against the worktree reported low risk with no affected indexed execution flows.

## Risks / Follow-ups
- Risk: `requireElement` and `firstExistingElement` are broad helpers. I covered Search, Bookmark navigation, Settings shortcut navigation, script guardrails, and build-for-testing, but full-suite CI is still the wider proof.
- Follow-up: remaining side-effecting waits should be converted in later chunks only when each interaction has a reliable state contract.

## Screenshots
none

## Closes
Closes: none
