### PR TITLE
fix(reader): active-versification projection for bookmarks

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
@@ -444,8 +444,10 @@ struct BibleReaderAnnotationPayloadFactory {
      Resolves a stored KJVA bookmark ordinal into the target document's rendered ordinal space.
 
      Android backups identify Bible bookmarks by KJVA ordinals even when the `book` column stores
-     module initials or NULL. Normal Bible documents need the active module's rendered ordinal for
-     Vue highlight matching, while Android's My Notes fake document uses KJVA ordinals directly.
+     module initials or NULL. Normal Bible documents reverse-map the stored KJVA reference into the
+     active module's versification (Android's `verseRange.toV11n(activeV11n)`) and use that module's
+     rendered ordinal for Vue highlight matching, while Android's My Notes fake document uses KJVA
+     ordinals directly.
 
      - Parameters:
        - kjvOrdinal: Persisted Android-compatible KJVA ordinal.
@@ -465,23 +467,48 @@ struct BibleReaderAnnotationPayloadFactory {
         ordinalProjection: BibleBookmarkOrdinalProjection
     ) -> VerseKeyReference {
         if let kjvaReference = JSwordKJVAVersification.verseReference(ordinal: kjvOrdinal) {
-            let renderedOrdinal: Int
             switch ordinalProjection {
             case .activeModule:
-                renderedOrdinal = activeModule?.verseOrdinal(
+                // Reverse-map the stored KJVA reference into the active module's versification
+                // (Android's verseRange.toV11n(activeV11n)), then take that module's rendered
+                // ordinal. For divergent canons this lands on the true active verse (e.g. KJVA
+                // Ps 10:1 -> Vulgate Ps 9:22) instead of the identically-numbered KJVA verse; for
+                // KJV-family modules the mapping is identity.
+                if let activeModule,
+                   let mapped = SwordVersification.mapVerseFromKJVA(
+                       osisBookId: kjvaReference.osisId,
+                       chapter: kjvaReference.chapter,
+                       verse: kjvaReference.verse,
+                       targetVersification: activeModule.configEntry("Versification") ?? ""
+                   ),
+                   let activeOrdinal = activeModule.verseOrdinal(
+                       osisBookId: mapped.osisBookId,
+                       chapter: mapped.chapter,
+                       verse: mapped.verse
+                   ) {
+                    return VerseKeyReference(
+                        osisBookId: mapped.osisBookId,
+                        chapter: mapped.chapter,
+                        verse: mapped.verse,
+                        ordinal: activeOrdinal
+                    )
+                }
+                // No active module, or a reference the active module cannot render (e.g. a
+                // superscription): fall back to the KJVA coordinates and ordinal.
+                return VerseKeyReference(
                     osisBookId: kjvaReference.osisId,
                     chapter: kjvaReference.chapter,
-                    verse: kjvaReference.verse
-                ) ?? kjvaReference.ordinal
+                    verse: kjvaReference.verse,
+                    ordinal: kjvaReference.ordinal
+                )
             case .kjva:
-                renderedOrdinal = kjvaReference.ordinal
+                return VerseKeyReference(
+                    osisBookId: kjvaReference.osisId,
+                    chapter: kjvaReference.chapter,
+                    verse: kjvaReference.verse,
+                    ordinal: kjvaReference.ordinal
+                )
             }
-            return VerseKeyReference(
-                osisBookId: kjvaReference.osisId,
-                chapter: kjvaReference.chapter,
-                verse: kjvaReference.verse,
-                ordinal: renderedOrdinal
-            )
         }
         return verseReference(book: bookName, ordinal: sourceOrdinal)
             ?? activeModule?.verseReference(ordinal: sourceOrdinal)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
@@ -37,6 +37,13 @@ struct BibleReaderAnnotationPayloadFactory {
     private let bookCatalog: BibleReaderBookCatalog
     /// Synthetic unlabeled label identifier required by the web client.
     private let unlabeledLabelID: String
+    /// Active module versification, read once so per-bookmark projection avoids repeated SWORD reads.
+    private let activeVersification: String
+    /**
+     Whether the active module renders KJVA-compatible numbering (KJV-family), in which case the
+     reverse KJVA->active mapping is identity and can be skipped.
+     */
+    private let activeVersificationIsKJVACompatible: Bool
 
     /**
      Selects the ordinal domain used for Bible bookmark bridge payloads.
@@ -96,6 +103,11 @@ struct BibleReaderAnnotationPayloadFactory {
         self.activeModule = activeModule
         self.bookCatalog = bookCatalog
         self.unlabeledLabelID = unlabeledLabelID
+        let versification = activeModule?.configEntry("Versification")?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        self.activeVersification = versification
+        let normalized = versification.uppercased()
+        self.activeVersificationIsKJVACompatible = versification.isEmpty || normalized == "KJV" || normalized == "KJVA"
     }
 
     /**
@@ -469,17 +481,32 @@ struct BibleReaderAnnotationPayloadFactory {
         if let kjvaReference = JSwordKJVAVersification.verseReference(ordinal: kjvOrdinal) {
             switch ordinalProjection {
             case .activeModule:
-                // Reverse-map the stored KJVA reference into the active module's versification
-                // (Android's verseRange.toV11n(activeV11n)), then take that module's rendered
-                // ordinal. For divergent canons this lands on the true active verse (e.g. KJVA
-                // Ps 10:1 -> Vulgate Ps 9:22) instead of the identically-numbered KJVA verse; for
-                // KJV-family modules the mapping is identity.
+                // KJV-family modules render KJVA numbering identically, so skip the reverse map and
+                // take the active module's ordinal for the KJVA coordinates directly (no SWORD
+                // mapping per bookmark).
+                if activeVersificationIsKJVACompatible {
+                    let renderedOrdinal = activeModule?.verseOrdinal(
+                        osisBookId: kjvaReference.osisId,
+                        chapter: kjvaReference.chapter,
+                        verse: kjvaReference.verse
+                    ) ?? kjvaReference.ordinal
+                    return VerseKeyReference(
+                        osisBookId: kjvaReference.osisId,
+                        chapter: kjvaReference.chapter,
+                        verse: kjvaReference.verse,
+                        ordinal: renderedOrdinal
+                    )
+                }
+                // Divergent canon: reverse-map the stored KJVA reference into the active module's
+                // versification (Android's verseRange.toV11n(activeV11n)), then take that module's
+                // rendered ordinal, so it lands on the true active verse (e.g. KJVA Ps 10:1 ->
+                // Vulgate Ps 9:22) instead of the identically-numbered KJVA verse.
                 if let activeModule,
                    let mapped = SwordVersification.mapVerseFromKJVA(
                        osisBookId: kjvaReference.osisId,
                        chapter: kjvaReference.chapter,
                        verse: kjvaReference.verse,
-                       targetVersification: activeModule.configEntry("Versification") ?? ""
+                       targetVersification: activeVersification
                    ),
                    let activeOrdinal = activeModule.verseOrdinal(
                        osisBookId: mapped.osisBookId,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
@@ -165,12 +165,10 @@ struct BibleReaderCompareDocumentBuilder {
      - Failure modes: Returns an empty array when no installed module is categorized as a Bible.
      */
     private func installedCompareBibleModules(using manager: SwordManager) -> [ModuleInfo] {
-        // Mirror the reader's readable-Bible gate: exclude modules whose versification SWORD cannot
-        // map, matching the cached `installedBibleModules` the coordinator already filtered. ADR-0010.
+        // `installedModules()` already excludes unsupported modules (ADR-0010), so filtering by
+        // category matches the cached `installedBibleModules` the coordinator builds.
         let modules = installedBibleModules.isEmpty
-            ? manager.installedModules().filter {
-                $0.category == .bible && SwordVersification.isVersificationDefined($0.aboutMetadata.versification)
-            }
+            ? manager.installedModules().filter { $0.category == .bible }
             : installedBibleModules
 
         guard let activeIndex = modules.firstIndex(where: { $0.name == activeModuleName }) else {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderCompareDocumentBuilder.swift
@@ -165,8 +165,12 @@ struct BibleReaderCompareDocumentBuilder {
      - Failure modes: Returns an empty array when no installed module is categorized as a Bible.
      */
     private func installedCompareBibleModules(using manager: SwordManager) -> [ModuleInfo] {
+        // Mirror the reader's readable-Bible gate: exclude modules whose versification SWORD cannot
+        // map, matching the cached `installedBibleModules` the coordinator already filtered. ADR-0010.
         let modules = installedBibleModules.isEmpty
-            ? manager.installedModules().filter { $0.category == .bible }
+            ? manager.installedModules().filter {
+                $0.category == .bible && SwordVersification.isVersificationDefined($0.aboutMetadata.versification)
+            }
             : installedBibleModules
 
         guard let activeIndex = modules.firstIndex(where: { $0.name == activeModuleName }) else {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2608,10 +2608,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     public func restoreSavedPosition() {
         guard let pm = activeWindow?.pageManager else { return }
 
-        // Restore saved Bible module
+        // Restore saved Bible module only when SWORD recognizes its versification. A persisted or
+        // synced selection naming an unknown-versification module must not override the gated active
+        // module chosen during SWORD configuration, or it would render mis-numbered under KJV while
+        // being absent from every picker. ADR-0010.
         if let saved = pm.bibleDocument,
            let mgr = swordManager,
-           let mod = mgr.module(named: saved) {
+           let mod = mgr.module(named: saved),
+           SwordVersification.isVersificationDefined(mod.info.aboutMetadata.versification) {
             activeModule = mod
             activeModuleName = saved
             refreshBookList()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2570,14 +2570,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         self.installedMapModules = other.installedMapModules
         self.moduleBookList = other.moduleBookList
 
-        // Get own module handles from the shared manager (for independent cursor state). This
-        // re-resolves the sibling's active Bible BY NAME, so it carries the same versification gate as
-        // every other activation path (catalog, active-module resolution, restore, switch) for
-        // consistency and defense-in-depth: a sibling's active Bible name is already gated to a
-        // supported module today, but re-resolving an arbitrary name here without the check would
-        // reintroduce the ADR-0010 hole if a future path ever seeded an unsupported active name.
-        if let mod = mgr.module(named: other.activeModuleName),
-           SwordVersification.isVersificationDefined(mod.info.aboutMetadata.versification) {
+        // Get own module handles from the shared manager (for independent cursor state).
+        // `module(named:)` returns nil for an unsupported module, so an unsupported active Bible name
+        // is not re-resolved into this pane. See ADR-0010.
+        if let mod = mgr.module(named: other.activeModuleName) {
             self.activeModule = mod
             self.activeModuleName = other.activeModuleName
         }
@@ -2614,14 +2610,12 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     public func restoreSavedPosition() {
         guard let pm = activeWindow?.pageManager else { return }
 
-        // Restore saved Bible module only when SWORD recognizes its versification. A persisted or
-        // synced selection naming an unknown-versification module must not override the gated active
-        // module chosen during SWORD configuration, or it would render mis-numbered under KJV while
-        // being absent from every picker. ADR-0010.
+        // Restore the saved Bible module. `module(named:)` returns nil for an unsupported
+        // (e.g. unknown-versification) module, so a persisted or synced selection naming one is not
+        // restored and the supported module chosen during SWORD configuration remains. ADR-0010.
         if let saved = pm.bibleDocument,
            let mgr = swordManager,
-           let mod = mgr.module(named: saved),
-           SwordVersification.isVersificationDefined(mod.info.aboutMetadata.versification) {
+           let mod = mgr.module(named: saved) {
             activeModule = mod
             activeModuleName = saved
             refreshBookList()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -239,25 +239,55 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
-     Reverse-maps a stored KJVA bookmark ordinal into the active module's versification for
-     bookmark-list display and navigation.
+     Builds the bookmark-list active-versification resolver, or `nil` when the active module renders
+     in KJVA-compatible numbering.
 
      Android renders bookmark-list rows in the current Bible's versification (Android's
      `BookmarkItemAdapter`), so a bookmark stored at a KJVA ordinal shows and navigates to the active
-     module's mapped verse — KJVA Psalm 10 in a Vulgate module is Psalm 9. Falls back to KJVA
-     numbering (via the caller) when no active module is loaded or the reference cannot be mapped.
+     module's mapped verse — KJVA Psalm 10 in a Vulgate module is Psalm 9. But KJV-family modules
+     (KJV/KJVA, or no module) render identically to KJVA, so this returns `nil` for them and the list
+     keeps its fast in-memory KJVA path with no per-row SWORD work. For a divergent canon it reads the
+     versification once and returns a closure that memoizes per ordinal, so a large list performs at
+     most one SWORD mapping per unique ordinal — never a serialized SWORD call per row.
 
-     - Parameter kjvOrdinal: Persisted Android-compatible KJVA ordinal.
+     - Returns: A resolver mapping a KJVA ordinal to the active versification's book name plus
+       chapter/verse, or `nil` when the active module is KJVA-compatible.
+     - Side effects: Reads the active module's `Versification` conf once through the SWORD queue.
+     - Failure modes: The returned resolver yields `nil` for malformed or unmappable ordinals.
+     */
+    func bookmarkListActiveReferenceResolver() -> ((Int) -> (bookName: String, reference: BookmarkListVerseReference)?)? {
+        let activeVersification = activeModule?.configEntry("Versification") ?? ""
+        let normalized = normalizedVersificationName(activeVersification)
+        guard normalized != JSwordKJVAVersification.name, normalized != "KJV" else { return nil }
+
+        var cache: [Int: (bookName: String, reference: BookmarkListVerseReference)?] = [:]
+        return { [weak self] kjvOrdinal in
+            if let cached = cache[kjvOrdinal] { return cached }
+            let resolved = self?.bookmarkListActiveReference(
+                kjvOrdinal: kjvOrdinal,
+                versification: activeVersification
+            )
+            cache[kjvOrdinal] = resolved
+            return resolved
+        }
+    }
+
+    /**
+     Reverse-maps one stored KJVA ordinal into a target versification for bookmark-list rows.
+
+     - Parameters:
+       - kjvOrdinal: Persisted Android-compatible KJVA ordinal.
+       - activeVersification: Target module versification, read once by the resolver builder.
      - Returns: Active-versification display book name plus chapter/verse, or `nil` when the ordinal
        cannot be resolved or mapped.
      - Side effects: Runs inside the SWORD serialization queue via `SwordVersification`.
      - Failure modes: Returns `nil` for malformed KJVA ordinals or unmappable references.
      */
-    func bookmarkListActiveReference(
-        kjvOrdinal: Int
+    private func bookmarkListActiveReference(
+        kjvOrdinal: Int,
+        versification activeVersification: String
     ) -> (bookName: String, reference: BookmarkListVerseReference)? {
         guard let kjva = JSwordKJVAVersification.verseReference(ordinal: kjvOrdinal) else { return nil }
-        let activeVersification = activeModule?.configEntry("Versification") ?? ""
         guard let mapped = SwordVersification.mapVerseFromKJVA(
             osisBookId: kjva.osisId,
             chapter: kjva.chapter,

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -2570,8 +2570,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         self.installedMapModules = other.installedMapModules
         self.moduleBookList = other.moduleBookList
 
-        // Get own module handles from the shared manager (for independent cursor state)
-        if let mod = mgr.module(named: other.activeModuleName) {
+        // Get own module handles from the shared manager (for independent cursor state). This
+        // re-resolves the sibling's active Bible BY NAME, so it carries the same versification gate as
+        // every other activation path (catalog, active-module resolution, restore, switch) for
+        // consistency and defense-in-depth: a sibling's active Bible name is already gated to a
+        // supported module today, but re-resolving an arbitrary name here without the check would
+        // reintroduce the ADR-0010 hole if a future path ever seeded an unsupported active name.
+        if let mod = mgr.module(named: other.activeModuleName),
+           SwordVersification.isVersificationDefined(mod.info.aboutMetadata.versification) {
             self.activeModule = mod
             self.activeModuleName = other.activeModuleName
         }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -239,21 +239,57 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
+     Reverse-maps a stored KJVA bookmark ordinal into the active module's versification for
+     bookmark-list display and navigation.
+
+     Android renders bookmark-list rows in the current Bible's versification (Android's
+     `BookmarkItemAdapter`), so a bookmark stored at a KJVA ordinal shows and navigates to the active
+     module's mapped verse — KJVA Psalm 10 in a Vulgate module is Psalm 9. Falls back to KJVA
+     numbering (via the caller) when no active module is loaded or the reference cannot be mapped.
+
+     - Parameter kjvOrdinal: Persisted Android-compatible KJVA ordinal.
+     - Returns: Active-versification display book name plus chapter/verse, or `nil` when the ordinal
+       cannot be resolved or mapped.
+     - Side effects: Runs inside the SWORD serialization queue via `SwordVersification`.
+     - Failure modes: Returns `nil` for malformed KJVA ordinals or unmappable references.
+     */
+    func bookmarkListActiveReference(
+        kjvOrdinal: Int
+    ) -> (bookName: String, reference: BookmarkListVerseReference)? {
+        guard let kjva = JSwordKJVAVersification.verseReference(ordinal: kjvOrdinal) else { return nil }
+        let activeVersification = activeModule?.configEntry("Versification") ?? ""
+        guard let mapped = SwordVersification.mapVerseFromKJVA(
+            osisBookId: kjva.osisId,
+            chapter: kjva.chapter,
+            verse: kjva.verse,
+            targetVersification: activeVersification
+        ) else { return nil }
+        let displayName = bookName(forOsisId: mapped.osisBookId)
+            ?? JSwordKJVAVersification.longBookName(osisId: mapped.osisBookId)
+            ?? mapped.osisBookId
+        return (
+            bookName: displayName,
+            reference: BookmarkListVerseReference(chapter: mapped.chapter, verse: mapped.verse)
+        )
+    }
+
+    /**
      Converts a bookmark-modal My Notes link target into Android's My Notes document ordinal domain.
 
      Android builds the link from `bookmark.verseRange.start.ordinal` plus its source
      versification, then opens a My Notes document whose row ordinals are KJVA. iOS mirrors that by
-     resolving the source ordinal through a module with the requested versification and converting
-     the resulting verse identity to a KJVA ordinal before scrolling.
+     decoding the source ordinal from versification metadata alone (Android's `Verse(v11n, ordinal)`)
+     and converting the resulting verse identity to a KJVA ordinal before scrolling — no installed
+     source module is required. Resolution through an installed module remains only as a fallback for
+     a mis-cased or otherwise unrecognized versification name.
 
      - Parameters:
        - v11nName: Source versification emitted by the bookmark payload.
        - sourceOrdinal: Bookmark start ordinal in `v11nName`.
-     - Returns: KJVA ordinal for the same verse, or `nil` when no installed module can soundly
-       resolve the source ordinal.
-     - Side effects: May temporarily open or move SWORD modules through `verseReference`.
-     - Failure modes: Returns `nil` for invalid ordinals, unsupported versifications, or modules
-       that cannot resolve the source ordinal exactly.
+     - Returns: KJVA ordinal for the same verse, or `nil` when the source ordinal cannot be resolved.
+     - Side effects: Runs inside the SWORD serialization queue; the fallback may move SWORD modules
+       through `verseReference`.
+     - Failure modes: Returns `nil` for invalid ordinals or versifications SWORD cannot resolve.
      */
     private func kjvaMyNotesOrdinal(v11nName: String, sourceOrdinal: Int) -> Int? {
         guard sourceOrdinal > 0 else { return nil }
@@ -262,9 +298,21 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             return sourceOrdinal
         }
 
-        // Pass the module's real-cased versification name to the engine: SWORD's versification
-        // lookup is case-sensitive (e.g. "Vulg", "Synodal"), so `wanted` (uppercased) is used only
-        // for case-insensitive matching, never as the mapping source name.
+        // Primary, module-independent path: decode the source ordinal from the versification table
+        // itself and map the reference to KJVA. Mirrors Android's Verse(v11n, ordinal).toV11n(KJVA).
+        if let decoded = SwordVersification.decodeOrdinal(versification: v11nName, ordinal: sourceOrdinal),
+           let ordinal = kjvaOrdinal(
+               osisBookId: decoded.osisBookId,
+               chapter: decoded.chapter,
+               verse: decoded.verse,
+               sourceVersification: v11nName
+           ) {
+            return ordinal
+        }
+
+        // Fallback: resolve through an installed module whose versification matches case-insensitively
+        // (SWORD's lookup is case-sensitive, so `wanted` is used only for matching), using its
+        // real-cased conf value for the mapping.
         let activeVersification = activeModule?.configEntry("Versification") ?? ""
         if normalizedVersificationName(activeVersification) == wanted,
            let reference = activeModule?.verseReference(ordinal: sourceOrdinal),

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
@@ -166,6 +166,10 @@ struct BibleReaderModuleSwitchCoordinator {
         guard let mod = module(named: moduleName, context: context, logSubject: "module") else {
             return
         }
+        guard isReadableBibleModule(mod) else {
+            moduleSwitchLogger.warning("Cannot switch to module \(moduleName) — unrecognized versification")
+            return
+        }
 
         context.setBibleModule(mod, moduleName)
         context.refreshBookList()
@@ -196,6 +200,10 @@ struct BibleReaderModuleSwitchCoordinator {
      */
     func switchBibleDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
         guard let mod = module(named: moduleName, context: context, logSubject: "Bible document") else {
+            return
+        }
+        guard isReadableBibleModule(mod) else {
+            moduleSwitchLogger.warning("Cannot switch to Bible document \(moduleName) — unrecognized versification")
             return
         }
         guard let plan = validatedDocumentSwitchPlan(
@@ -601,6 +609,22 @@ struct BibleReaderModuleSwitchCoordinator {
             return nil
         }
         return mod
+    }
+
+    /**
+     Reports whether a resolved module is a readable Bible for the active reader.
+
+     A Bible module is readable only when SWORD recognizes its versification; an unknown versification
+     would render mis-numbered under KJV, so switching to it is rejected the same way the reader's
+     catalog and active-module resolution exclude it. See ADR-0010.
+
+     - Parameter module: Module resolved for a Bible switch.
+     - Returns: `true` when the module's versification is defined.
+     - Side effects: Reads SWORD's versification manager through the serialization queue.
+     - Failure modes: none.
+     */
+    private func isReadableBibleModule(_ module: SwordModule) -> Bool {
+        SwordVersification.isVersificationDefined(module.info.aboutMetadata.versification)
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModuleSwitchCoordinator.swift
@@ -166,10 +166,6 @@ struct BibleReaderModuleSwitchCoordinator {
         guard let mod = module(named: moduleName, context: context, logSubject: "module") else {
             return
         }
-        guard isReadableBibleModule(mod) else {
-            moduleSwitchLogger.warning("Cannot switch to module \(moduleName) — unrecognized versification")
-            return
-        }
 
         context.setBibleModule(mod, moduleName)
         context.refreshBookList()
@@ -200,10 +196,6 @@ struct BibleReaderModuleSwitchCoordinator {
      */
     func switchBibleDocument(to moduleName: String, context: BibleReaderModuleSwitchContext) {
         guard let mod = module(named: moduleName, context: context, logSubject: "Bible document") else {
-            return
-        }
-        guard isReadableBibleModule(mod) else {
-            moduleSwitchLogger.warning("Cannot switch to Bible document \(moduleName) — unrecognized versification")
             return
         }
         guard let plan = validatedDocumentSwitchPlan(
@@ -611,21 +603,6 @@ struct BibleReaderModuleSwitchCoordinator {
         return mod
     }
 
-    /**
-     Reports whether a resolved module is a readable Bible for the active reader.
-
-     A Bible module is readable only when SWORD recognizes its versification; an unknown versification
-     would render mis-numbered under KJV, so switching to it is rejected the same way the reader's
-     catalog and active-module resolution exclude it. See ADR-0010.
-
-     - Parameter module: Module resolved for a Bible switch.
-     - Returns: `true` when the module's versification is defined.
-     - Side effects: Reads SWORD's versification manager through the serialization queue.
-     - Failure modes: none.
-     */
-    private func isReadableBibleModule(_ module: SwordModule) -> Bool {
-        SwordVersification.isVersificationDefined(module.info.aboutMetadata.versification)
-    }
 
     /**
      Validates an installed module category and logs the controller-compatible warning on mismatch.

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
@@ -121,14 +121,10 @@ struct BibleReaderSwordCoordinator {
         applyBaseOptions(to: manager)
         applyDisplayOptions(to: manager, settings: displaySettings, defaults: defaults)
 
+        // `installedModules()` already excludes unsupported modules (e.g. an unknown-versification
+        // Bible), mirroring Android's `Books.installed()`, so partitioning by category is sufficient.
         let modules = manager.installedModules()
-        // A Bible module is readable only when SWORD recognizes its versification. Android marks a
-        // module with an unknown versification unsupported and never loads it; iOS mirrors that for
-        // reading/bookmarking (rendering an unmapped canon under KJV would mis-number verses and
-        // create offset notes). Such modules remain in `modules` for management/uninstall. ADR-0010.
-        let bibleModules = modules.filter {
-            $0.category == .bible && SwordVersification.isVersificationDefined($0.aboutMetadata.versification)
-        }
+        let bibleModules = modules.filter { $0.category == .bible }
         let commentaryModules = modules.filter { $0.category == .commentary }
         let dictionaryModules = modules.filter { $0.category == .dictionary }
         let generalBookModules = modules.filter { $0.category == .generalBook }
@@ -244,12 +240,10 @@ struct BibleReaderSwordCoordinator {
         requestedName: String,
         installedBibleModules: [ModuleInfo]
     ) -> (module: SwordModule?, name: String) {
-        // Honor the requested module only when SWORD recognizes its versification, so an
-        // unknown-versification module is never loaded as the active reader even when it is the
-        // persisted/requested selection. Otherwise fall back to KJV, then the first supported Bible.
-        // This keeps active-module resolution consistent with the readable-Bible gate. ADR-0010.
-        if let module = manager.module(named: requestedName),
-           SwordVersification.isVersificationDefined(module.info.aboutMetadata.versification) {
+        // `module(named:)` returns nil for an unsupported (e.g. unknown-versification) module, so an
+        // unknown-versification requested module falls through to KJV / the first supported Bible
+        // rather than becoming active. See ADR-0010.
+        if let module = manager.module(named: requestedName) {
             return (module, requestedName)
         }
         if let kjv = manager.module(named: "KJV") {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
@@ -122,7 +122,13 @@ struct BibleReaderSwordCoordinator {
         applyDisplayOptions(to: manager, settings: displaySettings, defaults: defaults)
 
         let modules = manager.installedModules()
-        let bibleModules = modules.filter { $0.category == .bible }
+        // A Bible module is readable only when SWORD recognizes its versification. Android marks a
+        // module with an unknown versification unsupported and never loads it; iOS mirrors that for
+        // reading/bookmarking (rendering an unmapped canon under KJV would mis-number verses and
+        // create offset notes). Such modules remain in `modules` for management/uninstall. ADR-0010.
+        let bibleModules = modules.filter {
+            $0.category == .bible && SwordVersification.isVersificationDefined($0.aboutMetadata.versification)
+        }
         let commentaryModules = modules.filter { $0.category == .commentary }
         let dictionaryModules = modules.filter { $0.category == .dictionary }
         let generalBookModules = modules.filter { $0.category == .generalBook }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSwordCoordinator.swift
@@ -244,7 +244,12 @@ struct BibleReaderSwordCoordinator {
         requestedName: String,
         installedBibleModules: [ModuleInfo]
     ) -> (module: SwordModule?, name: String) {
-        if let module = manager.module(named: requestedName) {
+        // Honor the requested module only when SWORD recognizes its versification, so an
+        // unknown-versification module is never loaded as the active reader even when it is the
+        // persisted/requested selection. Otherwise fall back to KJV, then the first supported Bible.
+        // This keeps active-module resolution consistent with the readable-Bible gate. ADR-0010.
+        if let module = manager.module(named: requestedName),
+           SwordVersification.isVersificationDefined(module.info.aboutMetadata.versification) {
             return (module, requestedName)
         }
         if let kjv = manager.module(named: "KJV") {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1218,6 +1218,9 @@ public struct BibleReaderView: View {
                 bibleOrdinalResolver: { book, ordinal in
                     panePresentationController?.bookmarkListVerseReference(book: book, ordinal: ordinal)
                 },
+                activeReferenceResolver: { kjvOrdinal in
+                    panePresentationController?.bookmarkListActiveReference(kjvOrdinal: kjvOrdinal)
+                },
                 showsDismissButton: false
             )
             #if os(iOS)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1218,9 +1218,7 @@ public struct BibleReaderView: View {
                 bibleOrdinalResolver: { book, ordinal in
                     panePresentationController?.bookmarkListVerseReference(book: book, ordinal: ordinal)
                 },
-                activeReferenceResolver: { kjvOrdinal in
-                    panePresentationController?.bookmarkListActiveReference(kjvOrdinal: kjvOrdinal)
-                },
+                activeReferenceResolver: panePresentationController?.bookmarkListActiveReferenceResolver() ?? nil,
                 showsDismissButton: false
             )
             #if os(iOS)

--- a/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bookmarks/BookmarkListView.swift
@@ -106,6 +106,12 @@ public struct BookmarkListView: View {
     /// Optional SWORD-backed resolver for Bible bookmark ordinals.
     var bibleOrdinalResolver: ((String, Int) -> BookmarkListVerseReference?)?
 
+    /**
+     Optional resolver mapping a stored KJVA ordinal into the active module's versification for
+     display and navigation (Android renders list rows in the current Bible's versification).
+     */
+    var activeReferenceResolver: ((Int) -> (bookName: String, reference: BookmarkListVerseReference)?)?
+
     /// Whether the list should expose sheet-style explicit dismiss chrome.
     private let showsDismissButton: Bool
 
@@ -117,6 +123,8 @@ public struct BookmarkListView: View {
        - onOpenStudyPad: Callback invoked when the user wants to open a selected label's study pad.
        - bibleOrdinalResolver: Optional resolver that maps `(bookName, ordinal)` to a concrete
          chapter/verse using the active Bible versification.
+       - activeReferenceResolver: Optional resolver that maps a stored KJVA ordinal to the active
+         module's versification (book name plus chapter/verse) for display and navigation.
        - showsDismissButton: Whether to show the sheet-style Done button; app-owned destination
          routes rely on navigation-stack back chrome instead.
      */
@@ -124,11 +132,13 @@ public struct BookmarkListView: View {
         onNavigate: ((String, Int) -> Void)? = nil,
         onOpenStudyPad: ((UUID) -> Void)? = nil,
         bibleOrdinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil,
+        activeReferenceResolver: ((Int) -> (bookName: String, reference: BookmarkListVerseReference)?)? = nil,
         showsDismissButton: Bool = true
     ) {
         self.onNavigate = onNavigate
         self.onOpenStudyPad = onOpenStudyPad
         self.bibleOrdinalResolver = bibleOrdinalResolver
+        self.activeReferenceResolver = activeReferenceResolver
         self.showsDismissButton = showsDismissButton
     }
 
@@ -148,7 +158,13 @@ public struct BookmarkListView: View {
     private var bookmarkListItems: [BookmarkListItem] {
         let bibleItems = bibleBookmarks
             .filter { ($0.notes?.notes ?? "").isEmpty }
-            .map { BookmarkListItem(bibleBookmark: $0, ordinalResolver: bibleOrdinalResolver) }
+            .map {
+                BookmarkListItem(
+                    bibleBookmark: $0,
+                    ordinalResolver: bibleOrdinalResolver,
+                    activeReferenceResolver: activeReferenceResolver
+                )
+            }
         let genericItems = genericBookmarks
             .filter { ($0.notes?.notes ?? "").isEmpty }
             .map(BookmarkListItem.init(genericBookmark:))
@@ -448,13 +464,19 @@ public struct BookmarkListView: View {
      */
     static func verseReference(
         for bookmark: BibleBookmark,
-        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
+        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil,
+        activeReferenceResolver: ((Int) -> (bookName: String, reference: BookmarkListVerseReference)?)? = nil
     ) -> String {
-        if let start = kjvaVerseReference(ordinal: bookmark.kjvOrdinalStart) {
+        // Prefer the active module's versification (Android renders list rows in the current Bible);
+        // fall back to KJVA numbering when no active module resolver is available.
+        let resolve: (Int) -> (bookName: String, reference: BookmarkListVerseReference)? = { ordinal in
+            activeReferenceResolver?(ordinal) ?? kjvaVerseReference(ordinal: ordinal)
+        }
+        if let start = resolve(bookmark.kjvOrdinalStart) {
             let effectiveKJVEnd = bookmark.kjvOrdinalEnd > bookmark.kjvOrdinalStart
                 ? bookmark.kjvOrdinalEnd
                 : bookmark.kjvOrdinalStart
-            let end = kjvaVerseReference(ordinal: effectiveKJVEnd) ?? start
+            let end = resolve(effectiveKJVEnd) ?? start
             return formattedBibleReference(
                 startBookName: start.bookName,
                 startReference: start.reference,
@@ -814,9 +836,14 @@ struct BookmarkListItem: Identifiable {
     /// Creates a normalized row for one Bible bookmark.
     init(
         bibleBookmark bookmark: BibleBookmark,
-        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil
+        ordinalResolver: ((String, Int) -> BookmarkListVerseReference?)? = nil,
+        activeReferenceResolver: ((Int) -> (bookName: String, reference: BookmarkListVerseReference)?)? = nil
     ) {
-        let reference = BookmarkListView.verseReference(for: bookmark, ordinalResolver: ordinalResolver)
+        let reference = BookmarkListView.verseReference(
+            for: bookmark,
+            ordinalResolver: ordinalResolver,
+            activeReferenceResolver: activeReferenceResolver
+        )
         let noteText = bookmark.notes?.notes ?? ""
         self.id = bookmark.id
         self.source = .bible(bookmark)
@@ -828,7 +855,10 @@ struct BookmarkListItem: Identifiable {
         self.customIcon = bookmark.customIcon
         self.noteText = noteText
         self.labels = bookmark.bookmarkToLabels?.compactMap { $0.label }.sorted { $0.name < $1.name } ?? []
-        if let target = BookmarkListView.kjvaVerseReference(ordinal: bookmark.kjvOrdinalStart) {
+        // Navigate in the active module's versification (Android's list navigation); fall back to
+        // KJVA numbering when no active module resolver is available.
+        if let target = activeReferenceResolver?(bookmark.kjvOrdinalStart)
+            ?? BookmarkListView.kjvaVerseReference(ordinal: bookmark.kjvOrdinalStart) {
             self.navigationTarget = (
                 bookName: target.bookName,
                 chapter: target.reference.chapter

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderDocumentSwitchControllerTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderDocumentSwitchControllerTests.swift
@@ -272,4 +272,41 @@ final class BibleReaderDocumentSwitchControllerTests: BibleUISwordFixtureTestCas
         XCTAssertEqual(pageManager.currentCategoryName, baselineCategoryName)
         XCTAssertEqual(persistCount, 0)
     }
+
+    /**
+     Protects the Bible switch API from activating a module with an unrecognized versification.
+
+     `switchBibleDocument(to:)` is public controller API reachable beyond the versification-filtered
+     picker (bridge, next/previous cycling, restore). A module whose versification SWORD cannot map
+     must not become the active Bible — it would render mis-numbered under KJV — so the switch leaves
+     the active Bible, category, PageManager state, and persistence untouched. See ADR-0010.
+     */
+    @MainActor
+    func testBibleDocumentSwitchRejectsUnknownVersificationModuleWithoutStateMutation() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "BOGUS", description: "Bogus Versification Bible", in: modulePath)
+        let bogusConf = URL(fileURLWithPath: modulePath).appendingPathComponent("mods.d/bogus.conf")
+        var conf = try String(contentsOf: bogusConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=BogusV11n")
+        try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        let baselineBibleModuleName = controller.activeModuleName
+        let baselineBibleDocument = pageManager.bibleDocument
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchBibleDocument(to: "BOGUS")
+
+        XCTAssertNotEqual(controller.activeModuleName, "BOGUS", "An unknown-versification module must not become the active Bible.")
+        XCTAssertEqual(controller.activeModuleName, baselineBibleModuleName)
+        XCTAssertEqual(pageManager.bibleDocument, baselineBibleDocument)
+        XCTAssertEqual(persistCount, 0)
+    }
 }

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderDocumentSwitchControllerTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderDocumentSwitchControllerTests.swift
@@ -309,4 +309,76 @@ final class BibleReaderDocumentSwitchControllerTests: BibleUISwordFixtureTestCas
         XCTAssertEqual(pageManager.bibleDocument, baselineBibleDocument)
         XCTAssertEqual(persistCount, 0)
     }
+
+    /**
+     Protects the module-only Bible switch API from activating an unknown-versification module.
+
+     `switchModule(to:)` changes the Bible without changing the visible category and, like
+     `switchBibleDocument(to:)`, is public controller API reachable beyond the versification-filtered
+     picker. A module whose versification SWORD cannot map must not become the active Bible. See
+     ADR-0010.
+     */
+    @MainActor
+    func testBibleModuleSwitchRejectsUnknownVersificationModuleWithoutStateMutation() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "BOGUS", description: "Bogus Versification Bible", in: modulePath)
+        let bogusConf = URL(fileURLWithPath: modulePath).appendingPathComponent("mods.d/bogus.conf")
+        var conf = try String(contentsOf: bogusConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=BogusV11n")
+        try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        let baselineBibleModuleName = controller.activeModuleName
+        let baselineBibleDocument = pageManager.bibleDocument
+        var persistCount = 0
+        controller.onPersistState = { persistCount += 1 }
+
+        controller.switchModule(to: "BOGUS")
+
+        XCTAssertNotEqual(controller.activeModuleName, "BOGUS", "An unknown-versification module must not become the active Bible.")
+        XCTAssertEqual(controller.activeModuleName, baselineBibleModuleName)
+        XCTAssertEqual(pageManager.bibleDocument, baselineBibleDocument)
+        XCTAssertEqual(persistCount, 0)
+    }
+
+    /**
+     Protects position restore from activating a persisted unknown-versification Bible.
+
+     `restoreSavedPosition` reads `PageManager.bibleDocument`, which a pre-gate release or a synced
+     workspace may set to an unknown-versification module. Restoring it would make it the active
+     Bible (rendered mis-numbered under KJV); instead the gated active module chosen during SWORD
+     configuration (here KJV) must remain. See ADR-0010.
+     */
+    @MainActor
+    func testRestoreSavedPositionSkipsPersistedUnknownVersificationBible() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "BOGUS", description: "Bogus Versification Bible", in: modulePath)
+        let bogusConf = URL(fileURLWithPath: modulePath).appendingPathComponent("mods.d/bogus.conf")
+        var conf = try String(contentsOf: bogusConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=BogusV11n")
+        try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        // The supported KJV is active after configuration.
+        XCTAssertEqual(controller.activeModuleName, "KJV")
+
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        pageManager.bibleDocument = "BOGUS"
+        window.pageManager = pageManager
+        controller.activeWindow = window
+
+        controller.restoreSavedPosition()
+
+        XCTAssertEqual(controller.activeModuleName, "KJV", "A persisted unknown-versification Bible must not be restored as active.")
+        XCTAssertEqual(controller.activeModule?.info.name, "KJV")
+    }
 }

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkListProjectionTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkListProjectionTests.swift
@@ -360,6 +360,43 @@ final class BookmarkListProjectionTests: XCTestCase {
     }
 
     /**
+     Verifies bookmark-list rows render and navigate in the active module's versification.
+
+     Android's `BookmarkItemAdapter` formats each row in the current Bible's versification, so a
+     bookmark stored at a KJVA ordinal must display and navigate to the active module's mapped verse
+     (KJVA Psalm 10:1 is Vulgate Psalm 9:22). Without an active-versification resolver the row falls
+     back to KJVA numbering. The resolver is injected, so this exercises the plumbing deterministically
+     without a divergent module installed.
+     */
+    func testBibleBookmarkRowRendersAndNavigatesInActiveVersification() throws {
+        let kjvaPsalm10Verse1 = try XCTUnwrap(
+            JSwordKJVAVersification.verseOrdinal(osisId: "Ps", chapter: 10, verse: 1)
+        )
+        let bookmark = BibleBookmark(
+            kjvOrdinalStart: kjvaPsalm10Verse1,
+            kjvOrdinalEnd: kjvaPsalm10Verse1,
+            ordinalStart: kjvaPsalm10Verse1,
+            ordinalEnd: kjvaPsalm10Verse1
+        )
+
+        // Active module is Vulgate: KJVA Psalm 10:1 maps back to Psalm 9:22.
+        let activeResolver: (Int) -> (bookName: String, reference: BookmarkListVerseReference)? = { ordinal in
+            ordinal == kjvaPsalm10Verse1
+                ? (bookName: "Psalms", reference: BookmarkListVerseReference(chapter: 9, verse: 22))
+                : nil
+        }
+        let activeItem = BookmarkListItem(bibleBookmark: bookmark, activeReferenceResolver: activeResolver)
+        XCTAssertEqual(activeItem.reference, "Psalms 9:22", "The row renders in the active versification, not KJVA numbering.")
+        XCTAssertEqual(activeItem.navigationTarget?.bookName, "Psalms")
+        XCTAssertEqual(activeItem.navigationTarget?.chapter, 9, "Navigation targets the active-versification chapter.")
+
+        // Without a resolver, the row falls back to KJVA numbering (Psalm 10).
+        let kjvaItem = BookmarkListItem(bibleBookmark: bookmark)
+        XCTAssertEqual(kjvaItem.reference, "Psalms 10:1")
+        XCTAssertEqual(kjvaItem.navigationTarget?.chapter, 10)
+    }
+
+    /**
      Builds a Bible bookmark projection row whose storage ordinals match its visible reference.
 
      Bookmark list rows now render, search, navigate, and sort from Android-compatible KJVA ordinals

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -543,16 +543,39 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies the bookmark-list active-versification resolver is nil for KJV-family active modules.
+
+     KJV-family modules render KJVA-compatible numbering, so the reverse KJVA->active mapping is
+     identity and the list must keep its fast in-memory path with no per-row SWORD work. Only a
+     divergent-canon active module returns a (memoizing) resolver.
+     */
+    @MainActor
+    func testBookmarkListActiveReferenceResolverIsNilForKJVFamilyModule() throws {
+        let (bridge, _) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        controller.bridgeDidSetClientReady(bridge)
+        controller.navigateTo(book: "Matthew", chapter: 1, verse: 1)
+
+        XCTAssertNil(
+            controller.bookmarkListActiveReferenceResolver(),
+            "KJV-family active modules render KJVA-compatibly, so the list must skip per-row SWORD mapping."
+        )
+    }
+
+    /**
      Verifies My Notes modal links omit their scroll target when source-to-KJVA conversion fails.
      *
      * Android's My Notes fake document scrolls within KJVA rows. When iOS cannot resolve the source
-     * versification named by a modal link, passing the original source ordinal would cross ordinal
-     * domains and scroll to the wrong bookmark. The safe parity behavior is to open the document and
-     * leave `setup_content.jumpToOrdinal` null.
+     * ordinal named by a modal link (here an ordinal beyond any versification's range), passing it
+     * would cross ordinal domains and scroll to the wrong bookmark. The safe parity behavior is to
+     * open the document and leave `setup_content.jumpToOrdinal` null. (An unrecognized versification
+     * name is NOT a failure — libsword renders such modules under KJV, so it resolves as KJV.)
      *
      * Failure meaning:
-     * - unsupported or uninstalled source versifications could leak source ordinals into the KJVA My
-     *   Notes document contract and navigate to unrelated notes.
+     * - an unresolvable source ordinal could leak into the KJVA My Notes document contract and
+     *   navigate to unrelated notes.
      */
     @MainActor
     func testReaderOpenMyNotesOmitsJumpTargetWhenSourceOrdinalCannotConvertToKJVA() throws {
@@ -564,7 +587,7 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         controller.navigateTo(book: "Matthew", chapter: 1, verse: 1)
         let baselineCount = recordedScripts().count
 
-        controller.bridge(bridge, openMyNotes: "UninstalledV11n", ordinal: 12_345)
+        controller.bridge(bridge, openMyNotes: "Vulg", ordinal: 10_000_000)
 
         let myNotesScripts = Array(recordedScripts().dropFirst(baselineCount))
         let setupPayload = try XCTUnwrap(

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
@@ -108,6 +108,40 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies an unknown-versification module requested as the active Bible falls back to a supported one.
+
+     The readable-Bible gate must also cover active-module resolution: a persisted or synced selection
+     naming an unknown-versification module must not become the active/rendered Bible (it would render
+     mis-numbered under KJV while being absent from every picker). The coordinator falls back to KJV.
+     See ADR-0010.
+     */
+    func testActiveBibleModuleFallsBackWhenRequestedModuleHasUnrecognizedVersification() throws {
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "BOGUS", description: "Bogus Versification Bible", in: modulePath)
+        let bogusConf = URL(fileURLWithPath: modulePath).appendingPathComponent("mods.d/bogus.conf")
+        var conf = try String(contentsOf: bogusConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=BogusV11n")
+        try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let state = BibleReaderSwordCoordinator().configure(
+            manager: manager,
+            selection: BibleReaderSwordSelection(
+                activeModuleName: "BOGUS",
+                activeCommentaryModuleName: nil,
+                activeDictionaryModuleName: nil,
+                activeGeneralBookModuleName: nil,
+                activeMapModuleName: nil
+            ),
+            displaySettings: .appDefaults
+        )
+
+        XCTAssertNotEqual(state.activeModuleName, "BOGUS", "An unknown-versification module must not become the active Bible.")
+        XCTAssertEqual(state.activeModuleName, "KJV", "The coordinator falls back to a supported Bible (KJV).")
+        XCTAssertEqual(state.activeModule?.info.name, "KJV")
+    }
+
+    /**
      Protects the SWORD global option mapping used by reader rendering.
 
      Android applies reader display settings through JSword filters; iOS mirrors those options with

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
@@ -123,6 +123,44 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies a Bible module declaring a recognized non-KJV canon survives the isSupported filter.
+
+     `isSupported` must exclude only versifications SWORD cannot map, not every non-KJV canon. This
+     guards against the filter ever being narrowed to reject a legitimate divergent canon (Vulgate,
+     Synodal, LXX, etc.): a module with `Versification=Vulg` stays in the inventory, is by-name
+     resolvable, and is readable. See ADR-0010.
+     */
+    func testKeepsBibleModuleWithRecognizedNonKJVVersification() throws {
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "VULGATE", description: "Vulgate-versification Bible", in: modulePath)
+        let vulgConf = URL(fileURLWithPath: modulePath).appendingPathComponent("mods.d/vulgate.conf")
+        var conf = try String(contentsOf: vulgConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=Vulg")
+        try conf.write(to: vulgConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        XCTAssertTrue(
+            manager.installedModules().contains { $0.name == "VULGATE" },
+            "A recognized non-KJV canon (Vulg) must remain installed/readable."
+        )
+        XCTAssertNotNil(manager.module(named: "VULGATE"), "module(named:) resolves a supported non-KJV canon.")
+
+        let state = BibleReaderSwordCoordinator().configure(
+            manager: manager,
+            selection: BibleReaderSwordSelection(
+                activeModuleName: "VULGATE",
+                activeCommentaryModuleName: nil,
+                activeDictionaryModuleName: nil,
+                activeGeneralBookModuleName: nil,
+                activeMapModuleName: nil
+            ),
+            displaySettings: .appDefaults
+        )
+        XCTAssertTrue(state.installedBibleModules.contains { $0.name == "VULGATE" })
+        XCTAssertEqual(state.activeModuleName, "VULGATE", "A supported non-KJV canon can be the active Bible.")
+    }
+
+    /**
      Verifies an unknown-versification module requested as the active Bible falls back to a supported one.
 
      The readable-Bible gate must also cover active-module resolution: a persisted or synced selection

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
@@ -63,6 +63,51 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies a Bible module with an unrecognized versification is excluded from the readable set.
+
+     Android marks a module whose versification JSword does not recognize unsupported and never loads
+     it. iOS mirrors that for reading/bookmarking: the coordinator drops such a module from
+     `installedBibleModules` (so it is not selectable or annotatable), while it remains in the raw
+     `installedModules` inventory so it can still be managed/uninstalled. See ADR-0010.
+     */
+    func testExcludesBibleModuleWithUnrecognizedVersificationFromReadableSet() throws {
+        let modulePath = try makeTemporarySwordFixturePath()
+        try seedBibleAliasModule(named: "BOGUS", description: "Bogus Versification Bible", in: modulePath)
+        // Point BOGUS at a versification SWORD does not recognize.
+        let bogusConf = URL(fileURLWithPath: modulePath)
+            .appendingPathComponent("mods.d/bogus.conf")
+        var conf = try String(contentsOf: bogusConf, encoding: .utf8)
+        conf = conf.replacingOccurrences(of: "Versification=KJV", with: "Versification=BogusV11n")
+        try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let state = BibleReaderSwordCoordinator().configure(
+            manager: manager,
+            selection: BibleReaderSwordSelection(
+                activeModuleName: "KJV",
+                activeCommentaryModuleName: nil,
+                activeDictionaryModuleName: nil,
+                activeGeneralBookModuleName: nil,
+                activeMapModuleName: nil
+            ),
+            displaySettings: .appDefaults
+        )
+
+        XCTAssertFalse(
+            state.installedBibleModules.contains { $0.name == "BOGUS" },
+            "A module with an unrecognized versification must not be readable/bookmarkable."
+        )
+        XCTAssertTrue(
+            state.installedBibleModules.contains { $0.name == "KJV" },
+            "A module with a recognized versification stays readable."
+        )
+        XCTAssertTrue(
+            state.installedModules.contains { $0.name == "BOGUS" },
+            "The unsupported module remains in the raw inventory for management/uninstall."
+        )
+    }
+
+    /**
      Protects the SWORD global option mapping used by reader rendering.
 
      Android applies reader display settings through JSword filters; iOS mirrors those options with

--- a/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ReaderSwordCoordinatorTests.swift
@@ -63,12 +63,13 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
     }
 
     /**
-     Verifies a Bible module with an unrecognized versification is excluded from the readable set.
+     Verifies a Bible module with an unrecognized versification is invisible to the coordinator.
 
-     Android marks a module whose versification JSword does not recognize unsupported and never loads
-     it. iOS mirrors that for reading/bookmarking: the coordinator drops such a module from
-     `installedBibleModules` (so it is not selectable or annotatable), while it remains in the raw
-     `installedModules` inventory so it can still be managed/uninstalled. See ADR-0010.
+     Android marks a module whose versification JSword does not recognize unsupported and never adds
+     it to `Books.installed()`, so it is invisible everywhere. iOS mirrors that with a single filter
+     in `SwordManager.installedModules()`: such a module appears in neither the raw `installedModules`
+     inventory nor `installedBibleModules`, so it is not selectable, annotatable, or shown as
+     installed. See ADR-0010.
      */
     func testExcludesBibleModuleWithUnrecognizedVersificationFromReadableSet() throws {
         let modulePath = try makeTemporarySwordFixturePath()
@@ -81,6 +82,20 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
         try conf.write(to: bogusConf, atomically: true, encoding: .utf8)
 
         let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+
+        // The single SwordManager filter (mirroring Android's Books.installed()) hides the unsupported
+        // module from the inventory and from by-name resolution.
+        XCTAssertFalse(
+            manager.installedModules().contains { $0.name == "BOGUS" },
+            "installedModules() must exclude an unknown-versification Bible."
+        )
+        XCTAssertTrue(
+            manager.installedModules().contains { $0.name == "KJV" },
+            "installedModules() keeps a supported Bible."
+        )
+        XCTAssertNil(manager.module(named: "BOGUS"), "module(named:) returns nil for an unsupported module.")
+        XCTAssertNotNil(manager.module(named: "KJV"), "module(named:) resolves a supported module.")
+
         let state = BibleReaderSwordCoordinator().configure(
             manager: manager,
             selection: BibleReaderSwordSelection(
@@ -101,9 +116,9 @@ final class ReaderSwordCoordinatorTests: BibleUISwordFixtureTestCase {
             state.installedBibleModules.contains { $0.name == "KJV" },
             "A module with a recognized versification stays readable."
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             state.installedModules.contains { $0.name == "BOGUS" },
-            "The unsupported module remains in the raw inventory for management/uninstall."
+            "The unsupported module is invisible in the inventory too, matching Android's Books.installed()."
         )
     }
 

--- a/Sources/SwordKit/CLibSword/include/flatapi.h
+++ b/Sources/SwordKit/CLibSword/include/flatapi.h
@@ -176,6 +176,11 @@ int SWVersification_decodeOrdinal(const char *versification,
                                   int *chapterOut,
                                   int *verseOut);
 
+/// Reports whether SWORD's VersificationMgr recognizes the given versification name (mirrors
+/// JSword `Versifications.isDefined`). An empty name is the KJV default and is always defined.
+/// Returns 1 when defined, 0 when not.
+int SWVersification_isSystemDefined(const char *versification);
+
 /// Pop the last error code. Returns 0 if no error.
 char SWModule_popError(void *module);
 

--- a/Sources/SwordKit/CLibSword/include/flatapi.h
+++ b/Sources/SwordKit/CLibSword/include/flatapi.h
@@ -151,6 +151,31 @@ int SWVersification_mapVerseToKJVA(const char *sourceVersification,
                                    int *kjvaChapterOut,
                                    int *kjvaVerseOut);
 
+/// Map an OSIS book/chapter/verse from KJVA into a target versification using SWORD's
+/// VersificationMgr — the reverse of SWVersification_mapVerseToKJVA. Writes the target OSIS book
+/// id, chapter, and verse to the out parameters. The returned book string is owned by the callee
+/// and remains valid until the next call on the same thread. An empty target versification name is
+/// treated as KJV. Returns 0 on success and nonzero when a versification is unknown or the inputs
+/// are invalid.
+int SWVersification_mapVerseFromKJVA(const char *targetVersification,
+                                     const char *kjvaOsisBookName,
+                                     int chapter,
+                                     int verse,
+                                     const char **targetOsisBookOut,
+                                     int *targetChapterOut,
+                                     int *targetVerseOut);
+
+/// Decode an intro-inclusive VerseKey index into an OSIS book/chapter/verse within the given
+/// versification, without an installed module. Writes the OSIS book id, chapter, and verse to the
+/// out parameters. The returned book string is owned by the callee and remains valid until the
+/// next call on the same thread. An empty versification name is treated as KJV. Returns 0 on
+/// success and nonzero when the versification is unknown or the ordinal is out of range.
+int SWVersification_decodeOrdinal(const char *versification,
+                                  long ordinal,
+                                  const char **osisBookOut,
+                                  int *chapterOut,
+                                  int *verseOut);
+
 /// Pop the last error code. Returns 0 if no error.
 char SWModule_popError(void *module);
 

--- a/Sources/SwordKit/CLibSword/include/flatapi.h
+++ b/Sources/SwordKit/CLibSword/include/flatapi.h
@@ -140,9 +140,9 @@ int SWModule_setVerseKeyIndex(void *module, long index);
 /// Map an OSIS book/chapter/verse from a source versification into KJVA using SWORD's
 /// VersificationMgr (the same av11n mapping data JSword uses on Android). Writes the KJVA OSIS
 /// book id, chapter, and verse to the out parameters. The returned book string is owned by the
-/// callee and remains valid until the next call on the same thread. An empty source versification
-/// name is treated as KJV. Returns 0 on success and nonzero when a versification is unknown or
-/// the inputs are invalid.
+/// callee and remains valid until the next call on the same thread. An empty OR unrecognized source
+/// versification name is treated as KJV (iOS libsword renders such modules under KJV). Returns 0 on
+/// success and nonzero when KJVA is missing or the inputs are invalid.
 int SWVersification_mapVerseToKJVA(const char *sourceVersification,
                                    const char *osisBookName,
                                    int chapter,
@@ -154,9 +154,9 @@ int SWVersification_mapVerseToKJVA(const char *sourceVersification,
 /// Map an OSIS book/chapter/verse from KJVA into a target versification using SWORD's
 /// VersificationMgr — the reverse of SWVersification_mapVerseToKJVA. Writes the target OSIS book
 /// id, chapter, and verse to the out parameters. The returned book string is owned by the callee
-/// and remains valid until the next call on the same thread. An empty target versification name is
-/// treated as KJV. Returns 0 on success and nonzero when a versification is unknown or the inputs
-/// are invalid.
+/// and remains valid until the next call on the same thread. An empty OR unrecognized target
+/// versification name is treated as KJV. Returns 0 on success and nonzero when KJVA is missing or
+/// the inputs are invalid.
 int SWVersification_mapVerseFromKJVA(const char *targetVersification,
                                      const char *kjvaOsisBookName,
                                      int chapter,
@@ -168,8 +168,8 @@ int SWVersification_mapVerseFromKJVA(const char *targetVersification,
 /// Decode an intro-inclusive VerseKey index into an OSIS book/chapter/verse within the given
 /// versification, without an installed module. Writes the OSIS book id, chapter, and verse to the
 /// out parameters. The returned book string is owned by the callee and remains valid until the
-/// next call on the same thread. An empty versification name is treated as KJV. Returns 0 on
-/// success and nonzero when the versification is unknown or the ordinal is out of range.
+/// next call on the same thread. An empty OR unrecognized versification name is treated as KJV.
+/// Returns 0 on success and nonzero when the ordinal is out of range.
 int SWVersification_decodeOrdinal(const char *versification,
                                   long ordinal,
                                   const char **osisBookOut,

--- a/Sources/SwordKit/CLibSword/sword_adapter.c
+++ b/Sources/SwordKit/CLibSword/sword_adapter.c
@@ -527,6 +527,11 @@ int SWModule_setVerseKeyIndex(void *module, long index) { return 1; }
 int SWVersification_mapVerseToKJVA(const char *sourceVersification, const char *osisBookName,
                                    int chapter, int verse, const char **kjvaOsisBookOut,
                                    int *kjvaChapterOut, int *kjvaVerseOut) { return 1; }
+int SWVersification_mapVerseFromKJVA(const char *targetVersification, const char *kjvaOsisBookName,
+                                     int chapter, int verse, const char **targetOsisBookOut,
+                                     int *targetChapterOut, int *targetVerseOut) { return 1; }
+int SWVersification_decodeOrdinal(const char *versification, long ordinal,
+                                  const char **osisBookOut, int *chapterOut, int *verseOut) { return 1; }
 
 void *InstallMgr_new(const char *basePath) {
     static int sentinel = 2;

--- a/Sources/SwordKit/CLibSword/sword_adapter.c
+++ b/Sources/SwordKit/CLibSword/sword_adapter.c
@@ -532,6 +532,7 @@ int SWVersification_mapVerseFromKJVA(const char *targetVersification, const char
                                      int *targetChapterOut, int *targetVerseOut) { return 1; }
 int SWVersification_decodeOrdinal(const char *versification, long ordinal,
                                   const char **osisBookOut, int *chapterOut, int *verseOut) { return 1; }
+int SWVersification_isSystemDefined(const char *versification) { return 1; }
 
 void *InstallMgr_new(const char *basePath) {
     static int sentinel = 2;

--- a/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
+++ b/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
@@ -112,13 +112,19 @@ extern "C" int SWVersification_mapVerseToKJVA(
         return 1;
     }
 
-    // SWORD and Android treat an empty versification name as the KJV default. A present-but-
-    // unrecognized name is NOT defaulted: it returns failure, matching Android — which rejects an
-    // unsupported module versification during metadata load — and the flatapi.h contract.
+    // An empty versification name defaults to KJV. A present-but-unrecognized name ALSO falls back to
+    // KJV: iOS libsword renders a module whose versification it does not recognize under KJV (unlike
+    // Android/JSword, which rejects it at load), so the module is usable and KJV-numbered as rendered.
+    // Mapping its ordinals as KJV keeps the stored KJVA columns consistent with how the module renders;
+    // returning failure would instead let the write path persist a raw source ordinal into the KJVA
+    // columns, which resolves to the wrong verse on sync/restore.
     const char *sourceName =
         (sourceVersification && *sourceVersification) ? sourceVersification : "KJV";
     const sword::VersificationMgr::System *sourceSystem =
         versificationMgr->getVersificationSystem(sourceName);
+    if (!sourceSystem) {
+        sourceSystem = versificationMgr->getVersificationSystem("KJV");
+    }
     const sword::VersificationMgr::System *kjvaSystem =
         versificationMgr->getVersificationSystem("KJVA");
     if (!sourceSystem || !kjvaSystem) {
@@ -165,14 +171,17 @@ extern "C" int SWVersification_mapVerseFromKJVA(
         return 1;
     }
 
-    // Reverse of SWVersification_mapVerseToKJVA: an empty target name defaults to KJV; a present-
-    // but-unrecognized name returns failure (matching the forward direction and Android).
+    // Reverse of SWVersification_mapVerseToKJVA: an empty OR present-but-unrecognized target name
+    // falls back to KJV (see the forward direction), since iOS libsword renders such modules under KJV.
     const char *targetName =
         (targetVersification && *targetVersification) ? targetVersification : "KJV";
     const sword::VersificationMgr::System *kjvaSystem =
         versificationMgr->getVersificationSystem("KJVA");
     const sword::VersificationMgr::System *targetSystem =
         versificationMgr->getVersificationSystem(targetName);
+    if (!targetSystem) {
+        targetSystem = versificationMgr->getVersificationSystem("KJV");
+    }
     if (!kjvaSystem || !targetSystem) {
         return 1;
     }
@@ -208,11 +217,15 @@ extern "C" int SWVersification_decodeOrdinal(
         return 1;
     }
 
-    // An empty name defaults to KJV; a present-but-unrecognized name returns failure.
+    // An empty OR present-but-unrecognized name falls back to KJV (iOS libsword renders such modules
+    // under KJV), so a stored source ordinal still decodes consistently with how the module renders.
     const char *name = (versification && *versification) ? versification : "KJV";
     sword::VersificationMgr *versificationMgr = sword::VersificationMgr::getSystemVersificationMgr();
-    if (!versificationMgr || !versificationMgr->getVersificationSystem(name)) {
+    if (!versificationMgr) {
         return 1;
+    }
+    if (!versificationMgr->getVersificationSystem(name)) {
+        name = "KJV";
     }
 
     // Decode the intro-inclusive VerseKey index within `name`'s versification without an installed

--- a/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
+++ b/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
@@ -112,18 +112,13 @@ extern "C" int SWVersification_mapVerseToKJVA(
         return 1;
     }
 
-    // SWORD and Android treat an empty versification name as the KJV default.
+    // SWORD and Android treat an empty versification name as the KJV default. A present-but-
+    // unrecognized name is NOT defaulted: it returns failure, matching Android — which rejects an
+    // unsupported module versification during metadata load — and the flatapi.h contract.
     const char *sourceName =
         (sourceVersification && *sourceVersification) ? sourceVersification : "KJV";
     const sword::VersificationMgr::System *sourceSystem =
         versificationMgr->getVersificationSystem(sourceName);
-    if (!sourceSystem) {
-        // SWORD renders a module whose versification name it does not recognize under KJV, so
-        // mirror that fallback instead of failing the mapping. Returning failure here would let the
-        // caller persist the raw source ordinal into the KJVA-domain storage columns, which is a
-        // cross-canon parity defect on restore/sync/export.
-        sourceSystem = versificationMgr->getVersificationSystem("KJV");
-    }
     const sword::VersificationMgr::System *kjvaSystem =
         versificationMgr->getVersificationSystem("KJVA");
     if (!sourceSystem || !kjvaSystem) {
@@ -150,6 +145,96 @@ extern "C" int SWVersification_mapVerseToKJVA(
     *kjvaOsisBookOut = mappedBookStorage.c_str();
     *kjvaChapterOut = mappedChapter;
     *kjvaVerseOut = mappedVerse;
+    return 0;
+}
+
+extern "C" int SWVersification_mapVerseFromKJVA(
+    const char *targetVersification,
+    const char *kjvaOsisBookName,
+    int chapter,
+    int verse,
+    const char **targetOsisBookOut,
+    int *targetChapterOut,
+    int *targetVerseOut) {
+    if (!kjvaOsisBookName || !targetOsisBookOut || !targetChapterOut || !targetVerseOut) {
+        return 1;
+    }
+
+    sword::VersificationMgr *versificationMgr = sword::VersificationMgr::getSystemVersificationMgr();
+    if (!versificationMgr) {
+        return 1;
+    }
+
+    // Reverse of SWVersification_mapVerseToKJVA: an empty target name defaults to KJV; a present-
+    // but-unrecognized name returns failure (matching the forward direction and Android).
+    const char *targetName =
+        (targetVersification && *targetVersification) ? targetVersification : "KJV";
+    const sword::VersificationMgr::System *kjvaSystem =
+        versificationMgr->getVersificationSystem("KJVA");
+    const sword::VersificationMgr::System *targetSystem =
+        versificationMgr->getVersificationSystem(targetName);
+    if (!kjvaSystem || !targetSystem) {
+        return 1;
+    }
+
+    // translateVerse is directional: calling it on the KJVA system with the target as destination
+    // maps a KJVA reference back onto the target versification (e.g. KJVA Ps 11:1 -> Vulg Ps 10:1).
+    thread_local std::string inputBookStorage;
+    thread_local std::string mappedBookStorage;
+    inputBookStorage = kjvaOsisBookName;
+    const char *book = inputBookStorage.c_str();
+    int mappedChapter = chapter;
+    int mappedVerse = verse;
+    int mappedVerseEnd = verse;
+    kjvaSystem->translateVerse(targetSystem, &book, &mappedChapter, &mappedVerse, &mappedVerseEnd);
+    if (!book) {
+        return 1;
+    }
+
+    mappedBookStorage = book;
+    *targetOsisBookOut = mappedBookStorage.c_str();
+    *targetChapterOut = mappedChapter;
+    *targetVerseOut = mappedVerse;
+    return 0;
+}
+
+extern "C" int SWVersification_decodeOrdinal(
+    const char *versification,
+    long ordinal,
+    const char **osisBookOut,
+    int *chapterOut,
+    int *verseOut) {
+    if (!osisBookOut || !chapterOut || !verseOut || ordinal <= 0) {
+        return 1;
+    }
+
+    // An empty name defaults to KJV; a present-but-unrecognized name returns failure.
+    const char *name = (versification && *versification) ? versification : "KJV";
+    sword::VersificationMgr *versificationMgr = sword::VersificationMgr::getSystemVersificationMgr();
+    if (!versificationMgr || !versificationMgr->getVersificationSystem(name)) {
+        return 1;
+    }
+
+    // Decode the intro-inclusive VerseKey index within `name`'s versification without an installed
+    // module — the same scheme SWModule_setVerseKeyIndex uses, but standalone — so a restored
+    // bookmark's original source ordinal resolves from versification metadata alone (as Android's
+    // Verse(v11n, ordinal) does).
+    sword::VerseKey key;
+    key.setVersificationSystem(name);
+    key.setIndex(ordinal);
+    if (key.getError() || key.getChapter() <= 0 || key.getVerse() <= 0 || key.getIndex() != ordinal) {
+        return 1;
+    }
+
+    thread_local std::string bookStorage;
+    bookStorage = safeCString(key.getOSISBookName());
+    if (bookStorage.empty()) {
+        return 1;
+    }
+
+    *osisBookOut = bookStorage.c_str();
+    *chapterOut = key.getChapter();
+    *verseOut = key.getVerse();
     return 0;
 }
 

--- a/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
+++ b/Sources/SwordKit/CLibSword/sword_versekey_adapter.cpp
@@ -251,4 +251,17 @@ extern "C" int SWVersification_decodeOrdinal(
     return 0;
 }
 
+extern "C" int SWVersification_isSystemDefined(const char *versification) {
+    // Mirrors JSword Versifications.isDefined: an empty name is the KJV default (always defined);
+    // a present name is defined only when SWORD's VersificationMgr knows it. Used to mark a module
+    // whose declared versification SWORD cannot map as unsupported for reading, matching Android's
+    // SwordBookMetaData rejection instead of silently rendering it under KJV.
+    const char *name = (versification && *versification) ? versification : "KJV";
+    sword::VersificationMgr *versificationMgr = sword::VersificationMgr::getSystemVersificationMgr();
+    if (!versificationMgr) {
+        return 0;
+    }
+    return versificationMgr->getVersificationSystem(name) ? 1 : 0;
+}
+
 #endif

--- a/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
@@ -400,6 +400,21 @@ public struct ModuleInfo: Sendable, Identifiable {
     /// Unique identifier (uses module name).
     public var id: String { name }
 
+    /**
+     Whether the reader can use this module, mirroring JSword `SwordBookMetaData.isSupported()`.
+
+     Android excludes an unsupported book from `Books.installed()` at the registry level, so it is
+     invisible everywhere (not readable, not in pickers, not shown as installed). iOS mirrors that by
+     filtering `SwordManager.installedModules()` and `module(named:)` on this predicate. Today the
+     only actionable reason a book is unsupported is a Bible whose declared versification SWORD does
+     not recognize (its verses would be mis-numbered under KJV); this is the single, extensible home
+     for any future unsupported reason (driver/type), as on Android. Non-Bible categories are
+     supported. See ADR-0010.
+     */
+    public var isSupported: Bool {
+        category != .bible || SwordVersification.isVersificationDefined(aboutMetadata.versification)
+    }
+
     public init(
         name: String,
         description: String,

--- a/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
@@ -107,6 +107,12 @@ public final class SwordManager: @unchecked Sendable {
             customModules: Self.androidCustomInstalledModules(modulePath: modulePath) +
                 Self.myBiblePackageInstalledModules(modulePath: modulePath)
         )
+        // Exclude modules SWORD cannot fully use (e.g. a Bible with an unrecognized versification),
+        // mirroring Android's `Books.installed()`, which never contains an unsupported book. Such a
+        // module is then invisible everywhere — not readable, not in pickers, and shown as
+        // not-installed in Downloads (so it appears re-downloadable, which overwrites a broken conf).
+        // Uninstall/index operate by name and are unaffected. See ADR-0010.
+        .filter(\.isSupported)
     }
 
     /// List installed modules filtered by category.
@@ -121,9 +127,19 @@ public final class SwordManager: @unchecked Sendable {
      */
     public func module(named name: String) -> SwordModule? {
         SwordRuntime.sync {
-            if let cached = moduleCache[name] { return cached }
-            guard let modHandle = SWMgr_getModuleByName(handle, name) else { return nil }
-            return getOrCreateModule(name: name, handle: modHandle)
+            let resolved: SwordModule?
+            if let cached = moduleCache[name] {
+                resolved = cached
+            } else if let modHandle = SWMgr_getModuleByName(handle, name) {
+                resolved = getOrCreateModule(name: name, handle: modHandle)
+            } else {
+                resolved = nil
+            }
+            // Do not surface an unsupported module (e.g. a Bible with an unrecognized versification),
+            // mirroring Android's `Books.installed().getBook()`, which returns null for such a book.
+            // The cache entry is left intact so enumeration internals are unaffected. See ADR-0010.
+            guard let resolved, resolved.info.isSupported else { return nil }
+            return resolved
         }
     }
 

--- a/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
@@ -102,7 +102,7 @@ public final class SwordManager: @unchecked Sendable {
             return modules
         }
 
-        return Self.mergedInstalledModules(
+        let merged = Self.mergedInstalledModules(
             swordModules: swordModules,
             customModules: Self.androidCustomInstalledModules(modulePath: modulePath) +
                 Self.myBiblePackageInstalledModules(modulePath: modulePath)
@@ -112,7 +112,11 @@ public final class SwordManager: @unchecked Sendable {
         // module is then invisible everywhere — not readable, not in pickers, and shown as
         // not-installed in Downloads (so it appears re-downloadable, which overwrites a broken conf).
         // Uninstall/index operate by name and are unaffected. See ADR-0010.
-        .filter(\.isSupported)
+        //
+        // `isSupported` reads SWORD's versification manager per Bible module; run the whole filter in
+        // one serialization hop (re-entrant `SwordRuntime.sync`) so a large library costs a single
+        // queue round-trip rather than one per module.
+        return SwordRuntime.sync { merged.filter(\.isSupported) }
     }
 
     /// List installed modules filtered by category.

--- a/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
@@ -57,14 +57,16 @@ public enum SwordVersification {
        - chapter: One-based chapter number in the source versification.
        - verse: One-based verse number in the source versification.
        - sourceVersification: SWORD versification name for the input reference; an empty string is
-         treated as KJV, matching SWORD and Android defaults. A name SWORD does not recognize also
-         falls back to KJV, mirroring how SWORD loads such modules.
+         treated as KJV, matching SWORD and Android defaults. A present-but-unrecognized name returns
+         `nil`, matching Android's rejection of an unsupported module versification.
      - Returns: The KJVA reference (verse `0` for a chapter superscription/introduction), or `nil`
-       when inputs are invalid or SWORD cannot map the reference into KJVA.
+       when inputs are invalid, the source versification is unrecognized, or SWORD cannot map the
+       reference into KJVA.
      - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
        versification manager.
-     - Failure modes: Returns `nil` for non-positive chapter/verse input, an empty book id, or a
-       mapped result with a non-positive chapter or negative verse.
+     - Failure modes: Returns `nil` for non-positive chapter/verse input, an empty book id, an
+       unrecognized source versification, or a mapped result with a non-positive chapter or negative
+       verse.
      */
     public static func mapVerseToKJVA(
         osisBookId: String,
@@ -105,6 +107,143 @@ public enum SwordVersification {
                 osisBookId: bookId,
                 chapter: Int(mappedChapter),
                 verse: Int(mappedVerse)
+            )
+        }
+    }
+
+    /// A verse reference resolved within an arbitrary (non-KJVA) versification.
+    public struct VerseCoordinate: Sendable, Equatable {
+        /// OSIS book identifier in the resolved versification.
+        public let osisBookId: String
+
+        /// One-based chapter number.
+        public let chapter: Int
+
+        /// Verse number; `0` denotes a chapter superscription/introduction.
+        public let verse: Int
+
+        /**
+         Creates a versification-resolved verse reference.
+
+         - Parameters:
+           - osisBookId: OSIS book identifier.
+           - chapter: One-based chapter number.
+           - verse: Verse number (`0` for a chapter introduction).
+         - Side effects: none.
+         - Failure modes: none.
+         */
+        public init(osisBookId: String, chapter: Int, verse: Int) {
+            self.osisBookId = osisBookId
+            self.chapter = chapter
+            self.verse = verse
+        }
+    }
+
+    /**
+     Maps a KJVA verse reference into a target versification (the reverse of `mapVerseToKJVA`).
+
+     Mirrors Android's `Verse.toV11n(activeV11n)`: a stored KJVA ordinal is rendered, displayed, and
+     navigated in the active module's versification, so divergent canons (LXX/Vulgate/Synodal and
+     similar) resolve onto their true active-module verses rather than being re-interpreted under
+     KJVA numbering. Used for highlight rendering, bookmark-list references, and navigation.
+
+     - Parameters:
+       - osisBookId: KJVA OSIS book identifier, such as `Ps` or `Gen`.
+       - chapter: One-based KJVA chapter number.
+       - verse: KJVA verse number (`0` for a chapter superscription/introduction).
+       - targetVersification: SWORD versification name to map into; an empty string is treated as
+         KJV, matching SWORD and Android defaults. A present-but-unrecognized name returns `nil`.
+     - Returns: The target-versification reference, or `nil` when inputs are invalid, the target
+       versification is unrecognized, or SWORD cannot map the reference.
+     - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
+       versification manager.
+     - Failure modes: Returns `nil` for a non-positive chapter, a negative verse, an empty book id,
+       an unrecognized target versification, or a mapped result outside the target's verse range.
+     */
+    public static func mapVerseFromKJVA(
+        osisBookId: String,
+        chapter: Int,
+        verse: Int,
+        targetVersification: String
+    ) -> VerseCoordinate? {
+        guard chapter > 0, verse >= 0, !osisBookId.isEmpty else { return nil }
+
+        return SwordRuntime.sync {
+            var mappedBook: UnsafePointer<CChar>?
+            var mappedChapter: Int32 = 0
+            var mappedVerse: Int32 = 0
+
+            let status = osisBookId.withCString { bookPointer in
+                targetVersification.withCString { versificationPointer in
+                    SWVersification_mapVerseFromKJVA(
+                        versificationPointer,
+                        bookPointer,
+                        Int32(chapter),
+                        Int32(verse),
+                        &mappedBook,
+                        &mappedChapter,
+                        &mappedVerse
+                    )
+                }
+            }
+
+            guard status == 0, let mappedBook else { return nil }
+            let bookId = String(cString: mappedBook)
+            guard !bookId.isEmpty, mappedChapter > 0, mappedVerse >= 0 else { return nil }
+            return VerseCoordinate(
+                osisBookId: bookId,
+                chapter: Int(mappedChapter),
+                verse: Int(mappedVerse)
+            )
+        }
+    }
+
+    /**
+     Decodes an intro-inclusive ordinal into its verse reference within a versification.
+
+     Mirrors Android's `Verse(v11n, ordinal)`: a persisted source ordinal is resolved from the
+     versification's own metadata, so a restored bookmark's original ordinal converts even when the
+     module that produced it is not installed — matching this engine's module-independent goal.
+
+     - Parameters:
+       - versification: SWORD versification name owning `ordinal`; an empty string is treated as KJV.
+         A present-but-unrecognized name returns `nil`.
+       - ordinal: Intro-inclusive SWORD `VerseKey` index (the same scheme the module cursor uses).
+     - Returns: The decoded reference, or `nil` when the versification is unrecognized or the ordinal
+       is out of range or resolves to an introduction slot.
+     - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
+       versification manager.
+     - Failure modes: Returns `nil` for a non-positive ordinal, an unrecognized versification, or an
+       ordinal that does not round-trip to a real verse.
+     */
+    public static func decodeOrdinal(
+        versification: String,
+        ordinal: Int
+    ) -> VerseCoordinate? {
+        guard ordinal > 0 else { return nil }
+
+        return SwordRuntime.sync {
+            var decodedBook: UnsafePointer<CChar>?
+            var decodedChapter: Int32 = 0
+            var decodedVerse: Int32 = 0
+
+            let status = versification.withCString { versificationPointer in
+                SWVersification_decodeOrdinal(
+                    versificationPointer,
+                    CLong(ordinal),
+                    &decodedBook,
+                    &decodedChapter,
+                    &decodedVerse
+                )
+            }
+
+            guard status == 0, let decodedBook else { return nil }
+            let bookId = String(cString: decodedBook)
+            guard !bookId.isEmpty, decodedChapter > 0, decodedVerse > 0 else { return nil }
+            return VerseCoordinate(
+                osisBookId: bookId,
+                chapter: Int(decodedChapter),
+                verse: Int(decodedVerse)
             )
         }
     }

--- a/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
@@ -56,16 +56,15 @@ public enum SwordVersification {
        - osisBookId: OSIS book identifier in the source versification, such as `Ps` or `Gen`.
        - chapter: One-based chapter number in the source versification.
        - verse: One-based verse number in the source versification.
-       - sourceVersification: SWORD versification name for the input reference; an empty string is
-         treated as KJV, matching SWORD and Android defaults. A present-but-unrecognized name returns
-         `nil`, matching Android's rejection of an unsupported module versification.
+       - sourceVersification: SWORD versification name for the input reference; an empty OR
+         unrecognized name is treated as KJV (iOS libsword renders such modules under KJV, so their
+         ordinals map as KJV rather than failing into a raw-source-ordinal write).
      - Returns: The KJVA reference (verse `0` for a chapter superscription/introduction), or `nil`
-       when inputs are invalid, the source versification is unrecognized, or SWORD cannot map the
-       reference into KJVA.
+       when inputs are invalid or SWORD cannot map the reference into KJVA.
      - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
        versification manager.
-     - Failure modes: Returns `nil` for non-positive chapter/verse input, an empty book id, an
-       unrecognized source versification, or a mapped result with a non-positive chapter or negative
+     - Failure modes: Returns `nil` for non-positive chapter/verse input, an empty book id, or a
+       mapped result with a non-positive chapter or negative
        verse.
      */
     public static func mapVerseToKJVA(
@@ -151,8 +150,8 @@ public enum SwordVersification {
        - osisBookId: KJVA OSIS book identifier, such as `Ps` or `Gen`.
        - chapter: One-based KJVA chapter number.
        - verse: KJVA verse number (`0` for a chapter superscription/introduction).
-       - targetVersification: SWORD versification name to map into; an empty string is treated as
-         KJV, matching SWORD and Android defaults. A present-but-unrecognized name returns `nil`.
+       - targetVersification: SWORD versification name to map into; an empty OR unrecognized name is
+         treated as KJV (iOS libsword renders such modules under KJV).
      - Returns: The target-versification reference, or `nil` when inputs are invalid, the target
        versification is unrecognized, or SWORD cannot map the reference.
      - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
@@ -206,8 +205,8 @@ public enum SwordVersification {
      module that produced it is not installed — matching this engine's module-independent goal.
 
      - Parameters:
-       - versification: SWORD versification name owning `ordinal`; an empty string is treated as KJV.
-         A present-but-unrecognized name returns `nil`.
+       - versification: SWORD versification name owning `ordinal`; an empty OR unrecognized name is
+         treated as KJV (iOS libsword renders such modules under KJV).
        - ordinal: Intro-inclusive SWORD `VerseKey` index (the same scheme the module cursor uses).
      - Returns: The decoded reference, or `nil` when the versification is unrecognized or the ordinal
        is out of range or resolves to an introduction slot.

--- a/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordVersification.swift
@@ -246,4 +246,26 @@ public enum SwordVersification {
             )
         }
     }
+
+    /**
+     Reports whether SWORD recognizes a module's declared versification.
+
+     Mirrors Android's JSword `Versifications.isDefined` check in `SwordBookMetaData`: a module whose
+     versification SWORD cannot map is unsupported for reading (Android marks it `supported = false`
+     and never loads it). iOS libsword would otherwise render such a module under KJV, mis-numbering a
+     divergent canon; callers use this to gate those modules out of the readable Bible set while
+     leaving them in the raw installed inventory for management/uninstall. See ADR-0010.
+
+     - Parameter versification: SWORD versification name from a module's `Versification` conf value;
+       an empty string is the KJV default and is always defined.
+     - Returns: `true` when SWORD's `VersificationMgr` recognizes the name, `false` otherwise.
+     - Side effects: Runs inside the SWORD serialization queue and reads SWORD's system
+       versification manager.
+     - Failure modes: none; an unrecognized or unavailable versification manager yields `false`.
+     */
+    public static func isVersificationDefined(_ versification: String) -> Bool {
+        SwordRuntime.sync {
+            versification.withCString { SWVersification_isSystemDefined($0) == 1 }
+        }
+    }
 }

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
@@ -78,6 +78,23 @@ final class SwordVersificationTests: XCTestCase {
     }
 
     /**
+     Verifies versification recognition mirrors JSword's `Versifications.isDefined`.
+
+     A module whose declared versification SWORD recognizes (KJV, KJVA, Vulg, Synodal) is defined; a
+     present-but-unrecognized name is not (so the reader can mark it unsupported, matching Android);
+     an empty name is the KJV default and is always defined. See ADR-0010.
+     */
+    func testReportsWhetherAVersificationIsSystemDefined() {
+        XCTAssertTrue(SwordVersification.isVersificationDefined("KJV"))
+        XCTAssertTrue(SwordVersification.isVersificationDefined("KJVA"))
+        XCTAssertTrue(SwordVersification.isVersificationDefined("Vulg"))
+        XCTAssertTrue(SwordVersification.isVersificationDefined("Synodal"))
+        XCTAssertTrue(SwordVersification.isVersificationDefined(""), "An empty name is the KJV default.")
+        XCTAssertFalse(SwordVersification.isVersificationDefined("BogusV11n"))
+        XCTAssertFalse(SwordVersification.isVersificationDefined("NotAVersification"))
+    }
+
+    /**
      Verifies shared canonical references map to KJVA unchanged and defaults/invalid inputs behave.
 
      KJV and KJVA share Genesis..Malachi and the New Testament numbering, so a KJV reference maps to

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
@@ -10,14 +10,76 @@ import XCTest
  */
 final class SwordVersificationTests: XCTestCase {
     /**
+     Verifies KJVA references map back into divergent canons — the reverse of `mapVerseToKJVA`.
+
+     Android renders, displays, and navigates a stored KJVA bookmark in the active module's
+     versification via `Verse.toV11n(activeV11n)`. The engine must produce the true active-canon
+     verse rather than the identically-numbered KJVA verse: KJVA Ps 11:1 is Vulgate Ps 10:1, and the
+     Synodal superscription round-trips (KJVA Ps 51:0 -> Synodal Ps 50:1). An empty target defaults
+     to KJV; a present-but-unrecognized target returns nil. Values captured from SWORD's tables.
+     */
+    func testMapsKJVAReferencesBackIntoDivergentCanons() {
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Ps", chapter: 11, verse: 1, targetVersification: "Vulg"),
+            .init(osisBookId: "Ps", chapter: 10, verse: 1),
+            "KJVA Psalm 11:1 is Vulgate Psalm 10:1."
+        )
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Ps", chapter: 10, verse: 1, targetVersification: "Vulg"),
+            .init(osisBookId: "Ps", chapter: 9, verse: 22),
+            "KJVA Psalm 10:1 is Vulgate Psalm 9:22."
+        )
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Ps", chapter: 51, verse: 0, targetVersification: "Synodal"),
+            .init(osisBookId: "Ps", chapter: 50, verse: 1),
+            "The KJVA Psalm 51 superscription round-trips to Synodal Psalm 50:1."
+        )
+        // Shared-canon identity, empty -> KJV, and unrecognized -> nil.
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: "KJV"),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1)
+        )
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: ""),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1)
+        )
+        XCTAssertNil(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: "NotAVersification")
+        )
+    }
+
+    /**
+     Verifies module-independent ordinal decoding — the iOS analogue of Android's `Verse(v11n, ord)`.
+
+     A restored bookmark's original source ordinal must resolve from versification metadata alone,
+     without the producing module installed. SWORD's intro-inclusive `VerseKey` index matches the
+     JSword ordinal scheme (index 4 is Genesis 1:1). An empty name defaults to KJV; a present-but-
+     unrecognized name and a non-positive ordinal return nil.
+     */
+    func testDecodesOrdinalsFromVersificationMetadataWithoutAModule() {
+        XCTAssertEqual(
+            SwordVersification.decodeOrdinal(versification: "KJV", ordinal: 4),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1),
+            "Intro-inclusive index 4 is Genesis 1:1, matching the JSword ordinal scheme."
+        )
+        XCTAssertEqual(
+            SwordVersification.decodeOrdinal(versification: "", ordinal: 4),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1),
+            "An empty versification name defaults to KJV."
+        )
+        XCTAssertNil(SwordVersification.decodeOrdinal(versification: "KJV", ordinal: 0))
+        XCTAssertNil(SwordVersification.decodeOrdinal(versification: "NotAVersification", ordinal: 4))
+    }
+
+    /**
      Verifies shared canonical references map to KJVA unchanged and defaults/invalid inputs behave.
 
      KJV and KJVA share Genesis..Malachi and the New Testament numbering, so a KJV reference maps to
      the identical KJVA reference; an empty source versification defaults to KJV; a versification
-     name SWORD does not recognize also falls back to KJV (mirroring SWORD's own module loading, so
-     the caller never persists a raw source ordinal into the KJVA columns); non-positive inputs and
-     empty book ids return nil. A failure means the adapter is not wired to SWORD's VersificationMgr
-     or mis-handles defaults.
+     name SWORD does not recognize returns nil (matching Android, which rejects an unsupported module
+     versification during metadata load, and the flat-API contract); non-positive inputs and empty
+     book ids return nil. A failure means the adapter is not wired to SWORD's VersificationMgr or
+     mis-handles defaults.
      */
     func testMapsSharedCanonAndDefaultsAndInvalidInputs() {
         XCTAssertEqual(
@@ -33,12 +95,11 @@ final class SwordVersificationTests: XCTestCase {
             SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: ""),
             .init(osisBookId: "Gen", chapter: 1, verse: 1)
         )
-        // A versification name SWORD does not recognize falls back to KJV rather than failing, so
-        // shared-canon references still resolve to their identical KJVA reference instead of nil
-        // (which would let callers store a raw source ordinal in the KJVA columns).
-        XCTAssertEqual(
-            SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: "NotAVersification"),
-            .init(osisBookId: "Gen", chapter: 1, verse: 1)
+        // A versification name SWORD does not recognize returns nil, matching Android's rejection of
+        // an unsupported module versification and the flat-API contract; only an empty name defaults
+        // to KJV.
+        XCTAssertNil(
+            SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: "NotAVersification")
         )
         XCTAssertNil(
             SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 0, verse: 1, sourceVersification: "KJV")
@@ -48,17 +109,6 @@ final class SwordVersificationTests: XCTestCase {
         )
     }
 
-    /**
-     Verifies genuine non-identity mapping for versification-divergent canons.
-
-     The Vulgate and Russian Synodal versifications number the Psalms per the Septuagint, offset by
-     one across a large range because Hebrew/KJVA Psalms 9 and 10 are a single psalm there. SWORD's
-     VersificationMgr remaps these verse-by-verse (the exact behavior Android's JSword `toV11n(KJVA)`
-     produces), so the engine must translate them onto their true KJVA counterparts rather than
-     re-interpreting the same numbers. These expectations were captured directly from SWORD's
-     compiled mapping tables. A failure means the mapping regressed to a name-identity lookup — the
-     issue #356 defect on the write side.
-     */
     /**
      Verifies divergent-canon Psalm-title verses map to KJVA chapter superscriptions (verse 0).
 
@@ -87,6 +137,17 @@ final class SwordVersificationTests: XCTestCase {
         )
     }
 
+    /**
+     Verifies genuine non-identity mapping for versification-divergent canons.
+
+     The Vulgate and Russian Synodal versifications number the Psalms per the Septuagint, offset by
+     one across a large range because Hebrew/KJVA Psalms 9 and 10 are a single psalm there. SWORD's
+     VersificationMgr remaps these verse-by-verse (the exact behavior Android's JSword `toV11n(KJVA)`
+     produces), so the engine must translate them onto their true KJVA counterparts rather than
+     re-interpreting the same numbers. These expectations were captured directly from SWORD's
+     compiled mapping tables. A failure means the mapping regressed to a name-identity lookup — the
+     issue #356 defect on the write side.
+     */
     func testMapsDivergentCanonPsalmsToKJVA() {
         // Vulgate follows the Septuagint Psalm numbering.
         XCTAssertEqual(

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordVersificationTests.swift
@@ -43,8 +43,10 @@ final class SwordVersificationTests: XCTestCase {
             SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: ""),
             .init(osisBookId: "Gen", chapter: 1, verse: 1)
         )
-        XCTAssertNil(
-            SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: "NotAVersification")
+        // An unrecognized target falls back to KJV (identity for shared canon), not nil.
+        XCTAssertEqual(
+            SwordVersification.mapVerseFromKJVA(osisBookId: "Gen", chapter: 1, verse: 1, targetVersification: "NotAVersification"),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1)
         )
     }
 
@@ -53,8 +55,8 @@ final class SwordVersificationTests: XCTestCase {
 
      A restored bookmark's original source ordinal must resolve from versification metadata alone,
      without the producing module installed. SWORD's intro-inclusive `VerseKey` index matches the
-     JSword ordinal scheme (index 4 is Genesis 1:1). An empty name defaults to KJV; a present-but-
-     unrecognized name and a non-positive ordinal return nil.
+     JSword ordinal scheme (index 4 is Genesis 1:1). An empty or unrecognized name defaults to KJV;
+     a non-positive ordinal returns nil.
      */
     func testDecodesOrdinalsFromVersificationMetadataWithoutAModule() {
         XCTAssertEqual(
@@ -67,19 +69,22 @@ final class SwordVersificationTests: XCTestCase {
             .init(osisBookId: "Gen", chapter: 1, verse: 1),
             "An empty versification name defaults to KJV."
         )
+        XCTAssertEqual(
+            SwordVersification.decodeOrdinal(versification: "NotAVersification", ordinal: 4),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1),
+            "An unrecognized versification name also defaults to KJV (libsword renders such modules under KJV)."
+        )
         XCTAssertNil(SwordVersification.decodeOrdinal(versification: "KJV", ordinal: 0))
-        XCTAssertNil(SwordVersification.decodeOrdinal(versification: "NotAVersification", ordinal: 4))
     }
 
     /**
      Verifies shared canonical references map to KJVA unchanged and defaults/invalid inputs behave.
 
      KJV and KJVA share Genesis..Malachi and the New Testament numbering, so a KJV reference maps to
-     the identical KJVA reference; an empty source versification defaults to KJV; a versification
-     name SWORD does not recognize returns nil (matching Android, which rejects an unsupported module
-     versification during metadata load, and the flat-API contract); non-positive inputs and empty
-     book ids return nil. A failure means the adapter is not wired to SWORD's VersificationMgr or
-     mis-handles defaults.
+     the identical KJVA reference; an empty OR unrecognized source versification defaults to KJV
+     (iOS libsword renders such modules under KJV, so their ordinals map as KJV instead of failing
+     into a raw-source-ordinal write); non-positive inputs and empty book ids return nil. A failure
+     means the adapter is not wired to SWORD's VersificationMgr or mis-handles defaults.
      */
     func testMapsSharedCanonAndDefaultsAndInvalidInputs() {
         XCTAssertEqual(
@@ -95,11 +100,11 @@ final class SwordVersificationTests: XCTestCase {
             SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: ""),
             .init(osisBookId: "Gen", chapter: 1, verse: 1)
         )
-        // A versification name SWORD does not recognize returns nil, matching Android's rejection of
-        // an unsupported module versification and the flat-API contract; only an empty name defaults
-        // to KJV.
-        XCTAssertNil(
-            SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: "NotAVersification")
+        // An unrecognized source versification falls back to KJV (identity for shared canon) rather
+        // than nil, so the caller never persists a raw source ordinal into the KJVA columns.
+        XCTAssertEqual(
+            SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 1, verse: 1, sourceVersification: "NotAVersification"),
+            .init(osisBookId: "Gen", chapter: 1, verse: 1)
         )
         XCTAssertNil(
             SwordVersification.mapVerseToKJVA(osisBookId: "Gen", chapter: 0, verse: 1, sourceVersification: "KJV")

--- a/docs/adr/0010-unrecognized-module-versification-handling.md
+++ b/docs/adr/0010-unrecognized-module-versification-handling.md
@@ -138,8 +138,11 @@ Android-aligned, cross-platform-consistent choice.
   (`BibleReaderSwordCoordinator`), not in `SwordManager.installedModules`, so
   management/uninstall of an unsupported module is preserved (more forgiving than
   Android, low risk).
-- Requires a maintenance commitment to keep libsword current, or legitimately-new
-  versifications would be treated as unsupported on iOS until libsword is updated.
+- Requires keeping libsword current, or legitimately-new versifications would be
+  treated as unsupported on iOS until libsword is updated. This is an **accepted**
+  maintenance cost: the project is committed to tracking Android on an ongoing
+  basis, so keeping libsword's av11n tables aligned with the shipped JSword is
+  part of normal upkeep, not a new burden this decision introduces.
 - The `unknown → KJV` mapping fallback (PR #360) is retained as defense-in-depth:
   it keeps any residual/legacy bookmark's stored value a valid KJVA ordinal even
   though such modules are no longer offered for new reading/bookmarking.

--- a/docs/adr/0010-unrecognized-module-versification-handling.md
+++ b/docs/adr/0010-unrecognized-module-versification-handling.md
@@ -46,7 +46,7 @@ Confirmed behavior:
   choice — the surrounding git history (2014–2016) only touches logging/memory,
   never the rejection itself.
 
-- **iOS (libsword)** — `SwordManager` has no `supported` gate;
+- **iOS (libsword)** — before this ADR, `SwordManager` had no `supported` gate;
   `VersificationMgr::getVersificationSystem(name)` returns null for an unknown
   name and SWORD falls back to KJV. **Empirically confirmed:** a module whose
   `.conf` is edited to `Versification=BogusV11n` is still listed
@@ -89,21 +89,31 @@ or a v11n newer than the pinned libsword.
 
 Accepted and implemented:
 
-1. **Match Android for truly-unrecognized versifications.** A Bible module whose
-   declared `Versification` is not registered in libsword is treated as
-   **unsupported** — not offered for reading or bookmarking — mirroring JSword's
-   `isSupported() == false`. Rationale: iOS should not render, and let users
-   annotate, content it cannot correctly interpret; doing so risks mis-numbered
-   verses, offset notes, and modules that exist on iOS but not Android.
+1. **Match Android fully: an unsupported module is invisible everywhere.** A Bible
+   module whose declared `Versification` is not registered in libsword is treated
+   as **unsupported** — mirroring JSword's `SwordBookMetaData.isSupported() == false`,
+   which keeps the book out of `Books.installed()` entirely. It is not readable, not
+   in any picker, not shown as installed in Downloads (so it appears as
+   re-downloadable, which overwrites and heals a broken conf), and not listed in
+   Settings/Import-Export. It lies dormant on disk exactly as on Android.
 
-   Implemented via `SwordVersification.isVersificationDefined(_:)` (backed by
-   `SWVersification_isSystemDefined`, mirroring JSword `Versifications.isDefined`),
-   applied where the reader partitions installed modules
-   (`BibleReaderSwordCoordinator.configure` and the Compare builder's fallback):
-   a Bible module is included in the readable set only when its versification is
-   defined. The unsupported module stays in the raw `installedModules` inventory,
-   so it remains manageable/uninstallable — iOS is intentionally more forgiving
-   than Android on management while matching it on reading.
+   Implemented with a **single filter in `SwordManager`**, the `Books.installed()`
+   equivalent: `ModuleInfo.isSupported` (a `.bible` module requires
+   `SwordVersification.isVersificationDefined(aboutMetadata.versification)`, backed by
+   `SWVersification_isSystemDefined` / JSword `Versifications.isDefined`) gates both
+   `installedModules()` and `module(named:)`. Every consumer inherits the exclusion,
+   so there are no per-path gates to keep in sync.
+
+   *Evolution:* an earlier iteration of this PR applied per-path versification gates
+   across the reader (catalog, active-module resolution, restore, switch, pane-copy)
+   and deliberately kept the module in the raw inventory so it stayed uninstallable.
+   Two adversarial reviews each found a newly-missed activation path, and the
+   "keep it uninstallable" clause was itself a divergence from Android (Android never
+   surfaces an unsupported book anywhere, including its delete list). This ADR
+   supersedes that approach with the single `SwordManager` filter above. Uninstall is
+   unaffected — it operates by name at the InstallMgr/file level, not through the
+   filtered inventory — but the Downloads UI now offers the module as re-downloadable
+   rather than as an installed item to remove, exactly as on Android.
 
 2. **Keep libsword's av11n tables reasonably current** with the JSword version
    AndBible ships, so a *legitimate* versification is recognized on both
@@ -132,12 +142,14 @@ Android-aligned, cross-platform-consistent choice.
 
 ## Consequences
 
-- Enables true parity: the same modules are usable (or not) for reading on iOS
-  and Android.
-- The readable-Bible gate lives at the reader boundary
-  (`BibleReaderSwordCoordinator`), not in `SwordManager.installedModules`, so
-  management/uninstall of an unsupported module is preserved (more forgiving than
-  Android, low risk).
+- Enables true parity: the same modules are usable (or not) on iOS and Android,
+  and an unsupported module is invisible on the same surfaces on both.
+- The gate lives in one place — `SwordManager.installedModules()` and
+  `module(named:)` (the `Books.installed()` equivalent) — so no reader path can
+  drift out of sync, and a future activation path is covered automatically.
+- An unsupported module has no direct "Uninstall" affordance (it is not shown as
+  installed); the user re-downloads to heal it, as on Android. Uninstall-by-name
+  and index deletion still work for supported modules and are unaffected.
 - Requires keeping libsword current, or legitimately-new versifications would be
   treated as unsupported on iOS until libsword is updated. This is an **accepted**
   maintenance cost: the project is committed to tracking Android on an ongoing
@@ -155,6 +167,8 @@ Android-aligned, cross-platform-consistent choice.
 - PR #359 (versification engine), PR #360 (active-versification projection +
   `unknown → KJV` mapping fallback).
 - jsword `SwordBookMetaData.java:899-904` (Android rejection), line 169 (KJV
-  default for absent v11n).
-- SwordKit `SwordVersification` (`mapVerseToKJVA` / `mapVerseFromKJVA` /
-  `decodeOrdinal`), `SwordManager.installedModules`.
+  default for absent v11n); `Books.installed()` as the single filtered registry.
+- SwordKit: `ModuleInfo.isSupported` and its use in `SwordManager.installedModules()`
+  / `module(named:)` (the single filter); `SwordVersification.isVersificationDefined`
+  (the primitive) and the mapping engine (`mapVerseToKJVA` / `mapVerseFromKJVA` /
+  `decodeOrdinal`).

--- a/docs/adr/0010-unrecognized-module-versification-handling.md
+++ b/docs/adr/0010-unrecognized-module-versification-handling.md
@@ -1,0 +1,144 @@
+---
+adr: ADR-0010
+title: "Unrecognized Module Versification Handling"
+description: >-
+  Decide how iOS treats a Bible module whose declared versification is not
+  registered in the pinned libsword, versus Android/JSword rejecting it at load.
+date: 2026-07-19
+status: proposed
+supersedes: []
+superseded-by: null
+decision-owner: "iOS parity maintainers + product"
+deciders: ["iOS parity maintainers", "product"]
+consulted:
+  - "jsword SwordBookMetaData.adjustBookType"
+  - "libsword VersificationMgr / VerseKey"
+  - "SwordKit SwordManager / SwordVersification"
+informed: ["AndBible iOS contributors"]
+tags: [parity, versification, module-loading, android-divergence]
+related-adrs: [ADR-0003]
+related-work-items: ["PR #359", "PR #360"]
+---
+
+# 0010: Unrecognized Module Versification Handling
+
+Status: Proposed (pending product sign-off)
+
+Date: 2026-07-19
+
+## Context
+
+A Bible module's `.conf` declares a `Versification` (v11n). Android and iOS
+diverge on what happens when that name is **present but not recognized** by the
+platform's versification library. (An **absent** `Versification` defaults to
+`KJV` on both platforms — jsword `SwordBookMetaData` line 169 sets the default;
+that case is not in scope.)
+
+Confirmed behavior:
+
+- **Android (JSword)** — `SwordBookMetaData.adjustBookType()`
+  (`jsword/.../book/sword/SwordBookMetaData.java:899-904`): if
+  `!Versifications.instance().isDefined(v11n)` it logs
+  `"Book not supported: Unknown versification"`, sets `supported = false`, and
+  returns. The book's `isSupported()` is then false, so AndBible does not load,
+  render, or allow bookmarking it. This is a long-standing, correctness-driven
+  design (JSword cannot map verses without the v11n's tables), not a recent
+  choice — the surrounding git history (2014–2016) only touches logging/memory,
+  never the rejection itself.
+
+- **iOS (libsword)** — `SwordManager` has no `supported` gate;
+  `VersificationMgr::getVersificationSystem(name)` returns null for an unknown
+  name and SWORD falls back to KJV. **Empirically confirmed:** a module whose
+  `.conf` is edited to `Versification=BogusV11n` is still listed
+  (`installedModules: ["KJV"]`), loaded, and rendered under KJV
+  (`verseOrdinal(Matt 1:1)=24118`; `rawEntry` returns the correct Matthew 1:1
+  text). So iOS treats an unrecognized v11n as KJV and keeps the module usable.
+
+Two consequences follow:
+
+1. **The versification sets can differ.** libsword is pinned; JSword ships with
+   AndBible. A v11n known to one but not the other is handled differently, so
+   neither "always reject" nor "always accept" is automatically parity.
+2. **Correctness depends on the module's real numbering.** SWORD reads a zText
+   index (`.bzv`) by verse ordinal. If the module's data is genuinely
+   KJV-numbered (a typo'd/custom conf name), reading it with a KJV key is
+   **correct**. If the module truly uses a different canon libsword doesn't
+   know, the KJV key **mis-indexes** it — shifted/garbled/missing verses.
+
+### Risk of the current iOS behavior (accept + map as KJV)
+
+- **KJV-compatible module (typo/custom name):** renders correctly; bookmarks
+  store correct KJVA ordinals. iOS is strictly more permissive than Android
+  here, with no harm.
+- **Genuinely divergent module unknown to libsword (rare):**
+  - Rendering is mis-indexed (verses shown under the wrong numbers).
+  - Bookmarks store the KJV-rendered position's KJVA ordinal, so the note can be
+    **off by the versification offset** (e.g. a whole Psalm, like the 9/10
+    shift). On sync/export the note lands on the wrong canonical reference.
+  - The module is visible on iOS but **absent on Android** (rejected) —
+    cross-platform inconsistency and user confusion.
+- **Data integrity:** the mapping-layer `unknown → KJV` fallback (PR #360)
+  guarantees a *valid* KJVA ordinal is stored (never a raw source ordinal), so
+  the failure mode is "wrong-but-canonical reference," not "garbage ordinal."
+
+In practice this is a **low-frequency** edge: mainstream CrossWire modules use
+registered versifications. The unknown case requires a malformed/custom `.conf`
+or a v11n newer than the pinned libsword.
+
+## Decision
+
+Proposed (recommended), pending sign-off:
+
+1. **Match Android for truly-unrecognized versifications.** A Bible module whose
+   declared `Versification` is not registered in libsword should be treated as
+   **unsupported** — not offered for reading or bookmarking — mirroring JSword's
+   `isSupported() == false`. Rationale: iOS should not render, and let users
+   annotate, content it cannot correctly interpret; doing so risks mis-numbered
+   verses, offset notes, and modules that exist on iOS but not Android.
+
+2. **Keep libsword's av11n tables reasonably current** with the JSword version
+   AndBible ships, so a *legitimate* versification is recognized on both
+   platforms and neither side rejects a module the other accepts. This is the
+   real parity lever; rejection is only the fallback for genuinely-unknown v11n.
+
+3. **Retain the mapping-layer `unknown → KJV` fallback as defense-in-depth**
+   (already in PR #360). It is a safety net that keeps any residual or legacy
+   bookmark's stored value a valid KJVA ordinal rather than a raw source ordinal,
+   under either decision. It does not need to change for this ADR.
+
+This is the "good UX decision," not cruft: accepting modules we cannot interpret
+is the "keep a random thing working" path; rejecting them is the principled,
+Android-aligned, cross-platform-consistent choice.
+
+### Alternatives considered
+
+- **A — Status quo (accept + render as KJV).** Simplest; more permissive than
+  Android; correct for KJV-compatible modules. Rejected as the primary rule
+  because it silently mis-renders divergent modules and creates offset notes and
+  iOS/Android inconsistency.
+- **C — Accept with a visible "unsupported versification, numbering may be
+  inaccurate" warning.** A middle ground that keeps the module readable while
+  flagging the risk. Viable if product wants to preserve read access to
+  unrecognized modules; still permits offset bookmarks, so weaker on data parity.
+
+## Consequences
+
+- Enables true parity: the same modules are usable (or not) on iOS and Android.
+- Requires a load-time filter in the module-loading layer (a follow-up to
+  PR #360; not implemented by this ADR): skip/flag modules whose v11n is not in
+  libsword's registered set, mirroring JSword's check.
+- Requires a maintenance commitment to keep libsword current, or legitimately-new
+  versifications would be rejected on iOS until libsword is updated.
+- If Alternative C is chosen instead, add the warning affordance and keep the
+  mapping fallback; do not silently render without signalling the limitation.
+- No change is forced on PR #360; its `unknown → KJV` mapping fallback is
+  compatible with whichever option is accepted.
+
+## Related
+
+- PR #359 (versification engine), PR #360 (active-versification projection +
+  `unknown → KJV` mapping fallback).
+- jsword `SwordBookMetaData.java:899-904` (Android rejection), line 169 (KJV
+  default for absent v11n).
+- SwordKit `SwordVersification` (`mapVerseToKJVA` / `mapVerseFromKJVA` /
+  `decodeOrdinal`), `SwordManager.installedModules`.

--- a/docs/adr/0010-unrecognized-module-versification-handling.md
+++ b/docs/adr/0010-unrecognized-module-versification-handling.md
@@ -5,7 +5,7 @@ description: >-
   Decide how iOS treats a Bible module whose declared versification is not
   registered in the pinned libsword, versus Android/JSword rejecting it at load.
 date: 2026-07-19
-status: proposed
+status: accepted
 supersedes: []
 superseded-by: null
 decision-owner: "iOS parity maintainers + product"
@@ -22,7 +22,7 @@ related-work-items: ["PR #359", "PR #360"]
 
 # 0010: Unrecognized Module Versification Handling
 
-Status: Proposed (pending product sign-off)
+Status: Accepted
 
 Date: 2026-07-19
 
@@ -87,14 +87,23 @@ or a v11n newer than the pinned libsword.
 
 ## Decision
 
-Proposed (recommended), pending sign-off:
+Accepted and implemented:
 
 1. **Match Android for truly-unrecognized versifications.** A Bible module whose
-   declared `Versification` is not registered in libsword should be treated as
+   declared `Versification` is not registered in libsword is treated as
    **unsupported** — not offered for reading or bookmarking — mirroring JSword's
    `isSupported() == false`. Rationale: iOS should not render, and let users
    annotate, content it cannot correctly interpret; doing so risks mis-numbered
    verses, offset notes, and modules that exist on iOS but not Android.
+
+   Implemented via `SwordVersification.isVersificationDefined(_:)` (backed by
+   `SWVersification_isSystemDefined`, mirroring JSword `Versifications.isDefined`),
+   applied where the reader partitions installed modules
+   (`BibleReaderSwordCoordinator.configure` and the Compare builder's fallback):
+   a Bible module is included in the readable set only when its versification is
+   defined. The unsupported module stays in the raw `installedModules` inventory,
+   so it remains manageable/uninstallable — iOS is intentionally more forgiving
+   than Android on management while matching it on reading.
 
 2. **Keep libsword's av11n tables reasonably current** with the JSword version
    AndBible ships, so a *legitimate* versification is recognized on both
@@ -123,16 +132,20 @@ Android-aligned, cross-platform-consistent choice.
 
 ## Consequences
 
-- Enables true parity: the same modules are usable (or not) on iOS and Android.
-- Requires a load-time filter in the module-loading layer (a follow-up to
-  PR #360; not implemented by this ADR): skip/flag modules whose v11n is not in
-  libsword's registered set, mirroring JSword's check.
+- Enables true parity: the same modules are usable (or not) for reading on iOS
+  and Android.
+- The readable-Bible gate lives at the reader boundary
+  (`BibleReaderSwordCoordinator`), not in `SwordManager.installedModules`, so
+  management/uninstall of an unsupported module is preserved (more forgiving than
+  Android, low risk).
 - Requires a maintenance commitment to keep libsword current, or legitimately-new
-  versifications would be rejected on iOS until libsword is updated.
-- If Alternative C is chosen instead, add the warning affordance and keep the
-  mapping fallback; do not silently render without signalling the limitation.
-- No change is forced on PR #360; its `unknown → KJV` mapping fallback is
-  compatible with whichever option is accepted.
+  versifications would be treated as unsupported on iOS until libsword is updated.
+- The `unknown → KJV` mapping fallback (PR #360) is retained as defense-in-depth:
+  it keeps any residual/legacy bookmark's stored value a valid KJVA ordinal even
+  though such modules are no longer offered for new reading/bookmarking.
+- Not chosen: Alternative C (render with a warning). If product later prefers
+  keeping unrecognized modules readable, revisit this ADR and add the warning
+  affordance instead of the read-time exclusion.
 
 ## Related
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,4 +65,4 @@ sections or their front-matter equivalents:
 - [0007: iOS Discrete Mode App Name Boundary](0007-ios-discrete-mode-app-name-boundary.md)
 - [0008: Parity Documentation Ownership](0008-parity-documentation-ownership.md)
 - [0009: Android Localization Source Of Truth](0009-android-localization-source-of-truth.md)
-- [0010: Unrecognized Module Versification Handling](0010-unrecognized-module-versification-handling.md) (Proposed)
+- [0010: Unrecognized Module Versification Handling](0010-unrecognized-module-versification-handling.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,3 +65,4 @@ sections or their front-matter equivalents:
 - [0007: iOS Discrete Mode App Name Boundary](0007-ios-discrete-mode-app-name-boundary.md)
 - [0008: Parity Documentation Ownership](0008-parity-documentation-ownership.md)
 - [0009: Android Localization Source Of Truth](0009-android-localization-source-of-truth.md)
+- [0010: Unrecognized Module Versification Handling](0010-unrecognized-module-versification-handling.md) (Proposed)


### PR DESCRIPTION
Follow-up to the merged versification engine (#359), addressing all five findings from a post-merge review. The engine now maps in **both** directions and decodes ordinals module-independently, so divergent-canon (Vulgate/LXX/Synodal) bookmarks render, list, navigate, and convert in the **active versification**, matching Android's implementation. KJV-family modules are behaviorally unchanged (identity mapping).

## Findings addressed

| # | Sev | Fix |
|---|-----|-----|
| 1 | Major | Highlight payload reverse-maps KJVA → active v11n (was coordinate-identity) — `renderedReference` now uses `mapVerseFromKJVA` + the active module's ordinal |
| 2 | Major | Bookmark list display + navigation resolve through an active-versification resolver (`bookmarkListActiveReference`), falling back to KJVA when no module is loaded |
| 3 | Major | `kjvaMyNotesOrdinal` decodes source ordinals from versification metadata alone (`decodeOrdinal`), no installed source module required; module resolution kept only as a mis-casing fallback |
| 4 | Minor | Present-but-unrecognized source v11n now returns nil (matches Android's rejection + the `flatapi.h` contract); only an empty name defaults to KJV |
| 5 | Minor | Moved a mis-attached test docblock back onto `testMapsDivergentCanonPsalmsToKJVA` |

## Engine additions (`SwordKit`)

- **`mapVerseFromKJVA(…targetVersification:)`**: SWORD `translateVerse` KJVA→target (the reverse of `mapVerseToKJVA`). Verified: KJVA Ps 11:1 → Vulg Ps 10:1, Ps 10:1 → Vulg Ps 9:22, and the superscription round-trips (KJVA Ps 51:0 → Synodal Ps 50:1).
- **`decodeOrdinal(versification:ordinal:)`**: module-independent intro-inclusive `VerseKey` decode (Android's `Verse(v11n, ordinal)`). SWORD's index matches the JSword scheme (index 4 = Gen 1:1).

Both mapping values were captured empirically from SWORD and locked into contract tests.

## Android parity

Mirrors Android's `verseRange.toV11n(activeV11n)` (ClientPageObjects / BookmarkItemAdapter) and `Verse(v11n, ordinal)` (BookmarkEntities). Reverse projection rides on the versification/canon definition, never an installed source module.

## Validation

- `SwordKitTests/SwordVersificationTests` (5) — forward, reverse, decode, defaults, unknown→nil
- `BibleUITests` full (407) — incl. a new active-versification list-row test (display + navigation)
- `BibleCoreTests` full (293)
- `git diff --check`; docblock + commit-message guardrails

## Notes

- Divergent-canon `#1` rendering has no bundled fixture (the test module is KJV-family, where identity == correct); it's covered by the reverse-map engine tests plus the injectable `#2` list test. `#3`'s primary decode path is exercised by the existing My Notes bridge test and the decode contract test.