### PR TITLE
fix(bookmarks): align restored bookmarks with Android KJVA ordinals

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Database/BookmarkStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/BookmarkStore.swift
@@ -96,31 +96,23 @@ public final class BookmarkStore {
     }
 
     /**
-     * Fetches Bible bookmarks whose stored KJVA ordinal range overlaps the given range.
+     * Fetches Bible bookmarks whose stored KJVA ordinal range overlaps the given KJVA range.
      * - Parameters:
-     *   - startOrdinal: Inclusive start of the query range.
-     *   - endOrdinal: Inclusive end of the query range.
-     *   - book: Optional book name filter used to avoid cross-book collisions when the current
-     *     ordinal scheme is only unique within a book.
+     *   - startOrdinal: Inclusive KJVA start of the query range.
+     *   - endOrdinal: Inclusive KJVA end of the query range.
+     *   - book: Deprecated compatibility parameter. Android backups store module initials or NULL in
+     *     `BibleBookmark.book`, so callers must not use this value to decide verse membership.
      * - Returns: Overlapping bookmarks.
      * - Failure: Fetch errors are swallowed and reported as an empty array.
-     * - Note: This query matches on stored KJVA ordinals, not the currently selected versification.
+     * - Note: This query matches on stored KJVA ordinals only; those ordinals are globally unique
+     *   across books and are the Android-compatible key for restored and native bookmark highlights.
      */
     public func bibleBookmarks(overlapping startOrdinal: Int, endOrdinal: Int, book: String? = nil) -> [BibleBookmark] {
-        let descriptor: FetchDescriptor<BibleBookmark>
-        if let book {
-            descriptor = FetchDescriptor<BibleBookmark>(
-                predicate: #Predicate {
-                    $0.kjvOrdinalStart <= endOrdinal && $0.kjvOrdinalEnd >= startOrdinal && $0.book == book
-                }
-            )
-        } else {
-            descriptor = FetchDescriptor<BibleBookmark>(
-                predicate: #Predicate {
-                    $0.kjvOrdinalStart <= endOrdinal && $0.kjvOrdinalEnd >= startOrdinal
-                }
-            )
-        }
+        let descriptor = FetchDescriptor<BibleBookmark>(
+            predicate: #Predicate {
+                $0.kjvOrdinalStart <= endOrdinal && $0.kjvOrdinalEnd >= startOrdinal
+            }
+        )
         return (try? modelContext.fetch(descriptor)) ?? []
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Models/Bookmark.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Models/Bookmark.swift
@@ -113,6 +113,9 @@ public final class BibleBookmark {
     /// Raw versification identifier for the originating module.
     public var v11n: String = "KJVA"
 
+    /// Module initials for the originating Bible document.
+    public var bookInitials: String = ""
+
     /// Optional book name captured at creation time for display and legacy lookup paths.
     public var book: String?
 
@@ -164,6 +167,7 @@ public final class BibleBookmark {
        - ordinalStart: Source-versification start ordinal.
        - ordinalEnd: Source-versification end ordinal.
        - v11n: Raw source versification identifier.
+       - bookInitials: Source Bible module initials.
        - createdAt: Bookmark creation timestamp.
        - lastUpdatedOn: Timestamp of the latest mutation.
        - wholeVerse: Whether the bookmark covers an entire verse.
@@ -177,6 +181,7 @@ public final class BibleBookmark {
         ordinalStart: Int = 0,
         ordinalEnd: Int = 0,
         v11n: String = "KJVA",
+        bookInitials: String = "",
         createdAt: Date = Date(),
         lastUpdatedOn: Date = Date(),
         wholeVerse: Bool = true
@@ -187,6 +192,7 @@ public final class BibleBookmark {
         self.ordinalStart = ordinalStart
         self.ordinalEnd = ordinalEnd
         self.v11n = v11n
+        self.bookInitials = bookInitials
         self.createdAt = createdAt
         self.lastUpdatedOn = lastUpdatedOn
         self.wholeVerse = wholeVerse

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
@@ -134,7 +134,7 @@ public protocol AndroidBookmarkResolverGateway {
 
  The stage-3 constants are computed from SWORD's canonical `canon.h`/`canon_kjva.h` tables:
  both canons share Genesis..Malachi exactly; KJVA then inserts 14 apocrypha books (182 chapters,
- 5,731 verses → 5,913 intro-inclusive ordinals), so the KJVA New Testament section starts at
+ 5,717 verses → 5,913 intro-inclusive ordinals), so the KJVA New Testament section starts at
  ordinal 30,028 versus KJV's 24,115.
 
  Side effects:

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
@@ -20,10 +20,10 @@ import SwordKit
  */
 public protocol AndroidBookmarkBookNameResolving {
     /**
-     Reports whether a raw Android `book` value matches an installed SWORD Bible's initials.
+     Reports whether a raw Android `book` value matches an installed passage module's initials.
 
      - Parameter rawValue: Raw string from the Android `book` column.
-     - Returns: `true` when the value equals an installed Bible module's initials.
+     - Returns: `true` when the value equals an installed Bible or commentary module's initials.
      - Side effects: may lazily enumerate installed modules.
      - Failure modes: returns `false` when module enumeration is unavailable.
      */
@@ -36,8 +36,8 @@ public protocol AndroidBookmarkBookNameResolving {
        - v11nName: Versification name stored with the Android bookmark row; empty means KJV.
        - ordinal: Intro-inclusive whole-Bible ordinal in `v11nName`.
        - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used as a fallback key.
-     - Returns: The SWORD book name (e.g. `Genesis`), or `nil` when no installed module matches
-       the bookmark's versification and no KJVA-versified module can use the fallback ordinal.
+     - Returns: The SWORD book name (e.g. `Genesis`), or `nil` when no installed module can
+       resolve the ordinal in a versification-sound way.
      - Side effects: may lazily create SWORD manager state and cache module book lists.
      - Failure modes: returns `nil` for intro ordinals and unresolvable versifications.
      */
@@ -47,22 +47,31 @@ public protocol AndroidBookmarkBookNameResolving {
 /**
  SWORD-backed resolver that derives display book names from installed Bible modules.
 
- The resolver prefers an installed Bible whose versification matches the bookmark's own `v11n`
- so ordinals resolve in the versification they were recorded in, exactly like Android's
- JSword reverse mapping. When no matching module exists it falls back to a KJVA-versified
- module using the bookmark's KJVA ordinal, which is versification-correct by construction.
+ The resolver tries every installed Bible whose versification matches the bookmark's own `v11n`
+ so ordinals resolve in the versification they were recorded in, exactly like Android's JSword
+ reverse mapping. Candidates that libsword cannot open (Android custom-driver or MyBible package
+ projections) or that lack the resolved book's content are skipped rather than aborting
+ derivation. When no matching module resolves, two versification-sound fallbacks use the
+ bookmark's KJVA ordinal: a KJVA-versified module when installed, then any KJV-versified module
+ restricted to Old Testament results, because KJV and KJVA ordinals are identical up to Malachi
+ and diverge only after the apocrypha insertion point.
 
  Side effects:
- - lazily creates a `SwordManager` on first resolution and caches per-module book lists
+ - lazily creates a `SwordManager` on first resolution; caches the module inventory, per-module
+   book lists, and per-versification module choices for the resolver's lifetime
 
  Failure modes:
- - resolution returns `nil` when no installed module matches and no KJVA module exists
+ - resolution returns `nil` when no installed module can resolve the ordinal soundly
+ - the caches never observe module installs performed after the first resolution, so restore
+   flows should use a fresh resolver instance per operation (the default service wiring does)
  */
 public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookNameResolving {
     private let managerProvider: () -> SwordManager?
     private var cachedManager: SwordManager??
-    private var cachedBibleInitials: Set<String>?
-    private var bookNamesByModule: [String: [String: String]] = [:]
+    private var cachedBibleModuleInfos: [ModuleInfo]?
+    private var cachedPassageInitials: Set<String>?
+    private var moduleNamesByV11n: [String: [String]] = [:]
+    private var bookListsByModule: [String: [BookInfo]] = [:]
 
     /**
      Creates a resolver backed by lazily created SWORD manager state.
@@ -77,15 +86,18 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
     }
 
     /**
-     Reports whether a raw Android `book` value matches an installed SWORD Bible's initials.
+     Reports whether a raw Android `book` value matches an installed passage module's initials.
+
+     Android's `book` column holds an `AbstractPassageBook`, which covers commentaries as well as
+     Bibles, so both categories participate in initials classification.
 
      - Parameter rawValue: Raw string from the Android `book` column.
-     - Returns: `true` when the value equals an installed Bible module's initials.
-     - Side effects: lazily enumerates installed Bible modules once.
+     - Returns: `true` when the value equals an installed Bible or commentary module's initials.
+     - Side effects: lazily enumerates installed modules once.
      - Failure modes: returns `false` when the SWORD manager cannot be created.
      */
     public func isInstalledBibleInitials(_ rawValue: String) -> Bool {
-        installedBibleInitials().contains(rawValue)
+        installedPassageInitials().contains(rawValue)
     }
 
     /**
@@ -96,23 +108,36 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
        - ordinal: Intro-inclusive whole-Bible ordinal in `v11nName`.
        - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used as a fallback key.
      - Returns: The SWORD book name for the resolved verse, or `nil` when unresolvable.
-     - Side effects: lazily creates the SWORD manager and caches module book-name maps.
-     - Failure modes: returns `nil` for intro ordinals, empty book lists, and versifications
-       with no installed module.
+     - Side effects: lazily creates the SWORD manager and populates the resolver caches.
+     - Failure modes: returns `nil` for intro ordinals, unloadable candidate modules, and
+       versifications with no sound resolution path.
      */
     public func displayBookName(v11nName: String, ordinal: Int, kjvOrdinal: Int) -> String? {
         guard let manager = manager() else { return nil }
 
-        if let moduleName = moduleName(matchingV11n: v11nName, manager: manager),
-           let name = bookName(moduleName: moduleName, ordinal: ordinal, manager: manager) {
-            return name
+        let wanted = normalizedV11n(v11nName)
+        for moduleName in moduleNames(matchingV11n: wanted) {
+            if let book = resolvedBook(moduleName: moduleName, ordinal: ordinal, manager: manager) {
+                return book.name
+            }
         }
 
-        guard normalizedV11n(v11nName) != "KJVA",
-              let kjvaModuleName = moduleName(matchingV11n: "KJVA", manager: manager) else {
-            return nil
+        if wanted != "KJVA" {
+            for moduleName in moduleNames(matchingV11n: "KJVA") {
+                if let book = resolvedBook(moduleName: moduleName, ordinal: kjvOrdinal, manager: manager) {
+                    return book.name
+                }
+            }
         }
-        return bookName(moduleName: kjvaModuleName, ordinal: kjvOrdinal, manager: manager)
+
+        guard wanted != "KJV" else { return nil }
+        for moduleName in moduleNames(matchingV11n: "KJV") {
+            if let book = resolvedBook(moduleName: moduleName, ordinal: kjvOrdinal, manager: manager),
+               book.testament == 1 {
+                return book.name
+            }
+        }
+        return nil
     }
 
     private func manager() -> SwordManager? {
@@ -124,17 +149,29 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
         return created
     }
 
-    private func installedBibleInitials() -> Set<String> {
-        if let cachedBibleInitials {
-            return cachedBibleInitials
+    private func bibleModuleInfos() -> [ModuleInfo] {
+        if let cachedBibleModuleInfos {
+            return cachedBibleModuleInfos
+        }
+        let infos = manager()?.installedModules(category: ModuleCategory.bible) ?? []
+        cachedBibleModuleInfos = infos
+        return infos
+    }
+
+    private func installedPassageInitials() -> Set<String> {
+        if let cachedPassageInitials {
+            return cachedPassageInitials
         }
         var initials = Set<String>()
         if let manager = manager() {
             for info in manager.installedModules(category: ModuleCategory.bible) {
                 initials.insert(info.name)
             }
+            for info in manager.installedModules(category: ModuleCategory.commentary) {
+                initials.insert(info.name)
+            }
         }
-        cachedBibleInitials = initials
+        cachedPassageInitials = initials
         return initials
     }
 
@@ -144,30 +181,32 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
         return trimmed.isEmpty ? "KJV" : trimmed.uppercased()
     }
 
-    private func moduleName(matchingV11n v11nName: String, manager: SwordManager) -> String? {
-        let wanted = normalizedV11n(v11nName)
-        for info in manager.installedModules(category: ModuleCategory.bible)
-        where normalizedV11n(info.aboutMetadata.versification) == wanted {
-            return info.name
+    private func moduleNames(matchingV11n normalizedName: String) -> [String] {
+        if let cached = moduleNamesByV11n[normalizedName] {
+            return cached
         }
-        return nil
+        var names: [String] = []
+        for info in bibleModuleInfos()
+        where normalizedV11n(info.aboutMetadata.versification) == normalizedName {
+            names.append(info.name)
+        }
+        moduleNamesByV11n[normalizedName] = names
+        return names
     }
 
-    private func bookName(moduleName: String, ordinal: Int, manager: SwordManager) -> String? {
+    private func resolvedBook(moduleName: String, ordinal: Int, manager: SwordManager) -> BookInfo? {
         guard let module = manager.module(named: moduleName),
               let reference = module.verseReference(ordinal: ordinal) else {
             return nil
         }
 
-        if let cached = bookNamesByModule[moduleName] {
-            return cached[reference.osisBookId]
+        let books: [BookInfo]
+        if let cached = bookListsByModule[moduleName] {
+            books = cached
+        } else {
+            books = module.getBookList()
+            bookListsByModule[moduleName] = books
         }
-
-        let names = Dictionary(
-            module.getBookList().map { ($0.osisId, $0.name) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        bookNamesByModule[moduleName] = names
-        return names[reference.osisBookId]
+        return books.first(where: { $0.osisId == reference.osisBookId })
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
@@ -45,44 +45,138 @@ public protocol AndroidBookmarkBookNameResolving {
 }
 
 /**
- SWORD-backed resolver that derives display book names from installed Bible modules.
+ One resolved Bible book produced by a resolver gateway for an ordinal lookup.
 
- The resolver tries every installed Bible whose versification matches the bookmark's own `v11n`
- so ordinals resolve in the versification they were recorded in, exactly like Android's JSword
- reverse mapping. Candidates that libsword cannot open (Android custom-driver or MyBible package
- projections) or that lack the resolved book's content are skipped rather than aborting
- derivation. When no matching module resolves, two versification-sound fallbacks use the
- bookmark's KJVA ordinal: a KJVA-versified module when installed, then any KJV-versified module
- restricted to Old Testament results, because KJV and KJVA ordinals are identical up to Malachi
- and diverge only after the apocrypha insertion point.
+ The selection core only needs the display name and the testament so it can gate
+ cross-versification fallbacks; everything else stays inside the gateway.
+ */
+public struct AndroidBookmarkResolvedBook: Sendable, Equatable {
+    /// Full display book name as reported by the module (e.g. `Genesis`).
+    public let name: String
+
+    /// Testament number: 1 = Old Testament, 2 = New Testament.
+    public let testament: Int
+
+    /**
+     Creates one resolved book result.
+
+     - Parameters:
+       - name: Full display book name.
+       - testament: Testament number, 1 for Old Testament and 2 for New Testament.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public init(name: String, testament: Int) {
+        self.name = name
+        self.testament = testament
+    }
+}
+
+/**
+ Module access boundary used by the Android bookmark book-name selection core.
+
+ Separating module enumeration and ordinal resolution behind this gateway keeps the fallback
+ selection logic pure and unit-testable without installed SWORD modules, while the production
+ gateway stays a thin SwordKit adapter.
 
  Side effects:
- - lazily creates a `SwordManager` on first resolution; caches the module inventory, per-module
-   book lists, and per-versification module choices for the resolver's lifetime
+ - implementations may perform module I/O and may cache results
+
+ Failure modes:
+ - implementations return empty collections or `nil` when module state is unavailable
+ */
+public protocol AndroidBookmarkResolverGateway {
+    /**
+     Lists installed Bible modules as `(initials, versification)` pairs in inventory order.
+
+     - Returns: Installed Bible descriptors; versification is the raw conf value (empty means KJV).
+     - Side effects: may lazily enumerate installed modules once.
+     - Failure modes: returns an empty array when module state is unavailable.
+     */
+    func bibleModules() -> [(name: String, versification: String)]
+
+    /**
+     Lists initials of installed passage modules (Bibles and commentaries).
+
+     - Returns: Initials set used to classify Android `book` column values.
+     - Side effects: may lazily enumerate installed modules once.
+     - Failure modes: returns an empty set when module state is unavailable.
+     */
+    func passageInitials() -> Set<String>
+
+    /**
+     Resolves one intro-inclusive whole-Bible ordinal against one module.
+
+     - Parameters:
+       - moduleName: Installed module initials to resolve against.
+       - ordinal: Intro-inclusive ordinal in that module's own versification.
+     - Returns: The resolved book, or `nil` when the module cannot be opened, the ordinal does
+       not resolve to a normal verse, or the module lacks the resolved book's content.
+     - Side effects: may open the module and cache its book list.
+     - Failure modes: returns `nil` rather than throwing.
+     */
+    func resolve(moduleName: String, ordinal: Int) -> AndroidBookmarkResolvedBook?
+}
+
+/**
+ SWORD-backed resolver that derives display book names from installed Bible modules.
+
+ The selection core tries every installed Bible whose versification matches the bookmark's own
+ `v11n`, skipping candidates the gateway cannot resolve (unloadable custom-driver or MyBible
+ projections, content-sparse modules). When no matching module resolves it falls back through
+ three versification-sound stages driven by the bookmark's KJVA ordinal:
+
+ 1. any KJVA-versified module, because `kjvOrdinal` is defined in KJVA;
+ 2. any KJV-versified module restricted to Old Testament results, because KJV and KJVA
+    intro-inclusive ordinals are identical from Genesis through Malachi;
+ 3. for ordinals at or beyond the KJVA New Testament section, any KJV-versified module after
+    subtracting the fixed apocrypha ordinal span, restricted to New Testament results.
+
+ The stage-3 constants are computed from SWORD's canonical `canon.h`/`canon_kjva.h` tables:
+ both canons share Genesis..Malachi exactly; KJVA then inserts 14 apocrypha books (182 chapters,
+ 5,731 verses → 5,913 intro-inclusive ordinals), so the KJVA New Testament section starts at
+ ordinal 30,028 versus KJV's 24,115.
+
+ Side effects:
+ - the default gateway lazily creates a `SwordManager` on first resolution and caches the module
+   inventory and per-module book lists for the resolver's lifetime
 
  Failure modes:
  - resolution returns `nil` when no installed module can resolve the ordinal soundly
- - the caches never observe module installs performed after the first resolution, so restore
-   flows should use a fresh resolver instance per operation (the default service wiring does)
+ - caches never observe module installs performed after the first resolution, so restore flows
+   should use a fresh resolver instance per operation (the default service wiring does)
  */
 public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookNameResolving {
-    private let managerProvider: () -> SwordManager?
-    private var cachedManager: SwordManager??
-    private var cachedBibleModuleInfos: [ModuleInfo]?
-    private var cachedPassageInitials: Set<String>?
+    /// First intro-inclusive ordinal of the KJVA New Testament section (`canon_kjva.h`).
+    static let kjvaNewTestamentStartOrdinal = 30028
+
+    /// Intro-inclusive ordinal span of the KJVA apocrypha insertion (`canon_kjva.h` minus `canon.h`).
+    static let kjvaApocryphaOrdinalSpan = 5913
+
+    private let gateway: AndroidBookmarkResolverGateway
     private var moduleNamesByV11n: [String: [String]] = [:]
-    private var bookListsByModule: [String: [BookInfo]] = [:]
 
     /**
-     Creates a resolver backed by lazily created SWORD manager state.
+     Creates a resolver backed by the production SwordKit gateway.
 
      - Parameter managerProvider: Factory for the SWORD manager; defaults to the shared module
        root used by the app. The factory runs at most once, on first resolution.
      - Side effects: none until the first resolution call.
      - Failure modes: a `nil` manager disables resolution and initials matching.
      */
-    public init(managerProvider: @escaping () -> SwordManager? = { SwordManager() }) {
-        self.managerProvider = managerProvider
+    public convenience init(managerProvider: @escaping () -> SwordManager? = { SwordManager() }) {
+        self.init(gateway: AndroidBookmarkSwordResolverGateway(managerProvider: managerProvider))
+    }
+
+    /**
+     Creates a resolver over an explicit module gateway.
+
+     - Parameter gateway: Module access boundary; tests inject deterministic fakes here.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public init(gateway: AndroidBookmarkResolverGateway) {
+        self.gateway = gateway
     }
 
     /**
@@ -94,10 +188,10 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
      - Parameter rawValue: Raw string from the Android `book` column.
      - Returns: `true` when the value equals an installed Bible or commentary module's initials.
      - Side effects: lazily enumerates installed modules once.
-     - Failure modes: returns `false` when the SWORD manager cannot be created.
+     - Failure modes: returns `false` when module state is unavailable.
      */
     public func isInstalledBibleInitials(_ rawValue: String) -> Bool {
-        installedPassageInitials().contains(rawValue)
+        gateway.passageInitials().contains(rawValue)
     }
 
     /**
@@ -106,59 +200,129 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
      - Parameters:
        - v11nName: Versification name stored with the Android bookmark row; empty means KJV.
        - ordinal: Intro-inclusive whole-Bible ordinal in `v11nName`.
-       - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used as a fallback key.
+       - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used by the fallback stages.
      - Returns: The SWORD book name for the resolved verse, or `nil` when unresolvable.
-     - Side effects: lazily creates the SWORD manager and populates the resolver caches.
+     - Side effects: lazily initializes the gateway's module state and the resolver caches.
      - Failure modes: returns `nil` for intro ordinals, unloadable candidate modules, and
        versifications with no sound resolution path.
      */
     public func displayBookName(v11nName: String, ordinal: Int, kjvOrdinal: Int) -> String? {
-        guard let manager = manager() else { return nil }
-
         let wanted = normalizedV11n(v11nName)
         for moduleName in moduleNames(matchingV11n: wanted) {
-            if let book = resolvedBook(moduleName: moduleName, ordinal: ordinal, manager: manager) {
+            if let book = gateway.resolve(moduleName: moduleName, ordinal: ordinal) {
                 return book.name
             }
         }
 
         if wanted != "KJVA" {
             for moduleName in moduleNames(matchingV11n: "KJVA") {
-                if let book = resolvedBook(moduleName: moduleName, ordinal: kjvOrdinal, manager: manager) {
+                if let book = gateway.resolve(moduleName: moduleName, ordinal: kjvOrdinal) {
                     return book.name
                 }
             }
         }
 
-        guard wanted != "KJV" else { return nil }
-        for moduleName in moduleNames(matchingV11n: "KJV") {
-            if let book = resolvedBook(moduleName: moduleName, ordinal: kjvOrdinal, manager: manager),
-               book.testament == 1 {
-                return book.name
+        if wanted != "KJV" {
+            for moduleName in moduleNames(matchingV11n: "KJV") {
+                if let book = gateway.resolve(moduleName: moduleName, ordinal: kjvOrdinal),
+                   book.testament == 1 {
+                    return book.name
+                }
+            }
+        }
+
+        if kjvOrdinal >= Self.kjvaNewTestamentStartOrdinal {
+            let shifted = kjvOrdinal - Self.kjvaApocryphaOrdinalSpan
+            for moduleName in moduleNames(matchingV11n: "KJV") {
+                if let book = gateway.resolve(moduleName: moduleName, ordinal: shifted),
+                   book.testament == 2 {
+                    return book.name
+                }
             }
         }
         return nil
     }
 
-    private func manager() -> SwordManager? {
-        if let cachedManager {
-            return cachedManager
-        }
-        let created = managerProvider()
-        cachedManager = created
-        return created
+    /// Android and SWORD both treat a missing versification name as the KJV default.
+    private func normalizedV11n(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "KJV" : trimmed.uppercased()
     }
 
-    private func bibleModuleInfos() -> [ModuleInfo] {
-        if let cachedBibleModuleInfos {
-            return cachedBibleModuleInfos
+    private func moduleNames(matchingV11n normalizedName: String) -> [String] {
+        if let cached = moduleNamesByV11n[normalizedName] {
+            return cached
         }
-        let infos = manager()?.installedModules(category: ModuleCategory.bible) ?? []
-        cachedBibleModuleInfos = infos
-        return infos
+        var names: [String] = []
+        for module in gateway.bibleModules()
+        where normalizedV11n(module.versification) == normalizedName {
+            names.append(module.name)
+        }
+        moduleNamesByV11n[normalizedName] = names
+        return names
+    }
+}
+
+/**
+ Production SwordKit adapter behind `AndroidBookmarkResolverGateway`.
+
+ The adapter keeps all SwordKit access in one thin layer: it lazily creates the manager,
+ enumerates the module inventory once, and caches per-module book lists so restore flows do not
+ re-scan `mods.d` per bookmark.
+
+ Side effects:
+ - lazily creates a `SwordManager` and caches inventory, initials, and book lists
+
+ Failure modes:
+ - all lookups degrade to empty results when the manager cannot be created
+ */
+final class AndroidBookmarkSwordResolverGateway: AndroidBookmarkResolverGateway {
+    private let managerProvider: () -> SwordManager?
+    private var cachedManager: SwordManager??
+    private var cachedBibleModules: [(name: String, versification: String)]?
+    private var cachedPassageInitials: Set<String>?
+    private var bookListsByModule: [String: [BookInfo]] = [:]
+
+    /**
+     Creates the SwordKit-backed gateway.
+
+     - Parameter managerProvider: Factory for the SWORD manager, run at most once.
+     - Side effects: none until first use.
+     - Failure modes: a `nil` manager disables all lookups.
+     */
+    init(managerProvider: @escaping () -> SwordManager?) {
+        self.managerProvider = managerProvider
     }
 
-    private func installedPassageInitials() -> Set<String> {
+    /**
+     Lists installed Bible modules as `(initials, versification)` pairs in inventory order.
+
+     - Returns: Installed Bible descriptors from the cached inventory.
+     - Side effects: lazily creates the manager and caches the inventory on first call.
+     - Failure modes: returns an empty array when the manager cannot be created.
+     */
+    func bibleModules() -> [(name: String, versification: String)] {
+        if let cachedBibleModules {
+            return cachedBibleModules
+        }
+        var modules: [(name: String, versification: String)] = []
+        if let manager = manager() {
+            for info in manager.installedModules(category: ModuleCategory.bible) {
+                modules.append((name: info.name, versification: info.aboutMetadata.versification))
+            }
+        }
+        cachedBibleModules = modules
+        return modules
+    }
+
+    /**
+     Lists initials of installed passage modules (Bibles and commentaries).
+
+     - Returns: Initials set from the cached inventory.
+     - Side effects: lazily creates the manager and caches the set on first call.
+     - Failure modes: returns an empty set when the manager cannot be created.
+     */
+    func passageInitials() -> Set<String> {
         if let cachedPassageInitials {
             return cachedPassageInitials
         }
@@ -175,27 +339,20 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
         return initials
     }
 
-    /// Android and SWORD both treat a missing versification name as the KJV default.
-    private func normalizedV11n(_ name: String) -> String {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "KJV" : trimmed.uppercased()
-    }
+    /**
+     Resolves one intro-inclusive ordinal against one installed module.
 
-    private func moduleNames(matchingV11n normalizedName: String) -> [String] {
-        if let cached = moduleNamesByV11n[normalizedName] {
-            return cached
-        }
-        var names: [String] = []
-        for info in bibleModuleInfos()
-        where normalizedV11n(info.aboutMetadata.versification) == normalizedName {
-            names.append(info.name)
-        }
-        moduleNamesByV11n[normalizedName] = names
-        return names
-    }
-
-    private func resolvedBook(moduleName: String, ordinal: Int, manager: SwordManager) -> BookInfo? {
-        guard let module = manager.module(named: moduleName),
+     - Parameters:
+       - moduleName: Installed module initials to resolve against.
+       - ordinal: Intro-inclusive ordinal in the module's own versification.
+     - Returns: The resolved book with its testament, or `nil` when the module cannot be opened,
+       the ordinal is not a normal verse, or the module's book list lacks the resolved book.
+     - Side effects: opens the module through SwordKit and caches its book list.
+     - Failure modes: returns `nil` rather than throwing.
+     */
+    func resolve(moduleName: String, ordinal: Int) -> AndroidBookmarkResolvedBook? {
+        guard let manager = manager(),
+              let module = manager.module(named: moduleName),
               let reference = module.verseReference(ordinal: ordinal) else {
             return nil
         }
@@ -207,6 +364,18 @@ public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookName
             books = module.getBookList()
             bookListsByModule[moduleName] = books
         }
-        return books.first(where: { $0.osisId == reference.osisBookId })
+        guard let book = books.first(where: { $0.osisId == reference.osisBookId }) else {
+            return nil
+        }
+        return AndroidBookmarkResolvedBook(name: book.name, testament: book.testament)
+    }
+
+    private func manager() -> SwordManager? {
+        if let cachedManager {
+            return cachedManager
+        }
+        let created = managerProvider()
+        cachedManager = created
+        return created
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidBookmarkBookNameResolver.swift
@@ -1,0 +1,173 @@
+// AndroidBookmarkBookNameResolver.swift - Android bookmark book-column normalization
+
+import Foundation
+import SwordKit
+
+/**
+ Resolves iOS display book names for Android-origin Bible bookmark rows.
+
+ Android's `BibleBookmark.book` column stores SWORD module initials (or NULL) because Android
+ renders bookmark references from `v11n` plus ordinals and only uses the column to pick a
+ translation for verse text. iOS repurposed the same field as the user-facing Bible book name
+ that drives list display, chapter-highlight queries, and navigation. Restore flows use this
+ boundary to translate Android's module-initials semantics into iOS display-name semantics.
+
+ Side effects:
+ - implementations may query installed SWORD modules
+
+ Failure modes:
+ - implementations return `nil` when no installed module can resolve the requested ordinal
+ */
+public protocol AndroidBookmarkBookNameResolving {
+    /**
+     Reports whether a raw Android `book` value matches an installed SWORD Bible's initials.
+
+     - Parameter rawValue: Raw string from the Android `book` column.
+     - Returns: `true` when the value equals an installed Bible module's initials.
+     - Side effects: may lazily enumerate installed modules.
+     - Failure modes: returns `false` when module enumeration is unavailable.
+     */
+    func isInstalledBibleInitials(_ rawValue: String) -> Bool
+
+    /**
+     Derives the display book name for a bookmark ordinal in its own versification.
+
+     - Parameters:
+       - v11nName: Versification name stored with the Android bookmark row; empty means KJV.
+       - ordinal: Intro-inclusive whole-Bible ordinal in `v11nName`.
+       - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used as a fallback key.
+     - Returns: The SWORD book name (e.g. `Genesis`), or `nil` when no installed module matches
+       the bookmark's versification and no KJVA-versified module can use the fallback ordinal.
+     - Side effects: may lazily create SWORD manager state and cache module book lists.
+     - Failure modes: returns `nil` for intro ordinals and unresolvable versifications.
+     */
+    func displayBookName(v11nName: String, ordinal: Int, kjvOrdinal: Int) -> String?
+}
+
+/**
+ SWORD-backed resolver that derives display book names from installed Bible modules.
+
+ The resolver prefers an installed Bible whose versification matches the bookmark's own `v11n`
+ so ordinals resolve in the versification they were recorded in, exactly like Android's
+ JSword reverse mapping. When no matching module exists it falls back to a KJVA-versified
+ module using the bookmark's KJVA ordinal, which is versification-correct by construction.
+
+ Side effects:
+ - lazily creates a `SwordManager` on first resolution and caches per-module book lists
+
+ Failure modes:
+ - resolution returns `nil` when no installed module matches and no KJVA module exists
+ */
+public final class AndroidBookmarkSwordBookNameResolver: AndroidBookmarkBookNameResolving {
+    private let managerProvider: () -> SwordManager?
+    private var cachedManager: SwordManager??
+    private var cachedBibleInitials: Set<String>?
+    private var bookNamesByModule: [String: [String: String]] = [:]
+
+    /**
+     Creates a resolver backed by lazily created SWORD manager state.
+
+     - Parameter managerProvider: Factory for the SWORD manager; defaults to the shared module
+       root used by the app. The factory runs at most once, on first resolution.
+     - Side effects: none until the first resolution call.
+     - Failure modes: a `nil` manager disables resolution and initials matching.
+     */
+    public init(managerProvider: @escaping () -> SwordManager? = { SwordManager() }) {
+        self.managerProvider = managerProvider
+    }
+
+    /**
+     Reports whether a raw Android `book` value matches an installed SWORD Bible's initials.
+
+     - Parameter rawValue: Raw string from the Android `book` column.
+     - Returns: `true` when the value equals an installed Bible module's initials.
+     - Side effects: lazily enumerates installed Bible modules once.
+     - Failure modes: returns `false` when the SWORD manager cannot be created.
+     */
+    public func isInstalledBibleInitials(_ rawValue: String) -> Bool {
+        installedBibleInitials().contains(rawValue)
+    }
+
+    /**
+     Derives the display book name for a bookmark ordinal in its own versification.
+
+     - Parameters:
+       - v11nName: Versification name stored with the Android bookmark row; empty means KJV.
+       - ordinal: Intro-inclusive whole-Bible ordinal in `v11nName`.
+       - kjvOrdinal: Intro-inclusive whole-Bible ordinal in KJVA used as a fallback key.
+     - Returns: The SWORD book name for the resolved verse, or `nil` when unresolvable.
+     - Side effects: lazily creates the SWORD manager and caches module book-name maps.
+     - Failure modes: returns `nil` for intro ordinals, empty book lists, and versifications
+       with no installed module.
+     */
+    public func displayBookName(v11nName: String, ordinal: Int, kjvOrdinal: Int) -> String? {
+        guard let manager = manager() else { return nil }
+
+        if let moduleName = moduleName(matchingV11n: v11nName, manager: manager),
+           let name = bookName(moduleName: moduleName, ordinal: ordinal, manager: manager) {
+            return name
+        }
+
+        guard normalizedV11n(v11nName) != "KJVA",
+              let kjvaModuleName = moduleName(matchingV11n: "KJVA", manager: manager) else {
+            return nil
+        }
+        return bookName(moduleName: kjvaModuleName, ordinal: kjvOrdinal, manager: manager)
+    }
+
+    private func manager() -> SwordManager? {
+        if let cachedManager {
+            return cachedManager
+        }
+        let created = managerProvider()
+        cachedManager = created
+        return created
+    }
+
+    private func installedBibleInitials() -> Set<String> {
+        if let cachedBibleInitials {
+            return cachedBibleInitials
+        }
+        var initials = Set<String>()
+        if let manager = manager() {
+            for info in manager.installedModules(category: ModuleCategory.bible) {
+                initials.insert(info.name)
+            }
+        }
+        cachedBibleInitials = initials
+        return initials
+    }
+
+    /// Android and SWORD both treat a missing versification name as the KJV default.
+    private func normalizedV11n(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "KJV" : trimmed.uppercased()
+    }
+
+    private func moduleName(matchingV11n v11nName: String, manager: SwordManager) -> String? {
+        let wanted = normalizedV11n(v11nName)
+        for info in manager.installedModules(category: ModuleCategory.bible)
+        where normalizedV11n(info.aboutMetadata.versification) == wanted {
+            return info.name
+        }
+        return nil
+    }
+
+    private func bookName(moduleName: String, ordinal: Int, manager: SwordManager) -> String? {
+        guard let module = manager.module(named: moduleName),
+              let reference = module.verseReference(ordinal: ordinal) else {
+            return nil
+        }
+
+        if let cached = bookNamesByModule[moduleName] {
+            return cached[reference.osisBookId]
+        }
+
+        let names = Dictionary(
+            module.getBookList().map { ($0.osisId, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        bookNamesByModule[moduleName] = names
+        return names[reference.osisBookId]
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/BookmarkService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/BookmarkService.swift
@@ -86,24 +86,49 @@ public final class BookmarkService {
 
     // MARK: - Bible Bookmarks
 
-    /// Create a new Bible bookmark for a verse range.
+    /**
+     Creates a new Bible bookmark for a verse range.
+
+     - Parameters:
+       - bookInitials: Module initials associated with the selected verse range.
+       - startOrdinal: Source-versification start ordinal reported by the reader.
+       - endOrdinal: Source-versification end ordinal reported by the reader.
+       - kjvOrdinalStart: Optional Android-compatible KJVA start ordinal used for restore-safe
+         membership queries.
+       - kjvOrdinalEnd: Optional Android-compatible KJVA end ordinal used for restore-safe
+         membership queries.
+       - v11n: Source versification for `startOrdinal`/`endOrdinal`.
+       - wholeVerse: Whether the bookmark covers whole verses instead of a text range.
+       - startOffset: Optional text-range start offset.
+       - endOffset: Optional text-range end offset.
+       - addNote: Legacy bridge flag retained for call-site compatibility; note rows are created
+         by the caller when note text is saved.
+     - Returns: Inserted Bible bookmark.
+     - Side effects: Inserts the bookmark.
+     - Failure modes: SwiftData save failures are handled by `BookmarkStore` and do not throw.
+     */
     @discardableResult
     public func addBibleBookmark(
         bookInitials: String,
         startOrdinal: Int,
         endOrdinal: Int,
+        kjvOrdinalStart: Int? = nil,
+        kjvOrdinalEnd: Int? = nil,
         v11n: String = "KJVA",
         wholeVerse: Bool = true,
         startOffset: Int? = nil,
         endOffset: Int? = nil,
         addNote: Bool = false
     ) -> BibleBookmark {
+        let storedKJVAStart = kjvOrdinalStart ?? startOrdinal
+        let storedKJVAEnd = kjvOrdinalEnd ?? endOrdinal
         let bookmark = BibleBookmark(
-            kjvOrdinalStart: startOrdinal,
-            kjvOrdinalEnd: endOrdinal,
+            kjvOrdinalStart: storedKJVAStart,
+            kjvOrdinalEnd: storedKJVAEnd,
             ordinalStart: startOrdinal,
             ordinalEnd: endOrdinal,
             v11n: v11n,
+            bookInitials: bookInitials,
             wholeVerse: wholeVerse
         )
         bookmark.startOffset = startOffset
@@ -112,22 +137,42 @@ public final class BookmarkService {
         return bookmark
     }
 
-    /// Create a Bible bookmark that renders as a paragraph break in the web reader.
+    /**
+     Creates a Bible bookmark that renders as a paragraph break in the web reader.
+
+     - Parameters:
+       - bookInitials: Module initials associated with the selected verse.
+       - startOrdinal: Source-versification start ordinal reported by the reader.
+       - endOrdinal: Source-versification end ordinal reported by the reader.
+       - kjvOrdinalStart: Optional Android-compatible KJVA start ordinal.
+       - kjvOrdinalEnd: Optional Android-compatible KJVA end ordinal.
+       - v11n: Source versification for `startOrdinal`/`endOrdinal`.
+       - book: Optional display book fallback for legacy list paths.
+     - Returns: Inserted paragraph-break bookmark.
+     - Side effects: Ensures the paragraph-break system label exists, inserts the bookmark, and
+       attaches that system label.
+     - Failure modes: SwiftData save failures are handled by `BookmarkStore` and do not throw.
+     */
     @discardableResult
     public func addParagraphBreakBibleBookmark(
         bookInitials: String,
         startOrdinal: Int,
         endOrdinal: Int,
+        kjvOrdinalStart: Int? = nil,
+        kjvOrdinalEnd: Int? = nil,
         v11n: String = "KJVA",
         book: String? = nil
     ) -> BibleBookmark {
         ensureSystemLabels()
+        let storedKJVAStart = kjvOrdinalStart ?? startOrdinal
+        let storedKJVAEnd = kjvOrdinalEnd ?? endOrdinal
         let bookmark = BibleBookmark(
-            kjvOrdinalStart: startOrdinal,
-            kjvOrdinalEnd: endOrdinal,
+            kjvOrdinalStart: storedKJVAStart,
+            kjvOrdinalEnd: storedKJVAEnd,
             ordinalStart: startOrdinal,
             ordinalEnd: endOrdinal,
             v11n: v11n,
+            bookInitials: bookInitials,
             wholeVerse: false
         )
         bookmark.book = book
@@ -216,8 +261,11 @@ public final class BookmarkService {
     }
 
     /**
-     Get bookmarks overlapping a verse range (for rendering highlights).
-     Pass `book` to prevent cross-book ordinal collisions.
+     Get bookmarks overlapping a KJVA verse range for rendering highlights.
+
+     Android persists bookmark membership in KJVA-compatible ordinals. The optional `book` argument
+     is retained for source compatibility with older callers, but it is intentionally ignored because
+     Android backups store module initials or NULL in `BibleBookmark.book`.
      */
     public func bookmarks(for startOrdinal: Int, endOrdinal: Int, book: String? = nil) -> [BibleBookmark] {
         store.bibleBookmarks(overlapping: startOrdinal, endOrdinal: endOrdinal, book: book)

--- a/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/JSwordKJVAVersification.swift
@@ -326,6 +326,37 @@ public enum JSwordKJVAVersification {
     }
 
     /**
+     Computes the KJVA ordinal for a reference, clamping out-of-range chapters/verses to the
+     nearest addressable verse in the same book.
+
+     iOS lacks a full JSword `Versification.toV11n(KJVA)` mapping engine, so a reference from a
+     versification-divergent module (e.g. a merged LXX/Vulgate/Synodal Psalm chapter with more
+     verses than the KJVA chapter) can fall outside KJVA's exact numbering. Rather than reject such
+     a reference — which would force callers to persist a non-KJVA ordinal — this clamps the
+     chapter into the book and the verse into that chapter, matching JSword's behavior of mapping
+     an absent verse onto the nearest existing KJVA verse. Only genuinely unknown books return
+     `nil`. This is a bounded approximation, not a true versification remap: it corrects
+     out-of-range numbering but cannot realign whole-chapter offsets between canons.
+
+     - Parameters:
+       - osisId: Canonical OSIS id or supported alias.
+       - chapter: One-based chapter number in the source module's numbering.
+       - verse: One-based verse number in the source module's numbering.
+     - Returns: A valid KJVA ordinal inside `osisId`, or `nil` when the book is unknown.
+     - Side effects: none.
+     - Failure modes: Unknown OSIS ids return `nil`; negative inputs clamp to `1`.
+     */
+    public static func nearestVerseOrdinal(osisId: String, chapter: Int, verse: Int) -> Int? {
+        guard let book = book(forOsisId: osisId), !book.chapterVerseCounts.isEmpty else {
+            return nil
+        }
+        let clampedChapter = min(max(chapter, 1), book.chapterVerseCounts.count)
+        let lastVerse = book.chapterVerseCounts[clampedChapter - 1]
+        let clampedVerse = min(max(verse, 1), lastVerse)
+        return verseOrdinal(osisId: osisId, chapter: clampedChapter, verse: clampedVerse)
+    }
+
+    /**
      Resolves a concrete verse reference from a JSword KJVA progress ordinal.
 
      Android Reading Progress stores memorized verses and target ranges as KJVA ordinals and then

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
@@ -1,0 +1,111 @@
+// RemoteSyncBookmarkAndroidBookStore.swift — Local preservation of Android bookmark book columns
+
+import Foundation
+
+/**
+ Preserves raw Android `BibleBookmark.book` column values in iOS's local-only settings store.
+
+ Android stores SWORD module initials (or NULL) in the bookmark `book` column, while iOS rewrites
+ the same field into a display book name during restore so bookmark rendering works (issue #356).
+ This store keeps the original Android value per bookmark so outbound sync snapshots and backup
+ exports can round-trip Android's module-initials semantics instead of leaking display names into
+ Android's column.
+
+ Data dependencies:
+ - `SettingsStore` provides local-only key-value persistence in the `LocalStore`
+
+ Side effects:
+ - writes and removes namespaced `Setting` rows in the local SwiftData settings table
+
+ Failure modes:
+ - underlying `SettingsStore` writes swallow persistence failures, so callers should treat this
+   store as best-effort preservation rather than transactional storage
+
+ Concurrency:
+ - this type inherits the confinement requirements of the supplied `SettingsStore`
+ */
+public final class RemoteSyncBookmarkAndroidBookStore {
+    /// Sentinel persisted for Android rows whose `book` column was NULL. Real SWORD module
+    /// initials never contain double underscores, so the sentinel cannot collide with data.
+    private static let nullSentinel = "__android_null__"
+
+    private let settingsStore: SettingsStore
+
+    private enum Keys {
+        static let prefix = "remote_sync.bookmarks.android_book"
+    }
+
+    /**
+     Creates a local-only store for preserved Android bookmark `book` column values.
+
+     - Parameter settingsStore: Local settings store used for persistence.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(settingsStore: SettingsStore) {
+        self.settingsStore = settingsStore
+    }
+
+    /**
+     Stores or replaces one preserved raw Android `book` value.
+
+     - Parameters:
+       - rawBook: Raw Android column value; `nil` records that Android stored NULL.
+       - bookmarkID: Bible bookmark identifier that owns the value.
+     - Side effects: writes one namespaced local `Setting` row.
+     - Failure modes: persistence failures are swallowed by `SettingsStore`.
+     */
+    public func setRawBook(_ rawBook: String?, for bookmarkID: UUID) {
+        settingsStore.setString(scopedKey(bookmarkID: bookmarkID), value: rawBook ?? Self.nullSentinel)
+    }
+
+    /**
+     Reads one preserved raw Android `book` value.
+
+     - Parameter bookmarkID: Bible bookmark identifier that owns the value.
+     - Returns: `.some(value)` when a value was preserved (`value` itself is `nil` when Android
+       stored NULL), or `nil` when this bookmark has no preserved entry.
+     - Side effects: none.
+     - Failure modes: missing stored keys return `nil`.
+     */
+    public func rawBook(for bookmarkID: UUID) -> String?? {
+        guard let stored = settingsStore.getString(scopedKey(bookmarkID: bookmarkID)),
+              !stored.isEmpty else {
+            return nil
+        }
+        return .some(stored == Self.nullSentinel ? nil : stored)
+    }
+
+    /**
+     Projects one bookmark's Android-facing `book` value for outbound snapshots.
+
+     - Parameters:
+       - bookmarkID: Bible bookmark identifier being projected.
+       - localBook: Current iOS display value stored on the SwiftData model.
+     - Returns: The preserved raw Android value when one exists, otherwise `localBook`.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    public func androidBookValue(for bookmarkID: UUID, localBook: String?) -> String? {
+        if let preserved = rawBook(for: bookmarkID) {
+            return preserved
+        }
+        return localBook
+    }
+
+    /**
+     Removes every preserved Android `book` entry.
+
+     - Side effects: deletes all namespaced rows for this store.
+     - Failure modes: persistence failures are swallowed by `SettingsStore`.
+     */
+    public func clearAll() {
+        for entry in settingsStore.entries(withPrefix: Keys.prefix) {
+            settingsStore.remove(entry.key)
+        }
+    }
+
+    private func scopedKey(bookmarkID: UUID) -> String {
+        "\(Keys.prefix).\(bookmarkID.uuidString.lowercased())"
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
@@ -85,8 +85,9 @@ public final class RemoteSyncBookmarkAndroidBookStore {
 
      - Parameters:
        - bookmarkID: Bible bookmark identifier being projected.
-       - localBook: Current iOS display value stored on the SwiftData model.
-     - Returns: The preserved raw Android value when one exists, otherwise `localBook`.
+       - localBook: Local Android-facing source module initials, or `nil` when unknown.
+     - Returns: The preserved raw Android value when one exists, otherwise the local source module
+       initials.
      - Side effects: none.
      - Failure modes: none.
      */

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkAndroidBookStore.swift
@@ -25,8 +25,12 @@ import Foundation
  - this type inherits the confinement requirements of the supplied `SettingsStore`
  */
 public final class RemoteSyncBookmarkAndroidBookStore {
-    /// Sentinel persisted for Android rows whose `book` column was NULL. Real SWORD module
-    /// initials never contain double underscores, so the sentinel cannot collide with data.
+    /**
+     Sentinel persisted for Android rows whose `book` column was NULL.
+
+     Real SWORD module initials never contain double underscores, so the sentinel cannot collide
+     with preserved data values.
+     */
     private static let nullSentinel = "__android_null__"
 
     private let settingsStore: SettingsStore

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkPatchApplyService.swift
@@ -531,6 +531,7 @@ public final class RemoteSyncBookmarkPatchApplyService {
     ) throws -> WorkingSnapshot {
         let labelAliasStore = RemoteSyncBookmarkLabelAliasStore(settingsStore: settingsStore)
         let playbackSettingsStore = RemoteSyncBookmarkPlaybackSettingsStore(settingsStore: settingsStore)
+        let androidBookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
         let reverseAliases = Dictionary(
             uniqueKeysWithValues: labelAliasStore.allAliases().map { ($0.localLabelID, $0.remoteLabelID) }
         )
@@ -620,7 +621,7 @@ public final class RemoteSyncBookmarkPatchApplyService {
                     v11n: bookmark.v11n,
                     playbackSettingsJSON: playbackJSON,
                     createdAt: bookmark.createdAt,
-                    book: bookmark.book,
+                    book: androidBookStore.androidBookValue(for: bookmark.id, localBook: bookmark.book),
                     startOffset: bookmark.startOffset,
                     endOffset: bookmark.endOffset,
                     primaryLabelID: bookmark.primaryLabelId.map { reverseAliases[$0] ?? $0 },

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkPatchApplyService.swift
@@ -621,7 +621,10 @@ public final class RemoteSyncBookmarkPatchApplyService {
                     v11n: bookmark.v11n,
                     playbackSettingsJSON: playbackJSON,
                     createdAt: bookmark.createdAt,
-                    book: androidBookStore.androidBookValue(for: bookmark.id, localBook: bookmark.book),
+                    book: androidBookStore.androidBookValue(
+                        for: bookmark.id,
+                        localBook: androidBookColumnValue(for: bookmark)
+                    ),
                     startOffset: bookmark.startOffset,
                     endOffset: bookmark.endOffset,
                     primaryLabelID: bookmark.primaryLabelId.map { reverseAliases[$0] ?? $0 },
@@ -1715,6 +1718,23 @@ public final class RemoteSyncBookmarkPatchApplyService {
             return nil
         }
         return json
+    }
+
+    /**
+     Projects the local Bible bookmark source module into Android's `BibleBookmark.book` value.
+
+     Patch replay compares current local rows against Android-shaped patch rows. Since iOS uses
+     `BibleBookmark.book` for display text, the Android-facing current snapshot must instead read
+     the durable source-module initials field introduced for issue #356.
+
+     - Parameter bookmark: Local Bible bookmark being compared against incoming patch data.
+     - Returns: Module initials for Android, or `nil` when no source module is known.
+     - Side effects: none.
+     - Failure modes: Empty or whitespace-only initials export as NULL.
+     */
+    private func androidBookColumnValue(for bookmark: BibleBookmark) -> String? {
+        let initials = bookmark.bookInitials.trimmingCharacters(in: .whitespacesAndNewlines)
+        return initials.isEmpty ? nil : initials
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
@@ -716,13 +716,21 @@ public final class RemoteSyncBookmarkRestoreService {
      shapes Android actually produces are rewritten — NULL and installed-module initials — so
      locally created display names and localized names survive merge round-trips unchanged.
 
-     - Parameter bookmark: Staged Android bookmark row being materialized into SwiftData.
-     - Returns: The derived display book name, or the raw Android value when derivation is
-       unavailable or the raw value is not an Android module-initials shape.
+     - Parameters:
+       - bookmark: Staged Android bookmark row being materialized into SwiftData.
+       - previousDisplayBook: Display value the same bookmark ID carried locally before this
+         restore, used so previously healed names survive re-materializations (sync patch apply,
+         merge imports) when the enabling module has since been removed.
+     - Returns: The derived display book name; otherwise the retained previous display name when
+       derivation fails for a rewriteable value; otherwise the raw Android value.
      - Side effects: may lazily create SWORD state through the injected resolver.
-     - Failure modes: falls back to the raw value whenever resolution fails.
+     - Failure modes: falls back to the raw value whenever resolution fails and no previous
+       display name is retainable.
      */
-    private func normalizedDisplayBookName(for bookmark: RemoteSyncAndroidBibleBookmark) -> String? {
+    private func normalizedDisplayBookName(
+        for bookmark: RemoteSyncAndroidBibleBookmark,
+        previousDisplayBook: String?
+    ) -> String? {
         guard let bookNameResolver else { return bookmark.book }
 
         let shouldDerive: Bool
@@ -733,12 +741,20 @@ public final class RemoteSyncBookmarkRestoreService {
         }
         guard shouldDerive else { return bookmark.book }
 
-        let derived = bookNameResolver.displayBookName(
+        if let derived = bookNameResolver.displayBookName(
             v11nName: bookmark.v11n,
             ordinal: bookmark.ordinalStart,
             kjvOrdinal: bookmark.kjvOrdinalStart
-        )
-        return derived ?? bookmark.book
+        ) {
+            return derived
+        }
+
+        if let previousDisplayBook,
+           previousDisplayBook != bookmark.book,
+           !bookNameResolver.isInstalledBibleInitials(previousDisplayBook) {
+            return previousDisplayBook
+        }
+        return bookmark.book
     }
 
     /**
@@ -930,6 +946,15 @@ public final class RemoteSyncBookmarkRestoreService {
     ) throws -> RemoteSyncBookmarkRestoreReport {
         let prepared = try prepareRestore(from: snapshot)
 
+        var previousDisplayBooksByID: [UUID: String] = [:]
+        if let existing = try? modelContext.fetch(FetchDescriptor<BibleBookmark>()) {
+            for bookmark in existing {
+                if let book = bookmark.book {
+                    previousDisplayBooksByID[bookmark.id] = book
+                }
+            }
+        }
+
         try deleteExistingBookmarkGraph(from: modelContext)
 
         var labelsByID: [UUID: Label] = [:]
@@ -969,7 +994,10 @@ public final class RemoteSyncBookmarkRestoreService {
                 wholeVerse: preparedBookmark.bookmark.wholeVerse
             )
             let rawBook = preparedBookmark.bookmark.book
-            let displayBook = normalizedDisplayBookName(for: preparedBookmark.bookmark)
+            let displayBook = normalizedDisplayBookName(
+                for: preparedBookmark.bookmark,
+                previousDisplayBook: previousDisplayBooksByID[preparedBookmark.bookmark.id]
+            )
             bookmark.book = displayBook
             if displayBook != rawBook {
                 normalizedBookRewrites.append((bookmarkID: bookmark.id, rawBook: rawBook))

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
@@ -955,6 +955,7 @@ public final class RemoteSyncBookmarkRestoreService {
         ensureMissingSystemLabels(in: modelContext, labelsByID: &labelsByID)
 
         var bibleBookmarksByID: [UUID: BibleBookmark] = [:]
+        var normalizedBookRewrites: [(bookmarkID: UUID, rawBook: String?)] = []
         for preparedBookmark in prepared.bibleBookmarks {
             let bookmark = BibleBookmark(
                 id: preparedBookmark.bookmark.id,
@@ -967,7 +968,12 @@ public final class RemoteSyncBookmarkRestoreService {
                 lastUpdatedOn: preparedBookmark.bookmark.lastUpdatedOn,
                 wholeVerse: preparedBookmark.bookmark.wholeVerse
             )
-            bookmark.book = normalizedDisplayBookName(for: preparedBookmark.bookmark)
+            let rawBook = preparedBookmark.bookmark.book
+            let displayBook = normalizedDisplayBookName(for: preparedBookmark.bookmark)
+            bookmark.book = displayBook
+            if displayBook != rawBook {
+                normalizedBookRewrites.append((bookmarkID: bookmark.id, rawBook: rawBook))
+            }
             bookmark.startOffset = preparedBookmark.bookmark.startOffset
             bookmark.endOffset = preparedBookmark.bookmark.endOffset
             bookmark.primaryLabelId = preparedBookmark.localPrimaryLabelID
@@ -1072,8 +1078,14 @@ public final class RemoteSyncBookmarkRestoreService {
 
         let playbackSettingsStore = RemoteSyncBookmarkPlaybackSettingsStore(settingsStore: settingsStore)
         let labelAliasStore = RemoteSyncBookmarkLabelAliasStore(settingsStore: settingsStore)
+        let androidBookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
         playbackSettingsStore.clearAll()
         labelAliasStore.clearAll()
+        androidBookStore.clearAll()
+
+        for rewrite in normalizedBookRewrites {
+            androidBookStore.setRawBook(rewrite.rawBook, for: rewrite.bookmarkID)
+        }
 
         var preservedPlaybackSettingsCount = 0
         for preparedBookmark in prepared.bibleBookmarks {

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
@@ -711,10 +711,11 @@ public final class RemoteSyncBookmarkRestoreService {
      Normalizes one restored bookmark's `book` value into iOS display-name semantics.
 
      Android stores SWORD module initials (or NULL) in the `book` column because Android renders
-     references from `v11n` + ordinals; iOS uses the same field as the display book name that
-     keys list rendering, chapter-highlight queries, and navigation (issue #356). Only the two
-     shapes Android actually produces are rewritten — NULL and installed-module initials — so
-     locally created display names and localized names survive merge round-trips unchanged.
+     references from `v11n` + ordinals. iOS now keys list rendering, chapter-highlight queries,
+     and navigation from the KJVA ordinal columns, but still heals Android's rewriteable values so
+     older fallback paths and persisted display text avoid `Unknown`/module-initial labels. Only
+     the two shapes Android actually produces are rewritten — NULL and installed-module initials —
+     so locally created display names and localized names survive merge round-trips unchanged.
 
      - Parameters:
        - bookmark: Staged Android bookmark row being materialized into SwiftData.
@@ -755,6 +756,53 @@ public final class RemoteSyncBookmarkRestoreService {
             return previousDisplayBook
         }
         return bookmark.book
+    }
+
+    /**
+     Normalizes Android's `BibleBookmark.book` column into iOS source-module metadata.
+
+     Android stores the bookmark's source `AbstractPassageBook` initials in this column, while old
+     iOS snapshots may contain display Bible book names from the pre-#356 schema drift. The model's
+     `book` field remains display-facing, so this helper writes only plausible module initials to
+     `BibleBookmark.bookInitials` and leaves display names empty.
+
+     - Parameter bookmark: Staged Android-shaped Bible bookmark row.
+     - Returns: Source module initials, or an empty string when the row has no durable source
+       module identity.
+     - Side effects: may query the injected resolver to recognize installed module initials.
+     - Failure modes: Unknown single-token values are preserved as likely uninstalled module
+       initials so Android-origin rows remain round-trip capable.
+     */
+    private func normalizedSourceBookInitials(for bookmark: RemoteSyncAndroidBibleBookmark) -> String {
+        guard let raw = bookmark.book?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else {
+            return ""
+        }
+        if isKnownDisplayBookName(raw) {
+            return ""
+        }
+        if bookNameResolver?.isInstalledBibleInitials(raw) == true {
+            return raw
+        }
+        return raw.rangeOfCharacter(from: .whitespacesAndNewlines) == nil ? raw : ""
+    }
+
+    /**
+     Detects legacy iOS display book names that must not be re-exported as Android module initials.
+
+     - Parameter rawValue: Trimmed value from Android's `BibleBookmark.book` column.
+     - Returns: `true` when the value matches a canonical KJVA book long name, short name, or OSIS
+       id from old iOS snapshots.
+     - Side effects: None.
+     - Failure modes: Unknown values return `false` so likely module initials can remain
+       round-trip capable.
+     */
+    private func isKnownDisplayBookName(_ rawValue: String) -> Bool {
+        JSwordKJVAVersification.books.contains {
+            rawValue.caseInsensitiveCompare($0.longName) == .orderedSame ||
+                rawValue.caseInsensitiveCompare($0.shortName) == .orderedSame ||
+                rawValue.caseInsensitiveCompare($0.osisId) == .orderedSame
+        }
     }
 
     /**
@@ -931,7 +979,8 @@ public final class RemoteSyncBookmarkRestoreService {
        - deletes existing local bookmark-category SwiftData rows
        - inserts replacement labels, Bible bookmarks, generic bookmarks, notes, junction rows, and StudyPad rows
        - saves `modelContext`
-       - clears and repopulates the local-only playback-settings and label-alias side stores
+       - clears and repopulates the local-only playback-settings, label-alias, and Android-book
+         side stores
      - Failure modes:
        - throws `RemoteSyncBookmarkRestoreError.duplicateSystemLabels` when multiple staged labels
          claim the same reserved system-label name
@@ -989,6 +1038,7 @@ public final class RemoteSyncBookmarkRestoreService {
                 ordinalStart: preparedBookmark.bookmark.ordinalStart,
                 ordinalEnd: preparedBookmark.bookmark.ordinalEnd,
                 v11n: preparedBookmark.bookmark.v11n,
+                bookInitials: normalizedSourceBookInitials(for: preparedBookmark.bookmark),
                 createdAt: preparedBookmark.bookmark.createdAt,
                 lastUpdatedOn: preparedBookmark.bookmark.lastUpdatedOn,
                 wholeVerse: preparedBookmark.bookmark.wholeVerse

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkRestoreService.swift
@@ -688,13 +688,58 @@ public final class RemoteSyncBookmarkRestoreService {
         let bookId: String?
     }
 
+    /// Resolver that translates Android `book` column semantics into iOS display book names.
+    private let bookNameResolver: AndroidBookmarkBookNameResolving?
+
     /**
      Creates a bookmark restore service.
 
-     - Side effects: none.
+     - Parameter bookNameResolver: Boundary that normalizes Android's module-initials `book`
+       column into the iOS display book name during restore. The default SWORD-backed resolver
+       derives names from each bookmark's own versification and ordinals; passing `nil` disables
+       normalization and preserves raw Android values verbatim.
+     - Side effects: none; the default resolver creates SWORD state lazily on first restore.
      - Failure modes: This initializer cannot fail.
      */
-    public init() {}
+    public init(
+        bookNameResolver: AndroidBookmarkBookNameResolving? = AndroidBookmarkSwordBookNameResolver()
+    ) {
+        self.bookNameResolver = bookNameResolver
+    }
+
+    /**
+     Normalizes one restored bookmark's `book` value into iOS display-name semantics.
+
+     Android stores SWORD module initials (or NULL) in the `book` column because Android renders
+     references from `v11n` + ordinals; iOS uses the same field as the display book name that
+     keys list rendering, chapter-highlight queries, and navigation (issue #356). Only the two
+     shapes Android actually produces are rewritten — NULL and installed-module initials — so
+     locally created display names and localized names survive merge round-trips unchanged.
+
+     - Parameter bookmark: Staged Android bookmark row being materialized into SwiftData.
+     - Returns: The derived display book name, or the raw Android value when derivation is
+       unavailable or the raw value is not an Android module-initials shape.
+     - Side effects: may lazily create SWORD state through the injected resolver.
+     - Failure modes: falls back to the raw value whenever resolution fails.
+     */
+    private func normalizedDisplayBookName(for bookmark: RemoteSyncAndroidBibleBookmark) -> String? {
+        guard let bookNameResolver else { return bookmark.book }
+
+        let shouldDerive: Bool
+        if let raw = bookmark.book {
+            shouldDerive = bookNameResolver.isInstalledBibleInitials(raw)
+        } else {
+            shouldDerive = true
+        }
+        guard shouldDerive else { return bookmark.book }
+
+        let derived = bookNameResolver.displayBookName(
+            v11nName: bookmark.v11n,
+            ordinal: bookmark.ordinalStart,
+            kjvOrdinal: bookmark.kjvOrdinalStart
+        )
+        return derived ?? bookmark.book
+    }
 
     /**
      Reads one staged Android bookmark SQLite database into a typed snapshot.
@@ -922,7 +967,7 @@ public final class RemoteSyncBookmarkRestoreService {
                 lastUpdatedOn: preparedBookmark.bookmark.lastUpdatedOn,
                 wholeVerse: preparedBookmark.bookmark.wholeVerse
             )
-            bookmark.book = preparedBookmark.bookmark.book
+            bookmark.book = normalizedDisplayBookName(for: preparedBookmark.bookmark)
             bookmark.startOffset = preparedBookmark.bookmark.startOffset
             bookmark.endOffset = preparedBookmark.bookmark.endOffset
             bookmark.primaryLabelId = preparedBookmark.localPrimaryLabelID

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkSnapshotService.swift
@@ -335,7 +335,10 @@ public final class RemoteSyncBookmarkSnapshotService {
                 v11n: bookmark.v11n,
                 playbackSettingsJSON: playbackJSON,
                 createdAt: bookmark.createdAt,
-                book: androidBookStore.androidBookValue(for: bookmark.id, localBook: bookmark.book),
+                book: androidBookStore.androidBookValue(
+                    for: bookmark.id,
+                    localBook: Self.androidBookColumnValue(for: bookmark)
+                ),
                 startOffset: bookmark.startOffset,
                 endOffset: bookmark.endOffset,
                 primaryLabelID: primaryLabelID,
@@ -895,6 +898,23 @@ public final class RemoteSyncBookmarkSnapshotService {
             return nil
         }
         return json
+    }
+
+    /**
+     Projects the local Bible bookmark source module into Android's `BibleBookmark.book` value.
+
+     The SwiftData `book` field is display-facing on iOS. Android's column stores source module
+     initials or NULL, so outbound snapshots must use the durable source-module field added for
+     #356 instead of leaking display names such as `Genesis`.
+
+     - Parameter bookmark: Local Bible bookmark being exported.
+     - Returns: Module initials for Android, or `nil` when no source module is known.
+     - Side effects: none.
+     - Failure modes: Empty or whitespace-only initials export as NULL.
+     */
+    private static func androidBookColumnValue(for bookmark: BibleBookmark) -> String? {
+        let initials = bookmark.bookInitials.trimmingCharacters(in: .whitespacesAndNewlines)
+        return initials.isEmpty ? nil : initials
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncBookmarkSnapshotService.swift
@@ -248,6 +248,7 @@ public final class RemoteSyncBookmarkSnapshotService {
         let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
         let labelAliasStore = RemoteSyncBookmarkLabelAliasStore(settingsStore: settingsStore)
         let playbackSettingsStore = RemoteSyncBookmarkPlaybackSettingsStore(settingsStore: settingsStore)
+        let androidBookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
         let reverseAliases = Dictionary(
             uniqueKeysWithValues: labelAliasStore.allAliases().map { ($0.localLabelID, $0.remoteLabelID) }
         )
@@ -334,7 +335,7 @@ public final class RemoteSyncBookmarkSnapshotService {
                 v11n: bookmark.v11n,
                 playbackSettingsJSON: playbackJSON,
                 createdAt: bookmark.createdAt,
-                book: bookmark.book,
+                book: androidBookStore.androidBookValue(for: bookmark.id, localBook: bookmark.book),
                 startOffset: bookmark.startOffset,
                 endOffset: bookmark.endOffset,
                 primaryLabelID: primaryLabelID,

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncResetService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncResetService.swift
@@ -53,6 +53,7 @@ public final class RemoteSyncResetService {
         RemoteSyncReadingPlanStatusStore(settingsStore: settingsStore).clearAll()
         RemoteSyncBookmarkPlaybackSettingsStore(settingsStore: settingsStore).clearAll()
         RemoteSyncBookmarkLabelAliasStore(settingsStore: settingsStore).clearAll()
+        RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore).clearAll()
         RemoteSyncWorkspaceFidelityStore(settingsStore: settingsStore).clearAll()
     }
 }

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidBookmarkBookNameResolverTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidBookmarkBookNameResolverTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import XCTest
+@testable import BibleCore
+
+/**
+ Selection-core contract tests for the Android bookmark book-name resolver.
+
+ These tests drive `AndroidBookmarkSwordBookNameResolver` through a deterministic fake gateway so
+ the candidate iteration, versification matching, and all cross-versification fallback stages are
+ executed without installed SWORD modules. Only the thin SwordKit gateway remains
+ integration-tested elsewhere.
+ */
+final class AndroidBookmarkBookNameResolverTests: XCTestCase {
+    /**
+     Verifies unresolvable versification-matched candidates are skipped, not fatal.
+
+     Round-1 review of issue #356 found the resolver committed to the first versification-matched
+     module even when libsword could not open it (custom-driver or MyBible projections) or when a
+     content-sparse module lacked the resolved book. The expected result is that later candidates
+     with the same versification still resolve. A failure means one unloadable module silently
+     disables restore normalization for the whole inventory.
+     */
+    func testResolverSkipsUnresolvableVersificationMatchedCandidates() {
+        let gateway = FakeResolverGateway(
+            modules: [
+                (name: "AMP", versification: ""),
+                (name: "KJV", versification: "KJV"),
+            ],
+            resolutions: [
+                FakeResolverGateway.Key(module: "KJV", ordinal: 4):
+                    AndroidBookmarkResolvedBook(name: "Genesis", testament: 1)
+            ]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertEqual(
+            resolver.displayBookName(v11nName: "KJV", ordinal: 4, kjvOrdinal: 4),
+            "Genesis",
+            "An unloadable first candidate must not block resolution through later candidates."
+        )
+    }
+
+    /**
+     Verifies KJVA bookmarks resolve through a KJVA-versified module using the KJVA ordinal.
+
+     Android's default bookmark versification is KJVA, so restored rows frequently carry KJVA
+     ordinals. The expected result is stage-two resolution through an installed KJVA module when
+     the primary versification match is empty. A failure means KJVA rows only resolve via the
+     Old-Testament-restricted KJV fallback.
+     */
+    func testResolverUsesKJVAModuleForKJVABookmarks() {
+        let gateway = FakeResolverGateway(
+            modules: [(name: "KJVA-MOD", versification: "KJVA")],
+            resolutions: [
+                FakeResolverGateway.Key(module: "KJVA-MOD", ordinal: 30031):
+                    AndroidBookmarkResolvedBook(name: "Matthew", testament: 2)
+            ]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertEqual(
+            resolver.displayBookName(v11nName: "KJVA", ordinal: 30031, kjvOrdinal: 30031),
+            "Matthew",
+            "KJVA rows must resolve directly through a KJVA-versified module."
+        )
+    }
+
+    /**
+     Verifies the Old-Testament-restricted KJV fallback for KJVA ordinals.
+
+     KJV and KJVA intro-inclusive ordinals are identical from Genesis through Malachi, so a KJVA
+     Old Testament ordinal may resolve through a KJV module — but only when the resolved book is
+     Old Testament. The expected result accepts Genesis and rejects a same-ordinal New Testament
+     resolution, which would indicate the ordinal lies in the diverged post-apocrypha range.
+     A failure means either stock-install KJVA OT rows stay unresolved or unsound cross-space
+     resolutions leak through.
+     */
+    func testResolverAppliesOldTestamentGateToKJVFallback() {
+        let gateway = FakeResolverGateway(
+            modules: [(name: "KJV", versification: "KJV")],
+            resolutions: [
+                FakeResolverGateway.Key(module: "KJV", ordinal: 4):
+                    AndroidBookmarkResolvedBook(name: "Genesis", testament: 1),
+                FakeResolverGateway.Key(module: "KJV", ordinal: 25000):
+                    AndroidBookmarkResolvedBook(name: "Luke", testament: 2),
+            ]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertEqual(
+            resolver.displayBookName(v11nName: "KJVA", ordinal: 4, kjvOrdinal: 4),
+            "Genesis",
+            "KJVA Old Testament ordinals must resolve through KJV modules."
+        )
+        XCTAssertNil(
+            resolver.displayBookName(v11nName: "KJVA", ordinal: 25000, kjvOrdinal: 25000),
+            "KJVA apocrypha-range ordinals must not accept New Testament KJV resolutions."
+        )
+    }
+
+    /**
+     Verifies the apocrypha-offset New Testament fallback for KJVA ordinals.
+
+     KJVA inserts 14 apocrypha books (5,913 intro-inclusive ordinals per SWORD's canon tables)
+     before the New Testament, so a KJVA New Testament ordinal equals the KJV ordinal plus that
+     span. The expected result shifts a KJVA Matthew 1:1 ordinal (30,031) to the KJV ordinal
+     (24,118) and accepts only a New Testament resolution. A failure means the dominant Android
+     bookmark shape — New Testament rows in KJVA — stays `Unknown` on stock KJV-only installs.
+     */
+    func testResolverShiftsKJVANewTestamentOrdinalsOntoKJVModules() {
+        let gateway = FakeResolverGateway(
+            modules: [(name: "KJV", versification: "KJV")],
+            resolutions: [
+                FakeResolverGateway.Key(module: "KJV", ordinal: 24118):
+                    AndroidBookmarkResolvedBook(name: "Matthew", testament: 2)
+            ]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertEqual(
+            resolver.displayBookName(v11nName: "KJVA", ordinal: 30031, kjvOrdinal: 30031),
+            "Matthew",
+            "KJVA New Testament ordinals must shift by the apocrypha span onto KJV modules."
+        )
+        XCTAssertEqual(
+            gateway.resolveCalls.last,
+            FakeResolverGateway.Key(module: "KJV", ordinal: 24118),
+            "The shifted ordinal must equal the KJVA ordinal minus the apocrypha span."
+        )
+    }
+
+    /**
+     Verifies ordinals below the KJVA New Testament section never enter the shifted fallback.
+
+     The shifted stage is only versification-sound for ordinals at or beyond the KJVA New
+     Testament start (30,028). The expected result is `nil` for an apocrypha-range ordinal when
+     no direct or Old-Testament-gated resolution exists. A failure means apocrypha bookmarks
+     would map onto arbitrary early-Bible books.
+     */
+    func testResolverNeverShiftsOrdinalsBelowNewTestamentStart() {
+        let gateway = FakeResolverGateway(
+            modules: [(name: "KJV", versification: "KJV")],
+            resolutions: [:]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertNil(
+            resolver.displayBookName(v11nName: "Luther", ordinal: 100, kjvOrdinal: 27000),
+            "Apocrypha-range KJVA ordinals must not be shifted into KJV space."
+        )
+        XCTAssertFalse(
+            gateway.resolveCalls.contains(FakeResolverGateway.Key(module: "KJV", ordinal: 27000 - 5913)),
+            "No shifted resolution may be attempted below the KJVA New Testament start."
+        )
+    }
+
+    /**
+     Verifies initials classification covers Bibles and commentaries.
+
+     Android's `book` column holds any `AbstractPassageBook`, including commentaries, so both
+     categories must classify as installed initials. A failure leaves commentary-bound bookmark
+     rows permanently un-normalized despite the module being installed.
+     */
+    func testResolverClassifiesBibleAndCommentaryInitials() {
+        let gateway = FakeResolverGateway(
+            modules: [(name: "KJV", versification: "KJV")],
+            resolutions: [:],
+            passageInitials: ["KJV", "TSK"]
+        )
+        let resolver = AndroidBookmarkSwordBookNameResolver(gateway: gateway)
+
+        XCTAssertTrue(resolver.isInstalledBibleInitials("KJV"))
+        XCTAssertTrue(resolver.isInstalledBibleInitials("TSK"))
+        XCTAssertFalse(resolver.isInstalledBibleInitials("ESV2011"))
+    }
+}
+
+/**
+ Deterministic gateway double recording resolution attempts for selection-core tests.
+
+ Side effects:
+ - records every `resolve` call key in `resolveCalls`
+
+ Failure modes:
+ - returns `nil` for resolution keys missing from the fixture map, matching real gateway misses
+ */
+private final class FakeResolverGateway: AndroidBookmarkResolverGateway {
+    /// One recorded module/ordinal resolution attempt.
+    struct Key: Hashable {
+        /// Module initials the resolver attempted.
+        let module: String
+
+        /// Ordinal the resolver attempted.
+        let ordinal: Int
+    }
+
+    private let modules: [(name: String, versification: String)]
+    private let resolutions: [Key: AndroidBookmarkResolvedBook]
+    private let fixedPassageInitials: Set<String>
+
+    /// Every resolution attempt in call order.
+    private(set) var resolveCalls: [Key] = []
+
+    /**
+     Creates the fake gateway.
+
+     - Parameters:
+       - modules: Installed Bible descriptors returned by `bibleModules()`.
+       - resolutions: Successful resolutions keyed by module and ordinal.
+       - passageInitials: Initials set returned by `passageInitials()`; defaults to module names.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(
+        modules: [(name: String, versification: String)],
+        resolutions: [Key: AndroidBookmarkResolvedBook],
+        passageInitials: Set<String>? = nil
+    ) {
+        self.modules = modules
+        self.resolutions = resolutions
+        self.fixedPassageInitials = passageInitials ?? Set(modules.map(\.name))
+    }
+
+    /**
+     Lists the fixture's installed Bible descriptors.
+
+     - Returns: The configured module list.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    func bibleModules() -> [(name: String, versification: String)] {
+        modules
+    }
+
+    /**
+     Lists the fixture's passage-module initials.
+
+     - Returns: The configured initials set.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    func passageInitials() -> Set<String> {
+        fixedPassageInitials
+    }
+
+    /**
+     Resolves one ordinal from the fixture map, recording the attempt.
+
+     - Parameters:
+       - moduleName: Module initials the resolver attempted.
+       - ordinal: Ordinal the resolver attempted.
+     - Returns: The fixture resolution, or `nil` when unmapped.
+     - Side effects: appends the attempt to `resolveCalls`.
+     - Failure modes: none.
+     */
+    func resolve(moduleName: String, ordinal: Int) -> AndroidBookmarkResolvedBook? {
+        let key = Key(module: moduleName, ordinal: ordinal)
+        resolveCalls.append(key)
+        return resolutions[key]
+    }
+}

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
@@ -93,6 +93,53 @@ final class AndroidDatabaseBackupTests: XCTestCase {
     }
 
     /**
+     Verifies nearest-verse clamping keeps versification-divergent references inside the KJVA book.
+
+     Bookmark creation on a module whose numbering diverges from KJVA (e.g. an LXX/Vulgate Psalm
+     chapter with more verses than KJVA) can produce a chapter/verse absent from KJVA. Exact
+     `verseOrdinal` returns nil for those, so the bookmark storage path clamps to the nearest
+     addressable KJVA verse instead of persisting a non-KJVA source ordinal. The expected result is
+     a valid KJVA ordinal in the correct book/chapter (KJVA Psalm 9 ends at verse 20), an unchanged
+     ordinal for in-range references, and nil only for genuinely unknown books. A failure means the
+     write path could store an ordinal that renders and exports as a completely wrong verse,
+     reintroducing the issue #356 symptom on the write side.
+     */
+    func testJSwordKJVAVersificationNearestVerseOrdinalClampsOutOfRangeReferences() {
+        // KJVA Psalm 9 has 20 verses; an LXX/Vulgate merged Psalm 9 verse 21 has no KJVA counterpart.
+        let exactPsalm9V20 = JSwordKJVAVersification.verseOrdinal(osisId: "Ps", chapter: 9, verse: 20)
+        XCTAssertNotNil(exactPsalm9V20)
+        XCTAssertNil(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Ps", chapter: 9, verse: 21),
+            "Verse 21 is outside KJVA Psalm 9 and must not resolve exactly."
+        )
+        XCTAssertEqual(
+            JSwordKJVAVersification.nearestVerseOrdinal(osisId: "Ps", chapter: 9, verse: 21),
+            exactPsalm9V20,
+            "An out-of-range verse must clamp to the last KJVA verse of the same chapter."
+        )
+        // In-range references are unchanged by clamping.
+        XCTAssertEqual(
+            JSwordKJVAVersification.nearestVerseOrdinal(osisId: "Gen", chapter: 1, verse: 1),
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 1),
+            "In-range references must clamp to themselves."
+        )
+        // An out-of-range chapter clamps into the book; an in-range verse is kept.
+        XCTAssertEqual(
+            JSwordKJVAVersification.nearestVerseOrdinal(osisId: "Jude", chapter: 5, verse: 3),
+            JSwordKJVAVersification.verseOrdinal(osisId: "Jude", chapter: 1, verse: 3),
+            "Jude has a single chapter, so chapter 5 clamps to chapter 1 while verse 3 stays in range."
+        )
+        // An out-of-range verse in the clamped chapter clamps to that chapter's last verse.
+        XCTAssertEqual(
+            JSwordKJVAVersification.nearestVerseOrdinal(osisId: "Jude", chapter: 5, verse: 99),
+            JSwordKJVAVersification.verseOrdinal(osisId: "Jude", chapter: 1, verse: 25),
+            "Jude 1 ends at verse 25, so an out-of-range verse clamps to Jude 1:25."
+        )
+        // Unknown books cannot be clamped.
+        XCTAssertNil(JSwordKJVAVersification.nearestVerseOrdinal(osisId: "NotABook", chapter: 1, verse: 1))
+    }
+
+    /**
      Verifies that iOS reads Android `.abdb.zip` archives by database file discovery and exposes
      both restorable and unsupported database sections.
 

--- a/Sources/BibleCore/Tests/BibleCoreTests/BookmarkServicePersistenceTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/BookmarkServicePersistenceTests.swift
@@ -53,6 +53,99 @@ final class BookmarkServicePersistenceTests: XCTestCase {
     }
 
     /**
+     Verifies bookmark creation can persist Android-compatible KJVA ordinals separately from source
+     module ordinals.
+     *
+     * Data dependencies:
+     * - creates one in-memory Bible bookmark through `BookmarkService`
+     *
+     * Side effects:
+     * - inserts and saves a `BibleBookmark`
+     *
+     * Failure modes:
+     * - fails if the service collapses KJVA storage back to source ordinals, which would make
+     *   restored and newly-created non-KJVA bookmarks drift from Android backup semantics.
+     * - fails if source module initials are dropped into display-only fields.
+     */
+    func testBookmarkServicePersistsKJVAOrdinalsSeparatelyFromSourceOrdinals() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+
+        let bookmark = bookmarkService.addBibleBookmark(
+            bookInitials: "KJV",
+            startOrdinal: 10,
+            endOrdinal: 12,
+            kjvOrdinalStart: 20,
+            kjvOrdinalEnd: 22,
+            v11n: "KJV",
+            wholeVerse: true
+        )
+
+        XCTAssertEqual(bookmark.ordinalStart, 10)
+        XCTAssertEqual(bookmark.ordinalEnd, 12)
+        XCTAssertEqual(bookmark.kjvOrdinalStart, 20)
+        XCTAssertEqual(bookmark.kjvOrdinalEnd, 22)
+        XCTAssertEqual(bookmark.v11n, "KJV")
+        XCTAssertEqual(bookmark.bookInitials, "KJV")
+    }
+
+    /**
+     Verifies restored Android bookmarks are found by KJVA overlap even when their `book` column is
+     NULL or module initials.
+     *
+     * Data dependencies:
+     * - inserts one restored-style bookmark with `book == nil`
+     * - inserts one restored-style bookmark whose `book` value is Android module initials
+     * - inserts one outside the queried KJVA chapter range
+     *
+     * Side effects:
+     * - writes test bookmarks into an in-memory SwiftData context
+     *
+     * Failure modes:
+     * - fails if the persistence query uses `BibleBookmark.book` for membership, reproducing issue
+     *   #356 by hiding restored bookmarks from reader highlights and My Notes.
+     */
+    func testBookmarkServiceKJVAPassageQueryIgnoresRestoredAndroidBookColumn() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+
+        let nilBookBookmark = BibleBookmark(
+            kjvOrdinalStart: 100,
+            kjvOrdinalEnd: 100,
+            ordinalStart: 1_000,
+            ordinalEnd: 1_000,
+            v11n: "KJVA"
+        )
+        nilBookBookmark.book = nil
+        let initialsBookmark = BibleBookmark(
+            kjvOrdinalStart: 110,
+            kjvOrdinalEnd: 110,
+            ordinalStart: 1_010,
+            ordinalEnd: 1_010,
+            v11n: "KJVA"
+        )
+        initialsBookmark.book = "KJV"
+        let outsideBookmark = BibleBookmark(
+            kjvOrdinalStart: 200,
+            kjvOrdinalEnd: 200,
+            ordinalStart: 2_000,
+            ordinalEnd: 2_000,
+            v11n: "KJVA"
+        )
+        outsideBookmark.book = "Genesis"
+        modelContext.insert(nilBookBookmark)
+        modelContext.insert(initialsBookmark)
+        modelContext.insert(outsideBookmark)
+        try modelContext.save()
+
+        let bookmarks = bookmarkService.bookmarks(for: 95, endOrdinal: 115, book: "Genesis")
+
+        XCTAssertEqual(Set(bookmarks.map(\.id)), Set([nilBookBookmark.id, initialsBookmark.id]))
+    }
+
+    /**
      Verifies that deleting a label clears bookmark junction rows and primary-label references
      before the label itself is removed.
      *
@@ -135,6 +228,7 @@ final class BookmarkServicePersistenceTests: XCTestCase {
      * Failure modes:
      * - throws if the in-memory SwiftData container cannot be created or queried
      * - fails if the bookmark is not linked to the paragraph-break label as its primary style label
+     * - fails if the source module initials are not stored with the Bible bookmark.
      */
     func testBookmarkServiceCreatesParagraphBreakBibleBookmark() throws {
         let container = try makeBookmarkRestoreModelContainer()
@@ -160,6 +254,7 @@ final class BookmarkServicePersistenceTests: XCTestCase {
 
         XCTAssertEqual(paragraphLabel.name, Label.paragraphBreakLabelName)
         XCTAssertEqual(reloadedBookmark.book, "Genesis")
+        XCTAssertEqual(reloadedBookmark.bookInitials, "KJV")
         XCTAssertFalse(reloadedBookmark.wholeVerse)
         XCTAssertEqual(reloadedBookmark.primaryLabelId, Label.paragraphBreakLabelId)
         XCTAssertEqual(link.bookmark?.id, bookmark.id)

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
@@ -325,10 +325,11 @@ final class RemoteSyncBookmarkTests: XCTestCase {
         let settingsStore = SettingsStore(modelContext: modelContext)
         let resolver = FakeAndroidBookmarkBookNameResolver(
             installedBibleInitials: ["KJV"],
-            namesByOrdinal: [10: "Genesis"]
+            namesByOrdinal: [10: "Genesis", 20: "Exodus"]
         )
         let service = RemoteSyncBookmarkRestoreService(bookNameResolver: resolver)
         let bookmarkID = UUID(uuidString: "f5000000-0000-0000-0000-000000000001")!
+        let nullBookBookmarkID = UUID(uuidString: "f5000000-0000-0000-0000-000000000002")!
 
         let databaseURL = try makeAndroidBookmarksDatabase(
             labels: [],
@@ -351,7 +352,26 @@ final class RemoteSyncBookmarkTests: XCTestCase {
                     customIcon: nil,
                     editActionMode: nil,
                     editActionContent: nil
-                )
+                ),
+                .init(
+                    id: nullBookBookmarkID,
+                    kjvOrdinalStart: 20,
+                    kjvOrdinalEnd: 20,
+                    ordinalStart: 20,
+                    ordinalEnd: 20,
+                    playbackSettingsJSON: nil,
+                    createdAt: Date(timeIntervalSince1970: 1_700_300_200),
+                    book: nil,
+                    startOffset: nil,
+                    endOffset: nil,
+                    primaryLabelID: nil,
+                    lastUpdatedOn: Date(timeIntervalSince1970: 1_700_300_300),
+                    wholeVerse: true,
+                    type: nil,
+                    customIcon: nil,
+                    editActionMode: nil,
+                    editActionContent: nil
+                ),
             ],
             bibleNotes: [],
             bibleLinks: [],
@@ -370,16 +390,103 @@ final class RemoteSyncBookmarkTests: XCTestCase {
         )
 
         let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
-        XCTAssertEqual(restored.count, 1)
+        let booksByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.book) })
+        XCTAssertEqual(restored.count, 2)
         XCTAssertEqual(
-            restored[0].book,
+            booksByID[bookmarkID],
             "Genesis",
             "The SQLite restore path must rewrite Android module initials into display book names."
         )
         XCTAssertEqual(
-            RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore).rawBook(for: bookmarkID),
+            booksByID[nullBookBookmarkID],
+            "Exodus",
+            "The SQLite restore path must derive display names for NULL Android book columns."
+        )
+        let bookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
+        XCTAssertEqual(
+            bookStore.rawBook(for: bookmarkID),
             .some("KJV"),
             "The SQLite restore path must preserve the raw Android value for round-trip export."
+        )
+        XCTAssertEqual(
+            bookStore.rawBook(for: nullBookBookmarkID),
+            .some(nil),
+            "The SQLite restore path must preserve NULL Android book values for round-trip export."
+        )
+
+        let outbound = RemoteSyncBookmarkSnapshotService().snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let outboundBooks = Dictionary(
+            uniqueKeysWithValues: outbound.bibleBookmarkRowsByKey.values.map { ($0.id, $0.book) }
+        )
+        XCTAssertEqual(
+            outboundBooks[bookmarkID],
+            "KJV",
+            "Outbound Android snapshots must project the preserved module initials, not display names."
+        )
+        XCTAssertEqual(
+            outboundBooks[nullBookBookmarkID],
+            String??.some(nil),
+            "Outbound Android snapshots must project preserved NULL book values as NULL."
+        )
+    }
+
+    /**
+     Verifies previously healed display names survive re-materialization when derivation fails.
+
+     Sync patch apply and merge imports rebuild the local graph from Android-shaped snapshots that
+     carry preserved raw values. When the module that enabled the original derivation is no longer
+     installed, the expected result keeps the earlier healed display name for the same bookmark ID
+     instead of regressing to `Unknown`/initials. A failure means an unrelated incoming sync patch
+     would visibly break bookmarks that were already displaying correctly.
+     */
+    func testRemoteSyncBookmarkRestoreRetainsHealedNamesWhenDerivationFails() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let bookmarkID = UUID(uuidString: "f6000000-0000-0000-0000-000000000001")!
+
+        let healingResolver = FakeAndroidBookmarkBookNameResolver(
+            installedBibleInitials: ["KJV"],
+            namesByOrdinal: [4: "Genesis"]
+        )
+        let snapshot = RemoteSyncAndroidBookmarkSnapshot(
+            labels: [],
+            bibleBookmarks: [
+                makeNormalizationBookmark(id: bookmarkID, ordinalStart: 4, book: "KJV")
+            ],
+            genericBookmarks: [],
+            studyPadEntries: []
+        )
+        _ = try RemoteSyncBookmarkRestoreService(bookNameResolver: healingResolver).replaceLocalBookmarks(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let failingResolver = FakeAndroidBookmarkBookNameResolver(
+            installedBibleInitials: ["KJV"],
+            namesByOrdinal: [:]
+        )
+        _ = try RemoteSyncBookmarkRestoreService(bookNameResolver: failingResolver).replaceLocalBookmarks(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertEqual(
+            restored[0].book,
+            "Genesis",
+            "Re-materialization with failing derivation must keep the previously healed display name."
+        )
+        XCTAssertEqual(
+            RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore).rawBook(for: bookmarkID),
+            .some("KJV"),
+            "The preserved raw Android value must survive re-materialization."
         )
     }
 

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
@@ -198,11 +198,11 @@ final class RemoteSyncBookmarkTests: XCTestCase {
         let snapshot = RemoteSyncAndroidBookmarkSnapshot(
             labels: [],
             bibleBookmarks: [
-                makeNormalizationBookmark(id: initialsID, ordinalStart: 4, book: "KJV"),
-                makeNormalizationBookmark(id: nullBookID, ordinalStart: 1533, book: nil),
+                makeNormalizationBookmark(id: initialsID, ordinalStart: 4, book: "KJV", v11n: "KJV", kjvOrdinal: 40),
+                makeNormalizationBookmark(id: nullBookID, ordinalStart: 1533, book: nil, v11n: "KJVA", kjvOrdinal: 1533),
                 makeNormalizationBookmark(id: localizedID, ordinalStart: 4, book: "1. Mose"),
                 makeNormalizationBookmark(id: uninstalledID, ordinalStart: 4, book: "ESV2011"),
-                makeNormalizationBookmark(id: unresolvableID, ordinalStart: 999_999, book: "NASB"),
+                makeNormalizationBookmark(id: unresolvableID, ordinalStart: 999_999, book: "NASB", v11n: "Luther", kjvOrdinal: 999_998),
             ],
             genericBookmarks: [],
             studyPadEntries: []
@@ -242,9 +242,33 @@ final class RemoteSyncBookmarkTests: XCTestCase {
             "When derivation fails the raw Android value must be preserved rather than dropped."
         )
         XCTAssertEqual(
-            resolver.recordedRequests.map(\.v11nName),
-            ["KJV", "KJV", "KJV"],
-            "Derivation must resolve ordinals in each bookmark's own stored versification."
+            resolver.recordedRequests,
+            [
+                .init(v11nName: "KJV", ordinal: 4, kjvOrdinal: 40),
+                .init(v11nName: "KJVA", ordinal: 1533, kjvOrdinal: 1533),
+                .init(v11nName: "Luther", ordinal: 999_999, kjvOrdinal: 999_998),
+            ],
+            "Derivation must pass each bookmark's own versification, source ordinal, and KJVA ordinal."
+        )
+
+        let bookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
+        XCTAssertEqual(
+            bookStore.rawBook(for: initialsID),
+            .some("KJV"),
+            "Rewritten initials must be preserved for Android round-trip export."
+        )
+        XCTAssertEqual(
+            bookStore.rawBook(for: nullBookID),
+            .some(nil),
+            "Rewritten NULL book values must be preserved as NULL for Android round-trip export."
+        )
+        XCTAssertNil(
+            bookStore.rawBook(for: localizedID),
+            "Untouched values must not create fidelity entries."
+        )
+        XCTAssertNil(
+            bookStore.rawBook(for: unresolvableID),
+            "Failed derivations keep the raw value on the model and need no fidelity entry."
         )
     }
 
@@ -287,6 +311,79 @@ final class RemoteSyncBookmarkTests: XCTestCase {
     }
 
     /**
+     Verifies the full SQLite restore path normalizes Android module-initials book values.
+
+     The fixture writes an Android-shaped bookmarks database whose `book` column carries module
+     initials, exactly as real Android backups do, then restores it through `readSnapshot` plus
+     `replaceLocalBookmarks`. The expected result is a display book name on the SwiftData row and
+     a preserved raw value for round-trip export. A failure means the SQLite read path and the
+     normalization boundary have drifted apart while the snapshot-level tests stay green.
+     */
+    func testRemoteSyncBookmarkRestoreNormalizesBookColumnFromAndroidDatabase() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let resolver = FakeAndroidBookmarkBookNameResolver(
+            installedBibleInitials: ["KJV"],
+            namesByOrdinal: [10: "Genesis"]
+        )
+        let service = RemoteSyncBookmarkRestoreService(bookNameResolver: resolver)
+        let bookmarkID = UUID(uuidString: "f5000000-0000-0000-0000-000000000001")!
+
+        let databaseURL = try makeAndroidBookmarksDatabase(
+            labels: [],
+            bibleBookmarks: [
+                .init(
+                    id: bookmarkID,
+                    kjvOrdinalStart: 10,
+                    kjvOrdinalEnd: 10,
+                    ordinalStart: 10,
+                    ordinalEnd: 10,
+                    playbackSettingsJSON: nil,
+                    createdAt: Date(timeIntervalSince1970: 1_700_300_000),
+                    book: "KJV",
+                    startOffset: nil,
+                    endOffset: nil,
+                    primaryLabelID: nil,
+                    lastUpdatedOn: Date(timeIntervalSince1970: 1_700_300_100),
+                    wholeVerse: true,
+                    type: nil,
+                    customIcon: nil,
+                    editActionMode: nil,
+                    editActionContent: nil
+                )
+            ],
+            bibleNotes: [],
+            bibleLinks: [],
+            genericBookmarks: [],
+            genericNotes: [],
+            genericLinks: [],
+            studyPadEntries: [],
+            studyPadTexts: []
+        )
+
+        let snapshot = try service.readSnapshot(from: databaseURL)
+        _ = try service.replaceLocalBookmarks(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertEqual(
+            restored[0].book,
+            "Genesis",
+            "The SQLite restore path must rewrite Android module initials into display book names."
+        )
+        XCTAssertEqual(
+            RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore).rawBook(for: bookmarkID),
+            .some("KJV"),
+            "The SQLite restore path must preserve the raw Android value for round-trip export."
+        )
+    }
+
+    /**
      Builds one staged Android Bible bookmark row for book-name normalization tests.
 
      - Parameters:
@@ -300,15 +397,17 @@ final class RemoteSyncBookmarkTests: XCTestCase {
     private func makeNormalizationBookmark(
         id: UUID,
         ordinalStart: Int,
-        book: String?
+        book: String?,
+        v11n: String = "KJV",
+        kjvOrdinal: Int? = nil
     ) -> RemoteSyncAndroidBibleBookmark {
         RemoteSyncAndroidBibleBookmark(
             id: id,
-            kjvOrdinalStart: ordinalStart,
-            kjvOrdinalEnd: ordinalStart,
+            kjvOrdinalStart: kjvOrdinal ?? ordinalStart,
+            kjvOrdinalEnd: kjvOrdinal ?? ordinalStart,
             ordinalStart: ordinalStart,
             ordinalEnd: ordinalStart,
-            v11n: "KJV",
+            v11n: v11n,
             playbackSettingsJSON: nil,
             createdAt: Date(timeIntervalSince1970: 1_700_200_000),
             book: book,

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
@@ -169,6 +169,163 @@ final class RemoteSyncBookmarkTests: XCTestCase {
     }
 
     /**
+     Verifies restore normalizes Android's module-initials `book` column into display book names.
+
+     Android stores SWORD module initials (or NULL) in `BibleBookmark.book` and renders references
+     from `v11n` + ordinals, while iOS keys bookmark display, chapter-highlight queries, and
+     navigation on the same field as a display book name (issue #356). Restore must rewrite the
+     two Android-produced shapes — NULL and installed-module initials — through the resolver while
+     preserving every other value verbatim so locally created and localized names survive merges.
+     A failure here means restored Android bookmarks render as `Unknown`/initials plus garbage
+     chapter math again.
+     */
+    func testRemoteSyncBookmarkRestoreNormalizesAndroidBookColumnSemantics() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let resolver = FakeAndroidBookmarkBookNameResolver(
+            installedBibleInitials: ["KJV", "NASB"],
+            namesByOrdinal: [4: "Genesis", 1533: "Exodus"]
+        )
+        let service = RemoteSyncBookmarkRestoreService(bookNameResolver: resolver)
+
+        let initialsID = UUID(uuidString: "f3000000-0000-0000-0000-000000000001")!
+        let nullBookID = UUID(uuidString: "f3000000-0000-0000-0000-000000000002")!
+        let localizedID = UUID(uuidString: "f3000000-0000-0000-0000-000000000003")!
+        let uninstalledID = UUID(uuidString: "f3000000-0000-0000-0000-000000000004")!
+        let unresolvableID = UUID(uuidString: "f3000000-0000-0000-0000-000000000005")!
+
+        let snapshot = RemoteSyncAndroidBookmarkSnapshot(
+            labels: [],
+            bibleBookmarks: [
+                makeNormalizationBookmark(id: initialsID, ordinalStart: 4, book: "KJV"),
+                makeNormalizationBookmark(id: nullBookID, ordinalStart: 1533, book: nil),
+                makeNormalizationBookmark(id: localizedID, ordinalStart: 4, book: "1. Mose"),
+                makeNormalizationBookmark(id: uninstalledID, ordinalStart: 4, book: "ESV2011"),
+                makeNormalizationBookmark(id: unresolvableID, ordinalStart: 999_999, book: "NASB"),
+            ],
+            genericBookmarks: [],
+            studyPadEntries: []
+        )
+
+        _ = try service.replaceLocalBookmarks(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        let booksByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.book) })
+        XCTAssertEqual(
+            booksByID[initialsID],
+            "Genesis",
+            "Installed-module initials must be rewritten to the derived display book name."
+        )
+        XCTAssertEqual(
+            booksByID[nullBookID],
+            "Exodus",
+            "NULL Android book values must be derived from the bookmark's own ordinals."
+        )
+        XCTAssertEqual(
+            booksByID[localizedID],
+            "1. Mose",
+            "Values that are not installed-module initials must survive unchanged."
+        )
+        XCTAssertEqual(
+            booksByID[uninstalledID],
+            "ESV2011",
+            "Initials of modules that are not installed cannot be classified and must be preserved."
+        )
+        XCTAssertEqual(
+            booksByID[unresolvableID],
+            "NASB",
+            "When derivation fails the raw Android value must be preserved rather than dropped."
+        )
+        XCTAssertEqual(
+            resolver.recordedRequests.map(\.v11nName),
+            ["KJV", "KJV", "KJV"],
+            "Derivation must resolve ordinals in each bookmark's own stored versification."
+        )
+    }
+
+    /**
+     Verifies restore preserves raw Android `book` values verbatim when normalization is disabled.
+
+     Passing a nil resolver keeps the pre-#356 pass-through contract so callers that need
+     Android-fidelity round-trips can opt out. A failure here means normalization can no longer
+     be disabled and fidelity-sensitive flows would silently rewrite Android data.
+     */
+    func testRemoteSyncBookmarkRestoreWithoutResolverPreservesRawBookValues() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let service = RemoteSyncBookmarkRestoreService(bookNameResolver: nil)
+        let bookmarkID = UUID(uuidString: "f4000000-0000-0000-0000-000000000001")!
+
+        let snapshot = RemoteSyncAndroidBookmarkSnapshot(
+            labels: [],
+            bibleBookmarks: [
+                makeNormalizationBookmark(id: bookmarkID, ordinalStart: 4, book: "KJV")
+            ],
+            genericBookmarks: [],
+            studyPadEntries: []
+        )
+
+        _ = try service.replaceLocalBookmarks(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertEqual(
+            restored[0].book,
+            "KJV",
+            "A nil resolver must preserve the raw Android book value verbatim."
+        )
+    }
+
+    /**
+     Builds one staged Android Bible bookmark row for book-name normalization tests.
+
+     - Parameters:
+       - id: Stable bookmark identifier.
+       - ordinalStart: Source-versification start ordinal driving derivation.
+       - book: Raw Android `book` column value under test.
+     - Returns: A label-free staged bookmark row with KJV versification.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    private func makeNormalizationBookmark(
+        id: UUID,
+        ordinalStart: Int,
+        book: String?
+    ) -> RemoteSyncAndroidBibleBookmark {
+        RemoteSyncAndroidBibleBookmark(
+            id: id,
+            kjvOrdinalStart: ordinalStart,
+            kjvOrdinalEnd: ordinalStart,
+            ordinalStart: ordinalStart,
+            ordinalEnd: ordinalStart,
+            v11n: "KJV",
+            playbackSettingsJSON: nil,
+            createdAt: Date(timeIntervalSince1970: 1_700_200_000),
+            book: book,
+            startOffset: nil,
+            endOffset: nil,
+            primaryLabelID: nil,
+            notes: nil,
+            lastUpdatedOn: Date(timeIntervalSince1970: 1_700_200_100),
+            wholeVerse: true,
+            type: nil,
+            customIcon: nil,
+            editAction: nil,
+            labelLinks: []
+        )
+    }
+
+    /**
      Verifies that bookmark restore remains backward-compatible with Android bookmark databases
      created before note rows and StudyPad entries gained nullable content-type metadata.
 
@@ -1776,4 +1933,79 @@ final class RemoteSyncBookmarkTests: XCTestCase {
         ])
     }
 
+}
+
+/**
+ Deterministic in-memory resolver double for Android book-name normalization tests.
+
+ The fake answers initials membership from a fixed set and derives display names from a fixed
+ ordinal map while recording every derivation request, so tests can assert both the normalization
+ rule and the versification plumbing without SWORD modules.
+
+ Side effects:
+ - records derivation requests in `recordedRequests`
+
+ Failure modes:
+ - returns `nil` for ordinals missing from `namesByOrdinal`, matching real resolver misses
+ */
+private final class FakeAndroidBookmarkBookNameResolver: AndroidBookmarkBookNameResolving {
+    /// One recorded derivation request in call order.
+    struct Request: Equatable {
+        /// Versification name the service passed for this bookmark.
+        let v11nName: String
+
+        /// Source-versification ordinal the service passed.
+        let ordinal: Int
+
+        /// KJVA fallback ordinal the service passed.
+        let kjvOrdinal: Int
+    }
+
+    private let installedBibleInitials: Set<String>
+    private let namesByOrdinal: [Int: String]
+
+    /// Derivation requests observed by the fake, in call order.
+    private(set) var recordedRequests: [Request] = []
+
+    /**
+     Creates the fake resolver.
+
+     - Parameters:
+       - installedBibleInitials: Module initials treated as installed Bibles.
+       - namesByOrdinal: Display book names keyed by source ordinal.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(installedBibleInitials: Set<String>, namesByOrdinal: [Int: String]) {
+        self.installedBibleInitials = installedBibleInitials
+        self.namesByOrdinal = namesByOrdinal
+    }
+
+    /**
+     Reports whether a raw value matches the configured installed-Bible initials.
+
+     - Parameter rawValue: Raw Android `book` column value.
+     - Returns: `true` when the fixture set contains the value.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    func isInstalledBibleInitials(_ rawValue: String) -> Bool {
+        installedBibleInitials.contains(rawValue)
+    }
+
+    /**
+     Derives a display book name from the fixture ordinal map.
+
+     - Parameters:
+       - v11nName: Versification name passed by the service.
+       - ordinal: Source-versification ordinal passed by the service.
+       - kjvOrdinal: KJVA fallback ordinal passed by the service.
+     - Returns: The fixture name for `ordinal`, or `nil` when unmapped.
+     - Side effects: appends the request to `recordedRequests`.
+     - Failure modes: none.
+     */
+    func displayBookName(v11nName: String, ordinal: Int, kjvOrdinal: Int) -> String? {
+        recordedRequests.append(Request(v11nName: v11nName, ordinal: ordinal, kjvOrdinal: kjvOrdinal))
+        return namesByOrdinal[ordinal]
+    }
 }

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncBookmarkTests.swift
@@ -74,6 +74,27 @@ final class RemoteSyncBookmarkTests: XCTestCase {
         XCTAssertTrue(store.allAliases().isEmpty)
     }
 
+    /**
+     Verifies remote-sync reset clears the local-only Android bookmark book side store.
+
+     Issue #356 stores Android's raw `BibleBookmark.book` values outside the SwiftData display
+     field so outbound snapshots can preserve Android module initials and NULLs. Resetting remote
+     sync must clear that fidelity state with the other bookmark side stores, otherwise a later
+     account or bootstrap could inherit stale source-module mappings.
+     */
+    func testRemoteSyncResetServiceClearsBookmarkAndroidBookStore() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let store = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
+        let bookmarkID = UUID(uuidString: "c2000000-0000-0000-0000-000000000001")!
+        store.setRawBook("KJV", for: bookmarkID)
+
+        RemoteSyncResetService(settingsStore: settingsStore).resetAllCategories()
+
+        XCTAssertEqual(store.rawBook(for: bookmarkID), Optional<String?>.none)
+    }
+
     func testRemoteSyncBookmarkRestoreReadsAndroidSnapshot() throws {
         let service = RemoteSyncBookmarkRestoreService()
         let speakLabelID = UUID(uuidString: "d1000000-0000-0000-0000-000000000001")!
@@ -216,31 +237,41 @@ final class RemoteSyncBookmarkTests: XCTestCase {
 
         let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
         let booksByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.book) })
+        let sourceInitialsByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.bookInitials) })
         XCTAssertEqual(
             booksByID[initialsID],
             "Genesis",
             "Installed-module initials must be rewritten to the derived display book name."
         )
         XCTAssertEqual(
+            sourceInitialsByID[initialsID],
+            "KJV",
+            "Installed-module initials must also be retained on the bookmark as source metadata."
+        )
+        XCTAssertEqual(
             booksByID[nullBookID],
             "Exodus",
             "NULL Android book values must be derived from the bookmark's own ordinals."
         )
+        XCTAssertEqual(sourceInitialsByID[nullBookID], "")
         XCTAssertEqual(
             booksByID[localizedID],
             "1. Mose",
             "Values that are not installed-module initials must survive unchanged."
         )
+        XCTAssertEqual(sourceInitialsByID[localizedID], "")
         XCTAssertEqual(
             booksByID[uninstalledID],
             "ESV2011",
             "Initials of modules that are not installed cannot be classified and must be preserved."
         )
+        XCTAssertEqual(sourceInitialsByID[uninstalledID], "ESV2011")
         XCTAssertEqual(
             booksByID[unresolvableID],
             "NASB",
             "When derivation fails the raw Android value must be preserved rather than dropped."
         )
+        XCTAssertEqual(sourceInitialsByID[unresolvableID], "NASB")
         XCTAssertEqual(
             resolver.recordedRequests,
             [
@@ -262,12 +293,14 @@ final class RemoteSyncBookmarkTests: XCTestCase {
             .some(nil),
             "Rewritten NULL book values must be preserved as NULL for Android round-trip export."
         )
-        XCTAssertNil(
+        XCTAssertEqual(
             bookStore.rawBook(for: localizedID),
+            Optional<String?>.none,
             "Untouched values must not create fidelity entries."
         )
-        XCTAssertNil(
+        XCTAssertEqual(
             bookStore.rawBook(for: unresolvableID),
+            Optional<String?>.none,
             "Failed derivations keep the raw value on the model and need no fidelity entry."
         )
     }
@@ -307,6 +340,11 @@ final class RemoteSyncBookmarkTests: XCTestCase {
             restored[0].book,
             "KJV",
             "A nil resolver must preserve the raw Android book value verbatim."
+        )
+        XCTAssertEqual(
+            restored[0].bookInitials,
+            "KJV",
+            "A nil resolver still treats Android's non-empty book column as source module initials."
         )
     }
 
@@ -391,6 +429,7 @@ final class RemoteSyncBookmarkTests: XCTestCase {
 
         let restored = try modelContext.fetch(FetchDescriptor<BibleBookmark>())
         let booksByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.book) })
+        let sourceInitialsByID = Dictionary(uniqueKeysWithValues: restored.map { ($0.id, $0.bookInitials) })
         XCTAssertEqual(restored.count, 2)
         XCTAssertEqual(
             booksByID[bookmarkID],
@@ -402,6 +441,8 @@ final class RemoteSyncBookmarkTests: XCTestCase {
             "Exodus",
             "The SQLite restore path must derive display names for NULL Android book columns."
         )
+        XCTAssertEqual(sourceInitialsByID[bookmarkID], "KJV")
+        XCTAssertEqual(sourceInitialsByID[nullBookBookmarkID], "")
         let bookStore = RemoteSyncBookmarkAndroidBookStore(settingsStore: settingsStore)
         XCTAssertEqual(
             bookStore.rawBook(for: bookmarkID),
@@ -488,6 +529,54 @@ final class RemoteSyncBookmarkTests: XCTestCase {
             .some("KJV"),
             "The preserved raw Android value must survive re-materialization."
         )
+    }
+
+    /**
+     Verifies outbound Android snapshots use Bible bookmark source initials, not display book names.
+
+     Native iOS bookmark creation stores `book` as the display Bible book and `bookInitials` as the
+     source module. Android's `BibleBookmark.book` column expects module initials or NULL, so
+     snapshot export must read `bookInitials` and leave legacy rows without source metadata as NULL.
+     */
+    func testRemoteSyncBookmarkSnapshotExportsSourceInitialsInsteadOfDisplayBook() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let sourceBackedID = UUID(uuidString: "f7000000-0000-0000-0000-000000000001")!
+        let legacyDisplayOnlyID = UUID(uuidString: "f7000000-0000-0000-0000-000000000002")!
+        let sourceBacked = BibleBookmark(
+            id: sourceBackedID,
+            kjvOrdinalStart: 4,
+            kjvOrdinalEnd: 4,
+            ordinalStart: 10,
+            ordinalEnd: 10,
+            v11n: "KJV",
+            bookInitials: "KJV"
+        )
+        sourceBacked.book = "Genesis"
+        let legacyDisplayOnly = BibleBookmark(
+            id: legacyDisplayOnlyID,
+            kjvOrdinalStart: 5,
+            kjvOrdinalEnd: 5,
+            ordinalStart: 11,
+            ordinalEnd: 11,
+            v11n: "KJV"
+        )
+        legacyDisplayOnly.book = "Genesis"
+        modelContext.insert(sourceBacked)
+        modelContext.insert(legacyDisplayOnly)
+        try modelContext.save()
+
+        let snapshot = RemoteSyncBookmarkSnapshotService().snapshotCurrentState(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let outboundBooks = Dictionary(
+            uniqueKeysWithValues: snapshot.bibleBookmarkRowsByKey.values.map { ($0.id, $0.book) }
+        )
+
+        XCTAssertEqual(outboundBooks[sourceBackedID], "KJV")
+        XCTAssertEqual(outboundBooks[legacyDisplayOnlyID], String??.some(nil))
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAccessibilityState.swift
@@ -219,7 +219,7 @@ struct StudyPadAccessibilitySnapshot: Equatable {
  the controller's bridge/navigation responsibilities.
  */
 struct BibleReaderAccessibilitySnapshotFactory {
-    /// Resolves the current chapter's ordinal range using the reader's active versification.
+    /// Resolves the current chapter's bookmark storage range, preferably in Android KJVA ordinals.
     typealias ChapterOrdinalRangeResolver = () -> (start: Int, end: Int, verseCount: Int)?
 
     /// Resolves a persisted bookmark ordinal into a chapter/verse reference.
@@ -254,7 +254,7 @@ struct BibleReaderAccessibilitySnapshotFactory {
        - activeStudyPadLabelId: Active StudyPad label id, if any.
        - activeStudyPadLabelName: Active StudyPad label name, if any.
        - rowLimit: Maximum detailed rows exported for UI tests.
-       - chapterOrdinalRange: Closure that resolves the visible chapter ordinal range.
+       - chapterOrdinalRange: Closure that resolves the visible chapter's bookmark storage range.
        - verseReference: Closure that resolves ordinals using the active reader versification.
      - Side effects: None during initialization.
      - Failure modes: Missing services or failed ordinal resolution produce empty snapshots rather
@@ -364,7 +364,8 @@ struct BibleReaderAccessibilitySnapshotFactory {
     
      - Returns: Sorted Bible bookmarks with non-empty note content for the current chapter.
      - Side effects: Reads bookmarks from `BookmarkService`.
-     - Failure modes: Missing service or unresolved chapter range returns an empty list.
+     - Failure modes: Missing service or unresolved KJVA/storage chapter range returns an empty
+       list.
      */
     func currentChapterMyNotesBookmarks() -> [BibleBookmark] {
         guard let service = bookmarkService,
@@ -375,8 +376,8 @@ struct BibleReaderAccessibilitySnapshotFactory {
                 return !note.isEmpty
             }
             .sorted {
-                if $0.ordinalStart != $1.ordinalStart {
-                    return $0.ordinalStart < $1.ordinalStart
+                if $0.kjvOrdinalStart != $1.kjvOrdinalStart {
+                    return $0.kjvOrdinalStart < $1.kjvOrdinalStart
                 }
                 return $0.createdAt < $1.createdAt
             }
@@ -384,12 +385,20 @@ struct BibleReaderAccessibilitySnapshotFactory {
 
     /// Stable row token for the My Notes accessibility export.
     private func myNotesReferenceToken(for bookmark: BibleBookmark) -> String {
-        let startReference = verseReference(currentBook, bookmark.ordinalStart)
-        let endReference = verseReference(currentBook, bookmark.ordinalEnd)
-        let startVerse = startReference?.verse ?? 1
-        let endVerse = max(startVerse, endReference?.verse ?? startVerse)
+        let startReference = JSwordKJVAVersification.verseReference(ordinal: bookmark.kjvOrdinalStart)
+        let effectiveKJVEndOrdinal = bookmark.kjvOrdinalEnd > bookmark.kjvOrdinalStart
+            ? bookmark.kjvOrdinalEnd
+            : bookmark.kjvOrdinalStart
+        let endReference = JSwordKJVAVersification.verseReference(ordinal: effectiveKJVEndOrdinal)
+        let legacyStartReference = verseReference(currentBook, bookmark.ordinalStart)
+        let legacyEndReference = verseReference(currentBook, bookmark.ordinalEnd)
+        let startVerse = startReference?.verse ?? legacyStartReference?.verse ?? 1
+        let endVerse = max(startVerse, endReference?.verse ?? legacyEndReference?.verse ?? startVerse)
         let verseToken = startVerse == endVerse ? "\(startVerse)" : "\(startVerse)_\(endVerse)"
-        let chapter = startReference?.chapter ?? currentChapter
-        return "\(BibleReaderRenderedContentState.token(currentBook))_\(chapter)_\(verseToken)"
+        let chapter = startReference?.chapter ?? legacyStartReference?.chapter ?? currentChapter
+        let bookName = startReference
+            .flatMap { JSwordKJVAVersification.longBookName(osisId: $0.osisId) }
+            ?? currentBook
+        return "\(BibleReaderRenderedContentState.token(bookName))_\(chapter)_\(verseToken)"
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationBridgeCoordinator.swift
@@ -43,6 +43,10 @@ struct BibleReaderAnnotationBridgeCoordinator {
     private let payloadFactory: BibleReaderAnnotationPayloadFactory
     /// Current reader book name used by bookmark creation.
     private let currentBook: String
+    /// Supplies the current module versification for source ordinal fidelity.
+    private let currentV11n: () -> String
+    /// Projects rendered reader ordinals into Android's KJVA bookmark storage domain.
+    private let kjvaOrdinalRange: (Int, Int) -> (start: Int, end: Int)?
     /// Active notes content type supplier for note and StudyPad journal creation.
     private let currentNotesContentType: () -> String
     /// Current workspace settings supplier for auto-label and cursor mutations.
@@ -70,6 +74,8 @@ struct BibleReaderAnnotationBridgeCoordinator {
        - bookmarkService: Bookmark persistence facade.
        - payloadFactory: Projection factory for typed bridge DTOs.
        - currentBook: Current book name for new Bible bookmark rows.
+       - currentV11n: Closure returning the active module versification.
+       - kjvaOrdinalRange: Closure converting rendered reader ordinals to KJVA storage ordinals.
        - currentNotesContentType: Closure returning the active notes content type.
        - workspaceSettings: Closure returning the active workspace settings.
        - setWorkspaceSettings: Closure applying updated workspace settings.
@@ -87,6 +93,8 @@ struct BibleReaderAnnotationBridgeCoordinator {
         bookmarkService: BookmarkService,
         payloadFactory: BibleReaderAnnotationPayloadFactory,
         currentBook: String,
+        currentV11n: @escaping () -> String,
+        kjvaOrdinalRange: @escaping (Int, Int) -> (start: Int, end: Int)?,
         currentNotesContentType: @escaping () -> String,
         workspaceSettings: @escaping () -> WorkspaceSettings?,
         setWorkspaceSettings: @escaping (WorkspaceSettings) -> Void,
@@ -101,6 +109,8 @@ struct BibleReaderAnnotationBridgeCoordinator {
         self.bookmarkService = bookmarkService
         self.payloadFactory = payloadFactory
         self.currentBook = currentBook
+        self.currentV11n = currentV11n
+        self.kjvaOrdinalRange = kjvaOrdinalRange
         self.currentNotesContentType = currentNotesContentType
         self.workspaceSettings = workspaceSettings
         self.setWorkspaceSettings = setWorkspaceSettings
@@ -319,6 +329,8 @@ struct BibleReaderAnnotationBridgeCoordinator {
             bookmarkService: bookmarkService,
             payloadFactory: payloadFactory,
             currentBook: currentBook,
+            currentV11n: currentV11n,
+            kjvaOrdinalRange: kjvaOrdinalRange,
             currentNotesContentType: currentNotesContentType
         )
     }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
@@ -11,10 +11,10 @@ import SwordKit
  bookmark, label, and StudyPad payloads from drifting as controller responsibilities are extracted.
 
  Inputs:
- - active module state used to resolve JSword/SWORD-style ordinals and verse text
- - the current reader book used when older bookmarks do not carry an explicit book
- - the current module initials used by the web client as `bookInitials`
- - the effective book list for OSIS lookups
+- active module state used to resolve JSword/SWORD-style ordinals and verse text
+- the current reader book used when older bookmarks do not carry an explicit book
+- the current module initials used as a fallback for active-document projection
+- the effective book list for OSIS lookups
 
  Outputs:
  - typed `BibleView` bridge DTOs and document payload DTOs consumed by Vue.js
@@ -37,6 +37,24 @@ struct BibleReaderAnnotationPayloadFactory {
     private let bookCatalog: BibleReaderBookCatalog
     /// Synthetic unlabeled label identifier required by the web client.
     private let unlabeledLabelID: String
+
+    /**
+     Selects the ordinal domain used for Bible bookmark bridge payloads.
+
+     Normal reader documents highlight against the active module's rendered ordinals, while
+     Android's My Notes fake document renders bookmark rows in KJVA ordinals. Keeping the choice
+     explicit prevents `ordinalRange` and `originalOrdinalRange` from drifting back into the same
+     domain.
+
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private enum BibleBookmarkOrdinalProjection {
+        /// Project visible row ordinals into the active reader module when possible.
+        case activeModule
+        /// Project visible row ordinals into Android's KJVA bookmark domain.
+        case kjva
+    }
 
     /**
      Normalizes Swift hash values into the non-negative `hashCode` shape expected by BibleView.
@@ -102,7 +120,7 @@ struct BibleReaderAnnotationPayloadFactory {
      - Failure modes: same as `bookmarkJSON(_:)`.
      */
     func bookmarkJSONForMyNotes(_ bookmark: BibleBookmark) -> BibleBookmarkData {
-        bookmarkJSON(bookmark)
+        bibleBookmarkJSON(bookmark, editAction: EditActionData(), ordinalProjection: .kjva)
     }
 
     /**
@@ -282,12 +300,18 @@ struct BibleReaderAnnotationPayloadFactory {
      - Parameters:
        - bookmark: Bible bookmark model to project.
        - editAction: Edit-action DTO value required by the target bridge context.
+       - ordinalProjection: Target document ordinal domain: active module for normal Bible
+         documents, KJVA for Android's My Notes fake document.
      - Returns: A typed Bible bookmark payload.
      - Side effects: reads verse text from the active SWORD module when available.
      - Failure modes: missing label relationships are filtered through shared serialization
        support.
      */
-    private func bibleBookmarkJSON(_ bookmark: BibleBookmark, editAction: EditActionData?) -> BibleBookmarkData {
+    private func bibleBookmarkJSON(
+        _ bookmark: BibleBookmark,
+        editAction: EditActionData?,
+        ordinalProjection: BibleBookmarkOrdinalProjection = .activeModule
+    ) -> BibleBookmarkData {
         let id = bookmark.id.uuidString
         let hashCode = Self.normalizedBridgeHashCode(from: id.hashValue)
         let createdAt = bridgeTimestampMilliseconds(bookmark.createdAt)
@@ -306,21 +330,40 @@ struct BibleReaderAnnotationPayloadFactory {
         let bookmarkBook = bookmark.book ?? currentBook
         let rangeProjection = bibleBookmarkRangeProjection(
             bookName: bookmarkBook,
-            startOrdinal: bookmark.ordinalStart,
-            endOrdinal: bookmark.ordinalEnd
+            sourceStartOrdinal: bookmark.ordinalStart,
+            sourceEndOrdinal: bookmark.ordinalEnd,
+            kjvStartOrdinal: bookmark.kjvOrdinalStart,
+            kjvEndOrdinal: bookmark.kjvOrdinalEnd,
+            ordinalProjection: ordinalProjection
         )
-        let fullText = loadVerseText(for: rangeProjection)
+        let textRangeProjection = ordinalProjection == .activeModule ? rangeProjection : bibleBookmarkRangeProjection(
+            bookName: bookmarkBook,
+            sourceStartOrdinal: bookmark.ordinalStart,
+            sourceEndOrdinal: bookmark.ordinalEnd,
+            kjvStartOrdinal: bookmark.kjvOrdinalStart,
+            kjvEndOrdinal: bookmark.kjvOrdinalEnd,
+            ordinalProjection: .activeModule
+        )
+        let fullText = loadVerseText(for: textRangeProjection)
+        let sourceModuleMetadata = sourceModuleMetadata(for: bookmark)
+        let hasSourceModule = !sourceModuleMetadata.initials.isEmpty
+        let effectiveWholeVerse = bookmark.wholeVerse || !hasSourceModule
+        let effectiveSourceEndOrdinal = bookmark.ordinalEnd > bookmark.ordinalStart
+            ? bookmark.ordinalEnd
+            : bookmark.ordinalStart
 
         return BibleBookmarkData(
             id: id,
             type: "bookmark",
             hashCode: hashCode,
-            ordinalRange: [bookmark.ordinalStart, bookmark.ordinalEnd],
-            offsetRange: bookmarkOffsetRange(startOffset: bookmark.startOffset, endOffset: bookmark.endOffset),
+            ordinalRange: [rangeProjection.start.ordinal, rangeProjection.end.ordinal],
+            offsetRange: effectiveWholeVerse
+                ? nil
+                : bookmarkOffsetRange(startOffset: bookmark.startOffset, endOffset: bookmark.endOffset),
             labels: labelPayload.labelIDs,
-            bookInitials: activeModuleName,
-            bookName: activeModuleName,
-            bookAbbreviation: rangeProjection.start.osisBookId,
+            bookInitials: sourceModuleMetadata.initials,
+            bookName: sourceModuleMetadata.name,
+            bookAbbreviation: sourceModuleMetadata.abbreviation,
             createdAt: createdAt,
             text: fullText,
             fullText: fullText,
@@ -330,15 +373,15 @@ struct BibleReaderAnnotationPayloadFactory {
             notes: hasNote ? noteText : nil,
             notesContentType: bookmark.notes?.contentType,
             hasNote: hasNote,
-            wholeVerse: bookmark.wholeVerse,
+            wholeVerse: effectiveWholeVerse,
             customIcon: bookmark.customIcon,
             editAction: editAction,
             osisRef: rangeProjection.osisRef,
-            originalOrdinalRange: [bookmark.kjvOrdinalStart, bookmark.kjvOrdinalEnd],
+            originalOrdinalRange: [bookmark.ordinalStart, effectiveSourceEndOrdinal],
             verseRange: rangeProjection.verseRange,
             verseRangeOnlyNumber: rangeProjection.verseRangeOnlyNumber,
             verseRangeAbbreviated: rangeProjection.verseRangeAbbreviated,
-            v11n: bookmark.v11n,
+            v11n: hasSourceModule ? bookmark.v11n : JSwordKJVAVersification.name,
             osisFragment: nil
         )
     }
@@ -348,27 +391,44 @@ struct BibleReaderAnnotationPayloadFactory {
      `ClientBibleBookmark` fields.
 
      - Parameters:
-       - bookName: Stored or current start book name.
-       - startOrdinal: Stored start ordinal in the bookmark versification.
-       - endOrdinal: Stored end ordinal in the bookmark versification.
+       - bookName: Stored or current start book name used only by legacy fallback paths.
+       - sourceStartOrdinal: Stored start ordinal in the bookmark source versification.
+       - sourceEndOrdinal: Stored end ordinal in the bookmark source versification.
+       - kjvStartOrdinal: Stored start ordinal in Android's KJVA bookmark domain.
+       - kjvEndOrdinal: Stored end ordinal in Android's KJVA bookmark domain.
+       - ordinalProjection: Target document ordinal domain for emitted `ordinalRange`.
      - Returns: A normalized range projection. Invalid or reversed end ordinals collapse to the
        start verse, matching existing single-verse normalization.
-     - Side effects: May query the active SWORD module for ordinal-to-verse resolution.
-     - Failure modes: falls back to the no-module compatibility projection when SWORD cannot
-       resolve a verse.
+     - Side effects: May query the active SWORD module for KJVA-to-rendered ordinal projection.
+     - Failure modes: falls back to the source ordinal and no-module compatibility projection when
+       a malformed legacy row cannot be resolved through KJVA.
      */
     private func bibleBookmarkRangeProjection(
         bookName: String,
-        startOrdinal: Int,
-        endOrdinal: Int
+        sourceStartOrdinal: Int,
+        sourceEndOrdinal: Int,
+        kjvStartOrdinal: Int,
+        kjvEndOrdinal: Int,
+        ordinalProjection: BibleBookmarkOrdinalProjection
     ) -> BookmarkBridgeVerseRangeProjection {
-        let startReference = verseReference(book: bookName, ordinal: startOrdinal)
-            ?? activeModule?.verseReference(ordinal: startOrdinal)
-            ?? fallbackVerseReference(bookName: bookName, ordinal: startOrdinal)
-        let effectiveEndOrdinal = endOrdinal > startOrdinal ? endOrdinal : startOrdinal
-        let endReference = verseReference(book: bookName, ordinal: effectiveEndOrdinal)
-            ?? activeModule?.verseReference(ordinal: effectiveEndOrdinal)
-            ?? startReference
+        let startReference = renderedReference(
+            kjvOrdinal: kjvStartOrdinal,
+            sourceOrdinal: sourceStartOrdinal,
+            bookName: bookName,
+            ordinalProjection: ordinalProjection
+        )
+        let effectiveSourceEndOrdinal = sourceEndOrdinal > sourceStartOrdinal
+            ? sourceEndOrdinal
+            : sourceStartOrdinal
+        let effectiveKJVEndOrdinal = kjvEndOrdinal > kjvStartOrdinal
+            ? kjvEndOrdinal
+            : kjvStartOrdinal
+        let endReference = renderedReference(
+            kjvOrdinal: effectiveKJVEndOrdinal,
+            sourceOrdinal: effectiveSourceEndOrdinal,
+            bookName: bookName,
+            ordinalProjection: ordinalProjection
+        )
 
         return BookmarkBridgeVerseRangeProjection(
             startBookName: bridgeBookName(for: startReference, fallback: bookName),
@@ -378,6 +438,80 @@ struct BibleReaderAnnotationPayloadFactory {
             endBookAbbreviation: bridgeBookAbbreviation(for: endReference),
             end: endReference
         )
+    }
+
+    /**
+     Resolves a stored KJVA bookmark ordinal into the target document's rendered ordinal space.
+
+     Android backups identify Bible bookmarks by KJVA ordinals even when the `book` column stores
+     module initials or NULL. Normal Bible documents need the active module's rendered ordinal for
+     Vue highlight matching, while Android's My Notes fake document uses KJVA ordinals directly.
+
+     - Parameters:
+       - kjvOrdinal: Persisted Android-compatible KJVA ordinal.
+       - sourceOrdinal: Persisted source ordinal used only by legacy fallback paths.
+       - bookName: Stored or current book name used only by legacy fallback paths.
+       - ordinalProjection: Target document ordinal domain for emitted ordinals.
+     - Returns: Verse reference with an active-module ordinal when possible, otherwise a KJVA or
+       compatibility fallback reference.
+     - Side effects: May temporarily move the active SWORD module cursor through
+       `verseOrdinal(osisBookId:chapter:verse:)`.
+     - Failure modes: Malformed KJVA ordinals fall back to legacy source-ordinal resolution.
+     */
+    private func renderedReference(
+        kjvOrdinal: Int,
+        sourceOrdinal: Int,
+        bookName: String,
+        ordinalProjection: BibleBookmarkOrdinalProjection
+    ) -> VerseKeyReference {
+        if let kjvaReference = JSwordKJVAVersification.verseReference(ordinal: kjvOrdinal) {
+            let renderedOrdinal: Int
+            switch ordinalProjection {
+            case .activeModule:
+                renderedOrdinal = activeModule?.verseOrdinal(
+                    osisBookId: kjvaReference.osisId,
+                    chapter: kjvaReference.chapter,
+                    verse: kjvaReference.verse
+                ) ?? kjvaReference.ordinal
+            case .kjva:
+                renderedOrdinal = kjvaReference.ordinal
+            }
+            return VerseKeyReference(
+                osisBookId: kjvaReference.osisId,
+                chapter: kjvaReference.chapter,
+                verse: kjvaReference.verse,
+                ordinal: renderedOrdinal
+            )
+        }
+        return verseReference(book: bookName, ordinal: sourceOrdinal)
+            ?? activeModule?.verseReference(ordinal: sourceOrdinal)
+            ?? fallbackVerseReference(bookName: bookName, ordinal: sourceOrdinal)
+    }
+
+    /**
+     Projects source module metadata for Android's bookmark modal contract.
+
+     Android's `ClientBibleBookmark` emits metadata from `bookmark.book`, the source passage book
+     stored with the bookmark. iOS keeps display book names in `BibleBookmark.book`, so the bridge
+     must read the separate source-module initials field and only use the active module description
+     when it is actually the same module.
+
+     - Parameter bookmark: Bible bookmark being serialized.
+     - Returns: Source initials/name/abbreviation tuple, or empty strings when Android would have
+       had a NULL source book.
+     - Side effects: none.
+     - Failure modes: Missing active-module description falls back to initials.
+     */
+    private func sourceModuleMetadata(for bookmark: BibleBookmark) -> (initials: String, name: String, abbreviation: String) {
+        let initials = bookmark.bookInitials.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !initials.isEmpty else {
+            return ("", "", "")
+        }
+        let activeDescription = activeModuleName == initials
+            ? activeModule?.info.description.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            : ""
+        let name = activeDescription.isEmpty ? initials : activeDescription
+        return (initials, name, initials)
     }
 
     /**
@@ -442,7 +576,9 @@ struct BibleReaderAnnotationPayloadFactory {
      - Failure modes: None.
      */
     private func bridgeBookName(for reference: VerseKeyReference, fallback: String) -> String {
-        BibleReaderController.bookName(forOsisId: reference.osisBookId) ?? fallback
+        BibleReaderController.bookName(forOsisId: reference.osisBookId)
+            ?? JSwordKJVAVersification.longBookName(osisId: reference.osisBookId)
+            ?? fallback
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
@@ -83,8 +83,8 @@ struct BibleReaderBookmarkActionCoordinator {
 
      - Parameters:
        - bookInitials: Module initials associated with the selected text.
-       - startOrdinal: Inclusive starting verse ordinal.
-       - endOrdinal: Inclusive ending verse ordinal.
+       - startOrdinal: Inclusive source-versification starting verse ordinal.
+       - endOrdinal: Inclusive source-versification ending verse ordinal, or `0` for a single-verse selection.
        - addNote: Whether the bookmark sheet should open directly to note editing.
        - wholeVerse: Whether the new bookmark highlights whole verses.
        - startOffset: Optional text-range start offset.
@@ -93,8 +93,9 @@ struct BibleReaderBookmarkActionCoordinator {
      - Returns: Bookmark update and optional modal/config persistence events.
      - Side effects: May insert a Bible bookmark and bookmark-to-label rows.
      - Failure modes: Missing labels in workspace settings are ignored by `BookmarkService`;
-       unresolvable KJVA projection falls back to the rendered ordinal range so the bridge remains
-       usable for unsupported versifications.
+       unresolvable KJVA projection falls back to the normalized source ordinal range so the bridge
+       remains usable for unsupported versifications without persisting reversed or zero-ended
+       source ranges.
      */
     func addOrUpdateBibleBookmark(
         bookInitials: String,
@@ -121,8 +122,8 @@ struct BibleReaderBookmarkActionCoordinator {
         } else {
             bookmark = bookmarkService.addBibleBookmark(
                 bookInitials: bookInitials,
-                startOrdinal: startOrdinal,
-                endOrdinal: endOrdinal,
+                startOrdinal: sourceStart,
+                endOrdinal: sourceEnd,
                 kjvOrdinalStart: storageRange.start,
                 kjvOrdinalEnd: storageRange.end,
                 v11n: currentV11n(),
@@ -206,11 +207,13 @@ struct BibleReaderBookmarkActionCoordinator {
      - Parameters:
        - bookInitials: Module initials associated with the selected verse.
        - startOrdinal: Source-versification start ordinal reported by Vue.
-       - endOrdinal: Source-versification end ordinal reported by Vue.
+       - endOrdinal: Source-versification end ordinal reported by Vue, or `0` for a single-verse
+         paragraph marker.
      - Returns: Bridge update result containing the inserted paragraph-break bookmark payload.
      - Side effects: Inserts a Bible bookmark and attaches Android's paragraph-break system label.
-     - Failure modes: Unresolvable KJVA projection falls back to the rendered ordinal range so
-       unsupported versifications can still create paragraph breaks.
+     - Failure modes: Unresolvable KJVA projection falls back to the normalized source ordinal range
+       so unsupported versifications can still create paragraph breaks without persisting reversed
+       or zero-ended source ranges.
      */
     func addParagraphBreakBibleBookmark(
         bookInitials: String,
@@ -223,8 +226,8 @@ struct BibleReaderBookmarkActionCoordinator {
         let storageRange = kjvaOrdinalRange(sourceStart, sourceEnd) ?? (start: sourceStart, end: sourceEnd)
         let bookmark = bookmarkService.addParagraphBreakBibleBookmark(
             bookInitials: bookInitials,
-            startOrdinal: startOrdinal,
-            endOrdinal: endOrdinal,
+            startOrdinal: sourceStart,
+            endOrdinal: sourceEnd,
             kjvOrdinalStart: storageRange.start,
             kjvOrdinalEnd: storageRange.end,
             v11n: currentV11n(),

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderBookmarkActionCoordinator.swift
@@ -35,6 +35,10 @@ struct BibleReaderBookmarkActionCoordinator {
     private let payloadFactory: BibleReaderAnnotationPayloadFactory
     /// Current reader book name used for legacy bookmark rows that do not carry their own book.
     private let currentBook: String
+    /// Supplies the current module versification for source ordinal fidelity.
+    private let currentV11n: () -> String
+    /// Projects rendered reader ordinals into Android's KJVA bookmark storage domain.
+    private let kjvaOrdinalRange: (Int, Int) -> (start: Int, end: Int)?
     /// Supplies the active Android-compatible notes content type for newly-created note rows.
     private let currentNotesContentType: () -> String
 
@@ -45,6 +49,8 @@ struct BibleReaderBookmarkActionCoordinator {
        - bookmarkService: Persistence facade for bookmark, label, note, and StudyPad mutations.
        - payloadFactory: Factory that projects persisted models into typed Vue bridge DTOs.
        - currentBook: Current reader book name to store on newly-created Bible bookmarks.
+       - currentV11n: Closure returning the active module versification for newly-created rows.
+       - kjvaOrdinalRange: Closure converting rendered start/end ordinals into KJVA storage ordinals.
        - currentNotesContentType: Closure returning the current notes-content-type preference for
          new note rows.
      - Side effects: None during initialization.
@@ -54,11 +60,17 @@ struct BibleReaderBookmarkActionCoordinator {
         bookmarkService: BookmarkService,
         payloadFactory: BibleReaderAnnotationPayloadFactory,
         currentBook: String,
+        currentV11n: @escaping () -> String = { "KJVA" },
+        kjvaOrdinalRange: @escaping (Int, Int) -> (start: Int, end: Int)? = { start, end in
+            (start: min(start, end), end: max(start, end))
+        },
         currentNotesContentType: @escaping () -> String
     ) {
         self.bookmarkService = bookmarkService
         self.payloadFactory = payloadFactory
         self.currentBook = currentBook
+        self.currentV11n = currentV11n
+        self.kjvaOrdinalRange = kjvaOrdinalRange
         self.currentNotesContentType = currentNotesContentType
     }
 
@@ -80,7 +92,9 @@ struct BibleReaderBookmarkActionCoordinator {
        - workspaceSettings: Active workspace settings for auto labels and StudyPad cursors.
      - Returns: Bookmark update and optional modal/config persistence events.
      - Side effects: May insert a Bible bookmark and bookmark-to-label rows.
-     - Failure modes: Missing labels in workspace settings are ignored by `BookmarkService`.
+     - Failure modes: Missing labels in workspace settings are ignored by `BookmarkService`;
+       unresolvable KJVA projection falls back to the rendered ordinal range so the bridge remains
+       usable for unsupported versifications.
      */
     func addOrUpdateBibleBookmark(
         bookInitials: String,
@@ -92,8 +106,12 @@ struct BibleReaderBookmarkActionCoordinator {
         endOffset: Int? = nil,
         workspaceSettings: WorkspaceSettings?
     ) -> BibleReaderBookmarkActionResult {
-        let existing = bookmarkService.bookmarks(for: startOrdinal, endOrdinal: startOrdinal, book: currentBook)
-            .first(where: { $0.ordinalStart == startOrdinal })
+        let effectiveEndOrdinal = endOrdinal > 0 ? endOrdinal : startOrdinal
+        let sourceStart = min(startOrdinal, effectiveEndOrdinal)
+        let sourceEnd = max(startOrdinal, effectiveEndOrdinal)
+        let storageRange = kjvaOrdinalRange(sourceStart, sourceEnd) ?? (start: sourceStart, end: sourceEnd)
+        let existing = bookmarkService.bookmarks(for: storageRange.start, endOrdinal: storageRange.start, book: currentBook)
+            .first(where: { $0.kjvOrdinalStart == storageRange.start })
 
         let bookmark: BibleBookmark
         let isNew: Bool
@@ -105,6 +123,9 @@ struct BibleReaderBookmarkActionCoordinator {
                 bookInitials: bookInitials,
                 startOrdinal: startOrdinal,
                 endOrdinal: endOrdinal,
+                kjvOrdinalStart: storageRange.start,
+                kjvOrdinalEnd: storageRange.end,
+                v11n: currentV11n(),
                 wholeVerse: wholeVerse,
                 startOffset: startOffset,
                 endOffset: endOffset,
@@ -179,17 +200,34 @@ struct BibleReaderBookmarkActionCoordinator {
     }
 
     /**
-     Creates a Bible paragraph-break bookmark.
+     Creates a Bible paragraph-break bookmark using the same KJVA storage projection as normal
+     Bible bookmarks.
+
+     - Parameters:
+       - bookInitials: Module initials associated with the selected verse.
+       - startOrdinal: Source-versification start ordinal reported by Vue.
+       - endOrdinal: Source-versification end ordinal reported by Vue.
+     - Returns: Bridge update result containing the inserted paragraph-break bookmark payload.
+     - Side effects: Inserts a Bible bookmark and attaches Android's paragraph-break system label.
+     - Failure modes: Unresolvable KJVA projection falls back to the rendered ordinal range so
+       unsupported versifications can still create paragraph breaks.
      */
     func addParagraphBreakBibleBookmark(
         bookInitials: String,
         startOrdinal: Int,
         endOrdinal: Int
     ) -> BibleReaderBookmarkActionResult {
+        let effectiveEndOrdinal = endOrdinal > 0 ? endOrdinal : startOrdinal
+        let sourceStart = min(startOrdinal, effectiveEndOrdinal)
+        let sourceEnd = max(startOrdinal, effectiveEndOrdinal)
+        let storageRange = kjvaOrdinalRange(sourceStart, sourceEnd) ?? (start: sourceStart, end: sourceEnd)
         let bookmark = bookmarkService.addParagraphBreakBibleBookmark(
             bookInitials: bookInitials,
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal,
+            kjvOrdinalStart: storageRange.start,
+            kjvOrdinalEnd: storageRange.end,
+            v11n: currentV11n(),
             book: currentBook
         )
         return BibleReaderBookmarkActionResult(

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -45,7 +45,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /// Whether the WebView is currently showing the My Notes document (vs Bible text).
     private(set) var showingMyNotes = false
-    /// Optional My Notes row ordinal requested before the Vue client was ready.
+    /// Optional KJVA My Notes row ordinal requested before the Vue client was ready.
     private var pendingClientReadyMyNotesJumpOrdinal: Int?
     /// Monotonic marker used by lightweight UI-test exports when My Notes state or documents rebuild.
     private(set) var myNotesMutationRevision = 0
@@ -239,6 +239,80 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
+     Converts a bookmark-modal My Notes link target into Android's My Notes document ordinal domain.
+
+     Android builds the link from `bookmark.verseRange.start.ordinal` plus its source
+     versification, then opens a My Notes document whose row ordinals are KJVA. iOS mirrors that by
+     resolving the source ordinal through a module with the requested versification and converting
+     the resulting verse identity to a KJVA ordinal before scrolling.
+
+     - Parameters:
+       - v11nName: Source versification emitted by the bookmark payload.
+       - sourceOrdinal: Bookmark start ordinal in `v11nName`.
+     - Returns: KJVA ordinal for the same verse, or `nil` when no installed module can soundly
+       resolve the source ordinal.
+     - Side effects: May temporarily open or move SWORD modules through `verseReference`.
+     - Failure modes: Returns `nil` for invalid ordinals, unsupported versifications, or modules
+       that cannot resolve the source ordinal exactly.
+     */
+    private func kjvaMyNotesOrdinal(v11nName: String, sourceOrdinal: Int) -> Int? {
+        guard sourceOrdinal > 0 else { return nil }
+        let wanted = normalizedVersificationName(v11nName)
+        if wanted == JSwordKJVAVersification.name {
+            return sourceOrdinal
+        }
+
+        if normalizedVersificationName(activeModule?.configEntry("Versification") ?? "") == wanted,
+           let ordinal = kjvaOrdinal(sourceOrdinal: sourceOrdinal, in: activeModule) {
+            return ordinal
+        }
+
+        for info in installedBibleModules
+        where normalizedVersificationName(info.aboutMetadata.versification) == wanted {
+            guard let module = swordManager?.module(named: info.name),
+                  let ordinal = kjvaOrdinal(sourceOrdinal: sourceOrdinal, in: module) else {
+                continue
+            }
+            return ordinal
+        }
+        return nil
+    }
+
+    /**
+     Converts one module-local source ordinal to KJVA using the resolved verse identity.
+
+     - Parameters:
+       - sourceOrdinal: Ordinal in the supplied module's active versification.
+       - module: Module whose versification owns `sourceOrdinal`.
+     - Returns: Matching KJVA ordinal, or `nil` if either side rejects the verse.
+     - Side effects: Temporarily moves the module cursor through `verseReference`.
+     - Failure modes: Returns `nil` for invalid ordinals and references outside KJVA.
+     */
+    private func kjvaOrdinal(sourceOrdinal: Int, in module: SwordModule?) -> Int? {
+        guard let reference = module?.verseReference(ordinal: sourceOrdinal) else {
+            return nil
+        }
+        return JSwordKJVAVersification.verseOrdinal(
+            osisId: reference.osisBookId,
+            chapter: reference.chapter,
+            verse: reference.verse
+        )
+    }
+
+    /**
+     Normalizes empty/SWORD versification names the same way Android and SWORD treat defaults.
+
+     - Parameter name: Raw versification value.
+     - Returns: Uppercase versification key; empty input becomes `KJV`.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func normalizedVersificationName(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "KJV" : trimmed.uppercased()
+    }
+
+    /**
      Resolves the ordinal range for a chapter in the active module's versification.
 
      - Parameters:
@@ -273,7 +347,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             activeStudyPadLabelId: activeStudyPadLabelId,
             activeStudyPadLabelName: activeStudyPadLabelName,
             chapterOrdinalRange: { [self] in
-                currentChapterOrdinalRange()
+                bookmarkQueryOrdinalRange(book: currentBook, chapter: currentChapter)
             },
             verseReference: { [self] book, ordinal in
                 verseReference(book: book, ordinal: ordinal)
@@ -4063,13 +4137,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      Opens the chapter-level My Notes document in the current pane.
      */
     public func bridge(_ bridge: BibleBridge, openMyNotes v11n: String, ordinal: Int) {
-        loadMyNotesDocument(jumpToOrdinal: ordinal)
+        loadMyNotesDocument(jumpToOrdinal: kjvaMyNotesOrdinal(v11nName: v11n, sourceOrdinal: ordinal) ?? ordinal)
     }
 
     /**
      Loads the My Notes document for the current chapter into the WebView.
 
-     - Parameter jumpToOrdinal: Optional rendered My Notes row ordinal to scroll to after loading.
+     - Parameter jumpToOrdinal: Optional KJVA My Notes row ordinal to scroll to after loading.
      - Side effects: Marks My Notes as the visible reader document, clears competing StudyPad and
        editing state, rebuilds the chapter's note-backed bookmarks, emits the My Notes document to
        Vue when the client is ready, or stores the request for client-ready replay when it is not.
@@ -4093,7 +4167,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             currentChapter: currentChapter,
             osisBookId: osisBookId(for: currentBook),
             jumpToOrdinal: jumpToOrdinal,
-            chapterRange: { [weak self] in self?.currentChapterOrdinalRange() },
+            chapterRange: { [weak self] in
+                guard let self else { return nil }
+                return self.bookmarkQueryOrdinalRange(book: self.currentBook, chapter: self.currentChapter)
+            },
             bookmarks: { [weak self] in self?.currentChapterMyNotesBookmarks() ?? [] },
             bookmarkPayload: { [self] bookmark in buildBookmarkJSONForMyNotes(bookmark) },
             prepareVisibleState: { [weak self] in
@@ -5320,12 +5397,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return nil
         }
 
-        // Query bookmarks for this chapter's ordinal range
-        guard let range = chapterOrdinalRange(book: book, chapter: chapter, verseCount: loadedChapter.verseCount) else {
-            logger.error("Failed to resolve SWORD chapter range for \(osisBookId, privacy: .public).\(chapter)")
+        // Query bookmarks through Android's KJVA range so restored rows with module initials or
+        // NULL in `book` still highlight in infinite-scroll chapters.
+        guard let range = bookmarkQueryOrdinalRange(book: book, chapter: chapter, verseCount: loadedChapter.verseCount) else {
+            logger.error("Failed to resolve bookmark range for \(osisBookId, privacy: .public).\(chapter)")
             return nil
         }
-        let chapterBookmarks = bookmarkService?.bookmarks(for: range.start, endOrdinal: range.end, book: book) ?? []
+        let chapterBookmarks = bookmarkService?.bookmarks(for: range.start, endOrdinal: range.end) ?? []
 
         guard let document = buildDocumentJSON(
             osisBookId: osisBookId,
@@ -5436,14 +5514,47 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     // MARK: - Bookmark Helpers
 
-    /// Query bookmarks for the current chapter's ordinal range, filtered by current book.
+    /**
+     Resolves the storage-domain bookmark range for a chapter.
+
+     Android persists Bible bookmark membership in KJVA-compatible ordinals. Prefer that range for
+     highlight, My Notes, and list membership so restored Android rows with module initials or NULL
+     in `BibleBookmark.book` still match the visible chapter. The active-module range remains a
+     fallback for unsupported canons and legacy rows whose KJVA columns mirror source ordinals.
+
+     - Parameters:
+       - book: Display book name for the visible chapter.
+       - chapter: One-based chapter number.
+       - verseCount: Optional visible last verse count from the already-loaded chapter.
+     - Returns: Inclusive storage range and verse count, or `nil` when neither KJVA nor active
+       module versification can resolve the chapter.
+     - Side effects: May query the active SWORD module through `chapterOrdinalRange`.
+     - Failure modes: Returns `nil` for unknown books, out-of-range chapters, or unsupported
+       module/canon combinations.
+     */
+    private func bookmarkQueryOrdinalRange(
+        book: String,
+        chapter: Int,
+        verseCount: Int? = nil
+    ) -> (start: Int, end: Int, verseCount: Int)? {
+        let osisId = osisBookId(for: book)
+        if let kjvaRange = JSwordKJVAVersification.verseOrdinalRange(osisId: osisId, chapter: chapter) {
+            let resolvedVerseCount = verseCount
+                ?? JSwordKJVAVersification.verseCount(osisId: osisId, chapter: chapter)
+                ?? max(0, kjvaRange.count)
+            return (start: kjvaRange.lowerBound, end: kjvaRange.upperBound, verseCount: resolvedVerseCount)
+        }
+        return chapterOrdinalRange(book: book, chapter: chapter, verseCount: verseCount)
+    }
+
+    /// Query bookmarks for the current chapter's Android-compatible KJVA ordinal range.
     private func bookmarksForCurrentChapter(verseCount: Int) -> [BibleBookmark] {
         guard let service = bookmarkService else { return [] }
-        guard let range = chapterOrdinalRange(book: currentBook, chapter: currentChapter, verseCount: verseCount) else {
+        guard let range = bookmarkQueryOrdinalRange(book: currentBook, chapter: currentChapter, verseCount: verseCount) else {
             logger.error("Failed to resolve bookmark range for \(self.currentBook, privacy: .public) \(self.currentChapter)")
             return []
         }
-        return service.bookmarks(for: range.start, endOrdinal: range.end, book: currentBook)
+        return service.bookmarks(for: range.start, endOrdinal: range.end)
     }
 
     // MARK: - Default Labels
@@ -5730,6 +5841,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             bookmarkService: bookmarkService,
             payloadFactory: annotationPayloadFactory(),
             currentBook: currentBook,
+            currentV11n: { [weak self] in
+                let versification = self?.activeModule?.configEntry("Versification")?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return versification.isEmpty ? "KJV" : versification
+            },
+            kjvaOrdinalRange: { [weak self] startOrdinal, endOrdinal in
+                self?.bookmarkStorageKJVARange(startOrdinal: startOrdinal, endOrdinal: endOrdinal)
+            },
             currentNotesContentType: { [weak self] in
                 self?.currentNotesContentType() ?? "HTML"
             },
@@ -6123,6 +6242,71 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         return BibleReaderProgressBridgeCoordinator.ReadingProgressBridgeTarget(
             kjvBookOrdinal: kjvBookOrdinal,
             bookName: currentBook
+        )
+    }
+
+    /**
+     Resolves a rendered reader bookmark selection into Android's inclusive KJVA storage span.
+
+     Newly-created iOS bookmarks keep their source ordinals for local fidelity, but Android backup
+     compatibility depends on KJVA ordinals. This uses the memorization resolver's proven
+     rendered-to-KJVA path so bookmark creation, restore, and chapter queries share one durable key.
+
+     - Parameters:
+       - startOrdinal: First rendered ordinal reported by Vue.
+       - endOrdinal: Last rendered ordinal reported by Vue.
+     - Returns: Inclusive KJVA span, or `nil` when the rendered selection cannot be represented in
+       KJVA.
+     - Side effects: May temporarily move the active SWORD module cursor through
+       `memorizationOrdinalResolution`.
+     - Failure modes: Returns `nil` for invalid endpoints or references outside KJVA.
+     */
+    private func bookmarkStorageKJVARange(
+        startOrdinal: Int,
+        endOrdinal: Int
+    ) -> (start: Int, end: Int)? {
+        let effectiveEndOrdinal = endOrdinal > 0 ? endOrdinal : startOrdinal
+        let lower = min(startOrdinal, effectiveEndOrdinal)
+        let upper = max(startOrdinal, effectiveEndOrdinal)
+        if let resolution = memorizationOrdinalResolution(startOrdinal: lower, endOrdinal: upper) {
+            return (start: resolution.startOrdinal, end: resolution.endOrdinal)
+        }
+        // Exact KJVA numbering rejected the selection (a versification-divergent module verse with
+        // no same-numbered KJVA counterpart). Persisting the raw source ordinal here would render
+        // and export as a completely wrong verse (issue #356 on the write side), so clamp each
+        // endpoint to the nearest addressable KJVA verse in the resolved book instead.
+        guard let clampedStart = clampedKJVAStorageOrdinal(sourceOrdinal: lower),
+              let clampedEnd = clampedKJVAStorageOrdinal(sourceOrdinal: upper) else {
+            return nil
+        }
+        return (start: min(clampedStart, clampedEnd), end: max(clampedStart, clampedEnd))
+    }
+
+    /**
+     Clamps one rendered source ordinal to the nearest addressable KJVA storage ordinal.
+
+     Used only when exact KJVA resolution fails for a versification-divergent module. Resolves the
+     source ordinal to its book/chapter/verse through the active module, then maps that identity
+     onto the nearest valid KJVA verse in the same book. This keeps persisted bookmark ordinals
+     inside the Android-compatible KJVA domain and in the correct book, at the cost of exact verse
+     fidelity for canons whose numbering diverges from KJVA — a bounded approximation until iOS
+     gains a full JSword-style versification mapping engine.
+
+     - Parameter sourceOrdinal: Rendered ordinal in the active module's versification.
+     - Returns: Nearest KJVA storage ordinal, or `nil` when the reference cannot be resolved to a
+       KJVA book at all.
+     - Side effects: May temporarily move the active SWORD module cursor through `verseReference`.
+     - Failure modes: Returns `nil` for invalid ordinals and references outside the KJVA canon.
+     */
+    private func clampedKJVAStorageOrdinal(sourceOrdinal: Int) -> Int? {
+        guard sourceOrdinal > 0,
+              let reference = memorizationVerseReference(renderedOrdinal: sourceOrdinal) else {
+            return nil
+        }
+        return JSwordKJVAVersification.nearestVerseOrdinal(
+            osisId: reference.osisBookId,
+            chapter: reference.chapter,
+            verse: reference.verse
         )
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -4135,9 +4135,23 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
     /**
      Opens the chapter-level My Notes document in the current pane.
+
+     Android passes My Notes modal links as the source versification plus the bookmark's original
+     source ordinal, while the fake My Notes document itself renders rows in KJVA order. This bridge
+     converts the source ordinal before loading the document so the optional scroll target stays in
+     the document's ordinal domain.
+
+     - Parameters:
+       - bridge: BibleView bridge instance that delivered the action; unused because the controller
+         owns document loading state.
+       - v11n: Source versification name associated with `ordinal`.
+       - ordinal: Source-versification ordinal from the bookmark modal link.
+     - Side effects: Loads or queues the My Notes document through `loadMyNotesDocument`.
+     - Failure modes: If the source ordinal cannot be projected to KJVA, the document opens without
+       a scroll target rather than sending an ordinal from the wrong domain.
      */
     public func bridge(_ bridge: BibleBridge, openMyNotes v11n: String, ordinal: Int) {
-        loadMyNotesDocument(jumpToOrdinal: kjvaMyNotesOrdinal(v11nName: v11n, sourceOrdinal: ordinal) ?? ordinal)
+        loadMyNotesDocument(jumpToOrdinal: kjvaMyNotesOrdinal(v11nName: v11n, sourceOrdinal: ordinal))
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -5,12 +5,11 @@ import SwiftData
 import BibleCore
 
 /**
- Verse reference resolved from an Android/JSword-style bookmark ordinal.
+ Verse reference resolved from a bookmark ordinal.
 
  Bookmark rows are built from persisted SwiftData records, but those records store ordinals in the
- source versification rather than chapter/verse text. The reader injects a resolver backed by
- SWORD's `VerseKey` so the list can display and navigate bookmarks without reintroducing local
- ordinal arithmetic.
+ Android-compatible KJVA columns used by backup/restore. The reader can still inject a resolver
+ backed by SWORD's `VerseKey` for legacy rows whose KJVA columns only mirror source ordinals.
  */
 public struct BookmarkListVerseReference: Sendable, Equatable {
     /// One-based chapter number.
@@ -451,6 +450,19 @@ public struct BookmarkListView: View {
         for bookmark: BibleBookmark,
         ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
     ) -> String {
+        if let start = kjvaVerseReference(ordinal: bookmark.kjvOrdinalStart) {
+            let effectiveKJVEnd = bookmark.kjvOrdinalEnd > bookmark.kjvOrdinalStart
+                ? bookmark.kjvOrdinalEnd
+                : bookmark.kjvOrdinalStart
+            let end = kjvaVerseReference(ordinal: effectiveKJVEnd) ?? start
+            return formattedBibleReference(
+                startBookName: start.bookName,
+                startReference: start.reference,
+                endBookName: end.bookName,
+                endReference: end.reference
+            )
+        }
+
         let bookName = bookmark.book ?? "Unknown"
         let startReference = ordinalResolver?(bookName, bookmark.ordinalStart)
             ?? compatibilityVerseReference(ordinal: bookmark.ordinalStart)
@@ -459,21 +471,68 @@ public struct BookmarkListView: View {
         let endReference = ordinalResolver?(bookName, effectiveEnd)
             ?? compatibilityVerseReference(ordinal: effectiveEnd)
 
-        if effectiveEnd == bookmark.ordinalStart || endReference == startReference {
-            return "\(bookName) \(startReference.chapter):\(startReference.verse)"
-        } else if endReference.chapter == startReference.chapter {
-            return "\(bookName) \(startReference.chapter):\(startReference.verse)-\(endReference.verse)"
+        return formattedBibleReference(
+            startBookName: bookName,
+            startReference: startReference,
+            endBookName: bookName,
+            endReference: endReference
+        )
+    }
+
+    /**
+     Resolves a stored Android-compatible KJVA ordinal for bookmark-list display and navigation.
+
+     - Parameter ordinal: Persisted KJVA verse ordinal.
+     - Returns: Display book name and chapter/verse reference, or `nil` for invalid ordinals.
+     - Side effects: None.
+     - Failure modes: Unknown ordinals return `nil` so legacy fallback paths can handle older rows.
+     */
+    fileprivate static func kjvaVerseReference(
+        ordinal: Int
+    ) -> (bookName: String, reference: BookmarkListVerseReference)? {
+        guard let reference = JSwordKJVAVersification.verseReference(ordinal: ordinal) else {
+            return nil
+        }
+        return (
+            bookName: JSwordKJVAVersification.longBookName(osisId: reference.osisId) ?? reference.osisId,
+            reference: BookmarkListVerseReference(chapter: reference.chapter, verse: reference.verse)
+        )
+    }
+
+    /**
+     Formats a Bible bookmark range using JSword-style same-chapter and cross-chapter shorthand.
+
+     - Parameters:
+       - startBookName: Display name for the start book.
+       - startReference: Start chapter/verse reference.
+       - endBookName: Display name for the end book.
+       - endReference: End chapter/verse reference.
+     - Returns: User-visible bookmark reference text.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    fileprivate static func formattedBibleReference(
+        startBookName: String,
+        startReference: BookmarkListVerseReference,
+        endBookName: String,
+        endReference: BookmarkListVerseReference
+    ) -> String {
+        if startBookName == endBookName, endReference == startReference {
+            return "\(startBookName) \(startReference.chapter):\(startReference.verse)"
+        } else if startBookName == endBookName, endReference.chapter == startReference.chapter {
+            return "\(startBookName) \(startReference.chapter):\(startReference.verse)-\(endReference.verse)"
+        } else if startBookName == endBookName {
+            return "\(startBookName) \(startReference.chapter):\(startReference.verse)-\(endReference.chapter):\(endReference.verse)"
         } else {
-            return "\(bookName) \(startReference.chapter):\(startReference.verse)-\(endReference.chapter):\(endReference.verse)"
+            return "\(startBookName) \(startReference.chapter):\(startReference.verse)-\(endBookName) \(endReference.chapter):\(endReference.verse)"
         }
     }
 
     /**
      Compatibility fallback for no-module bookmark list previews.
 
-     Real reader-owned bookmark lists should inject `bibleOrdinalResolver` so ordinals are decoded
-     through SWORD's versification. The fallback keeps design previews and isolated unit tests
-     functional when no reader/controller exists.
+     Real rows should resolve through the KJVA columns first. The injected resolver and this
+     fallback remain for malformed legacy rows that predate Android-compatible bookmark storage.
      */
     fileprivate static func compatibilityVerseReference(ordinal: Int) -> BookmarkListVerseReference {
         let chapter = max(1, ((ordinal - 1) / 40) + 1)
@@ -769,13 +828,20 @@ struct BookmarkListItem: Identifiable {
         self.customIcon = bookmark.customIcon
         self.noteText = noteText
         self.labels = bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
-        let bookName = bookmark.book ?? "Genesis"
-        let resolvedStart = ordinalResolver?(bookName, bookmark.ordinalStart)
-            ?? BookmarkListView.compatibilityVerseReference(ordinal: bookmark.ordinalStart)
-        self.navigationTarget = (
-            bookName: bookName,
-            chapter: resolvedStart.chapter
-        )
+        if let target = BookmarkListView.kjvaVerseReference(ordinal: bookmark.kjvOrdinalStart) {
+            self.navigationTarget = (
+                bookName: target.bookName,
+                chapter: target.reference.chapter
+            )
+        } else {
+            let bookName = bookmark.book ?? "Genesis"
+            let resolvedStart = ordinalResolver?(bookName, bookmark.ordinalStart)
+                ?? BookmarkListView.compatibilityVerseReference(ordinal: bookmark.ordinalStart)
+            self.navigationTarget = (
+                bookName: bookName,
+                chapter: resolvedStart.chapter
+            )
+        }
     }
 
     /// Creates a normalized row for one generic bookmark.

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkListProjectionTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkListProjectionTests.swift
@@ -31,12 +31,10 @@ final class BookmarkListProjectionTests: XCTestCase {
     func testBookmarkListProjectionSortsCreatedDateAndBibleOrderLikeAndroid() {
         let exodus = bibleItem(
             reference: "Exodus 2:1",
-            ordinal: 81,
             createdAt: Date(timeIntervalSince1970: 100)
         )
         let matthew = bibleItem(
             reference: "Matthew 3:1",
-            ordinal: 1_000,
             createdAt: Date(timeIntervalSince1970: 200)
         )
 
@@ -77,8 +75,8 @@ final class BookmarkListProjectionTests: XCTestCase {
        is cleared.
      */
     func testBookmarkListProjectionSearchNarrowsAndClearsRows() {
-        let exodus = bibleItem(reference: "Exodus 2:1", ordinal: 81)
-        let matthew = bibleItem(reference: "Matthew 3:1", ordinal: 1_000)
+        let exodus = bibleItem(reference: "Exodus 2:1")
+        let matthew = bibleItem(reference: "Matthew 3:1")
 
         let filtered = BookmarkListProjection.filteredItems(
             [exodus, matthew],
@@ -128,10 +126,9 @@ final class BookmarkListProjectionTests: XCTestCase {
         let seedLabel = Label(name: "UI Test Seed")
         let genesis = bibleItem(
             reference: "Genesis 1:1",
-            ordinal: 1,
             labels: [seedLabel]
         )
-        let exodus = bibleItem(reference: "Exodus 2:1", ordinal: 81)
+        let exodus = bibleItem(reference: "Exodus 2:1")
 
         let filtered = BookmarkListProjection.filteredItems(
             [genesis, exodus],
@@ -182,10 +179,9 @@ final class BookmarkListProjectionTests: XCTestCase {
         let seedLabel = Label(name: "UI Test Seed")
         let genesis = bibleItem(
             reference: "Genesis 1:1",
-            ordinal: 1,
             labels: [seedLabel]
         )
-        let exodus = bibleItem(reference: "Exodus 2:1", ordinal: 81)
+        let exodus = bibleItem(reference: "Exodus 2:1")
         let items = [genesis, exodus]
 
         let labelFiltered = BookmarkListProjection.filteredItems(
@@ -363,12 +359,29 @@ final class BookmarkListProjectionTests: XCTestCase {
         XCTAssertTrue(try modelContext.fetch(FetchDescriptor<GenericBookmark>()).isEmpty)
     }
 
+    /**
+     Builds a Bible bookmark projection row whose storage ordinals match its visible reference.
+
+     Bookmark list rows now render, search, navigate, and sort from Android-compatible KJVA ordinals
+     rather than the legacy display-name `book` field. Test fixtures therefore resolve the supplied
+     reference through `JSwordKJVAVersification` so assertions exercise the same persisted contract as
+     restored Android bookmarks.
+
+     - Parameters:
+       - reference: Human-readable `Book Chapter:Verse` reference covered by the KJVA table.
+       - createdAt: Creation timestamp used by sort-order assertions.
+       - labels: Labels that should appear assigned to the row.
+     - Returns: A normalized Bible bookmark list item.
+     - Side effects: assigns unsaved label relationship objects to the bookmark.
+     - Failure modes: Records an XCTest failure and falls back to Genesis 1:1 when the reference
+       cannot be parsed or resolved.
+     */
     private func bibleItem(
         reference: String,
-        ordinal: Int,
         createdAt: Date = Date(timeIntervalSince1970: 100),
         labels: [Label] = []
     ) -> BookmarkListItem {
+        let ordinal = kjvaOrdinal(for: reference)
         let bookmark = BibleBookmark(
             kjvOrdinalStart: ordinal,
             kjvOrdinalEnd: ordinal,
@@ -404,6 +417,43 @@ final class BookmarkListProjectionTests: XCTestCase {
             }
             return BookmarkListVerseReference(chapter: chapter, verse: verse)
         }
+    }
+
+    /**
+     Resolves a compact display reference into the JSword KJVA ordinal expected by bookmark storage.
+
+     - Parameter reference: Human-readable `Book Chapter:Verse` reference, using JSword long or short
+       book names from the KJVA table.
+     - Returns: The resolved KJVA verse ordinal, or Genesis 1:1 after recording a test failure.
+     - Side effects: May record an XCTest failure when fixture text drifts from the KJVA contract.
+     - Failure modes: Malformed references, unknown books, and out-of-range chapter/verse values fail
+       the current test and use Genesis 1:1 so the suite can report the original assertion context.
+     */
+    private func kjvaOrdinal(for reference: String) -> Int {
+        guard let separator = reference.lastIndex(of: " ") else {
+            XCTFail("Malformed Bible reference fixture: \(reference)")
+            return 4
+        }
+        let bookName = String(reference[..<separator])
+        let chapterVerse = reference[reference.index(after: separator)...].split(separator: ":")
+        guard chapterVerse.count == 2,
+              let chapter = Int(chapterVerse[0]),
+              let verse = Int(chapterVerse[1]) else {
+            XCTFail("Malformed Bible reference fixture: \(reference)")
+            return 4
+        }
+        guard let osisId = JSwordKJVAVersification.books.first(where: {
+            $0.longName == bookName || $0.shortName == bookName || $0.osisId == bookName
+        })?.osisId,
+              let ordinal = JSwordKJVAVersification.verseOrdinal(
+                osisId: osisId,
+                chapter: chapter,
+                verse: verse
+              ) else {
+            XCTFail("Unresolvable KJVA reference fixture: \(reference)")
+            return 4
+        }
+        return ordinal
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -536,6 +536,41 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies My Notes modal links omit their scroll target when source-to-KJVA conversion fails.
+     *
+     * Android's My Notes fake document scrolls within KJVA rows. When iOS cannot resolve the source
+     * versification named by a modal link, passing the original source ordinal would cross ordinal
+     * domains and scroll to the wrong bookmark. The safe parity behavior is to open the document and
+     * leave `setup_content.jumpToOrdinal` null.
+     *
+     * Failure meaning:
+     * - unsupported or uninstalled source versifications could leak source ordinals into the KJVA My
+     *   Notes document contract and navigate to unrelated notes.
+     */
+    @MainActor
+    func testReaderOpenMyNotesOmitsJumpTargetWhenSourceOrdinalCannotConvertToKJVA() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        controller.bridgeDidSetClientReady(bridge)
+        controller.navigateTo(book: "Matthew", chapter: 1, verse: 1)
+        let baselineCount = recordedScripts().count
+
+        controller.bridge(bridge, openMyNotes: "UninstalledV11n", ordinal: 12_345)
+
+        let myNotesScripts = Array(recordedScripts().dropFirst(baselineCount))
+        let setupPayload = try XCTUnwrap(
+            bridgeEmissionPayload(from: myNotesScripts, event: "setup_content") as? [String: Any]
+        )
+        XCTAssertTrue(setupPayload["jumpToOrdinal"] is NSNull)
+        let documentPayload = try XCTUnwrap(
+            bridgeEmissionPayload(from: myNotesScripts, event: "add_documents") as? [String: Any]
+        )
+        XCTAssertEqual(documentPayload["type"] as? String, "notes")
+    }
+
+    /**
      Verifies StudyPad requests made before the Vue client is ready replay after client-ready.
 
      Android treats StudyPad as a reader document, so selecting a StudyPad label while the shared
@@ -1447,6 +1482,200 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         XCTAssertEqual(payloads.first?.bookName, "NRSV")
         XCTAssertEqual(payloads.first?.bookAbbreviation, "NRSV")
         XCTAssertEqual(payloads.first?.verseRange, "John 3:16-17")
+    }
+
+    /**
+     Verifies Bible bookmark creation normalizes source ordinal ranges before storage and export.
+     *
+     * Android treats an `endOrdinal` of `0` as a single-verse selection and stores increasing verse
+     * ranges. The iOS bridge must apply that normalization before both KJVA projection and SwiftData
+     * persistence so later Android backup export and My Notes modal links receive source ordinals from
+     * the same normalized domain.
+     *
+     * Expected result:
+     * - the injected KJVA projector receives normalized source start/end values
+     * - persisted `ordinalStart`/`ordinalEnd` never keep the bridge's zero or reversed raw inputs
+     * - emitted `originalOrdinalRange` matches the normalized persisted source range
+     *
+     * Failure meaning:
+     * - native iOS-created bookmarks can corrupt Android-compatible backup snapshots or reintroduce
+     *   wrong-domain modal navigation for non-KJVA source modules.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorPersistsNormalizedSourceRangeForNewBibleBookmark() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+        let john317 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 17)
+        )
+        let john318 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 18)
+        )
+        var projectedRanges = [
+            (start: john316, end: john316),
+            (start: john317, end: john318),
+        ]
+        var projectionInputs: [(start: Int, end: Int)] = []
+        let coordinator = makeBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            currentV11n: { "NRSV" },
+            kjvaOrdinalRange: { start, end in
+                projectionInputs.append((start: start, end: end))
+                guard !projectedRanges.isEmpty else {
+                    XCTFail("Unexpected KJVA projection request")
+                    return nil
+                }
+                return projectedRanges.removeFirst()
+            }
+        )
+
+        let zeroEndResult = coordinator.addOrUpdateBibleBookmark(
+            bookInitials: "NRSV",
+            startOrdinal: 42,
+            endOrdinal: 0,
+            addNote: false,
+            wholeVerse: true,
+            workspaceSettings: nil
+        )
+        let zeroEndBookmark = try XCTUnwrap(
+            bookmarkService.bookmarks(for: john316, endOrdinal: john316)
+                .first(where: { $0.kjvOrdinalStart == john316 })
+        )
+        guard case .bookmarksUpdated(let zeroEndPayloads) = zeroEndResult.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+
+        XCTAssertEqual(projectionInputs.count, 1)
+        XCTAssertEqual(projectionInputs[0].start, 42)
+        XCTAssertEqual(projectionInputs[0].end, 42)
+        XCTAssertEqual(zeroEndBookmark.ordinalStart, 42)
+        XCTAssertEqual(zeroEndBookmark.ordinalEnd, 42)
+        XCTAssertEqual(zeroEndBookmark.kjvOrdinalStart, john316)
+        XCTAssertEqual(zeroEndBookmark.kjvOrdinalEnd, john316)
+        XCTAssertEqual(zeroEndPayloads.first?.ordinalRange, [john316, john316])
+        XCTAssertEqual(zeroEndPayloads.first?.originalOrdinalRange, [42, 42])
+
+        let reversedResult = coordinator.addOrUpdateBibleBookmark(
+            bookInitials: "NRSV",
+            startOrdinal: 53,
+            endOrdinal: 52,
+            addNote: false,
+            wholeVerse: true,
+            workspaceSettings: nil
+        )
+        let reversedBookmark = try XCTUnwrap(
+            bookmarkService.bookmarks(for: john317, endOrdinal: john318)
+                .first(where: { $0.kjvOrdinalStart == john317 })
+        )
+        guard case .bookmarksUpdated(let reversedPayloads) = reversedResult.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+
+        XCTAssertEqual(projectionInputs.count, 2)
+        XCTAssertEqual(projectionInputs[1].start, 52)
+        XCTAssertEqual(projectionInputs[1].end, 53)
+        XCTAssertEqual(reversedBookmark.ordinalStart, 52)
+        XCTAssertEqual(reversedBookmark.ordinalEnd, 53)
+        XCTAssertEqual(reversedBookmark.kjvOrdinalStart, john317)
+        XCTAssertEqual(reversedBookmark.kjvOrdinalEnd, john318)
+        XCTAssertEqual(reversedPayloads.first?.ordinalRange, [john317, john318])
+        XCTAssertEqual(reversedPayloads.first?.originalOrdinalRange, [52, 53])
+    }
+
+    /**
+     Verifies paragraph-break Bible bookmarks use the same normalized source ordinal storage contract
+     as normal Bible bookmarks.
+     *
+     * Paragraph breaks are labels on Bible bookmarks, so Android backup export and restored highlight
+     * lookup depend on their KJVA fields while modal/navigation metadata depends on their source
+     * ordinal fields. This protects both zero-ended and reversed bridge inputs from being persisted
+     * verbatim through the paragraph-break shortcut.
+     *
+     * Failure meaning:
+     * - paragraph-break bookmarks can become non-portable to Android snapshots or emit malformed
+     *   `originalOrdinalRange` values even though normal Bible bookmark creation is fixed.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorPersistsNormalizedSourceRangeForParagraphBreakBibleBookmark() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let gen11 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 1)
+        )
+        let gen12 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 2)
+        )
+        let gen13 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 3)
+        )
+        var projectedRanges = [
+            (start: gen11, end: gen11),
+            (start: gen12, end: gen13),
+        ]
+        var projectionInputs: [(start: Int, end: Int)] = []
+        let coordinator = makeBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            currentV11n: { "NRSV" },
+            kjvaOrdinalRange: { start, end in
+                projectionInputs.append((start: start, end: end))
+                guard !projectedRanges.isEmpty else {
+                    XCTFail("Unexpected KJVA projection request")
+                    return nil
+                }
+                return projectedRanges.removeFirst()
+            }
+        )
+
+        let zeroEndResult = coordinator.addParagraphBreakBibleBookmark(
+            bookInitials: "NRSV",
+            startOrdinal: 72,
+            endOrdinal: 0
+        )
+        let zeroEndBookmark = try XCTUnwrap(
+            bookmarkService.bookmarks(for: gen11, endOrdinal: gen11)
+                .first(where: { $0.kjvOrdinalStart == gen11 })
+        )
+        guard case .bookmarksUpdated(let zeroEndPayloads) = zeroEndResult.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+
+        XCTAssertEqual(projectionInputs.count, 1)
+        XCTAssertEqual(projectionInputs[0].start, 72)
+        XCTAssertEqual(projectionInputs[0].end, 72)
+        XCTAssertEqual(zeroEndBookmark.ordinalStart, 72)
+        XCTAssertEqual(zeroEndBookmark.ordinalEnd, 72)
+        XCTAssertEqual(zeroEndBookmark.kjvOrdinalStart, gen11)
+        XCTAssertEqual(zeroEndBookmark.kjvOrdinalEnd, gen11)
+        XCTAssertEqual(zeroEndPayloads.first?.ordinalRange, [gen11, gen11])
+        XCTAssertEqual(zeroEndPayloads.first?.originalOrdinalRange, [72, 72])
+
+        let reversedResult = coordinator.addParagraphBreakBibleBookmark(
+            bookInitials: "NRSV",
+            startOrdinal: 83,
+            endOrdinal: 81
+        )
+        let reversedBookmark = try XCTUnwrap(
+            bookmarkService.bookmarks(for: gen12, endOrdinal: gen13)
+                .first(where: { $0.kjvOrdinalStart == gen12 })
+        )
+        guard case .bookmarksUpdated(let reversedPayloads) = reversedResult.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+
+        XCTAssertEqual(projectionInputs.count, 2)
+        XCTAssertEqual(projectionInputs[1].start, 81)
+        XCTAssertEqual(projectionInputs[1].end, 83)
+        XCTAssertEqual(reversedBookmark.ordinalStart, 81)
+        XCTAssertEqual(reversedBookmark.ordinalEnd, 83)
+        XCTAssertEqual(reversedBookmark.kjvOrdinalStart, gen12)
+        XCTAssertEqual(reversedBookmark.kjvOrdinalEnd, gen13)
+        XCTAssertEqual(reversedPayloads.first?.ordinalRange, [gen12, gen13])
+        XCTAssertEqual(reversedPayloads.first?.originalOrdinalRange, [81, 83])
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -114,22 +114,23 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
      For a range within one chapter, JSword emits `Book chapter:start-end`, so the iOS bookmark
      list should not expand the repeated chapter or collapse a real multi-verse range.
      */
-    func testBookmarkListVerseReferenceFormatsSameChapterRangeLikeJSword() {
+    func testBookmarkListVerseReferenceFormatsSameChapterRangeLikeJSword() throws {
+        let startOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 5)
+        )
+        let endOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 7)
+        )
         let bookmark = BibleBookmark(
-            kjvOrdinalStart: 5,
-            kjvOrdinalEnd: 7,
-            ordinalStart: 5,
-            ordinalEnd: 7,
+            kjvOrdinalStart: startOrdinal,
+            kjvOrdinalEnd: endOrdinal,
+            ordinalStart: startOrdinal,
+            ordinalEnd: endOrdinal,
             v11n: "KJVA"
         )
         bookmark.book = "Genesis"
 
-        let reference = BookmarkListView.verseReference(for: bookmark) { _, ordinal in
-            [
-                5: BookmarkListVerseReference(chapter: 1, verse: 5),
-                7: BookmarkListVerseReference(chapter: 1, verse: 7),
-            ][ordinal]
-        }
+        let reference = BookmarkListView.verseReference(for: bookmark)
 
         XCTAssertEqual(reference, "Genesis 1:5-7")
     }
@@ -142,24 +143,204 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
      endChapter:endVerse`. A failure here means two different ranges such as `Genesis 1:5-2:5` and
      `Genesis 1:5` can be rendered ambiguously or collapsed in the iOS bookmark list.
      */
-    func testBookmarkListVerseReferenceKeepsCrossChapterEndChapterLikeJSword() {
+    func testBookmarkListVerseReferenceKeepsCrossChapterEndChapterLikeJSword() throws {
+        let startOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 31)
+        )
+        let endOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 2, verse: 5)
+        )
         let bookmark = BibleBookmark(
-            kjvOrdinalStart: 5,
-            kjvOrdinalEnd: 45,
-            ordinalStart: 5,
-            ordinalEnd: 45,
+            kjvOrdinalStart: startOrdinal,
+            kjvOrdinalEnd: endOrdinal,
+            ordinalStart: startOrdinal,
+            ordinalEnd: endOrdinal,
             v11n: "KJVA"
         )
         bookmark.book = "Genesis"
 
-        let reference = BookmarkListView.verseReference(for: bookmark) { _, ordinal in
-            [
-                5: BookmarkListVerseReference(chapter: 1, verse: 5),
-                45: BookmarkListVerseReference(chapter: 2, verse: 5),
-            ][ordinal]
-        }
+        let reference = BookmarkListView.verseReference(for: bookmark)
 
-        XCTAssertEqual(reference, "Genesis 1:5-2:5")
+        XCTAssertEqual(reference, "Genesis 1:31-2:5")
+    }
+
+    /**
+     Verifies bookmark-list display and row navigation ignore Android's restored `book` payload.
+     *
+     * Data dependencies:
+     * - constructs restored-style Bible bookmarks whose `book` column is NULL or module initials
+     * - uses a deliberately bogus source ordinal so only the KJVA columns can resolve John 3:16
+     *
+     * Expected result:
+     * - list text renders the KJVA verse reference
+     * - tapping the row navigates to the KJVA-derived display book and chapter
+     *
+     * Failure meaning:
+     * - issue #356 has regressed and restored Android bookmarks can again show Unknown/module
+     *   initials or navigate to a bogus arithmetic chapter.
+     */
+    func testBookmarkListReferenceAndNavigationUseKJVAOrdinalsForRestoredAndroidBookValues() throws {
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+
+        for storedBook in [String?.none, "KJV"] {
+            let bookmark = BibleBookmark(
+                kjvOrdinalStart: john316,
+                kjvOrdinalEnd: john316,
+                ordinalStart: 999_999,
+                ordinalEnd: 999_999,
+                v11n: "KJVA"
+            )
+            bookmark.book = storedBook
+
+            XCTAssertEqual(BookmarkListView.verseReference(for: bookmark), "John 3:16")
+            let row = BookmarkListItem(bibleBookmark: bookmark)
+            XCTAssertEqual(row.navigationTarget?.bookName, "John")
+            XCTAssertEqual(row.navigationTarget?.chapter, 3)
+        }
+    }
+
+    /**
+     Verifies bridge payload projection uses Android-compatible KJVA ordinals for visible bookmark
+     ranges while preserving Android's source ordinal and source module metadata fields.
+     *
+     * Data dependencies:
+     * - constructs one restored-style bookmark with source module initials stored separately from
+     *   the display `book` field
+     * - gives the source ordinal a bogus value so the test fails unless KJVA drives projection
+     *
+     * Expected result:
+     * - Vue `ordinalRange`, `osisRef`, and display ranges all resolve to John 3:16
+     * - `originalOrdinalRange` carries Android's source ordinal, not the KJVA storage key
+     * - `bookInitials` and related modal fields come from the bookmark source module, not the
+     *   currently active module
+     *
+     * Failure meaning:
+     * - restored Android bookmarks may not highlight in Vue, or bridge payloads may again display
+     *   module initials as Bible book names.
+     */
+    func testBookmarkPayloadUsesKJVAOrdinalsForRestoredAndroidBookmark() throws {
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: john316,
+            kjvOrdinalEnd: john316,
+            ordinalStart: 999_999,
+            ordinalEnd: 999_999,
+            v11n: "KJVA"
+        )
+        bookmark.bookInitials = "KJV"
+        let factory = BibleReaderAnnotationPayloadFactory(
+            currentBook: "Genesis",
+            activeModuleName: "NASB",
+            activeModule: nil,
+            bookCatalog: BibleReaderBookCatalog(activeModule: nil, moduleBookList: []),
+            unlabeledLabelID: Label.unlabeledId.uuidString
+        )
+
+        let payload = factory.bookmarkJSON(bookmark)
+
+        XCTAssertEqual(payload.ordinalRange, [john316, john316])
+        XCTAssertEqual(payload.originalOrdinalRange, [999_999, 999_999])
+        XCTAssertEqual(payload.bookInitials, "KJV")
+        XCTAssertEqual(payload.bookName, "KJV")
+        XCTAssertEqual(payload.bookAbbreviation, "KJV")
+        XCTAssertEqual(payload.osisRef, "John.3.16")
+        XCTAssertEqual(payload.verseRange, "John 3:16")
+        XCTAssertEqual(payload.verseRangeAbbreviated, "John 3:16")
+    }
+
+    /**
+     Verifies restored Android bookmarks with a NULL source module use Android's whole-verse
+     fallback contract.
+     *
+     * Android serializes `BibleBookmark.book == null` as a whole-verse KJVA bookmark: module
+     * metadata fields are empty, text offsets are suppressed, and the payload `v11n` falls back to
+     * KJVA. iOS represents that NULL source module as an empty `bookInitials` value.
+     *
+     * Failure meaning:
+     * - restored Android bookmarks with NULL `book` values could reintroduce stale source offsets
+     *   or non-KJVA bridge metadata that Android deliberately omits.
+     */
+    func testBookmarkPayloadTreatsMissingSourceBookLikeAndroidNullBook() throws {
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: john316,
+            kjvOrdinalEnd: john316,
+            ordinalStart: 123,
+            ordinalEnd: 123,
+            v11n: "NRSV",
+            wholeVerse: false
+        )
+        bookmark.book = "John"
+        bookmark.startOffset = 2
+        bookmark.endOffset = 5
+        let factory = BibleReaderAnnotationPayloadFactory(
+            currentBook: "John",
+            activeModuleName: "NASB",
+            activeModule: nil,
+            bookCatalog: BibleReaderBookCatalog(activeModule: nil, moduleBookList: []),
+            unlabeledLabelID: Label.unlabeledId.uuidString
+        )
+
+        let payload = factory.bookmarkJSON(bookmark)
+
+        XCTAssertEqual(payload.bookInitials, "")
+        XCTAssertEqual(payload.bookName, "")
+        XCTAssertEqual(payload.bookAbbreviation, "")
+        XCTAssertNil(payload.offsetRange)
+        XCTAssertTrue(payload.wholeVerse)
+        XCTAssertEqual(payload.v11n, JSwordKJVAVersification.name)
+        XCTAssertEqual(payload.originalOrdinalRange, [123, 123])
+        XCTAssertEqual(payload.ordinalRange, [john316, john316])
+        XCTAssertEqual(payload.osisRef, "John.3.16")
+        XCTAssertEqual(payload.verseRange, "John 3:16")
+    }
+
+    /**
+     Verifies My Notes bookmark payloads use Android's KJVA fake-document ordinal domain.
+     *
+     * Android renders `MyNotesDocument` with `ClientBibleBookmark(bookmark, KJVA)`, so the
+     * bookmark's visible `ordinalRange` is KJVA while `originalOrdinalRange` remains the source
+     * versification ordinal used by modal links. A failure here means the iOS My Notes document can
+     * drift back to active-module ordinals and break link/scroll parity with Android.
+     */
+    func testMyNotesBookmarkPayloadUsesKJVAOrdinalRangeAndSourceOriginalOrdinals() throws {
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+        let john317 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 17)
+        )
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: john316,
+            kjvOrdinalEnd: john317,
+            ordinalStart: 42,
+            ordinalEnd: 43,
+            v11n: "NRSV",
+            bookInitials: "NRSV"
+        )
+        bookmark.book = "John"
+        let factory = BibleReaderAnnotationPayloadFactory(
+            currentBook: "Genesis",
+            activeModuleName: "KJV",
+            activeModule: nil,
+            bookCatalog: BibleReaderBookCatalog(activeModule: nil, moduleBookList: []),
+            unlabeledLabelID: Label.unlabeledId.uuidString
+        )
+
+        let payload = factory.bookmarkJSONForMyNotes(bookmark)
+
+        XCTAssertEqual(payload.ordinalRange, [john316, john317])
+        XCTAssertEqual(payload.originalOrdinalRange, [42, 43])
+        XCTAssertEqual(payload.bookInitials, "NRSV")
+        XCTAssertEqual(payload.bookName, "NRSV")
+        XCTAssertEqual(payload.v11n, "NRSV")
+        XCTAssertEqual(payload.verseRange, "John 3:16-17")
     }
 
     /**
@@ -312,6 +493,49 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies My Notes modal links convert source ordinals into Android's KJVA document domain.
+     *
+     * Android's bookmark modal builds `my-notes://` links from `v11n` plus
+     * `originalOrdinalRange[0]`. The destination My Notes document renders rows in KJVA, so iOS
+     * must convert that source ordinal before emitting `setup_content.jumpToOrdinal`; otherwise NT
+     * KJV bookmarks scroll to the wrong row because KJVA includes the apocrypha span before
+     * Matthew.
+     */
+    @MainActor
+    func testReaderOpenMyNotesConvertsSourceOrdinalToKJVAJumpTarget() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let module = try XCTUnwrap(manager.module(named: "KJV"))
+        let sourceOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Matt", chapter: 1, verse: 1))
+        let kjvaOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Matt", chapter: 1, verse: 1)
+        )
+        let kjvaEndOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Matt", chapter: 1, verse: 25)
+        )
+        controller.bridgeDidSetClientReady(bridge)
+        controller.navigateTo(book: "Matthew", chapter: 1, verse: 1)
+        let baselineCount = recordedScripts().count
+
+        controller.bridge(bridge, openMyNotes: "KJV", ordinal: sourceOrdinal)
+
+        let myNotesScripts = Array(recordedScripts().dropFirst(baselineCount))
+        let setupPayload = try XCTUnwrap(
+            bridgeEmissionPayload(from: myNotesScripts, event: "setup_content") as? [String: Any]
+        )
+        XCTAssertEqual(setupPayload["jumpToOrdinal"] as? Int, kjvaOrdinal)
+        let documentPayload = try XCTUnwrap(
+            bridgeEmissionPayload(from: myNotesScripts, event: "add_documents") as? [String: Any]
+        )
+        XCTAssertEqual(documentPayload["ordinalRange"] as? [Int], [
+            kjvaOrdinal,
+            kjvaEndOrdinal,
+        ])
+    }
+
+    /**
      Verifies StudyPad requests made before the Vue client is ready replay after client-ready.
 
      Android treats StudyPad as a reader document, so selecting a StudyPad label while the shared
@@ -434,11 +658,19 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
         let startOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 31))
         let endOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 2))
+        let kjvStartOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 31)
+        )
+        let kjvEndOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 2, verse: 2)
+        )
 
         let bookmark = bookmarkService.addBibleBookmark(
             bookInitials: "KJV",
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal,
+            kjvOrdinalStart: kjvStartOrdinal,
+            kjvOrdinalEnd: kjvEndOrdinal,
             wholeVerse: true
         )
         bookmark.book = "Genesis"
@@ -482,12 +714,20 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         let module = try XCTUnwrap(manager.module(named: controller.activeModuleName))
         let startOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 31))
         let endOrdinal = try XCTUnwrap(module.verseOrdinal(osisBookId: "Gen", chapter: 2, verse: 2))
+        let kjvStartOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 1, verse: 31)
+        )
+        let kjvEndOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Gen", chapter: 2, verse: 2)
+        )
 
         let label = bookmarkService.createLabel(name: "Cross Chapter", color: Label.defaultColor)
         let bookmark = bookmarkService.addBibleBookmark(
             bookInitials: "KJV",
             startOrdinal: startOrdinal,
             endOrdinal: endOrdinal,
+            kjvOrdinalStart: kjvStartOrdinal,
+            kjvOrdinalEnd: kjvEndOrdinal,
             wholeVerse: true
         )
         bookmark.book = "Genesis"
@@ -1148,6 +1388,68 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies native bookmark creation stores the reader's source ordinals and Android KJVA ordinals
+     as separate fields.
+     *
+     * Data dependencies:
+     * - creates one bookmark through the bridge action coordinator
+     * - injects the same rendered-to-KJVA projection closure the controller supplies in production
+     *
+     * Expected result:
+     * - source ordinals preserve the rendered selection
+     * - source module initials, KJVA ordinals, and `v11n` preserve the Android-compatible storage
+     *   identity
+     *
+     * Failure meaning:
+     * - iOS-created bookmarks can become non-portable to Android or fail restored-bookmark
+     *   highlight queries when the active module versification differs from KJVA.
+     */
+    @MainActor
+    func testBookmarkActionCoordinatorStoresKJVAMappingForNewBibleBookmark() throws {
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let john316 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 16)
+        )
+        let john317 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "John", chapter: 3, verse: 17)
+        )
+        let coordinator = makeBookmarkActionCoordinator(
+            bookmarkService: bookmarkService,
+            currentV11n: { "NRSV" },
+            kjvaOrdinalRange: { _, _ in (start: john316, end: john317) }
+        )
+
+        let result = coordinator.addOrUpdateBibleBookmark(
+            bookInitials: "NRSV",
+            startOrdinal: 42,
+            endOrdinal: 43,
+            addNote: false,
+            wholeVerse: true,
+            workspaceSettings: nil
+        )
+
+        let bookmark = try XCTUnwrap(bookmarkService.bookmarks(for: john316, endOrdinal: john316).first)
+        XCTAssertEqual(bookmark.bookInitials, "NRSV")
+        XCTAssertEqual(bookmark.book, "Genesis")
+        XCTAssertEqual(bookmark.ordinalStart, 42)
+        XCTAssertEqual(bookmark.ordinalEnd, 43)
+        XCTAssertEqual(bookmark.kjvOrdinalStart, john316)
+        XCTAssertEqual(bookmark.kjvOrdinalEnd, john317)
+        XCTAssertEqual(bookmark.v11n, "NRSV")
+        guard case .bookmarksUpdated(let payloads) = result.events.first else {
+            return XCTFail("Expected add_or_update_bookmarks event")
+        }
+        XCTAssertEqual(payloads.first?.ordinalRange, [john316, john317])
+        XCTAssertEqual(payloads.first?.originalOrdinalRange, [42, 43])
+        XCTAssertEqual(payloads.first?.bookInitials, "NRSV")
+        XCTAssertEqual(payloads.first?.bookName, "NRSV")
+        XCTAssertEqual(payloads.first?.bookAbbreviation, "NRSV")
+        XCTAssertEqual(payloads.first?.verseRange, "John 3:16-17")
+    }
+
+    /**
      Verifies primary-label changes reject Android's reserved unlabelled system label.
 
      Android `BibleJavascriptInterface.setAsPrimaryLabel` returns before mutation when the selected
@@ -1242,7 +1544,11 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
      */
     private func makeBookmarkActionCoordinator(
         bookmarkService: BookmarkService,
-        notesContentType: String = "HTML"
+        notesContentType: String = "HTML",
+        currentV11n: @escaping () -> String = { "KJVA" },
+        kjvaOrdinalRange: @escaping (Int, Int) -> (start: Int, end: Int)? = { start, end in
+            (start: min(start, end), end: max(start, end))
+        }
     ) -> BibleReaderBookmarkActionCoordinator {
         BibleReaderBookmarkActionCoordinator(
             bookmarkService: bookmarkService,
@@ -1254,6 +1560,8 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
                 unlabeledLabelID: Label.unlabeledId.uuidString
             ),
             currentBook: "Genesis",
+            currentV11n: currentV11n,
+            kjvaOrdinalRange: kjvaOrdinalRange,
             currentNotesContentType: { notesContentType }
         )
     }
@@ -1283,7 +1591,9 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         controller.navigateTo(book: "Psalms", chapter: 119, verse: 1)
 
         for verse in 1...60 {
-            let ordinal = (119 - 1) * 40 + verse
+            let ordinal = try XCTUnwrap(
+                JSwordKJVAVersification.verseOrdinal(osisId: "Ps", chapter: 119, verse: verse)
+            )
             let bookmark = BibleBookmark(
                 kjvOrdinalStart: ordinal,
                 kjvOrdinalEnd: ordinal,
@@ -1326,7 +1636,12 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         let modelContext = ModelContext(container)
         let bookmarkStore = BookmarkStore(modelContext: modelContext)
         let bookmarkService = BookmarkService(store: bookmarkStore)
-        let noteOrdinal = (119 - 1) * 40 + 3
+        let noteOrdinal = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Ps", chapter: 119, verse: 3)
+        )
+        let noteChapterRange = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinalRange(osisId: "Ps", chapter: 119)
+        )
         let noteBookmark = BibleBookmark(
             kjvOrdinalStart: noteOrdinal,
             kjvOrdinalEnd: noteOrdinal,
@@ -1355,12 +1670,18 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
             activeStudyPadLabelId: label.id,
             activeStudyPadLabelName: label.name,
             rowLimit: 2,
-            chapterOrdinalRange: { (start: noteOrdinal - 2, end: noteOrdinal + 2, verseCount: 5) },
+            chapterOrdinalRange: {
+                (
+                    start: noteChapterRange.lowerBound,
+                    end: noteChapterRange.upperBound,
+                    verseCount: noteChapterRange.count
+                )
+            },
             verseReference: { _, ordinal in
                 VerseKeyReference(
                     osisBookId: "Ps",
                     chapter: 119,
-                    verse: ordinal - ((119 - 1) * 40),
+                    verse: ordinal - noteChapterRange.lowerBound + 1,
                     ordinal: ordinal
                 )
             }


### PR DESCRIPTION
## Summary

Fixes Android bookmark restore semantics by separating Android's source-module `book` value from iOS's display book name. Restored and native Bible bookmarks now render, highlight, navigate, and export from KJVA ordinals instead of relying on the repurposed display `book` field.

## Scope

- `BibleBookmark` persistence now stores source module initials separately in `bookInitials`.
- Remote sync, Android database backup restore, patch replay, and snapshot export preserve Android's module-initials-or-NULL `BibleBookmark.book` contract.
- Bookmark list rows, reader highlights, My Notes, accessibility state, and bridge payloads resolve references from KJVA ordinal columns.
- Native bookmark creation stores source ordinals plus Android-compatible KJVA storage ordinals.
- Tests cover restore normalization, outbound export, KJVA querying, bridge payloads, My Notes projection, reset cleanup, and divergent-canon clamping.

## Contract References

- Android stores `BibleBookmark.book` as `AbstractPassageBook.initials` or NULL, not as a Bible book display name.
- Android renders bookmark references from versification ordinals, with KJVA as the shared cross-module storage domain.
- Android treats NULL-source-book bridge payloads as whole-verse KJVA payloads with no text offsets.

## Change Details

- Added `BibleBookmark.bookInitials` for Android source module identity while keeping `BibleBookmark.book` display-facing for legacy iOS fallback paths.
- Removed the display-book predicate from bookmark overlap queries; KJVA ordinals are globally unique and match Android's lookup model.
- Changed list display, navigation targets, reader chapter queries, and My Notes payloads to use KJVA ordinals first.
- Changed outbound Android snapshots and patch comparison to export source initials or preserved NULL, never display names such as `Genesis`.
- Added nearest-addressable KJVA clamping when exact source-to-KJVA projection fails, preventing write-side corruption for divergent versification edge cases.

## Validation Evidence

- `xcodebuild test -scheme BibleCoreTests` passed: 292 tests, 0 failures.
- `xcodebuild test -scheme BibleUITests -only-testing:BibleUITests/BookmarkReaderBridgeTests` passed: 33 tests, 0 failures.
- `python3 scripts/check_repo_standards.py docblocks --all-files` passed.
- `git diff --check` passed.
- KJVA constants were recomputed against libsword `canon.h` / `canon_kjva.h`.

## Risks / Follow-Ups

- iOS still lacks a full JSword-style `toV11n(KJVA)` mapping engine. This PR prevents wrong-domain ordinal corruption and fixes the mainstream #356 restore path, but divergent canons such as LXX, Vulgate, and Synodal still need a dedicated mapping engine and legacy-row backfill follow-up.
- `bookInitials` is a new SwiftData/CloudKit-synced attribute with an empty-string default, so existing rows migrate as unknown-source bookmarks until recreated or restored.

## Issue Closure

Closes #356
