### PR TITLE
feat(sync): synchronize non-secret AI settings

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -16,6 +16,7 @@ env:
   UI_TEST_TIMEOUT_MINUTES: "90"
   UI_TEST_TIMINGS_FILE: Tests/UI/Fixtures/ui_test_timings.json
   ANDBIBLE_ANDROID_ROOT: ../and-bible
+  ANDBIBLE_ANDROID_REF: 0f3b85823cebbfafeb5a51675827f5314cac3c56
 
 jobs:
   repo-standards:
@@ -84,6 +85,9 @@ jobs:
 
       - name: Check Android workspace Room authority
         run: python3 scripts/check_android_workspace_schema_authority.py
+
+      - name: Check Android AI settings Room authority
+        run: python3 scripts/check_android_ai_settings_schema_authority.py
 
       - name: Run repo standards unit tests
         run: python3 -m unittest discover -s scripts -p 'test_*.py'

--- a/AndBible/AndBibleApp.swift
+++ b/AndBible/AndBibleApp.swift
@@ -1467,19 +1467,7 @@ struct AndBibleApp: App {
      */
     @MainActor
     private func handleRemoteSyncError(_ error: Error, for category: RemoteSyncCategory) {
-        switch error {
-        case WebDAVClientError.invalidURL:
-            remoteSyncErrorMessage = String(localized: "invalid_url_message")
-        case RemoteSyncPatchDiscoveryError.incompatiblePatchVersion:
-            remoteSyncErrorMessage = [
-                String(localized: "sync_cant_fetch"),
-                String(localized: "sync_update_app"),
-            ]
-            .joined(separator: " ")
-        default:
-            let localizedMessage = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-            remoteSyncErrorMessage = localizedMessage.isEmpty ? String(localized: "sync_error") : localizedMessage
-        }
+        remoteSyncErrorMessage = RemoteSyncFailurePresentation(error: error).localizedMessage
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/AI/AISettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/AI/AISettingsStore.swift
@@ -29,15 +29,24 @@ public final class AISettingsStore {
     /// Context used for all AI model reads and writes.
     private let modelContext: ModelContext
 
+    /// Strict synchronized projector bound to the same device-local credential source as the caller.
+    private let remoteSyncSnapshotService: RemoteSyncAISettingsSnapshotService
+
     /**
      Creates a store bound to one SwiftData context.
 
-     - Parameter modelContext: Context whose schema includes the registered AI models.
+     - Parameters:
+       - modelContext: Context whose schema includes the registered AI models.
+       - remoteSyncSnapshotService: Strict AI sync projector used when journaling saved changes.
      - Side effects: none.
      - Failure modes: Missing model registrations surface when a fetch or save is attempted.
      */
-    public init(modelContext: ModelContext) {
+    public init(
+        modelContext: ModelContext,
+        remoteSyncSnapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService()
+    ) {
         self.modelContext = modelContext
+        self.remoteSyncSnapshotService = remoteSyncSnapshotService
     }
 
     /**
@@ -434,7 +443,8 @@ public final class AISettingsStore {
     private func saveSynchronizedChanges() throws {
         try RemoteSyncMutationJournalService.savePendingGraphChanges(
             for: .aiSettings,
-            modelContext: modelContext
+            modelContext: modelContext,
+            aiSettingsSnapshotService: remoteSyncSnapshotService
         )
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/AI/AISettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/AI/AISettingsStore.swift
@@ -10,6 +10,9 @@ public enum AISettingsStoreError: Error, Equatable, Sendable {
 
     /// A requested configured model does not exist.
     case modelNotFound(UUID)
+
+    /// Android's provider/model composite identity already exists.
+    case modelAlreadyExists(providerID: UUID, modelID: String)
 }
 
 /**
@@ -52,13 +55,13 @@ public final class AISettingsStore {
         }
         let settings = GlobalAISettings()
         modelContext.insert(settings)
-        try modelContext.save()
+        try saveSynchronizedChanges()
         return settings
     }
 
     /** Saves mutations already made to managed AI models. */
     public func save() throws {
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /**
@@ -78,11 +81,10 @@ public final class AISettingsStore {
         let settings = try globalSettings()
         let previousValue = settings.aiDisclaimerAccepted
         do {
-            try modelContext.transaction {
+            try performSynchronizedMutation {
                 settings.aiDisclaimerAccepted = isAccepted
             }
         } catch {
-            modelContext.rollback()
             settings.aiDisclaimerAccepted = previousValue
             throw error
         }
@@ -109,15 +111,17 @@ public final class AISettingsStore {
     /** Inserts and saves a non-secret provider configuration. */
     public func insertProvider(_ provider: LLMProviderConfig) throws {
         modelContext.insert(provider)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /**
      Deletes a provider and applies Android's dependent-row semantics without SwiftData relationships.
 
-     Configured models and their usage are deleted. Prompt, global-default, and built-in override
-     references to those models are cleared. Keychain deletion remains an explicit credential-store
-     operation so persistence failure cannot silently orphan a still-needed secret.
+     Configured models are deleted while historical per-device usage remains, matching Android's
+     logical non-foreign-key usage relationship. Prompt and built-in override references to those
+     models are cleared. When the deleted provider owns the global default, Android's first remaining
+     configured model is promoted. Keychain deletion remains an explicit credential-store operation
+     so persistence failure cannot silently orphan a still-needed secret.
 
      - Parameter providerID: Provider configuration to remove.
      - Side effects: Mutates and saves every affected AI settings row in one context transaction.
@@ -127,8 +131,11 @@ public final class AISettingsStore {
         guard let provider = try provider(id: providerID) else { return }
         let removedModelIDs = Set(try models(providerConfigId: providerID).map(\.id))
         let settings = try globalSettings()
+        let replacementDefaultID = try allModels().first {
+            !removedModelIDs.contains($0.id)
+        }?.id
 
-        try modelContext.transaction {
+        try performSynchronizedMutation {
             for model in try allModels() where removedModelIDs.contains(model.id) {
                 modelContext.delete(model)
             }
@@ -136,14 +143,11 @@ public final class AISettingsStore {
                 prompt.configuredModelId = nil
             }
             if settings.defaultModelId.map(removedModelIDs.contains) == true {
-                settings.defaultModelId = nil
+                settings.defaultModelId = replacementDefaultID
             }
             for override in try builtInOverrides()
             where override.configuredModelId.map(removedModelIDs.contains) == true {
                 override.configuredModelId = nil
-            }
-            for usage in try usageRecords() where removedModelIDs.contains(usage.configuredModelId) {
-                modelContext.delete(usage)
             }
             modelContext.delete(provider)
         }
@@ -178,41 +182,51 @@ public final class AISettingsStore {
     }
 
     /**
-     Inserts a configured model after verifying its provider exists.
+     Inserts a configured model after verifying its provider exists and enforcing Android's unique
+     `(providerConfigId, modelId)` index in code for CloudKit-compatible SwiftData schemas.
 
-     - Throws: `AISettingsStoreError.providerNotFound` or SwiftData errors.
+     - Throws: `AISettingsStoreError.providerNotFound`,
+       `AISettingsStoreError.modelAlreadyExists`, or SwiftData errors.
      */
     public func insertModel(_ model: LLMConfiguredModel) throws {
         guard try provider(id: model.providerConfigId) != nil else {
             throw AISettingsStoreError.providerNotFound(model.providerConfigId)
         }
+        guard try models(providerConfigId: model.providerConfigId).allSatisfy({
+            $0.modelId != model.modelId
+        }) else {
+            throw AISettingsStoreError.modelAlreadyExists(
+                providerID: model.providerConfigId,
+                modelID: model.modelId
+            )
+        }
         modelContext.insert(model)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /**
-     Deletes one configured model and clears every dependent v23 reference.
+     Deletes one configured model and clears every dependent v23 reference. When it is the global
+     default, Android's first remaining configured model is promoted. Historical usage rows remain
+     addressable by their logical model identity, matching Android's non-foreign-key schema.
 
      - Parameter modelID: Configured model identity to remove.
-     - Side effects: Clears prompt/default/override references, removes usage, and deletes the model
-       in one context transaction.
+     - Side effects: Clears prompt/override references, promotes the first remaining default when
+       needed and deletes the model in one synchronized transaction.
      - Throws: SwiftData fetch or transaction errors.
      */
     public func deleteModel(id modelID: UUID) throws {
         guard let model = try model(id: modelID) else { return }
         let settings = try globalSettings()
-        try modelContext.transaction {
+        let replacementDefaultID = try allModels().first { $0.id != modelID }?.id
+        try performSynchronizedMutation {
             for prompt in try userPrompts() where prompt.configuredModelId == modelID {
                 prompt.configuredModelId = nil
             }
             if settings.defaultModelId == modelID {
-                settings.defaultModelId = nil
+                settings.defaultModelId = replacementDefaultID
             }
             for override in try builtInOverrides() where override.configuredModelId == modelID {
                 override.configuredModelId = nil
-            }
-            for usage in try usageRecords() where usage.configuredModelId == modelID {
-                modelContext.delete(usage)
             }
             modelContext.delete(model)
         }
@@ -237,13 +251,13 @@ public final class AISettingsStore {
     /** Inserts and saves a user-created prompt. */
     public func insertPrompt(_ prompt: AgentPrompt) throws {
         modelContext.insert(prompt)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /** Deletes and saves a user-created prompt. */
     public func deletePrompt(_ prompt: AgentPrompt) throws {
         modelContext.delete(prompt)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /** Returns user-created categories ordered like Android. */
@@ -265,7 +279,7 @@ public final class AISettingsStore {
     /** Inserts and saves a user-created category. */
     public func insertCategory(_ category: PromptCategory) throws {
         modelContext.insert(category)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /**
@@ -279,7 +293,7 @@ public final class AISettingsStore {
      */
     public func deleteCategory(id categoryID: UUID, deletePrompts: Bool) throws {
         guard let category = try userCategory(id: categoryID) else { return }
-        try modelContext.transaction {
+        try performSynchronizedMutation {
             for prompt in try userPrompts() where prompt.categoryId == categoryID {
                 if deletePrompts {
                     modelContext.delete(prompt)
@@ -327,7 +341,7 @@ public final class AISettingsStore {
         } else if let modelID {
             modelContext.insert(BuiltInPromptOverride(id: promptID, configuredModelId: modelID))
         }
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /** Returns every cumulative usage row. */
@@ -378,14 +392,14 @@ public final class AISettingsStore {
         let cost = estimatedCostUSD.isFinite ? max(estimatedCostUSD, 0) : 0
         let updatedCost = row.estimatedCostUSD + cost
         row.estimatedCostUSD = updatedCost.isFinite ? updatedCost : .greatestFiniteMagnitude
-        try modelContext.save()
+        try saveSynchronizedChanges()
         return row
     }
 
     /** Inserts and saves a device-local raw LLM log. */
     public func insertRawLog(_ record: LLMRawLogRecord) throws {
         modelContext.insert(record)
-        try modelContext.save()
+        try saveSynchronizedChanges()
     }
 
     /** Returns local raw logs newest first. */
@@ -405,7 +419,40 @@ public final class AISettingsStore {
             )
         )
         records.forEach(modelContext.delete)
-        try modelContext.save()
+        try saveSynchronizedChanges()
+    }
+
+    /**
+     Commits pending AI model changes with Android-compatible mutation metadata.
+
+     Raw-log-only mutations pass through the same atomic boundary but produce no `AI_SETTINGS`
+     journal row because raw logs are absent from the synchronized snapshot.
+
+     - Side Effects: Saves pending SwiftData changes and category-scoped sync metadata together.
+     - Throws: Rethrows strict projection, journal, or SwiftData commit failures.
+     */
+    private func saveSynchronizedChanges() throws {
+        try RemoteSyncMutationJournalService.savePendingGraphChanges(
+            for: .aiSettings,
+            modelContext: modelContext
+        )
+    }
+
+    /**
+     Stages a compound AI mutation and commits it with one remote-sync journal generation.
+
+     - Parameter mutation: Fetch and mutation work to perform before the shared save boundary.
+     - Side Effects: Mutates the bound context, then atomically saves graph and journal metadata.
+     - Throws: Rethrows mutation or save failures after rolling back the complete context.
+     */
+    private func performSynchronizedMutation(_ mutation: () throws -> Void) throws {
+        do {
+            try mutation()
+            try saveSynchronizedChanges()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
     }
 }
 
@@ -420,15 +467,27 @@ public final class AICredentialStore {
     /// Secret backend; tests may inject a deterministic in-memory implementation.
     private let secretStore: SecretStoring
 
+    /// Strict reader used by security-sensitive publication without widening ordinary read behavior.
+    private let strictSecretReader: (String) throws -> String?
+
     /**
      Creates a credential store over an explicit secret backend.
 
      - Parameter secretStore: Keychain-backed production store or test double.
      - Side effects: none.
-     - Failure modes: Backend failures occur only on write or delete.
+     - Failure modes: Strict reads, writes, and deletes preserve backend-specific failures.
      */
     public init(secretStore: SecretStoring) {
         self.secretStore = secretStore
+        if let strictSecretStore = secretStore as? any StrictSecretReading {
+            strictSecretReader = { key in
+                try strictSecretStore.secretStrict(forKey: key)
+            }
+        } else {
+            strictSecretReader = { key in
+                secretStore.secret(forKey: key)
+            }
+        }
     }
 
     /**
@@ -447,6 +506,22 @@ public final class AICredentialStore {
     /** Reads a provider API key, returning `nil` when no non-empty key exists. */
     public func credential(for providerID: UUID) -> String? {
         secretStore.secret(forKey: Self.key(for: providerID)).flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /**
+     Reads a provider API key while distinguishing confirmed absence from backend failure.
+
+     Sync publication uses this path so a temporarily inaccessible Keychain cannot be mistaken for
+     an absent credential and allow an embedded copy to enter remote state. Test-only stores without
+     strict-read support preserve their deterministic nonthrowing behavior.
+
+     - Parameter providerID: Provider configuration identity.
+     - Returns: Non-empty provider credential, or `nil` only when the backing store reports absence.
+     - Side Effects: Reads one device-local secret-store entry.
+     - Throws: Rethrows strict backend lookup or payload failures.
+     */
+    public func credentialStrict(for providerID: UUID) throws -> String? {
+        try strictSecretReader(Self.key(for: providerID)).flatMap { $0.isEmpty ? nil : $0 }
     }
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsDatabaseMigrator.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsDatabaseMigrator.swift
@@ -1,0 +1,528 @@
+// RemoteSyncAISettingsDatabaseMigrator.swift -- Android-equivalent staged AI Room migrations
+
+import Foundation
+import SQLite3
+
+/** Typed failures emitted before a staged AI settings database can be imported as Room v23. */
+enum RemoteSyncAISettingsDatabaseMigrationError: Error, Equatable {
+    /// The staged file could not be opened or queried as an existing SQLite database.
+    case invalidSQLiteDatabase
+
+    /// Android has no authoritative or deterministically derivable Room source schema.
+    case unsupportedSourceVersion(Int)
+
+    /// Archive metadata and the staged database disagree about their source generation.
+    case sourceVersionMismatch(expected: Int, actual: Int)
+
+    /// One exact Android migration step failed and the staged transaction was rolled back.
+    case migrationFailed(from: Int, to: Int)
+}
+
+/**
+ Migrates writable staged Android AI settings databases through the production Room chain.
+
+ Every accepted predecessor is backed by an Android `AiSettingsDatabase` schema that its production
+ migration chain can advance. Android omitted the generated v12 export, but that schema is derived
+ exactly from exported v11 plus Android's 11-to-12 migration and Room 2.7.2 identity algorithm.
+ Version 17 is a transient export created in the same Android feature commit as v18; it contains a
+ column that no migration creates or removes, so Android cannot migrate that fresh schema forward.
+ Migration runs only on downloaded temporary files; live app persistence is never opened here.
+ */
+enum RemoteSyncAISettingsDatabaseMigrator {
+    /// Android generations with exported or exactly derivable Room schemas accepted for import.
+    static let supportedSourceVersions: Set<Int> = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+        13, 14, 15, 16, 18, 19, 20, 21, 22, 23,
+    ]
+
+    /** Returns whether Android supplies an authoritative AI settings schema for one source version. */
+    static func supportsSourceVersion(_ version: Int) -> Bool {
+        supportedSourceVersions.contains(version)
+    }
+
+    /**
+     Migrates and validates one staged AI settings database before any row decoding.
+
+     - Parameters:
+       - databaseURL: Existing writable staged SQLite file; live app databases must never be passed.
+       - expectedSourceVersion: Optional version encoded by archive metadata. When supplied, it must
+         equal the staged database's pre-migration `user_version`.
+     - Side Effects:
+       - opens the staged file read-write
+       - executes every Android migration edge in one transaction
+       - suppresses predecessor sync triggers during data-changing steps
+       - replaces Room identity metadata and `user_version` with exact v23 values
+       - commits only after complete v23 schema and payload validation succeeds
+     - Throws: Typed source/open/migration failures or exact database-contract errors. Every failed
+       predecessor migration rolls the staged file back to its original generation.
+     */
+    static func migrateAndValidateStagedDatabase(
+        at databaseURL: URL,
+        expectedSourceVersion: Int? = nil
+    ) throws {
+        var database: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(databaseURL.path, &database, flags, nil) == SQLITE_OK,
+              let database else {
+            if let database { sqlite3_close(database) }
+            throw RemoteSyncAISettingsDatabaseMigrationError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(database) }
+
+        let sourceVersion = try userVersion(in: database)
+        if let expectedSourceVersion, expectedSourceVersion != sourceVersion {
+            throw RemoteSyncAISettingsDatabaseMigrationError.sourceVersionMismatch(
+                expected: expectedSourceVersion,
+                actual: sourceVersion
+            )
+        }
+        guard supportsSourceVersion(sourceVersion) else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.unsupportedSourceVersion(sourceVersion)
+        }
+        let validatedRuntimeTriggerNames = try RemoteSyncAndroidDatabaseContract
+            .validateAISettingsSourceDatabase(database, sourceVersion: sourceVersion)
+
+        let targetVersion = RemoteSyncAndroidDatabaseContract.schemaVersion(for: .aiSettings)
+        let targetIdentityHash = RemoteSyncAndroidDatabaseContract.identityHash(for: .aiSettings)
+        if sourceVersion == targetVersion {
+            try RemoteSyncAndroidDatabaseContract.validateInboundDatabase(
+                database,
+                category: .aiSettings
+            )
+            return
+        }
+
+        try execute("PRAGMA foreign_keys = ON;", in: database, from: sourceVersion, to: targetVersion)
+        try execute("BEGIN IMMEDIATE TRANSACTION;", in: database, from: sourceVersion, to: targetVersion)
+        do {
+            for version in sourceVersion..<targetVersion {
+                try applyMigration(from: version, in: database)
+            }
+            try dropRuntimeSyncTriggers(
+                validatedRuntimeTriggerNames,
+                in: database,
+                from: sourceVersion,
+                to: targetVersion
+            )
+            try execute(
+                "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT);",
+                in: database,
+                from: sourceVersion,
+                to: targetVersion
+            )
+            try execute(
+                "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '\(targetIdentityHash)');",
+                in: database,
+                from: sourceVersion,
+                to: targetVersion
+            )
+            try execute(
+                "PRAGMA user_version = \(targetVersion);",
+                in: database,
+                from: sourceVersion,
+                to: targetVersion
+            )
+            try RemoteSyncAndroidDatabaseContract.validateInboundDatabase(
+                database,
+                category: .aiSettings
+            )
+            try execute("COMMIT;", in: database, from: sourceVersion, to: targetVersion)
+        } catch {
+            _ = try? execute("ROLLBACK;", in: database, from: sourceVersion, to: targetVersion)
+            throw error
+        }
+    }
+
+    /** Executes one Android migration while matching its sync-trigger suppression lifecycle. */
+    private static func applyMigration(from version: Int, in database: OpaquePointer) throws {
+        let nextVersion = version + 1
+        do {
+            try setSyncTriggersDisabled(true, in: database, from: version, to: nextVersion)
+            do {
+                for statement in migrationStatements(from: version) {
+                    try execute(statement, in: database, from: version, to: nextVersion)
+                }
+            } catch {
+                try? setSyncTriggersDisabled(false, in: database, from: version, to: nextVersion)
+                throw error
+            }
+            try setSyncTriggersDisabled(false, in: database, from: version, to: nextVersion)
+        } catch let error as RemoteSyncAISettingsDatabaseMigrationError {
+            throw error
+        } catch {
+            throw RemoteSyncAISettingsDatabaseMigrationError.migrationFailed(
+                from: version,
+                to: nextVersion
+            )
+        }
+    }
+
+    /** Mirrors Android's per-step `SyncConfiguration.triggersDisabled` lifecycle. */
+    private static func setSyncTriggersDisabled(
+        _ disabled: Bool,
+        in database: OpaquePointer,
+        from: Int,
+        to: Int
+    ) throws {
+        guard try tableExists("SyncConfiguration", in: database, from: from, to: to) else {
+            return
+        }
+        let sql = disabled
+            ? "INSERT OR REPLACE INTO SyncConfiguration (keyName, booleanValue) VALUES ('triggersDisabled', 1);"
+            : "DELETE FROM SyncConfiguration WHERE keyName = 'triggersDisabled';"
+        try execute(sql, in: database, from: from, to: to)
+    }
+
+    /** Removes only source triggers authenticated before migration started. */
+    private static func dropRuntimeSyncTriggers(
+        _ triggerNames: Set<String>,
+        in database: OpaquePointer,
+        from: Int,
+        to: Int
+    ) throws {
+        for triggerName in triggerNames.sorted() {
+            let quotedName = "\"\(triggerName.replacingOccurrences(of: "\"", with: "\"\""))\""
+            try execute("DROP TRIGGER IF EXISTS \(quotedName);", in: database, from: from, to: to)
+        }
+    }
+
+    /** Returns whether one migration-support table exists without creating it. */
+    private static func tableExists(
+        _ table: String,
+        in database: OpaquePointer,
+        from: Int,
+        to: Int
+    ) throws -> Bool {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            database,
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?;",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK, let statement else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.migrationFailed(from: from, to: to)
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_bind_text(
+            statement,
+            1,
+            table,
+            -1,
+            unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        ) == SQLITE_OK,
+        sqlite3_step(statement) == SQLITE_ROW else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.migrationFailed(from: from, to: to)
+        }
+        return sqlite3_column_int64(statement, 0) > 0
+    }
+
+    /** Reads an exact nonnegative SQLite `user_version` that fits Swift `Int`. */
+    private static func userVersion(in database: OpaquePointer) throws -> Int {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, "PRAGMA user_version;", -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              sqlite3_column_type(statement, 0) == SQLITE_INTEGER,
+              let value = Int(exactly: sqlite3_column_int64(statement, 0)),
+              value >= 0,
+              sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.invalidSQLiteDatabase
+        }
+        return value
+    }
+
+    /** Executes one migration statement and maps SQLite diagnostics to its exact version edge. */
+    private static func execute(
+        _ sql: String,
+        in database: OpaquePointer,
+        from: Int,
+        to: Int
+    ) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseMigrationError.migrationFailed(from: from, to: to)
+        }
+    }
+
+    /** Returns the exact SQL statements from Android `AiSettingsMigrations.kt` for one edge. */
+    static func migrationStatements(from version: Int) -> [String] {
+        switch version {
+        case 1:
+            return ["ALTER TABLE `AgentPrompt` ADD COLUMN `editBeforeRun` INTEGER NOT NULL DEFAULT 0"]
+        case 2:
+            return ["ALTER TABLE `AgentPrompt` ADD COLUMN `noDocumentCreation` INTEGER NOT NULL DEFAULT 0"]
+        case 3:
+            return addGlobalSettingsAndUsage
+        case 4:
+            return setCommentaryTokenDefault
+        case 5:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInPrompts` TEXT NOT NULL DEFAULT ''"]
+        case 6:
+            return [
+                "ALTER TABLE `GlobalAiSettings` ADD COLUMN `maxIterations` INTEGER NOT NULL DEFAULT 10",
+                "ALTER TABLE `AgentPrompt` ADD COLUMN `maxIterations` INTEGER DEFAULT NULL",
+            ]
+        case 7:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `commentaryDeselected` TEXT NOT NULL DEFAULT ''"]
+        case 8:
+            return addConfiguredModels
+        case 9:
+            return raiseCommentaryTokenDefault
+        case 10:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiLanguage` TEXT DEFAULT NULL"]
+        case 11:
+            return [
+                "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0",
+            ]
+        case 12:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0"]
+        case 13:
+            return ["ALTER TABLE `AgentPrompt` ADD COLUMN `bibleOnly` INTEGER NOT NULL DEFAULT 0"]
+        case 14:
+            return ["ALTER TABLE `AgentPrompt` ADD COLUMN `isTextTransformation` INTEGER NOT NULL DEFAULT 0"]
+        case 15:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0"]
+        case 16:
+            return addPromptCategories
+        case 17:
+            return [
+                "ALTER TABLE `PromptCategory` ADD COLUMN `hidden` INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInCategories` TEXT NOT NULL DEFAULT ''",
+            ]
+        case 18:
+            return [
+                "ALTER TABLE `GlobalAiSettings` ADD COLUMN `customAgentSystemPrompt` TEXT DEFAULT NULL",
+                "ALTER TABLE `GlobalAiSettings` ADD COLUMN `customTextTransformationSystemPrompt` TEXT DEFAULT NULL",
+            ]
+        case 19:
+            return ["ALTER TABLE `GlobalAiSettings` ADD COLUMN `favoritePrompts` TEXT NOT NULL DEFAULT ''"]
+        case 20:
+            return addRawLogTable
+        case 21:
+            return addBuiltinPromptOverride
+        case 22:
+            return [
+                "ALTER TABLE `GlobalAiSettings` ADD COLUMN `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0"
+            ]
+        default:
+            return []
+        }
+    }
+
+    /// Android's exact v3-to-v4 table and column additions.
+    private static let addGlobalSettingsAndUsage = [
+        """
+        CREATE TABLE IF NOT EXISTS `GlobalAiSettings` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `agentPermissionMode` TEXT DEFAULT NULL,
+            `permanentlyAllowedTools` TEXT DEFAULT NULL,
+            `permanentlyDeniedTools` TEXT DEFAULT NULL,
+            `aiExcludedDocuments` TEXT NOT NULL,
+            `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS `LlmUsageRecord` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `providerConfigId` BLOB NOT NULL,
+            `deviceId` TEXT NOT NULL,
+            `inputTokens` INTEGER NOT NULL DEFAULT 0,
+            `outputTokens` INTEGER NOT NULL DEFAULT 0,
+            `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0,
+            `cacheReadTokens` INTEGER NOT NULL DEFAULT 0,
+            `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0,
+            FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `LlmUsageRecord` (`providerConfigId`)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `LlmUsageRecord` (`providerConfigId`, `deviceId`)",
+        "ALTER TABLE `LlmProviderConfig` ADD COLUMN `customInputPrice` REAL NOT NULL DEFAULT 0.0",
+        "ALTER TABLE `LlmProviderConfig` ADD COLUMN `customOutputPrice` REAL NOT NULL DEFAULT 0.0",
+    ]
+
+    /// Android's exact v4-to-v5 default-normalizing table rebuild.
+    private static let setCommentaryTokenDefault = [
+        """
+        CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `agentPermissionMode` TEXT DEFAULT NULL,
+            `permanentlyAllowedTools` TEXT DEFAULT NULL,
+            `permanentlyDeniedTools` TEXT DEFAULT NULL,
+            `aiExcludedDocuments` TEXT NOT NULL,
+            `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000
+        )
+        """,
+        """
+        INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`)
+        SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`,
+            CASE WHEN `commentaryMaxResponseTokens` = 0 THEN 4000 ELSE `commentaryMaxResponseTokens` END
+        FROM `GlobalAiSettings`
+        """,
+        "DROP TABLE `GlobalAiSettings`",
+        "ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`",
+    ]
+
+    /// Android's exact v8-to-v9 provider/model/prompt/usage restructuring.
+    private static let addConfiguredModels = [
+        """
+        CREATE TABLE IF NOT EXISTS `LlmConfiguredModel` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `providerConfigId` BLOB NOT NULL,
+            `modelId` TEXT NOT NULL,
+            `orderNumber` INTEGER NOT NULL DEFAULT 0,
+            `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+            `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+            `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+            `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+            FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `LlmConfiguredModel` (`providerConfigId`)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `LlmConfiguredModel` (`providerConfigId`, `modelId`)",
+        """
+        CREATE TABLE IF NOT EXISTS `LlmProviderConfig_new` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `providerType` TEXT NOT NULL,
+            `displayName` TEXT NOT NULL,
+            `endpoint` TEXT DEFAULT NULL,
+            `apiFormat` TEXT DEFAULT NULL,
+            `orderNumber` INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+        """
+        INSERT INTO `LlmProviderConfig_new` (`id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber`)
+        SELECT `id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber` FROM `LlmProviderConfig`
+        """,
+        "DROP TABLE `LlmProviderConfig`",
+        "ALTER TABLE `LlmProviderConfig_new` RENAME TO `LlmProviderConfig`",
+        "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `LlmProviderConfig` (`orderNumber`)",
+        """
+        CREATE TABLE IF NOT EXISTS `AgentPrompt_new` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `name` TEXT NOT NULL,
+            `description` TEXT DEFAULT NULL,
+            `promptTemplate` TEXT NOT NULL,
+            `showIn` TEXT NOT NULL,
+            `orderNumber` INTEGER NOT NULL DEFAULT 0,
+            `createdAt` INTEGER NOT NULL DEFAULT 0,
+            `strictContextMatching` INTEGER NOT NULL DEFAULT 1,
+            `permissionMode` TEXT DEFAULT NULL,
+            `allowedTools` TEXT DEFAULT NULL,
+            `deniedTools` TEXT DEFAULT NULL,
+            `configuredModelId` BLOB DEFAULT NULL,
+            `editBeforeRun` INTEGER NOT NULL DEFAULT 0,
+            `noDocumentCreation` INTEGER NOT NULL DEFAULT 0,
+            `maxIterations` INTEGER DEFAULT NULL,
+            FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+        )
+        """,
+        """
+        INSERT INTO `AgentPrompt_new` (`id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, `configuredModelId`, `editBeforeRun`, `noDocumentCreation`, `maxIterations`)
+        SELECT `id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, NULL, `editBeforeRun`, `noDocumentCreation`, `maxIterations` FROM `AgentPrompt`
+        """,
+        "DROP TABLE `AgentPrompt`",
+        "ALTER TABLE `AgentPrompt_new` RENAME TO `AgentPrompt`",
+        "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `AgentPrompt` (`orderNumber`)",
+        "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `AgentPrompt` (`createdAt`)",
+        "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `AgentPrompt` (`configuredModelId`)",
+        """
+        CREATE TABLE IF NOT EXISTS `LlmUsageRecord_new` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `configuredModelId` BLOB NOT NULL,
+            `deviceId` TEXT NOT NULL,
+            `inputTokens` INTEGER NOT NULL DEFAULT 0,
+            `outputTokens` INTEGER NOT NULL DEFAULT 0,
+            `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0,
+            `cacheReadTokens` INTEGER NOT NULL DEFAULT 0,
+            `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0
+        )
+        """,
+        "DROP TABLE `LlmUsageRecord`",
+        "ALTER TABLE `LlmUsageRecord_new` RENAME TO `LlmUsageRecord`",
+        "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `LlmUsageRecord` (`configuredModelId`)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `LlmUsageRecord` (`configuredModelId`, `deviceId`)",
+        "ALTER TABLE `GlobalAiSettings` ADD COLUMN `defaultModelId` BLOB DEFAULT NULL",
+    ]
+
+    /// Android's exact v9-to-v10 commentary-token default normalization.
+    private static let raiseCommentaryTokenDefault = [
+        """
+        CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `agentPermissionMode` TEXT DEFAULT NULL,
+            `permanentlyAllowedTools` TEXT DEFAULT NULL,
+            `permanentlyDeniedTools` TEXT DEFAULT NULL,
+            `aiExcludedDocuments` TEXT NOT NULL,
+            `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000,
+            `hiddenBuiltInPrompts` TEXT NOT NULL,
+            `maxIterations` INTEGER NOT NULL DEFAULT 10,
+            `commentaryDeselected` TEXT NOT NULL,
+            `defaultModelId` BLOB DEFAULT NULL
+        )
+        """,
+        """
+        INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`, `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId`)
+        SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`,
+            CASE WHEN `commentaryMaxResponseTokens` = 4000 THEN 15000 ELSE `commentaryMaxResponseTokens` END,
+            `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId`
+        FROM `GlobalAiSettings`
+        """,
+        "DROP TABLE `GlobalAiSettings`",
+        "ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`",
+    ]
+
+    /// Android's exact v16-to-v17 prompt-category additions.
+    private static let addPromptCategories = [
+        """
+        CREATE TABLE IF NOT EXISTS `PromptCategory` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `name` TEXT NOT NULL,
+            `orderNumber` INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+        "ALTER TABLE `AgentPrompt` ADD COLUMN `categoryId` BLOB DEFAULT NULL",
+        "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `AgentPrompt` (`categoryId`)",
+    ]
+
+    /// Android's exact v20-to-v21 local raw-log schema addition.
+    private static let addRawLogTable = [
+        """
+        CREATE TABLE IF NOT EXISTS `LlmRawLogRecord` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `promptId` BLOB DEFAULT NULL,
+            `promptName` TEXT NOT NULL DEFAULT '',
+            `promptDescription` TEXT DEFAULT NULL,
+            `configuredModelId` BLOB DEFAULT NULL,
+            `modelName` TEXT NOT NULL DEFAULT '',
+            `providerType` TEXT NOT NULL DEFAULT '',
+            `timestamp` INTEGER NOT NULL DEFAULT 0,
+            `totalInputTokens` INTEGER NOT NULL DEFAULT 0,
+            `totalOutputTokens` INTEGER NOT NULL DEFAULT 0,
+            `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0,
+            `logData` BLOB NOT NULL,
+            `iterationCount` INTEGER NOT NULL DEFAULT 0,
+            `wasError` INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `LlmRawLogRecord` (`timestamp`)",
+        "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `LlmRawLogRecord` (`promptId`)",
+        "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `LlmRawLogRecord` (`configuredModelId`)",
+        "ALTER TABLE `GlobalAiSettings` ADD COLUMN `rawLogRetentionDays` INTEGER DEFAULT 30",
+    ]
+
+    /// Android's exact v21-to-v22 built-in prompt override addition.
+    private static let addBuiltinPromptOverride = [
+        """
+        CREATE TABLE IF NOT EXISTS `BuiltinPromptOverride` (
+            `id` BLOB NOT NULL PRIMARY KEY,
+            `configuredModelId` BLOB DEFAULT NULL,
+            FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `BuiltinPromptOverride` (`configuredModelId`)",
+    ]
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsDatabaseWriter.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsDatabaseWriter.swift
@@ -1,0 +1,1056 @@
+// RemoteSyncAISettingsDatabaseWriter.swift -- Android v23 AI settings SQLite publication
+
+import Foundation
+import SQLite3
+
+private let remoteSyncAISettingsWriterSQLiteTransient = unsafeBitCast(
+    -1,
+    to: sqlite3_destructor_type.self
+)
+
+/**
+ Selects whether an AI settings publication contains the complete current generation or only rows
+ named by the supplied Android `LogEntry` operations.
+ */
+public enum RemoteSyncAISettingsDatabaseWriteMode: Sendable, Equatable {
+    /// Inserts every row from the supplied snapshot, as required by an initial backup.
+    case full
+
+    /// Inserts only rows named by UPSERT log entries; DELETE entries carry no content row.
+    case sparse
+}
+
+/**
+ Fail-closed errors raised while materializing Android's AI settings Room database.
+
+ Filesystem errors are rethrown directly so callers retain the destination path and Cocoa error code.
+ No destination is replaced unless schema creation, row insertion, contract validation, and SQLite
+ commit all succeed in a staged sibling file.
+ */
+public enum RemoteSyncAISettingsDatabaseWriterError: Error, Equatable {
+    /// A caller requested a schema generation other than Android's supported v23 contract.
+    case unsupportedSchemaVersion(Int)
+
+    /// SQLite could not create, populate, validate, commit, or close the staged database.
+    case invalidSQLiteDatabase
+
+    /// More than one snapshot row used the same Android table primary key.
+    case duplicateIdentifier(table: String, id: UUID)
+
+    /// More than one row used an Android unique composite identity.
+    case duplicateCompositeIdentity(table: String, first: String, second: String)
+
+    /// A present global settings row did not use Android's fixed singleton UUID.
+    case invalidGlobalSettingsIdentity(UUID)
+
+    /// More than one global settings row was supplied.
+    case duplicateGlobalSettings
+
+    /// A formal Android foreign-key reference did not resolve in the complete source snapshot.
+    case orphanFormalReference(table: String, id: UUID, parentTable: String, parentID: UUID)
+
+    /// A floating-point value could not be represented as a finite SQLite REAL.
+    case invalidFloatingPointValue(table: String, id: UUID)
+
+    /// A selected log entry named a table outside Android's seven synchronized AI tables.
+    case unsupportedLogTable(String)
+
+    /// A selected log identity was not Android's UUID BLOB plus empty-text secondary identifier.
+    case invalidLogIdentity(table: String)
+
+    /// More than one selected log entry addressed the same Android row.
+    case duplicateLogIdentity(table: String, id: UUID)
+
+    /// A sparse UPSERT selected an identity absent from the current snapshot.
+    case missingUpsertRow(table: String, id: UUID)
+
+    /// A full publication paired a DELETE operation with a row that is still present.
+    case inconsistentDeleteRow(table: String, id: UUID)
+}
+
+/** Counts written for one successfully published Android AI settings database. */
+public struct RemoteSyncAISettingsDatabaseWriteReport: Sendable, Equatable {
+    /// Exact Android Room schema version written to `PRAGMA user_version`.
+    public let schemaVersion: Int
+
+    /// Number of non-secret provider rows written.
+    public let providerCount: Int
+
+    /// Number of configured-model rows written.
+    public let configuredModelCount: Int
+
+    /// Number of agent-prompt rows written.
+    public let agentPromptCount: Int
+
+    /// Number of global-settings singleton rows written.
+    public let globalSettingsCount: Int
+
+    /// Number of per-device usage rows written.
+    public let usageRecordCount: Int
+
+    /// Number of user prompt-category rows written.
+    public let promptCategoryCount: Int
+
+    /// Number of built-in prompt override rows written.
+    public let builtinPromptOverrideCount: Int
+
+    /// Number of Android conflict/tombstone rows written.
+    public let logEntryCount: Int
+
+    /// Always zero because raw model logs are device-local and excluded from publication.
+    public let rawLogRecordCount: Int
+}
+
+/**
+ Writes Android-compatible `AiSettingsDatabase` v23 files from credential-free iOS snapshots.
+
+ The writer always creates the complete Room schema shell supplied by
+ `RemoteSyncAndroidDatabaseContract`, including the intentionally empty `LlmRawLogRecord` table.
+ It accepts no credential store or API-key value, so secrets cannot enter the database through this
+ API. Full publications insert every snapshot row. Sparse publications use the passed `LogEntry`
+ values as the exact row selection: UPSERT includes the matching current row, while DELETE includes
+ only its tombstone.
+
+ Side effects:
+ - creates a temporary SQLite file beside the destination
+ - executes Android's v23 DDL and inserts selected content and metadata in one transaction
+ - validates the completed file against the exact Room schema and bounded payload contract
+ - atomically moves or replaces the destination only after SQLite closes successfully
+
+ Failure modes:
+ - rejects duplicate identities, invalid singleton state, formal foreign-key orphans, non-finite
+   values, malformed log identities, inconsistent full-backup logs, and any schema other than v23
+ - rethrows filesystem errors and reports SQLite failures as
+   `RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase`
+
+ Concurrency:
+ - instances hold only an injected `FileManager`, but callers must serialize writes to one destination
+ - each invocation uses a unique sibling staging file and is deterministic for equivalent row sets
+ */
+public final class RemoteSyncAISettingsDatabaseWriter {
+    /// Exact Android `AiSettingsDatabase` generation emitted by this writer.
+    public static let supportedAndroidSchemaVersion = 23
+
+    private static let synchronizedTables: Set<String> = [
+        "LlmProviderConfig",
+        "LlmConfiguredModel",
+        "AgentPrompt",
+        "GlobalAiSettings",
+        "LlmUsageRecord",
+        "PromptCategory",
+        "BuiltinPromptOverride",
+    ]
+
+    private let fileManager: FileManager
+
+    /**
+     Creates an AI settings database writer.
+
+     - Parameter fileManager: Filesystem implementation used for staging and atomic publication.
+     - Side Effects: none; directories and files are created only by a write method.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    /**
+     Atomically writes a complete Android AI settings initial-backup database.
+
+     - Parameters:
+       - destinationURL: Final SQLite file URL to create or replace.
+       - snapshot: Complete current seven-table AI settings projection.
+       - logEntries: Selected Android metadata rows to include; initial backups normally pass none.
+       - schemaVersion: Must equal 23.
+     - Returns: Exact counts committed to the published file.
+     - Side Effects: Creates and atomically publishes one complete v23 SQLite database.
+     - Throws: Typed snapshot, log, schema, SQLite, or filesystem failures; the previous destination
+       remains unchanged on failure.
+     */
+    public func writeFullDatabase(
+        at destinationURL: URL,
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        logEntries: [RemoteSyncLogEntry] = [],
+        schemaVersion: Int = supportedAndroidSchemaVersion
+    ) throws -> RemoteSyncAISettingsDatabaseWriteReport {
+        try writeDatabase(
+            at: destinationURL,
+            snapshot: snapshot,
+            selectedLogEntries: logEntries,
+            mode: .full,
+            schemaVersion: schemaVersion
+        )
+    }
+
+    /**
+     Atomically writes one sparse Android AI settings patch database.
+
+     UPSERT rows present in `snapshot` are included. Metadata-only UPSERTs remain valid because
+     Android can retain their `LogEntry` after formal-FK cleanup removes the payload row. Selected
+     DELETE operations also write only `LogEntry`; unselected snapshot rows are not inserted.
+
+     - Parameters:
+       - destinationURL: Final SQLite file URL to create or replace.
+       - snapshot: Complete current seven-table projection used to resolve UPSERT identities.
+       - selectedLogEntries: Exact Android operations carried by this patch.
+       - schemaVersion: Must equal 23.
+     - Returns: Counts of sparse content rows and log entries committed to the file.
+     - Side Effects: Creates and atomically publishes one sparse v23 SQLite database.
+     - Throws: Typed snapshot, log, schema, SQLite, or filesystem failures; the previous destination
+       remains unchanged on failure.
+     */
+    public func writeSparseDatabase(
+        at destinationURL: URL,
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        selectedLogEntries: [RemoteSyncLogEntry],
+        schemaVersion: Int = supportedAndroidSchemaVersion
+    ) throws -> RemoteSyncAISettingsDatabaseWriteReport {
+        try writeDatabase(
+            at: destinationURL,
+            snapshot: snapshot,
+            selectedLogEntries: selectedLogEntries,
+            mode: .sparse,
+            schemaVersion: schemaVersion
+        )
+    }
+
+    /**
+     Writes a full or sparse database through the shared validated publication path.
+
+     - Parameters:
+       - destinationURL: Final SQLite file URL to create or replace.
+       - snapshot: Complete current source generation.
+       - selectedLogEntries: Metadata rows to write and, in sparse mode, row-selection operations.
+       - mode: Complete initial-backup or sparse patch behavior.
+       - schemaVersion: Must equal 23.
+     - Returns: Counts committed to the published database.
+     - Side Effects: Stages, validates, commits, closes, and atomically publishes a SQLite file.
+     - Throws: Rethrows every validation, SQLite, and filesystem failure without publishing a partial
+       destination.
+     */
+    public func writeDatabase(
+        at destinationURL: URL,
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        selectedLogEntries: [RemoteSyncLogEntry],
+        mode: RemoteSyncAISettingsDatabaseWriteMode,
+        schemaVersion: Int = supportedAndroidSchemaVersion
+    ) throws -> RemoteSyncAISettingsDatabaseWriteReport {
+        guard schemaVersion == Self.supportedAndroidSchemaVersion,
+              RemoteSyncAndroidDatabaseContract.schemaVersion(for: .aiSettings) == schemaVersion else {
+            throw RemoteSyncAISettingsDatabaseWriterError.unsupportedSchemaVersion(schemaVersion)
+        }
+
+        let allRows = try Self.validatedRows(from: snapshot)
+        let logIdentities = try Self.validatedLogIdentities(selectedLogEntries)
+        let rows = try Self.selectedRows(
+            from: allRows,
+            logEntries: selectedLogEntries,
+            identities: logIdentities,
+            mode: mode
+        )
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let stagingURL = destinationURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(destinationURL.lastPathComponent).\(UUID().uuidString.lowercased()).tmp"
+        )
+        try? fileManager.removeItem(at: stagingURL)
+        var keepStagingFile = false
+        defer {
+            if !keepStagingFile {
+                try? fileManager.removeItem(at: stagingURL)
+            }
+        }
+
+        try writeStagedDatabase(
+            at: stagingURL,
+            rows: rows,
+            logEntries: selectedLogEntries
+        )
+        try publish(stagingURL: stagingURL, destinationURL: destinationURL)
+        keepStagingFile = true
+
+        return RemoteSyncAISettingsDatabaseWriteReport(
+            schemaVersion: schemaVersion,
+            providerCount: rows.providers.count,
+            configuredModelCount: rows.configuredModels.count,
+            agentPromptCount: rows.agentPrompts.count,
+            globalSettingsCount: rows.globalSettings.count,
+            usageRecordCount: rows.usageRecords.count,
+            promptCategoryCount: rows.promptCategories.count,
+            builtinPromptOverrideCount: rows.builtinOverrides.count,
+            logEntryCount: selectedLogEntries.count,
+            rawLogRecordCount: 0
+        )
+    }
+
+    /** Complete validated source rows keyed by Android UUID identities. */
+    private struct ValidatedRows {
+        let providers: [RemoteSyncAndroidAIProvider]
+        let configuredModels: [RemoteSyncAndroidAIConfiguredModel]
+        let agentPrompts: [RemoteSyncAndroidAIAgentPrompt]
+        let globalSettings: [RemoteSyncAndroidGlobalAISettings]
+        let usageRecords: [RemoteSyncAndroidAIUsageRecord]
+        let promptCategories: [RemoteSyncAndroidAIPromptCategory]
+        let builtinOverrides: [RemoteSyncAndroidAIBuiltinPromptOverride]
+
+        var providersByID: [UUID: RemoteSyncAndroidAIProvider] {
+            Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
+        }
+
+        var configuredModelsByID: [UUID: RemoteSyncAndroidAIConfiguredModel] {
+            Dictionary(uniqueKeysWithValues: configuredModels.map { ($0.id, $0) })
+        }
+
+        var agentPromptsByID: [UUID: RemoteSyncAndroidAIAgentPrompt] {
+            Dictionary(uniqueKeysWithValues: agentPrompts.map { ($0.id, $0) })
+        }
+
+        var globalSettingsByID: [UUID: RemoteSyncAndroidGlobalAISettings] {
+            Dictionary(uniqueKeysWithValues: globalSettings.map { ($0.id, $0) })
+        }
+
+        var usageRecordsByID: [UUID: RemoteSyncAndroidAIUsageRecord] {
+            Dictionary(uniqueKeysWithValues: usageRecords.map { ($0.id, $0) })
+        }
+
+        var promptCategoriesByID: [UUID: RemoteSyncAndroidAIPromptCategory] {
+            Dictionary(uniqueKeysWithValues: promptCategories.map { ($0.id, $0) })
+        }
+
+        var builtinOverridesByID: [UUID: RemoteSyncAndroidAIBuiltinPromptOverride] {
+            Dictionary(uniqueKeysWithValues: builtinOverrides.map { ($0.id, $0) })
+        }
+    }
+
+    /** Sparse or full rows selected for one physical SQLite file. */
+    private struct SelectedRows {
+        var providers: [RemoteSyncAndroidAIProvider] = []
+        var configuredModels: [RemoteSyncAndroidAIConfiguredModel] = []
+        var agentPrompts: [RemoteSyncAndroidAIAgentPrompt] = []
+        var globalSettings: [RemoteSyncAndroidGlobalAISettings] = []
+        var usageRecords: [RemoteSyncAndroidAIUsageRecord] = []
+        var promptCategories: [RemoteSyncAndroidAIPromptCategory] = []
+        var builtinOverrides: [RemoteSyncAndroidAIBuiltinPromptOverride] = []
+    }
+
+    /** UUID decoded from one already validated Android log identity. */
+    private struct LogIdentity {
+        let tableName: String
+        let id: UUID
+    }
+
+    /**
+     Validates complete snapshot invariants before any filesystem mutation begins.
+
+     Logical references (`AgentPrompt.categoryId`, global default model, and usage model) deliberately
+     remain unchecked because Android permits them to dangle. Only physical Room foreign keys are
+     enforced here.
+     */
+    private static func validatedRows(
+        from snapshot: RemoteSyncAISettingsCurrentSnapshot
+    ) throws -> ValidatedRows {
+        let rows = ValidatedRows(
+            providers: Array(snapshot.providerRowsByKey.values),
+            configuredModels: Array(snapshot.configuredModelRowsByKey.values),
+            agentPrompts: Array(snapshot.agentPromptRowsByKey.values),
+            globalSettings: Array(snapshot.globalSettingsRowsByKey.values),
+            usageRecords: Array(snapshot.usageRowsByKey.values),
+            promptCategories: Array(snapshot.promptCategoryRowsByKey.values),
+            builtinOverrides: Array(snapshot.builtinOverrideRowsByKey.values)
+        )
+
+        try requireUniqueIDs(rows.providers, table: "LlmProviderConfig", id: \.id)
+        try requireUniqueIDs(rows.configuredModels, table: "LlmConfiguredModel", id: \.id)
+        try requireUniqueIDs(rows.agentPrompts, table: "AgentPrompt", id: \.id)
+        try requireUniqueIDs(rows.globalSettings, table: "GlobalAiSettings", id: \.id)
+        try requireUniqueIDs(rows.usageRecords, table: "LlmUsageRecord", id: \.id)
+        try requireUniqueIDs(rows.promptCategories, table: "PromptCategory", id: \.id)
+        try requireUniqueIDs(rows.builtinOverrides, table: "BuiltinPromptOverride", id: \.id)
+
+        guard rows.globalSettings.count <= 1 else {
+            throw RemoteSyncAISettingsDatabaseWriterError.duplicateGlobalSettings
+        }
+        if let global = rows.globalSettings.first, global.id != GlobalAISettings.singletonID {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidGlobalSettingsIdentity(global.id)
+        }
+
+        try requireUniqueComposite(
+            rows.configuredModels,
+            table: "LlmConfiguredModel",
+            first: { $0.providerConfigId.uuidString.lowercased() },
+            second: \.modelId
+        )
+        try requireUniqueComposite(
+            rows.usageRecords,
+            table: "LlmUsageRecord",
+            first: { $0.configuredModelId.uuidString.lowercased() },
+            second: \.deviceId
+        )
+
+        let providerIDs = Set(rows.providers.map(\.id))
+        let configuredModelIDs = Set(rows.configuredModels.map(\.id))
+        for row in rows.configuredModels where !providerIDs.contains(row.providerConfigId) {
+            throw RemoteSyncAISettingsDatabaseWriterError.orphanFormalReference(
+                table: "LlmConfiguredModel",
+                id: row.id,
+                parentTable: "LlmProviderConfig",
+                parentID: row.providerConfigId
+            )
+        }
+        for row in rows.agentPrompts {
+            if let parentID = row.configuredModelId, !configuredModelIDs.contains(parentID) {
+                throw RemoteSyncAISettingsDatabaseWriterError.orphanFormalReference(
+                    table: "AgentPrompt",
+                    id: row.id,
+                    parentTable: "LlmConfiguredModel",
+                    parentID: parentID
+                )
+            }
+        }
+        for row in rows.builtinOverrides {
+            if let parentID = row.configuredModelId, !configuredModelIDs.contains(parentID) {
+                throw RemoteSyncAISettingsDatabaseWriterError.orphanFormalReference(
+                    table: "BuiltinPromptOverride",
+                    id: row.id,
+                    parentTable: "LlmConfiguredModel",
+                    parentID: parentID
+                )
+            }
+        }
+        for row in rows.configuredModels where !row.inputPricePerMillion.isFinite
+            || !row.outputPricePerMillion.isFinite
+            || !row.cacheCreationPricePerMillion.isFinite
+            || !row.cacheReadPricePerMillion.isFinite {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidFloatingPointValue(
+                table: "LlmConfiguredModel",
+                id: row.id
+            )
+        }
+        for row in rows.usageRecords where !row.estimatedCostUsd.isFinite {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidFloatingPointValue(
+                table: "LlmUsageRecord",
+                id: row.id
+            )
+        }
+        return rows
+    }
+
+    /** Validates log table membership, UUID storage, empty secondary identity, and uniqueness. */
+    private static func validatedLogIdentities(
+        _ entries: [RemoteSyncLogEntry]
+    ) throws -> [LogIdentity] {
+        var seen: Set<String> = []
+        var result: [LogIdentity] = []
+        for entry in entries {
+            guard synchronizedTables.contains(entry.tableName) else {
+                throw RemoteSyncAISettingsDatabaseWriterError.unsupportedLogTable(entry.tableName)
+            }
+            guard entry.entityID1.kind == .blob,
+                  let data = entry.entityID1.blobData,
+                  let id = RemoteSyncAISettingsSnapshotService.uuid(from: data),
+                  entry.entityID2.kind == .text,
+                  entry.entityID2.textValue == "" else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidLogIdentity(table: entry.tableName)
+            }
+            if entry.tableName == "GlobalAiSettings", id != GlobalAISettings.singletonID {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidGlobalSettingsIdentity(id)
+            }
+            let key = "\(entry.tableName)\u{0}\(id.uuidString.lowercased())"
+            guard seen.insert(key).inserted else {
+                throw RemoteSyncAISettingsDatabaseWriterError.duplicateLogIdentity(
+                    table: entry.tableName,
+                    id: id
+                )
+            }
+            result.append(LogIdentity(tableName: entry.tableName, id: id))
+        }
+        return result
+    }
+
+    /** Builds a deterministic full set or resolves sparse UPSERT operations against current rows. */
+    private static func selectedRows(
+        from rows: ValidatedRows,
+        logEntries: [RemoteSyncLogEntry],
+        identities: [LogIdentity],
+        mode: RemoteSyncAISettingsDatabaseWriteMode
+    ) throws -> SelectedRows {
+        switch mode {
+        case .full:
+            for (entry, identity) in zip(logEntries, identities) {
+                let rowIsPresent = containsRow(identity, in: rows)
+                if entry.type == .upsert, !rowIsPresent {
+                    throw missingUpsert(identity)
+                }
+                if entry.type == .delete, rowIsPresent {
+                    throw RemoteSyncAISettingsDatabaseWriterError.inconsistentDeleteRow(
+                        table: identity.tableName,
+                        id: identity.id
+                    )
+                }
+            }
+            return SelectedRows(
+                providers: rows.providers.sorted(by: providerSort),
+                configuredModels: rows.configuredModels.sorted(by: configuredModelSort),
+                agentPrompts: rows.agentPrompts.sorted(by: promptSort),
+                globalSettings: rows.globalSettings,
+                usageRecords: rows.usageRecords.sorted(by: usageSort),
+                promptCategories: rows.promptCategories.sorted(by: categorySort),
+                builtinOverrides: rows.builtinOverrides.sorted { $0.id.uuidString < $1.id.uuidString }
+            )
+        case .sparse:
+            var selected = SelectedRows()
+            for (entry, identity) in zip(logEntries, identities) where entry.type == .upsert {
+                switch identity.tableName {
+                case "LlmProviderConfig":
+                    if let row = rows.providersByID[identity.id] { selected.providers.append(row) }
+                case "LlmConfiguredModel":
+                    if let row = rows.configuredModelsByID[identity.id] {
+                        selected.configuredModels.append(row)
+                    }
+                case "AgentPrompt":
+                    if let row = rows.agentPromptsByID[identity.id] { selected.agentPrompts.append(row) }
+                case "GlobalAiSettings":
+                    if let row = rows.globalSettingsByID[identity.id] {
+                        selected.globalSettings.append(row)
+                    }
+                case "LlmUsageRecord":
+                    if let row = rows.usageRecordsByID[identity.id] {
+                        selected.usageRecords.append(row)
+                    }
+                case "PromptCategory":
+                    if let row = rows.promptCategoriesByID[identity.id] {
+                        selected.promptCategories.append(row)
+                    }
+                case "BuiltinPromptOverride":
+                    if let row = rows.builtinOverridesByID[identity.id] {
+                        selected.builtinOverrides.append(row)
+                    }
+                default:
+                    throw RemoteSyncAISettingsDatabaseWriterError.unsupportedLogTable(identity.tableName)
+                }
+            }
+            selected.providers.sort(by: providerSort)
+            selected.configuredModels.sort(by: configuredModelSort)
+            selected.agentPrompts.sort(by: promptSort)
+            selected.usageRecords.sort(by: usageSort)
+            selected.promptCategories.sort(by: categorySort)
+            selected.builtinOverrides.sort { $0.id.uuidString < $1.id.uuidString }
+            return selected
+        }
+    }
+
+    /** Returns whether one validated complete source generation contains a selected identity. */
+    private static func containsRow(_ identity: LogIdentity, in rows: ValidatedRows) -> Bool {
+        switch identity.tableName {
+        case "LlmProviderConfig": rows.providersByID[identity.id] != nil
+        case "LlmConfiguredModel": rows.configuredModelsByID[identity.id] != nil
+        case "AgentPrompt": rows.agentPromptsByID[identity.id] != nil
+        case "GlobalAiSettings": rows.globalSettingsByID[identity.id] != nil
+        case "LlmUsageRecord": rows.usageRecordsByID[identity.id] != nil
+        case "PromptCategory": rows.promptCategoriesByID[identity.id] != nil
+        case "BuiltinPromptOverride": rows.builtinOverridesByID[identity.id] != nil
+        default: false
+        }
+    }
+
+    /** Constructs the typed error used when a sparse UPSERT has no corresponding content row. */
+    private static func missingUpsert(
+        _ identity: LogIdentity
+    ) -> RemoteSyncAISettingsDatabaseWriterError {
+        .missingUpsertRow(table: identity.tableName, id: identity.id)
+    }
+
+    /** Rejects repeated primary UUIDs without using a trapping dictionary initializer. */
+    private static func requireUniqueIDs<Row>(
+        _ rows: [Row],
+        table: String,
+        id: (Row) -> UUID
+    ) throws {
+        var seen: Set<UUID> = []
+        for row in rows {
+            let value = id(row)
+            guard seen.insert(value).inserted else {
+                throw RemoteSyncAISettingsDatabaseWriterError.duplicateIdentifier(table: table, id: value)
+            }
+        }
+    }
+
+    /** Rejects repeated Android unique-index pairs before SQLite insertion. */
+    private static func requireUniqueComposite<Row>(
+        _ rows: [Row],
+        table: String,
+        first: (Row) -> String,
+        second: (Row) -> String
+    ) throws {
+        var seen: Set<String> = []
+        for row in rows {
+            let firstValue = first(row)
+            let secondValue = second(row)
+            let key = "\(firstValue.utf8.count):\(firstValue)\(secondValue.utf8.count):\(secondValue)"
+            guard seen.insert(key).inserted else {
+                throw RemoteSyncAISettingsDatabaseWriterError.duplicateCompositeIdentity(
+                    table: table,
+                    first: firstValue,
+                    second: secondValue
+                )
+            }
+        }
+    }
+
+    /** Creates and validates a committed sibling SQLite file without exposing it at the destination. */
+    private func writeStagedDatabase(
+        at url: URL,
+        rows: SelectedRows,
+        logEntries: [RemoteSyncLogEntry]
+    ) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(
+            url.path,
+            &database,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_EXCLUSIVE,
+            nil
+        ) == SQLITE_OK, let database else {
+            if let database { sqlite3_close(database) }
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+        sqlite3_extended_result_codes(database, 1)
+
+        do {
+            try execute("BEGIN IMMEDIATE TRANSACTION;", in: database)
+            try execute(
+                RemoteSyncAndroidDatabaseContract.createSchemaSQL(for: .aiSettings),
+                in: database
+            )
+            for row in rows.providers { try insertProvider(row, in: database) }
+            for row in rows.configuredModels { try insertConfiguredModel(row, in: database) }
+            for row in rows.agentPrompts { try insertAgentPrompt(row, in: database) }
+            for row in rows.globalSettings { try insertGlobalSettings(row, in: database) }
+            for row in rows.usageRecords { try insertUsageRecord(row, in: database) }
+            for row in rows.promptCategories { try insertPromptCategory(row, in: database) }
+            for row in rows.builtinOverrides { try insertBuiltinOverride(row, in: database) }
+            for entry in logEntries { try insertLogEntry(entry, in: database) }
+
+            try rejectAnyRawLogRows(in: database)
+            try RemoteSyncAndroidDatabaseContract.validateInboundDatabase(database, category: .aiSettings)
+            try execute("COMMIT;", in: database)
+        } catch {
+            try? execute("ROLLBACK;", in: database)
+            sqlite3_close(database)
+            throw error
+        }
+
+        guard sqlite3_close(database) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Atomically adopts the closed staging file while preserving an existing destination on failure. */
+    private func publish(stagingURL: URL, destinationURL: URL) throws {
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            _ = try fileManager.replaceItemAt(destinationURL, withItemAt: stagingURL)
+        } else {
+            try fileManager.moveItem(at: stagingURL, to: destinationURL)
+        }
+    }
+
+    /** Inserts one exact Android `LlmProviderConfig` row without any credential field. */
+    private func insertProvider(_ row: RemoteSyncAndroidAIProvider, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO LlmProviderConfig (id, providerType, displayName, endpoint, apiFormat, orderNumber) VALUES (?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindText(row.providerType, to: statement, index: 2)
+        try bindText(row.displayName, to: statement, index: 3)
+        try bindOptionalText(row.endpoint, to: statement, index: 4)
+        try bindOptionalText(row.apiFormat, to: statement, index: 5)
+        try bindInt32(row.orderNumber, field: "LlmProviderConfig.orderNumber", to: statement, index: 6)
+        try stepDone(statement)
+    }
+
+    /** Inserts one exact Android `LlmConfiguredModel` row. */
+    private func insertConfiguredModel(
+        _ row: RemoteSyncAndroidAIConfiguredModel,
+        in database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            "INSERT INTO LlmConfiguredModel (id, providerConfigId, modelId, orderNumber, inputPricePerMillion, outputPricePerMillion, cacheCreationPricePerMillion, cacheReadPricePerMillion) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindUUID(row.providerConfigId, to: statement, index: 2)
+        try bindText(row.modelId, to: statement, index: 3)
+        try bindInt32(row.orderNumber, field: "LlmConfiguredModel.orderNumber", to: statement, index: 4)
+        try bindDouble(row.inputPricePerMillion, to: statement, index: 5)
+        try bindDouble(row.outputPricePerMillion, to: statement, index: 6)
+        try bindDouble(row.cacheCreationPricePerMillion, to: statement, index: 7)
+        try bindDouble(row.cacheReadPricePerMillion, to: statement, index: 8)
+        try stepDone(statement)
+    }
+
+    /** Inserts one exact Android `AgentPrompt` row while preserving raw converter strings. */
+    private func insertAgentPrompt(_ row: RemoteSyncAndroidAIAgentPrompt, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO AgentPrompt (id, name, description, promptTemplate, showIn, orderNumber, createdAt, strictContextMatching, permissionMode, allowedTools, deniedTools, configuredModelId, editBeforeRun, noDocumentCreation, maxIterations, autoIncludeDocuments, autoIncludeCommentaries, bibleOnly, isTextTransformation, categoryId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindText(row.name, to: statement, index: 2)
+        try bindOptionalText(row.promptDescription, to: statement, index: 3)
+        try bindText(row.promptTemplate, to: statement, index: 4)
+        try bindText(row.showIn, to: statement, index: 5)
+        try bindInt32(row.orderNumber, field: "AgentPrompt.orderNumber", to: statement, index: 6)
+        try bindInt64(row.createdAt, to: statement, index: 7)
+        try bindBool(row.strictContextMatching, to: statement, index: 8)
+        try bindOptionalText(row.permissionMode, to: statement, index: 9)
+        try bindOptionalText(row.allowedTools, to: statement, index: 10)
+        try bindOptionalText(row.deniedTools, to: statement, index: 11)
+        try bindOptionalUUID(row.configuredModelId, to: statement, index: 12)
+        try bindBool(row.editBeforeRun, to: statement, index: 13)
+        try bindBool(row.noDocumentCreation, to: statement, index: 14)
+        try bindOptionalInt32(row.maxIterations, field: "AgentPrompt.maxIterations", to: statement, index: 15)
+        try bindBool(row.autoIncludeDocuments, to: statement, index: 16)
+        try bindBool(row.autoIncludeCommentaries, to: statement, index: 17)
+        try bindBool(row.bibleOnly, to: statement, index: 18)
+        try bindBool(row.isTextTransformation, to: statement, index: 19)
+        try bindOptionalUUID(row.categoryId, to: statement, index: 20)
+        try stepDone(statement)
+    }
+
+    /** Inserts Android's exact `GlobalAiSettings` singleton row. */
+    private func insertGlobalSettings(
+        _ row: RemoteSyncAndroidGlobalAISettings,
+        in database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            "INSERT INTO GlobalAiSettings (id, agentPermissionMode, permanentlyAllowedTools, permanentlyDeniedTools, aiExcludedDocuments, commentaryMaxResponseTokens, hiddenBuiltInPrompts, maxIterations, commentaryDeselected, defaultModelId, aiLanguage, askModelBeforeRun, aiDisclaimerAccepted, hiddenBuiltInCategories, customAgentSystemPrompt, customTextTransformationSystemPrompt, favoritePrompts, rawLogRetentionDays, autoHideAgentLogOnCompletion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindOptionalText(row.agentPermissionMode, to: statement, index: 2)
+        try bindOptionalText(row.permanentlyAllowedTools, to: statement, index: 3)
+        try bindOptionalText(row.permanentlyDeniedTools, to: statement, index: 4)
+        try bindText(row.aiExcludedDocuments, to: statement, index: 5)
+        try bindInt32(row.commentaryMaxResponseTokens, field: "GlobalAiSettings.commentaryMaxResponseTokens", to: statement, index: 6)
+        try bindText(row.hiddenBuiltInPrompts, to: statement, index: 7)
+        try bindInt32(row.maxIterations, field: "GlobalAiSettings.maxIterations", to: statement, index: 8)
+        try bindText(row.commentaryDeselected, to: statement, index: 9)
+        try bindOptionalUUID(row.defaultModelId, to: statement, index: 10)
+        try bindOptionalText(row.aiLanguage, to: statement, index: 11)
+        try bindBool(row.askModelBeforeRun, to: statement, index: 12)
+        try bindBool(row.aiDisclaimerAccepted, to: statement, index: 13)
+        try bindText(row.hiddenBuiltInCategories, to: statement, index: 14)
+        try bindOptionalText(row.customAgentSystemPrompt, to: statement, index: 15)
+        try bindOptionalText(row.customTextTransformationSystemPrompt, to: statement, index: 16)
+        try bindText(row.favoritePrompts, to: statement, index: 17)
+        try bindOptionalInt32(row.rawLogRetentionDays, field: "GlobalAiSettings.rawLogRetentionDays", to: statement, index: 18)
+        try bindBool(row.autoHideAgentLogOnCompletion, to: statement, index: 19)
+        try stepDone(statement)
+    }
+
+    /** Inserts one exact Android `LlmUsageRecord` row. */
+    private func insertUsageRecord(_ row: RemoteSyncAndroidAIUsageRecord, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO LlmUsageRecord (id, configuredModelId, deviceId, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, estimatedCostUsd) VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindUUID(row.configuredModelId, to: statement, index: 2)
+        try bindText(row.deviceId, to: statement, index: 3)
+        try bindInt64(row.inputTokens, to: statement, index: 4)
+        try bindInt64(row.outputTokens, to: statement, index: 5)
+        try bindInt64(row.cacheCreationTokens, to: statement, index: 6)
+        try bindInt64(row.cacheReadTokens, to: statement, index: 7)
+        try bindDouble(row.estimatedCostUsd, to: statement, index: 8)
+        try stepDone(statement)
+    }
+
+    /** Inserts one exact Android `PromptCategory` row. */
+    private func insertPromptCategory(
+        _ row: RemoteSyncAndroidAIPromptCategory,
+        in database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            "INSERT INTO PromptCategory (id, name, orderNumber, hidden) VALUES (?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindText(row.name, to: statement, index: 2)
+        try bindInt32(row.orderNumber, field: "PromptCategory.orderNumber", to: statement, index: 3)
+        try bindBool(row.hidden, to: statement, index: 4)
+        try stepDone(statement)
+    }
+
+    /** Inserts one exact Android `BuiltinPromptOverride` row. */
+    private func insertBuiltinOverride(
+        _ row: RemoteSyncAndroidAIBuiltinPromptOverride,
+        in database: OpaquePointer
+    ) throws {
+        let statement = try prepare(
+            "INSERT INTO BuiltinPromptOverride (id, configuredModelId) VALUES (?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindUUID(row.id, to: statement, index: 1)
+        try bindOptionalUUID(row.configuredModelId, to: statement, index: 2)
+        try stepDone(statement)
+    }
+
+    /** Inserts one validated Android conflict or tombstone row. */
+    private func insertLogEntry(_ entry: RemoteSyncLogEntry, in database: OpaquePointer) throws {
+        let statement = try prepare(
+            "INSERT INTO LogEntry (tableName, entityId1, entityId2, type, lastUpdated, sourceDevice) VALUES (?, ?, ?, ?, ?, ?);",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        try bindText(entry.tableName, to: statement, index: 1)
+        try bindSQLiteValue(entry.entityID1, to: statement, index: 2)
+        try bindSQLiteValue(entry.entityID2, to: statement, index: 3)
+        try bindText(entry.type.rawValue, to: statement, index: 4)
+        try bindInt64(entry.lastUpdated, to: statement, index: 5)
+        try bindText(entry.sourceDevice, to: statement, index: 6)
+        try stepDone(statement)
+    }
+
+    /** Ensures no device-local raw model log entered the publication through schema-side mutation. */
+    private func rejectAnyRawLogRows(in database: OpaquePointer) throws {
+        let statement = try prepare("SELECT 1 FROM LlmRawLogRecord LIMIT 1;", in: database)
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Prepares one SQLite statement or reports a fail-closed database error. */
+    private func prepare(_ sql: String, in database: OpaquePointer) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+        return statement
+    }
+
+    /** Executes one SQLite statement batch and rejects any non-success status. */
+    private func execute(_ sql: String, in database: OpaquePointer) throws {
+        guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Requires one prepared insert to finish exactly once. */
+    private func stepDone(_ statement: OpaquePointer?) throws {
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds one UUID using Android Room's raw 16-byte BLOB representation. */
+    private func bindUUID(_ value: UUID, to statement: OpaquePointer?, index: Int32) throws {
+        let data = RemoteSyncAISettingsSnapshotService.uuidBlob(value)
+        let result = data.withUnsafeBytes {
+            sqlite3_bind_blob(statement, index, $0.baseAddress, 16, remoteSyncAISettingsWriterSQLiteTransient)
+        }
+        guard result == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds a nullable UUID without converting it to text. */
+    private func bindOptionalUUID(_ value: UUID?, to statement: OpaquePointer?, index: Int32) throws {
+        guard let value else {
+            guard sqlite3_bind_null(statement, index) == SQLITE_OK else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            return
+        }
+        try bindUUID(value, to: statement, index: index)
+    }
+
+    /** Binds UTF-8 text with an explicit length so embedded NUL bytes round-trip verbatim. */
+    private func bindText(_ value: String, to statement: OpaquePointer?, index: Int32) throws {
+        let bytes = value.utf8CString
+        let length = try RemoteSyncWireInteger.int32(exactly: bytes.count - 1, field: "SQLite.textByteCount")
+        let result = bytes.withUnsafeBufferPointer {
+            sqlite3_bind_text(
+                statement,
+                index,
+                $0.baseAddress,
+                length,
+                remoteSyncAISettingsWriterSQLiteTransient
+            )
+        }
+        guard result == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds nullable UTF-8 text while preserving nil versus empty. */
+    private func bindOptionalText(_ value: String?, to statement: OpaquePointer?, index: Int32) throws {
+        guard let value else {
+            guard sqlite3_bind_null(statement, index) == SQLITE_OK else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            return
+        }
+        try bindText(value, to: statement, index: index)
+    }
+
+    /** Binds an Android Kotlin `Int` after exact signed-32-bit validation. */
+    private func bindInt32(
+        _ value: Int,
+        field: String,
+        to statement: OpaquePointer?,
+        index: Int32
+    ) throws {
+        let wireValue = try RemoteSyncWireInteger.int32(exactly: value, field: field)
+        guard sqlite3_bind_int(statement, index, wireValue) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds a nullable Android Kotlin `Int` after exact signed-32-bit validation. */
+    private func bindOptionalInt32(
+        _ value: Int?,
+        field: String,
+        to statement: OpaquePointer?,
+        index: Int32
+    ) throws {
+        guard let value else {
+            guard sqlite3_bind_null(statement, index) == SQLITE_OK else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            return
+        }
+        try bindInt32(value, field: field, to: statement, index: index)
+    }
+
+    /** Binds one Android Kotlin `Long` without narrowing. */
+    private func bindInt64(_ value: Int64, to statement: OpaquePointer?, index: Int32) throws {
+        guard sqlite3_bind_int64(statement, index, value) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds one finite Android REAL value. */
+    private func bindDouble(_ value: Double, to statement: OpaquePointer?, index: Int32) throws {
+        guard value.isFinite, sqlite3_bind_double(statement, index, value) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds one Boolean as Android's exact INTEGER 0 or 1 representation. */
+    private func bindBool(_ value: Bool, to statement: OpaquePointer?, index: Int32) throws {
+        guard sqlite3_bind_int(statement, index, value ? 1 : 0) == SQLITE_OK else {
+            throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+        }
+    }
+
+    /** Binds one typed Android sync identity without normalizing its SQLite storage class. */
+    private func bindSQLiteValue(
+        _ value: RemoteSyncSQLiteValue,
+        to statement: OpaquePointer?,
+        index: Int32
+    ) throws {
+        switch value.kind {
+        case .null:
+            guard sqlite3_bind_null(statement, index) == SQLITE_OK else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+        case .integer:
+            guard let payload = value.integerValue else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            try bindInt64(payload, to: statement, index: index)
+        case .real:
+            guard let payload = value.realValue, payload.isFinite else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            try bindDouble(payload, to: statement, index: index)
+        case .text:
+            guard let payload = value.textValue else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            try bindText(payload, to: statement, index: index)
+        case .blob:
+            guard let payload = value.blobData else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+            let length = try RemoteSyncWireInteger.int32(
+                exactly: payload.count,
+                field: "LogEntry.identityByteCount"
+            )
+            let result = payload.withUnsafeBytes {
+                sqlite3_bind_blob(
+                    statement,
+                    index,
+                    $0.baseAddress,
+                    length,
+                    remoteSyncAISettingsWriterSQLiteTransient
+                )
+            }
+            guard result == SQLITE_OK else {
+                throw RemoteSyncAISettingsDatabaseWriterError.invalidSQLiteDatabase
+            }
+        }
+    }
+
+    private static func providerSort(
+        _ lhs: RemoteSyncAndroidAIProvider,
+        _ rhs: RemoteSyncAndroidAIProvider
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func configuredModelSort(
+        _ lhs: RemoteSyncAndroidAIConfiguredModel,
+        _ rhs: RemoteSyncAndroidAIConfiguredModel
+    ) -> Bool {
+        if lhs.providerConfigId != rhs.providerConfigId {
+            return lhs.providerConfigId.uuidString < rhs.providerConfigId.uuidString
+        }
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.modelId != rhs.modelId { return lhs.modelId < rhs.modelId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func promptSort(
+        _ lhs: RemoteSyncAndroidAIAgentPrompt,
+        _ rhs: RemoteSyncAndroidAIAgentPrompt
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func usageSort(
+        _ lhs: RemoteSyncAndroidAIUsageRecord,
+        _ rhs: RemoteSyncAndroidAIUsageRecord
+    ) -> Bool {
+        if lhs.configuredModelId != rhs.configuredModelId {
+            return lhs.configuredModelId.uuidString < rhs.configuredModelId.uuidString
+        }
+        if lhs.deviceId != rhs.deviceId { return lhs.deviceId < rhs.deviceId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func categorySort(
+        _ lhs: RemoteSyncAndroidAIPromptCategory,
+        _ rhs: RemoteSyncAndroidAIPromptCategory
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.name != rhs.name { return lhs.name < rhs.name }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchApplyService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchApplyService.swift
@@ -1,0 +1,944 @@
+// RemoteSyncAISettingsPatchApplyService.swift -- Incremental Android AI settings patch replay
+
+import Foundation
+import SwiftData
+
+/**
+ Errors raised while replaying Android AI settings patch archives against the local SwiftData graph.
+ */
+public enum RemoteSyncAISettingsPatchApplyError: Error, Equatable {
+    /// One Android `LogEntry` identifier could not be converted into the expected UUID row key.
+    case invalidLogEntryIdentifier(table: String, field: String)
+}
+
+/**
+ Summary of one successful Android AI settings patch replay batch.
+
+ The final row counts describe the normalized seven-table graph after Android-compatible formal
+ foreign-key cleanup. Accepted log entries remain counted even when cleanup prunes their rows.
+ */
+public struct RemoteSyncAISettingsPatchApplyReport: Sendable, Equatable {
+    /// Number of archives evaluated and recorded in patch status, including all-skipped archives.
+    public let appliedPatchCount: Int
+
+    /// Number of newer remote log entries accepted, including entries whose rows were later pruned.
+    public let appliedLogEntryCount: Int
+
+    /// Number of remote log entries skipped because local metadata was newer or equal.
+    public let skippedLogEntryCount: Int
+
+    /// Number of provider rows remaining after replay normalization.
+    public let providerCount: Int
+
+    /// Number of configured-model rows remaining after replay normalization.
+    public let configuredModelCount: Int
+
+    /// Number of agent-prompt rows remaining after replay normalization.
+    public let agentPromptCount: Int
+
+    /// Number of global-settings rows remaining after replay normalization.
+    public let globalSettingsCount: Int
+
+    /// Number of usage rows remaining after replay normalization.
+    public let usageRecordCount: Int
+
+    /// Number of prompt-category rows remaining after replay normalization.
+    public let promptCategoryCount: Int
+
+    /// Number of built-in prompt override rows remaining after replay normalization.
+    public let builtinOverrideCount: Int
+
+    /**
+     Creates one successful replay report from patch and final-row counts.
+
+     - Parameters:
+       - appliedPatchCount: Number of archives fully evaluated and recorded in patch status.
+       - appliedLogEntryCount: Number of strictly newer remote operations accepted.
+       - skippedLogEntryCount: Number of older or equal remote operations ignored.
+       - providerCount: Final provider-row count.
+       - configuredModelCount: Final configured-model-row count.
+       - agentPromptCount: Final agent-prompt-row count.
+       - globalSettingsCount: Final global-settings-row count.
+       - usageRecordCount: Final usage-row count.
+       - promptCategoryCount: Final prompt-category-row count.
+       - builtinOverrideCount: Final built-in override-row count.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        appliedPatchCount: Int,
+        appliedLogEntryCount: Int,
+        skippedLogEntryCount: Int,
+        providerCount: Int,
+        configuredModelCount: Int,
+        agentPromptCount: Int,
+        globalSettingsCount: Int,
+        usageRecordCount: Int,
+        promptCategoryCount: Int,
+        builtinOverrideCount: Int
+    ) {
+        self.appliedPatchCount = appliedPatchCount
+        self.appliedLogEntryCount = appliedLogEntryCount
+        self.skippedLogEntryCount = skippedLogEntryCount
+        self.providerCount = providerCount
+        self.configuredModelCount = configuredModelCount
+        self.agentPromptCount = agentPromptCount
+        self.globalSettingsCount = globalSettingsCount
+        self.usageRecordCount = usageRecordCount
+        self.promptCategoryCount = promptCategoryCount
+        self.builtinOverrideCount = builtinOverrideCount
+    }
+}
+
+/**
+ Replays Android `AI_SETTINGS` patch archives into the seven synchronized SwiftData tables.
+
+ Android evaluates sparse SQLite patches in table order and accepts a mutation only when its
+ `lastUpdated` value is strictly greater than the local `LogEntry` watermark. This service mirrors
+ that contract across an entire downloaded batch before publishing any mutation:
+
+ - current SwiftData rows and strict local metadata seed an in-memory working state
+ - archives are decompressed under the same per-file and cumulative bounds as other categories
+ - accepted upserts and deletes replay in Android's seven-table order
+ - formal foreign-key violations are pruned while logical dangling references remain intact
+ - accepted metadata survives cleanup even when a newly accepted row is pruned
+ - graph rows, log metadata, patch statuses, and fingerprints publish in one atomic transaction
+
+ `LlmRawLogRecord` is not synchronized: inbound rows are bounded and counted, while local rows are
+ never mutated or published. Provider credentials are structurally absent from every row type used
+ by this service and remain in the device-local credential store.
+
+ Data dependencies:
+ - `RemoteSyncInitialBackupMetadataRestoreService` reads staged `LogEntry` metadata
+ - `RemoteSyncAISettingsRestoreService` reads patch rows and stages the final graph replacement
+ - `RemoteSyncAISettingsSnapshotService` projects current rows and refreshes accepted fingerprints
+ - `RemoteSyncLogEntryStore` and `RemoteSyncPatchStatusStore` preserve sync bookkeeping
+
+ Side effects:
+ - reads gzip archives and creates short-lived extracted SQLite files
+ - reads the local seven-table AI settings graph and settings-backed sync metadata
+ - atomically replaces synchronized AI rows when at least one remote operation is accepted
+ - atomically replaces category log metadata, appends patch statuses, and refreshes fingerprints
+
+ Failure modes:
+ - rethrows bounded decompression, SQLite decoding, SwiftData fetch, validation, and commit errors
+ - throws `RemoteSyncAISettingsPatchApplyError` for malformed UUID identities
+ - rethrows cancellation before publication, between archives, and at the final durable checkpoint
+ - atomic publication rolls SwiftData and settings metadata back together on failure
+
+ Concurrency:
+ - this type is not `Sendable`; callers must use the execution context owning `ModelContext` and
+   `SettingsStore`
+ */
+public final class RemoteSyncAISettingsPatchApplyService {
+    /**
+     Mutable Android-shaped graph used to evaluate a complete patch batch before publication.
+
+     Every dictionary is keyed by the sole UUID primary key used by its Android table. Logical
+     references deliberately remain scalar UUIDs rather than being resolved into SwiftData links.
+     */
+    private struct WorkingSnapshot {
+        var providersByID: [UUID: RemoteSyncAndroidAIProvider]
+        var configuredModelsByID: [UUID: RemoteSyncAndroidAIConfiguredModel]
+        var agentPromptsByID: [UUID: RemoteSyncAndroidAIAgentPrompt]
+        var globalSettingsByID: [UUID: RemoteSyncAndroidGlobalAISettings]
+        var usageRecordsByID: [UUID: RemoteSyncAndroidAIUsageRecord]
+        var promptCategoriesByID: [UUID: RemoteSyncAndroidAIPromptCategory]
+        var builtinOverridesByID: [UUID: RemoteSyncAndroidAIBuiltinPromptOverride]
+
+        /**
+         Upserts one configured model with Android's unique-index replacement behavior.
+
+         Android declares `(providerConfigId, modelId)` unique and replays patch rows with
+         `ON CONFLICT DO UPDATE`. When another row already occupies that composite key, SQLite keeps
+         the existing primary UUID and updates its non-identity columns from the incoming row.
+
+         - Parameter row: Accepted configured-model row to insert or replace.
+         - Side effects: Mutates the configured-model dictionary.
+         - Failure modes: This helper cannot fail.
+         */
+        mutating func upsertConfiguredModel(_ row: RemoteSyncAndroidAIConfiguredModel) {
+            if let conflictingRow = configuredModelsByID.values.first(where: {
+                $0.providerConfigId == row.providerConfigId && $0.modelId == row.modelId
+            }) {
+                configuredModelsByID[conflictingRow.id] = RemoteSyncAndroidAIConfiguredModel(
+                    id: conflictingRow.id,
+                    providerConfigId: row.providerConfigId,
+                    modelId: row.modelId,
+                    orderNumber: row.orderNumber,
+                    inputPricePerMillion: row.inputPricePerMillion,
+                    outputPricePerMillion: row.outputPricePerMillion,
+                    cacheCreationPricePerMillion: row.cacheCreationPricePerMillion,
+                    cacheReadPricePerMillion: row.cacheReadPricePerMillion
+                )
+                return
+            }
+            configuredModelsByID[row.id] = row
+        }
+
+        /**
+         Upserts one usage row with Android's unique-index replacement behavior.
+
+         Android declares `(configuredModelId, deviceId)` unique. SQLite's conflict update preserves
+         the existing primary UUID while replacing its cumulative counters and estimated cost.
+
+         - Parameter row: Accepted usage record to insert or replace.
+         - Side effects: Mutates the usage-record dictionary.
+         - Failure modes: This helper cannot fail.
+         */
+        mutating func upsertUsageRecord(_ row: RemoteSyncAndroidAIUsageRecord) {
+            if let conflictingRow = usageRecordsByID.values.first(where: {
+                $0.configuredModelId == row.configuredModelId && $0.deviceId == row.deviceId
+            }) {
+                usageRecordsByID[conflictingRow.id] = RemoteSyncAndroidAIUsageRecord(
+                    id: conflictingRow.id,
+                    configuredModelId: row.configuredModelId,
+                    deviceId: row.deviceId,
+                    inputTokens: row.inputTokens,
+                    outputTokens: row.outputTokens,
+                    cacheCreationTokens: row.cacheCreationTokens,
+                    cacheReadTokens: row.cacheReadTokens,
+                    estimatedCostUsd: row.estimatedCostUsd
+                )
+                return
+            }
+            usageRecordsByID[row.id] = row
+        }
+
+        /**
+         Removes rows in one table that violate Android's declared AI settings foreign keys.
+
+         Android applies patches with foreign keys disabled and then deletes rows reported by
+         `pragma_foreign_key_check`. The equivalent graph rules are:
+
+         - configured models require an existing provider
+         - prompts with a configured model require that model
+         - built-in overrides with a configured model require that model
+
+         `AgentPrompt.categoryId`, `GlobalAiSettings.defaultModelId`, and
+         `LlmUsageRecord.configuredModelId` are logical references in Android's schema and therefore
+         remain unchanged when their target is absent.
+
+         - Parameter tableName: Table currently at Android's post-upsert FK-check phase.
+         - Side effects: Mutates only the named table's dictionary when it owns a formal foreign key.
+         - Failure modes: This helper cannot fail.
+         - Note: Accepted `LogEntry` metadata is stored separately and is never removed here.
+         */
+        mutating func pruneFormalForeignKeyViolations(in tableName: String) {
+            switch tableName {
+            case "LlmConfiguredModel":
+                let validProviderIDs = Set(providersByID.keys)
+                configuredModelsByID = configuredModelsByID.filter { _, row in
+                    validProviderIDs.contains(row.providerConfigId)
+                }
+            case "AgentPrompt":
+                let validConfiguredModelIDs = Set(configuredModelsByID.keys)
+                agentPromptsByID = agentPromptsByID.filter { _, row in
+                    guard let configuredModelID = row.configuredModelId else {
+                        return true
+                    }
+                    return validConfiguredModelIDs.contains(configuredModelID)
+                }
+            case "BuiltinPromptOverride":
+                let validConfiguredModelIDs = Set(configuredModelsByID.keys)
+                builtinOverridesByID = builtinOverridesByID.filter { _, row in
+                    guard let configuredModelID = row.configuredModelId else {
+                        return true
+                    }
+                    return validConfiguredModelIDs.contains(configuredModelID)
+                }
+            default:
+                break
+            }
+        }
+
+        /**
+         Converts mutable dictionaries into the deterministic snapshot accepted by the restore path.
+
+         - Returns: Seven-table Android-shaped snapshot with no formal foreign-key violations.
+         - Side effects: none.
+         - Failure modes: This helper cannot fail.
+         */
+        func materializedSnapshot() -> RemoteSyncAndroidAISettingsSnapshot {
+            RemoteSyncAndroidAISettingsSnapshot(
+                providers: providersByID.values.sorted(by: Self.providerSort),
+                configuredModels: configuredModelsByID.values.sorted(by: Self.configuredModelSort),
+                agentPrompts: agentPromptsByID.values.sorted(by: Self.agentPromptSort),
+                globalSettings: globalSettingsByID.values.sorted(by: Self.globalSettingsSort),
+                usageRecords: usageRecordsByID.values.sorted(by: Self.usageRecordSort),
+                promptCategories: promptCategoriesByID.values.sorted(by: Self.promptCategorySort),
+                builtinOverrides: builtinOverridesByID.values.sorted(by: Self.builtinOverrideSort)
+            )
+        }
+
+        /** Orders provider rows deterministically without changing Android's primary order. */
+        private static func providerSort(
+            _ lhs: RemoteSyncAndroidAIProvider,
+            _ rhs: RemoteSyncAndroidAIProvider
+        ) -> Bool {
+            if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+            if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders configured models deterministically by provider, configured order, and identity. */
+        private static func configuredModelSort(
+            _ lhs: RemoteSyncAndroidAIConfiguredModel,
+            _ rhs: RemoteSyncAndroidAIConfiguredModel
+        ) -> Bool {
+            if lhs.providerConfigId != rhs.providerConfigId {
+                return lhs.providerConfigId.uuidString < rhs.providerConfigId.uuidString
+            }
+            if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+            if lhs.modelId != rhs.modelId { return lhs.modelId < rhs.modelId }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders agent prompts deterministically by configured order, creation time, and identity. */
+        private static func agentPromptSort(
+            _ lhs: RemoteSyncAndroidAIAgentPrompt,
+            _ rhs: RemoteSyncAndroidAIAgentPrompt
+        ) -> Bool {
+            if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders the singleton global-settings table by identity for deterministic materialization. */
+        private static func globalSettingsSort(
+            _ lhs: RemoteSyncAndroidGlobalAISettings,
+            _ rhs: RemoteSyncAndroidGlobalAISettings
+        ) -> Bool {
+            lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders usage rows deterministically by logical model, device, and row identity. */
+        private static func usageRecordSort(
+            _ lhs: RemoteSyncAndroidAIUsageRecord,
+            _ rhs: RemoteSyncAndroidAIUsageRecord
+        ) -> Bool {
+            if lhs.configuredModelId != rhs.configuredModelId {
+                return lhs.configuredModelId.uuidString < rhs.configuredModelId.uuidString
+            }
+            if lhs.deviceId != rhs.deviceId { return lhs.deviceId < rhs.deviceId }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders custom prompt categories using Android's visible order with deterministic ties. */
+        private static func promptCategorySort(
+            _ lhs: RemoteSyncAndroidAIPromptCategory,
+            _ rhs: RemoteSyncAndroidAIPromptCategory
+        ) -> Bool {
+            if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+            if lhs.name != rhs.name { return lhs.name < rhs.name }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        /** Orders built-in prompt override rows by their stable built-in prompt identity. */
+        private static func builtinOverrideSort(
+            _ lhs: RemoteSyncAndroidAIBuiltinPromptOverride,
+            _ rhs: RemoteSyncAndroidAIBuiltinPromptOverride
+        ) -> Bool {
+            lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+
+    /// Android's exact incremental `AI_SETTINGS` table order; raw logs are intentionally absent.
+    private static let androidTableOrder = [
+        "LlmProviderConfig",
+        "LlmConfiguredModel",
+        "AgentPrompt",
+        "GlobalAiSettings",
+        "LlmUsageRecord",
+        "PromptCategory",
+        "BuiltinPromptOverride",
+    ]
+
+    /// Membership set used to discard tables outside Android's incremental AI sync contract.
+    private static let supportedTableNames = Set(androidTableOrder)
+
+    /// Reader for Android `LogEntry` metadata staged in each patch database.
+    private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
+
+    /// Reader and final graph writer for Android-shaped AI settings rows.
+    private let restoreService: RemoteSyncAISettingsRestoreService
+
+    /// Projector and accepted-fingerprint publisher for the local seven-table graph.
+    private let snapshotService: RemoteSyncAISettingsSnapshotService
+
+    /// File manager used to clean temporary expanded patch databases.
+    private let fileManager: FileManager
+
+    /// Scratch directory receiving uniquely named expanded SQLite patch files.
+    private let temporaryDirectory: URL
+
+    /**
+     Creates an AI settings patch replay service with injectable readers and scratch storage.
+
+     - Parameters:
+       - metadataRestoreService: Reader for Android patch metadata tables.
+       - restoreService: Reader for sparse AI rows and writer for the final normalized graph.
+       - snapshotService: Strict local projector and fingerprint baseline service.
+       - fileManager: File manager used for temporary database lifecycle.
+       - temporaryDirectory: Optional scratch directory; defaults to process temporary storage.
+     - Side effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init(
+        metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
+        restoreService: RemoteSyncAISettingsRestoreService = RemoteSyncAISettingsRestoreService(),
+        snapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil
+    ) {
+        self.metadataRestoreService = metadataRestoreService
+        self.restoreService = restoreService
+        self.snapshotService = snapshotService
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+    }
+
+    /**
+     Applies one ordered batch of staged Android AI settings patch archives.
+
+     - Parameters:
+       - stagedArchives: Downloaded gzip patches sorted in Android application order.
+       - modelContext: Clean SwiftData context containing the seven synchronized AI tables.
+       - settingsStore: Settings store bound to the exact supplied model context.
+     - Returns: Accepted/skipped operation counts and final normalized row counts.
+     - Side effects:
+       - extracts each archive into temporary storage and removes it after evaluation
+       - atomically publishes synchronized AI rows, metadata, statuses, and fingerprints
+     - Throws:
+       - rethrows bounded archive, metadata, row decode, SwiftData, transaction, and cancellation errors
+       - throws `RemoteSyncAISettingsPatchApplyError` for malformed identities
+     */
+    public func applyPatchArchives(
+        _ stagedArchives: [RemoteSyncStagedPatchArchive],
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAISettingsPatchApplyReport {
+        try applyPatchArchives(
+            stagedArchives,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            publishCheckpoint: { try Task.checkCancellation() }
+        )
+    }
+
+    /**
+     Replays patches with an injectable checkpoint around the atomic publication boundary.
+
+     The checkpoint makes cancellation and rollback deterministic in focused tests while production
+     callers use `Task.checkCancellation`. All archive mutations remain in memory until the final
+     settings-backed SwiftData transaction.
+
+     - Parameters:
+       - stagedArchives: Downloaded patches in Android replay order.
+       - modelContext: Exact clean context shared by AI models and settings metadata.
+       - settingsStore: Settings store bound to `modelContext`.
+       - publishCheckpoint: Throwing callback before the initial strict read and after final staging.
+     - Returns: Successful replay summary after the atomic transaction commits.
+     - Side effects: Reads patch files and atomically publishes AI sync state.
+     - Throws: Rethrows checkpoint, archive, decode, validation, context, fetch, and commit errors.
+     */
+    func applyPatchArchives(
+        _ stagedArchives: [RemoteSyncStagedPatchArchive],
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        publishCheckpoint: () throws -> Void
+    ) throws -> RemoteSyncAISettingsPatchApplyReport {
+        let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+
+        let initialState = try settingsStore.performAtomicBatch(in: modelContext) {
+            try publishCheckpoint()
+            return (
+                try currentSnapshot(from: modelContext, settingsStore: settingsStore),
+                try seededLogEntriesByKey(logEntryStore: logEntryStore)
+            )
+        }
+        var workingSnapshot = initialState.0
+        var logEntriesByKey = initialState.1
+        var appliedPatchStatuses: [RemoteSyncPatchStatus] = []
+        var appliedLogEntryCount = 0
+        var skippedLogEntryCount = 0
+        var cumulativeExpandedByteCount = UInt64(0)
+
+        for stagedArchive in stagedArchives {
+            try Task.checkCancellation()
+            let patchDatabaseURL = temporaryDatabaseURL(
+                prefix: "remote-sync-ai-settings-patch-",
+                suffix: ".sqlite3"
+            )
+            defer { try? fileManager.removeItem(at: patchDatabaseURL) }
+
+            let expandedByteCount = try RemoteSyncBoundedFileIO.inflateGzip(
+                at: stagedArchive.archiveFileURL,
+                to: patchDatabaseURL,
+                maximumCompressedByteCount: RemoteSyncArchiveStagingService.maximumCompressedPatchByteCount,
+                maximumExpandedByteCount: RemoteSyncArchiveStagingService.maximumExpandedPatchByteCount
+            )
+            let (nextCumulativeByteCount, overflow) = cumulativeExpandedByteCount
+                .addingReportingOverflow(expandedByteCount)
+            guard !overflow,
+                  nextCumulativeByteCount <= UInt64(
+                    RemoteSyncArchiveStagingService.maximumCumulativeExpandedPatchByteCount
+                  ) else {
+                throw RemoteSyncBoundedFileError.expandedSizeExceeded(
+                    overflow ? UInt64.max : nextCumulativeByteCount
+                )
+            }
+            cumulativeExpandedByteCount = nextCumulativeByteCount
+            try Task.checkCancellation()
+
+            let patchSnapshot = try restoreService.readSparsePatchSnapshot(
+                from: patchDatabaseURL,
+                expectedSourceVersion: stagedArchive.patch.schemaVersion
+            )
+            let metadataSnapshot = try metadataRestoreService.readSnapshot(from: patchDatabaseURL)
+            let patchLogEntries = metadataSnapshot.logEntries.filter {
+                Self.supportedTableNames.contains($0.tableName)
+            }
+            let canonicalPatchLogEntries = try patchLogEntries.map(canonicalLogEntry)
+            let acceptedLogEntries = canonicalPatchLogEntries.filter { entry in
+                let key = logEntryStore.key(for: .aiSettings, entry: entry)
+                guard let localEntry = logEntriesByKey[key] else {
+                    return true
+                }
+                return RemoteSyncLogEntryConflictOrder.isNewer(entry, than: localEntry)
+            }
+
+            skippedLogEntryCount += patchLogEntries.count - acceptedLogEntries.count
+            for tableName in Self.androidTableOrder {
+                try applyOperations(
+                    tableName: tableName,
+                    logEntries: acceptedLogEntries.filter { $0.tableName == tableName },
+                    patchSnapshot: patchSnapshot,
+                    workingSnapshot: &workingSnapshot,
+                    logEntriesByKey: &logEntriesByKey,
+                    logEntryStore: logEntryStore
+                )
+            }
+            try Task.checkCancellation()
+
+            appliedLogEntryCount += acceptedLogEntries.count
+            appliedPatchStatuses.append(
+                RemoteSyncPatchStatus(
+                    sourceDevice: stagedArchive.patch.sourceDevice,
+                    patchNumber: stagedArchive.patch.patchNumber,
+                    sizeBytes: stagedArchive.patch.file.size,
+                    appliedDate: stagedArchive.patch.file.timestamp
+                )
+            )
+        }
+
+        try Task.checkCancellation()
+        let materializedSnapshot = workingSnapshot.materializedSnapshot()
+        try settingsStore.performAtomicBatch(in: modelContext) {
+            if appliedLogEntryCount > 0 {
+                _ = try restoreService.replaceLocalAISettings(
+                    from: materializedSnapshot,
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                )
+            }
+            logEntryStore.replaceEntries(
+                logEntriesByKey.values.sorted(by: Self.logEntrySort),
+                for: .aiSettings
+            )
+            patchStatusStore.addStatuses(appliedPatchStatuses, for: .aiSettings)
+            try snapshotService.refreshBaselineFingerprintsStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            try publishCheckpoint()
+        }
+
+        return RemoteSyncAISettingsPatchApplyReport(
+            appliedPatchCount: appliedPatchStatuses.count,
+            appliedLogEntryCount: appliedLogEntryCount,
+            skippedLogEntryCount: skippedLogEntryCount,
+            providerCount: materializedSnapshot.providers.count,
+            configuredModelCount: materializedSnapshot.configuredModels.count,
+            agentPromptCount: materializedSnapshot.agentPrompts.count,
+            globalSettingsCount: materializedSnapshot.globalSettings.count,
+            usageRecordCount: materializedSnapshot.usageRecords.count,
+            promptCategoryCount: materializedSnapshot.promptCategories.count,
+            builtinOverrideCount: materializedSnapshot.builtinOverrides.count
+        )
+    }
+
+    /**
+     Seeds the conflict map from strictly decoded local AI settings log metadata.
+
+     Supported identifiers are canonicalized to UUID blobs with empty text secondary IDs so legacy
+     text UUIDs and current blobs share one logical key. Malformed supported identifiers fail closed,
+     and metadata for tables outside the seven-table contract is discarded rather than allowing raw
+     logs or future unknown tables to leak into iOS publication state.
+
+     - Parameter logEntryStore: Strict local metadata reader and key builder.
+     - Returns: Latest deterministic local entry for every persisted AI settings key.
+     - Side effects: Reads settings-backed local metadata.
+     - Throws: Rethrows strict metadata decoding errors.
+     */
+    private func seededLogEntriesByKey(
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws -> [String: RemoteSyncLogEntry] {
+        var entriesByKey: [String: RemoteSyncLogEntry] = [:]
+        for entry in try logEntryStore.entriesStrict(for: .aiSettings)
+            where Self.supportedTableNames.contains(entry.tableName) {
+            let keyedEntry = try canonicalLogEntry(entry)
+            let key = logEntryStore.key(for: .aiSettings, entry: keyedEntry)
+            guard let existingEntry = entriesByKey[key] else {
+                entriesByKey[key] = keyedEntry
+                continue
+            }
+            if Self.logEntrySort(existingEntry, keyedEntry) {
+                entriesByKey[key] = keyedEntry
+            }
+        }
+        return entriesByKey
+    }
+
+    /**
+     Projects the current seven-table SwiftData graph into mutable UUID-keyed dictionaries.
+
+     - Parameters:
+       - modelContext: SwiftData context to read strictly.
+       - settingsStore: Settings store used to create Android-compatible projection keys.
+     - Returns: Complete current AI settings working snapshot.
+     - Side effects: Reads the seven synchronized AI settings model tables.
+     - Throws: Rethrows strict snapshot projection and SwiftData fetch errors.
+     */
+    private func currentSnapshot(
+        from modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> WorkingSnapshot {
+        let current = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        return WorkingSnapshot(
+            providersByID: Self.rowsByID(current.providerRowsByKey.values, id: \.id),
+            configuredModelsByID: Self.rowsByID(current.configuredModelRowsByKey.values, id: \.id),
+            agentPromptsByID: Self.rowsByID(current.agentPromptRowsByKey.values, id: \.id),
+            globalSettingsByID: Self.rowsByID(current.globalSettingsRowsByKey.values, id: \.id),
+            usageRecordsByID: Self.rowsByID(current.usageRowsByKey.values, id: \.id),
+            promptCategoriesByID: Self.rowsByID(current.promptCategoryRowsByKey.values, id: \.id),
+            builtinOverridesByID: Self.rowsByID(current.builtinOverrideRowsByKey.values, id: \.id)
+        )
+    }
+
+    /**
+     Builds a UUID-keyed dictionary from a snapshot collection already validated for uniqueness.
+
+     - Parameters:
+       - rows: Strict snapshot rows to index.
+       - id: Key path selecting each row's Android UUID identity.
+     - Returns: Dictionary keyed by the selected UUID.
+     - Side effects: none.
+     - Failure modes: Duplicate identities retain the later iteration value; strict projection has
+       already rejected duplicates before this helper is called.
+     */
+    private static func rowsByID<Rows: Sequence, Row>(
+        _ rows: Rows,
+        id: KeyPath<Row, UUID>
+    ) -> [UUID: Row] where Rows.Element == Row {
+        Dictionary(rows.map { ($0[keyPath: id], $0) }, uniquingKeysWith: { _, replacement in replacement })
+    }
+
+    /**
+     Replays one Android table's accepted operations against the mutable working graph.
+
+     - Parameters:
+       - tableName: One name from Android's ordered seven-table contract.
+       - logEntries: Strictly newer canonical operations for that table.
+       - patchSnapshot: Sparse staged rows read from the current patch database.
+       - workingSnapshot: Full in-memory graph being evaluated across the batch.
+       - logEntriesByKey: Accepted metadata map updated independently of cleanup.
+       - logEntryStore: Store used to create canonical category keys.
+     - Side effects: Mutates working rows and accepted log metadata.
+     - Throws: Throws typed identity errors; unknown table names are ignored because this helper is
+       called only from the fixed Android table-order constant.
+     */
+    private func applyOperations(
+        tableName: String,
+        logEntries: [RemoteSyncLogEntry],
+        patchSnapshot: RemoteSyncAndroidAISettingsSnapshot,
+        workingSnapshot: inout WorkingSnapshot,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        switch tableName {
+        case "LlmProviderConfig":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.providers, id: \.id),
+                upsert: { workingSnapshot.providersByID[$0.id] = $0 },
+                delete: { workingSnapshot.providersByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "LlmConfiguredModel":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.configuredModels, id: \.id),
+                upsert: { workingSnapshot.upsertConfiguredModel($0) },
+                delete: { workingSnapshot.configuredModelsByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "AgentPrompt":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.agentPrompts, id: \.id),
+                upsert: { workingSnapshot.agentPromptsByID[$0.id] = $0 },
+                delete: { workingSnapshot.agentPromptsByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "GlobalAiSettings":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.globalSettings, id: \.id),
+                upsert: { workingSnapshot.globalSettingsByID[$0.id] = $0 },
+                delete: { workingSnapshot.globalSettingsByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "LlmUsageRecord":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.usageRecords, id: \.id),
+                upsert: { workingSnapshot.upsertUsageRecord($0) },
+                delete: { workingSnapshot.usageRecordsByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "PromptCategory":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.promptCategories, id: \.id),
+                upsert: { workingSnapshot.promptCategoriesByID[$0.id] = $0 },
+                delete: { workingSnapshot.promptCategoriesByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        case "BuiltinPromptOverride":
+            try applySingleIDOperations(
+                logEntries: logEntries,
+                tableName: tableName,
+                patchRows: Self.rowsByID(patchSnapshot.builtinOverrides, id: \.id),
+                upsert: { workingSnapshot.builtinOverridesByID[$0.id] = $0 },
+                delete: { workingSnapshot.builtinOverridesByID.removeValue(forKey: $0) },
+                afterUpserts: { workingSnapshot.pruneFormalForeignKeyViolations(in: tableName) },
+                logEntriesByKey: &logEntriesByKey,
+                logEntryStore: logEntryStore
+            )
+        default:
+            return
+        }
+    }
+
+    /**
+     Applies UUID-keyed upserts followed by deletes for one Android AI settings table.
+
+     Android applies upserts, prunes formal-FK violations for the current table, applies deletes, and
+     then accepts metadata. A metadata-only UPSERT is valid when its source row was already pruned;
+     it advances the watermark without inventing or mutating a payload row.
+
+     - Parameters:
+       - logEntries: Canonical newer operations for one table.
+       - tableName: Android table name used for diagnostics.
+       - patchRows: Sparse staged upsert rows keyed by UUID.
+       - upsert: In-memory insertion or replacement callback.
+       - delete: In-memory deletion callback.
+       - afterUpserts: Table-local formal-FK cleanup callback run before deletes, even with no rows.
+       - logEntriesByKey: Local metadata map receiving accepted watermarks.
+       - logEntryStore: Store used to compute category metadata keys.
+     - Side effects: Mutates caller-owned working rows and metadata through supplied inout state.
+     - Throws:
+       - `RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier` for malformed UUID keys
+     */
+    private func applySingleIDOperations<Row>(
+        logEntries: [RemoteSyncLogEntry],
+        tableName: String,
+        patchRows: [UUID: Row],
+        upsert: (Row) -> Void,
+        delete: (UUID) -> Void,
+        afterUpserts: () -> Void,
+        logEntriesByKey: inout [String: RemoteSyncLogEntry],
+        logEntryStore: RemoteSyncLogEntryStore
+    ) throws {
+        let upserts = logEntries.filter { $0.type == .upsert }.sorted(by: Self.logEntrySort)
+        let deletes = logEntries.filter { $0.type == .delete }.sorted(by: Self.logEntrySort)
+        for entry in upserts {
+            let canonicalEntry = try canonicalLogEntry(entry)
+            let rowID = try uuid(
+                from: canonicalEntry.entityID1,
+                tableName: tableName,
+                field: "entityId1"
+            )
+            if let row = patchRows[rowID] {
+                upsert(row)
+            }
+            logEntriesByKey[logEntryStore.key(for: .aiSettings, entry: canonicalEntry)] = canonicalEntry
+        }
+
+        afterUpserts()
+
+        for entry in deletes {
+            let canonicalEntry = try canonicalLogEntry(entry)
+            let rowID = try uuid(
+                from: canonicalEntry.entityID1,
+                tableName: tableName,
+                field: "entityId1"
+            )
+            delete(rowID)
+            logEntriesByKey[logEntryStore.key(for: .aiSettings, entry: canonicalEntry)] = canonicalEntry
+        }
+    }
+
+    /**
+     Canonicalizes one supported AI settings log identity to Android's UUID-blob representation.
+
+     - Parameter entry: Supported staged or local log entry.
+     - Returns: Entry with a 16-byte UUID `entityID1` and empty-text `entityID2`.
+     - Side effects: none.
+     - Throws: `RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier` when the primary
+       identity is neither a valid UUID blob nor UUID string.
+     */
+    private func canonicalLogEntry(_ entry: RemoteSyncLogEntry) throws -> RemoteSyncLogEntry {
+        guard Self.supportedTableNames.contains(entry.tableName) else {
+            return entry
+        }
+        let rowID = try uuid(
+            from: entry.entityID1,
+            tableName: entry.tableName,
+            field: "entityId1"
+        )
+        return RemoteSyncLogEntry(
+            tableName: entry.tableName,
+            entityID1: .blob(RemoteSyncAISettingsSnapshotService.uuidBlob(rowID)),
+            entityID2: RemoteSyncAISettingsSnapshotService.emptySecondaryEntityID,
+            type: entry.type,
+            lastUpdated: entry.lastUpdated,
+            sourceDevice: entry.sourceDevice
+        )
+    }
+
+    /**
+     Decodes one Android AI row identity from SQLite blob or text storage.
+
+     - Parameters:
+       - value: Raw `LogEntry.entityId1` SQLite value.
+       - tableName: Table name used for a typed diagnostic.
+       - field: Column name used for a typed diagnostic.
+     - Returns: UUID represented by the SQLite value.
+     - Side effects: none.
+     - Throws: `RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier` for invalid kinds,
+       malformed blobs, or malformed UUID text.
+     */
+    private func uuid(
+        from value: RemoteSyncSQLiteValue,
+        tableName: String,
+        field: String
+    ) throws -> UUID {
+        switch value.kind {
+        case .blob:
+            guard let data = value.blobData,
+                  let uuid = RemoteSyncAISettingsSnapshotService.uuid(from: data) else {
+                throw RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier(
+                    table: tableName,
+                    field: field
+                )
+            }
+            return uuid
+        case .text:
+            guard let textValue = value.textValue,
+                  let uuid = UUID(uuidString: textValue) else {
+                throw RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier(
+                    table: tableName,
+                    field: field
+                )
+            }
+            return uuid
+        default:
+            throw RemoteSyncAISettingsPatchApplyError.invalidLogEntryIdentifier(
+                table: tableName,
+                field: field
+            )
+        }
+    }
+
+    /**
+     Creates a unique temporary SQLite destination beneath configured scratch storage.
+
+     - Parameters:
+       - prefix: Human-readable filename prefix for diagnostics.
+       - suffix: Filename suffix including extension.
+     - Returns: Unique candidate URL that the bounded inflater may create.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private func temporaryDatabaseURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    /**
+     Provides deterministic ordering for persisted Android log metadata.
+
+     - Parameters:
+       - lhs: First accepted or seeded log entry.
+       - rhs: Second accepted or seeded log entry.
+     - Returns: `true` when `lhs` sorts before `rhs`; this order never changes conflict precedence.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.lastUpdated != rhs.lastUpdated { return lhs.lastUpdated < rhs.lastUpdated }
+        if lhs.tableName != rhs.tableName { return lhs.tableName < rhs.tableName }
+        if lhs.type != rhs.type { return lhs.type.rawValue < rhs.type.rawValue }
+        if lhs.sourceDevice != rhs.sourceDevice { return lhs.sourceDevice < rhs.sourceDevice }
+        if lhs.entityID1 != rhs.entityID1 {
+            return sortKey(for: lhs.entityID1) < sortKey(for: rhs.entityID1)
+        }
+        return sortKey(for: lhs.entityID2) < sortKey(for: rhs.entityID2)
+    }
+
+    /**
+     Converts one SQLite scalar into a stable deterministic metadata sort key.
+
+     - Parameter value: SQLite scalar to canonicalize for iteration order only.
+     - Returns: Kind-prefixed string representation.
+     - Side effects: none.
+     - Failure modes: This helper cannot fail.
+     */
+    private static func sortKey(for value: RemoteSyncSQLiteValue) -> String {
+        switch value.kind {
+        case .null:
+            return "null"
+        case .integer:
+            return "integer:\(value.integerValue ?? 0)"
+        case .real:
+            return "real:\(value.realValue?.bitPattern ?? 0)"
+        case .text:
+            return "text:\(value.textValue ?? "")"
+        case .blob:
+            return "blob:\(value.blobBase64Value ?? "")"
+        }
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchUploadService.swift
@@ -305,6 +305,9 @@ public final class RemoteSyncAISettingsPatchUploadService {
     /// Strict seven-table SwiftData projector and baseline store.
     private let snapshotService: RemoteSyncAISettingsSnapshotService
 
+    /// Mutation journal sharing the projector's device-local credential reader.
+    private let mutationJournalService: RemoteSyncMutationJournalService
+
     /// Complete Android Room v23 sparse-database writer.
     private let databaseWriter: RemoteSyncAISettingsDatabaseWriter
 
@@ -349,6 +352,10 @@ public final class RemoteSyncAISettingsPatchUploadService {
         self.adapter = adapter
         remotePatchReconciler = RemoteSyncRemotePatchReconciler(adapter: adapter)
         self.snapshotService = snapshotService
+        mutationJournalService = RemoteSyncMutationJournalService(
+            nowProvider: nowProvider,
+            aiSettingsSnapshotService: snapshotService
+        )
         databaseWriter = RemoteSyncAISettingsDatabaseWriter(fileManager: fileManager)
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
@@ -519,13 +526,12 @@ public final class RemoteSyncAISettingsPatchUploadService {
         }
 
         let hasPendingMutations = try settingsStore.performAtomicBatch(in: modelContext) {
-            let mutationJournal = RemoteSyncMutationJournalService(nowProvider: nowProvider)
-            try mutationJournal.recordLocalChanges(
+            try mutationJournalService.recordLocalChanges(
                 for: .aiSettings,
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
-            return try !mutationJournal.pendingMutations(
+            return try !mutationJournalService.pendingMutations(
                 for: .aiSettings,
                 settingsStore: settingsStore
             ).isEmpty
@@ -537,13 +543,12 @@ public final class RemoteSyncAISettingsPatchUploadService {
         let highestRemotePatchNumber = try await highestRemotePatchNumber(in: deviceFolderID)
         let generation: UploadGeneration? = try settingsStore.performAtomicBatch(in: modelContext) {
             let sourceDevice = Self.sourceDeviceName(from: deviceFolderID)
-            let mutationJournal = RemoteSyncMutationJournalService(nowProvider: nowProvider)
-            try mutationJournal.recordLocalChanges(
+            try mutationJournalService.recordLocalChanges(
                 for: .aiSettings,
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
-            let pendingMutations = try mutationJournal.pendingMutations(
+            let pendingMutations = try mutationJournalService.pendingMutations(
                 for: .aiSettings,
                 settingsStore: settingsStore
             )
@@ -794,7 +799,7 @@ public final class RemoteSyncAISettingsPatchUploadService {
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
-            try RemoteSyncMutationJournalService().mergeAcceptedLogEntries(
+            try mutationJournalService.mergeAcceptedLogEntries(
                 acceptedEntries: pendingUpload.updatedEntries,
                 uploadedEntries: pendingUpload.uploadedEntries ?? pendingUpload.updatedEntries.filter {
                     $0.lastUpdated == pendingUpload.timestamp && $0.sourceDevice == pendingUpload.sourceDevice
@@ -1179,7 +1184,7 @@ public final class RemoteSyncAISettingsPatchUploadService {
                   existingEntriesByKey[key]?.type != .delete || pendingMutations[key] != nil else {
                 continue
             }
-            let deleteEntry = try RemoteSyncMutationJournalService().entryForUpload(
+            let deleteEntry = try mutationJournalService.entryForUpload(
                 key: key,
                 stateFingerprint: nil,
                 type: .delete,
@@ -1242,7 +1247,7 @@ public final class RemoteSyncAISettingsPatchUploadService {
                   ) else {
                 continue
             }
-            let entry = try RemoteSyncMutationJournalService().entryForUpload(
+            let entry = try mutationJournalService.entryForUpload(
                 key: key,
                 stateFingerprint: snapshot.fingerprintsByKey[key],
                 type: .upsert,

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsPatchUploadService.swift
@@ -1,0 +1,1449 @@
+// RemoteSyncAISettingsPatchUploadService.swift -- Android-shaped outbound AI settings patch publication
+
+import Foundation
+import SwiftData
+
+/**
+ Errors raised while projecting, persisting, reconciling, or accepting an outbound AI settings patch.
+
+ The service fails closed so malformed outbox state or an unsupported Android schema can never
+ advance local acceptance metadata.
+ */
+public enum RemoteSyncAISettingsPatchUploadError: Error, Equatable {
+    /// No nonempty remote device-folder identifier is available for the AI settings category.
+    case missingDeviceFolderID
+
+    /// Persisted outbox metadata is malformed, tampered with, or targets another destination.
+    case invalidPendingUpload
+
+    /// The highest accepted local or remote patch number cannot be incremented safely.
+    case patchNumberOverflow
+
+    /// The requested wire schema is not Android's supported AI settings Room schema.
+    case unsupportedSchemaVersion(Int)
+
+    /// The database writer committed counts that differ from the service's signed sparse projection.
+    case databaseWriteReportMismatch
+}
+
+/**
+ Counts the changed rows emitted for one synchronized Android AI settings table.
+
+ Counts include only rows present in the sparse patch. `LlmRawLogRecord` is deliberately not a
+ synchronized table and therefore never appears in this report.
+ */
+public struct RemoteSyncAISettingsPatchTableReport: Sendable, Equatable {
+    /// Exact Android Room table name.
+    public let tableName: String
+
+    /// Number of complete rows emitted for `UPSERT` operations.
+    public let upsertedRowCount: Int
+
+    /// Number of tombstones emitted for `DELETE` operations.
+    public let deletedRowCount: Int
+
+    /**
+     Creates one deterministic table-level sparse-patch summary.
+
+     - Parameters:
+       - tableName: Exact synchronized Android table name.
+       - upsertedRowCount: Number of complete rows included in the patch.
+       - deletedRowCount: Number of delete-only log entries included in the patch.
+     - Side effects: None.
+     - Failure modes: This value initializer does not validate counts; production reports are built
+       only from validated outbox manifests.
+     */
+    public init(tableName: String, upsertedRowCount: Int, deletedRowCount: Int) {
+        self.tableName = tableName
+        self.upsertedRowCount = upsertedRowCount
+        self.deletedRowCount = deletedRowCount
+    }
+}
+
+/**
+ Summary of one remotely committed and locally accepted AI settings patch.
+
+ The report describes the exact durable generation that was reconciled. It does not re-read the live
+ AI settings graph, which may already contain newer local edits retained for a later patch.
+ */
+public struct RemoteSyncAISettingsPatchUploadReport: Sendable, Equatable {
+    /// Remote file metadata returned by reconciliation after the archive was created or matched.
+    public let uploadedFile: RemoteSyncFile
+
+    /// Monotonic patch number assigned within the current device folder.
+    public let patchNumber: Int64
+
+    /// Seven table summaries in Android's synchronization order.
+    public let tableReports: [RemoteSyncAISettingsPatchTableReport]
+
+    /// Total number of Android `LogEntry` rows emitted for upserts and tombstones.
+    public let logEntryCount: Int
+
+    /// Logical millisecond timestamp allocated to synthetic entries in this generation.
+    public let lastUpdated: Int64
+
+    /**
+     Creates one accepted AI settings patch summary.
+
+     - Parameters:
+       - uploadedFile: Accepted remote patch metadata.
+       - patchNumber: Monotonic source-device patch number.
+       - tableReports: Per-table upsert and delete counts.
+       - logEntryCount: Total emitted Android log rows.
+       - lastUpdated: Logical generation timestamp.
+     - Side effects: None.
+     - Failure modes: This value initializer cannot fail.
+     */
+    public init(
+        uploadedFile: RemoteSyncFile,
+        patchNumber: Int64,
+        tableReports: [RemoteSyncAISettingsPatchTableReport],
+        logEntryCount: Int,
+        lastUpdated: Int64
+    ) {
+        self.uploadedFile = uploadedFile
+        self.patchNumber = patchNumber
+        self.tableReports = tableReports
+        self.logEntryCount = logEntryCount
+        self.lastUpdated = lastUpdated
+    }
+}
+
+/**
+ Creates Android Room v23 sparse AI settings patches and publishes them through a durable outbox.
+
+ The service diffs only Android's seven `AI_SETTINGS` tables. Provider credentials and raw LLM logs
+ are not accepted as inputs, so neither can enter initial row projections, sparse rows, manifests, or
+ publication identity payloads. `RemoteSyncAISettingsDatabaseWriter` creates the complete Room v23
+ shell, including an empty `LlmRawLogRecord` table, and inserts only the rows supplied here.
+
+ Side effects include strict SwiftData reads, settings-backed mutation-journal and outbox writes,
+ temporary and Application Support file I/O, remote list/download/upload requests, and atomic accepted
+ metadata updates. Failed transport or local acceptance leaves the durable generation intact for an
+ idempotent retry. Conflict timestamps are never regenerated for journaled mutations; strict `>`
+ acceptance remains centralized in the shared mutation-log reconciliation contract.
+ */
+public final class RemoteSyncAISettingsPatchUploadService {
+    /** Immutable strict projection and metadata used to build one archive generation. */
+    private struct UploadGeneration {
+        /// Complete credential-free snapshot used by the writer to validate sparse row selection.
+        let sourceSnapshot: RemoteSyncAISettingsCurrentSnapshot
+
+        /// Full accepted baseline represented by the projected graph.
+        let acceptedBaseline: RemoteSyncAISettingsAcceptedBaseline
+
+        /// Baseline revision that must still be current during local acceptance.
+        let expectedAcceptedBaselineRevision: UUID?
+
+        /// Distinguishes a missing baseline from a legacy baseline whose revision is absent.
+        let expectedAcceptedBaselineExists: Bool
+
+        /// Sparse seven-table row and log projection.
+        let changeSet: ChangeSet
+
+        /// Monotonic source-device patch number.
+        let patchNumber: Int64
+
+        /// Android source-device name derived from the destination folder.
+        let sourceDevice: String
+
+        /// Logical timestamp used only when no mutation-time timestamp exists.
+        let timestamp: Int64
+    }
+
+    /**
+     Durable AI settings upload generation retained until remote and local acceptance both succeed.
+
+     The manifest signs archive identity, row counts, mutation-time log entries, and baseline compare-
+     and-swap metadata. It contains no provider credential field or arbitrary payload bytes.
+     */
+    private struct PendingUpload: Codable, Equatable {
+        /// Stable local generation identifier used in the archive basename.
+        let generationID: UUID
+
+        /// Remote destination folder this generation is permanently bound to.
+        let deviceFolderID: String
+
+        /// Android source-device identity represented in log entries.
+        let sourceDevice: String
+
+        /// Monotonic source-device patch number.
+        let patchNumber: Int64
+
+        /// Exact Android Room schema version used to create the archive.
+        let schemaVersion: Int
+
+        /// Android-compatible remote patch filename.
+        let patchFileName: String
+
+        /// Safe local durable archive basename.
+        let archiveFileName: String
+
+        /// SHA-256 digest used for remote reconciliation and manifest validation.
+        let archiveSHA256: String
+
+        /// Exact compressed archive byte count.
+        let archiveSize: Int64
+
+        /// Logical generation timestamp.
+        let timestamp: Int64
+
+        /// Complete accepted log map after applying this generation.
+        let updatedEntries: [RemoteSyncLogEntry]
+
+        /// Exact log entries emitted into the sparse database.
+        let uploadedEntries: [RemoteSyncLogEntry]?
+
+        /// Immutable projected accepted baseline.
+        let acceptedBaseline: RemoteSyncAISettingsAcceptedBaseline
+
+        /// Baseline revision captured before archive creation.
+        let expectedAcceptedBaselineRevision: UUID?
+
+        /// Whether a baseline existed before archive creation.
+        let expectedAcceptedBaselineExists: Bool
+
+        /// Upsert counts keyed by each of the seven synchronized Android tables.
+        let upsertCountsByTable: [String: Int]
+
+        /// Delete counts keyed by each of the seven synchronized Android tables.
+        let deleteCountsByTable: [String: Int]
+
+        /// Total Android log rows emitted into the patch.
+        let logEntryCount: Int
+
+        /// Self-authenticating publication identity; omitted while its payload is encoded.
+        var publicationIdentity: RemoteSyncPublicationIdentity? = nil
+    }
+
+    /** Sparse rows and preserved log operations for one outbound generation. */
+    private struct ChangeSet {
+        /// Changed provider configuration rows keyed by Android log identity.
+        var providerRowsByKey: [String: RemoteSyncAndroidAIProvider] = [:]
+
+        /// Changed configured-model rows keyed by Android log identity.
+        var configuredModelRowsByKey: [String: RemoteSyncAndroidAIConfiguredModel] = [:]
+
+        /// Changed custom-prompt rows keyed by Android log identity.
+        var agentPromptRowsByKey: [String: RemoteSyncAndroidAIAgentPrompt] = [:]
+
+        /// Changed singleton global-settings rows keyed by Android log identity.
+        var globalSettingsRowsByKey: [String: RemoteSyncAndroidGlobalAISettings] = [:]
+
+        /// Changed per-device usage rows keyed by Android log identity.
+        var usageRowsByKey: [String: RemoteSyncAndroidAIUsageRecord] = [:]
+
+        /// Changed prompt-category rows keyed by Android log identity.
+        var promptCategoryRowsByKey: [String: RemoteSyncAndroidAIPromptCategory] = [:]
+
+        /// Changed built-in prompt override rows keyed by Android log identity.
+        var builtinOverrideRowsByKey: [String: RemoteSyncAndroidAIBuiltinPromptOverride] = [:]
+
+        /// Sorted Android operations emitted into the sparse patch.
+        var logEntries: [RemoteSyncLogEntry] = []
+
+        /// Complete accepted log map after overlaying emitted operations.
+        var updatedEntriesByKey: [String: RemoteSyncLogEntry] = [:]
+
+        /** Returns deterministic upsert counts for all seven synchronized tables. */
+        var upsertCountsByTable: [String: Int] {
+            [
+                "LlmProviderConfig": providerRowsByKey.count,
+                "LlmConfiguredModel": configuredModelRowsByKey.count,
+                "AgentPrompt": agentPromptRowsByKey.count,
+                "GlobalAiSettings": globalSettingsRowsByKey.count,
+                "LlmUsageRecord": usageRowsByKey.count,
+                "PromptCategory": promptCategoryRowsByKey.count,
+                "BuiltinPromptOverride": builtinOverrideRowsByKey.count,
+            ]
+        }
+
+        /** Returns deterministic delete counts for all seven synchronized tables. */
+        var deleteCountsByTable: [String: Int] {
+            var counts = Dictionary(
+                uniqueKeysWithValues: RemoteSyncAISettingsPatchUploadService.supportedTableNames.map { ($0, 0) }
+            )
+            for entry in logEntries where entry.type == .delete {
+                counts[entry.tableName, default: 0] += 1
+            }
+            return counts
+        }
+    }
+
+    /** Changed rows and preserved operations collected for one synchronized table. */
+    private struct ChangedRows<Row> {
+        /// Sparse current rows keyed by Android log identity.
+        let rowsByKey: [String: Row]
+
+        /// Mutation-time or synthetic upsert operations paired with the sparse rows.
+        let logEntries: [RemoteSyncLogEntry]
+
+        /// Upsert operations keyed by the same canonical Android identities as `rowsByKey`.
+        let entriesByKey: [String: RemoteSyncLogEntry]
+    }
+
+    /// Exact Android `AI_SETTINGS` table order used for patches and public reports.
+    private static let supportedTableNames = [
+        "LlmProviderConfig",
+        "LlmConfiguredModel",
+        "AgentPrompt",
+        "GlobalAiSettings",
+        "LlmUsageRecord",
+        "PromptCategory",
+        "BuiltinPromptOverride",
+    ]
+
+    /// Fast membership set paired with `supportedTableNames`' deterministic order.
+    private static let supportedTableNameSet = Set(supportedTableNames)
+
+    /// Active remote backend used for discovery and publication.
+    private let adapter: any RemoteSyncAdapting
+
+    /// Digest-aware remote same-name patch reconciler.
+    private let remotePatchReconciler: RemoteSyncRemotePatchReconciler
+
+    /// Strict seven-table SwiftData projector and baseline store.
+    private let snapshotService: RemoteSyncAISettingsSnapshotService
+
+    /// Complete Android Room v23 sparse-database writer.
+    private let databaseWriter: RemoteSyncAISettingsDatabaseWriter
+
+    /// Filesystem dependency shared by temporary and durable archive operations.
+    private let fileManager: FileManager
+
+    /// Directory used for uncompressed transient SQLite databases.
+    private let temporaryDirectory: URL
+
+    /// Directory retaining restart-safe compressed outbox archives.
+    private let outboxDirectory: URL
+
+    /// Millisecond clock used to allocate monotonic synthetic operation timestamps.
+    private let nowProvider: () -> Int64
+
+    /// Settings row containing the current AI settings outbox generation.
+    static let pendingUploadKey = "remote_sync.pending_upload.ai_settings"
+
+    /**
+     Creates an AI settings patch upload service for one remote backend.
+
+     - Parameters:
+       - adapter: Backend used to list, reconcile, and upload patch archives.
+       - snapshotService: Strict projector for the seven non-secret synchronized tables.
+       - fileManager: Filesystem dependency used by writer and outbox operations.
+       - temporaryDirectory: Optional uncompressed-database directory override.
+       - outboxDirectory: Optional durable archive directory override.
+       - nowProvider: Millisecond clock; generated timestamps are advanced beyond all watermarks.
+     - Side effects: Construction creates no files and performs no reads or network requests.
+     - Failure modes: Construction cannot fail.
+     */
+    public init(
+        adapter: any RemoteSyncAdapting,
+        snapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService(),
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL? = nil,
+        outboxDirectory: URL? = nil,
+        nowProvider: @escaping () -> Int64 = {
+            Int64(Date().timeIntervalSince1970 * 1000.0)
+        }
+    ) {
+        self.adapter = adapter
+        remotePatchReconciler = RemoteSyncRemotePatchReconciler(adapter: adapter)
+        self.snapshotService = snapshotService
+        databaseWriter = RemoteSyncAISettingsDatabaseWriter(fileManager: fileManager)
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
+        self.outboxDirectory = outboxDirectory
+            ?? temporaryDirectory?.appendingPathComponent("remote-sync-ai-settings-outbox", isDirectory: true)
+            ?? Self.defaultOutboxDirectory(fileManager: fileManager)
+        self.nowProvider = nowProvider
+    }
+
+    /**
+     Builds and uploads the next sparse AI settings patch when local state differs from its baseline.
+
+     - Parameters:
+       - bootstrapState: Ready AI settings category state identifying the remote device folder.
+       - modelContext: Clean context containing all seven synchronized AI models and settings rows.
+       - settingsStore: Settings store constructed from `modelContext`.
+       - schemaVersion: Exact Android Room schema version; only v23 is accepted.
+     - Returns: Accepted generation report, or `nil` when no local mutation exists.
+     - Side effects: Records local mutations, persists/resumes an outbox, performs remote I/O, and
+       atomically publishes accepted log, status, progress, fingerprint, and row-identity state.
+     - Throws: Projection, journal, schema, filesystem, transport, reconciliation, or transaction errors.
+     - Important: Journaled mutation timestamps and tombstones are preserved across retries.
+     */
+    public func uploadPendingPatch(
+        bootstrapState: RemoteSyncBootstrapState,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = RemoteSyncCategory.aiSettings.currentSchemaVersion
+    ) async throws -> RemoteSyncAISettingsPatchUploadReport? {
+        try await uploadPendingPatch(
+            bootstrapState: bootstrapState,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: schemaVersion,
+            acceptanceCheckpoint: {}
+        )
+    }
+
+    /**
+     Resumes an existing AI settings outbox without projecting a new generation.
+
+     - Parameters:
+       - bootstrapState: Ready category state identifying the pending destination.
+       - modelContext: Clean context containing AI settings and synchronization metadata.
+       - settingsStore: Settings store constructed from `modelContext`.
+       - schemaVersion: Exact Android Room schema version expected by the manifest.
+     - Returns: Accepted pending-generation report, or `nil` when no outbox exists.
+     - Side effects: May reconcile/upload persisted bytes and atomically accept their metadata.
+     - Throws: Malformed state, destination/schema mismatch, stale baseline, transport, or local
+       acceptance errors.
+     - Important: This method never projects the live graph or allocates another patch number.
+     */
+    public func resumePendingUploadIfPresent(
+        bootstrapState: RemoteSyncBootstrapState,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = RemoteSyncCategory.aiSettings.currentSchemaVersion
+    ) async throws -> RemoteSyncAISettingsPatchUploadReport? {
+        try await resumePendingUploadIfPresent(
+            bootstrapState: bootstrapState,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: schemaVersion,
+            acceptanceCheckpoint: {}
+        )
+    }
+
+    /**
+     Explicitly discards an unaccepted AI settings outbox at a destination-replacement boundary.
+
+     - Parameters:
+       - modelContext: Clean context containing local synchronization settings.
+       - settingsStore: Store containing the pending manifest.
+     - Side effects: Atomically removes the manifest, then best-effort removes its archive. Accepted
+       metadata and live AI rows remain unchanged and therefore dirty.
+     - Throws: Malformed-manifest or settings transaction errors leave the archive untouched.
+     */
+    public func discardPendingUploadForDestinationReplacement(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws {
+        guard let pendingUpload = try settingsStore.performAtomicBatch(in: modelContext, {
+            try loadPendingUpload(settingsStore: settingsStore)
+        }) else {
+            return
+        }
+        try invalidatePendingUpload(
+            pendingUpload,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Resumes a durable generation with a deterministic pre-commit checkpoint for failure tests.
+
+     - Parameters:
+       - bootstrapState: Ready category state identifying the pending destination.
+       - modelContext: Clean context containing AI settings and synchronization metadata.
+       - settingsStore: Store containing the pending manifest.
+       - schemaVersion: Exact Android Room schema version expected by the manifest.
+       - acceptanceCheckpoint: Callback after all acceptance mutations and before commit.
+     - Returns: Accepted pending-generation report, or `nil` when no outbox exists.
+     - Side effects: Reconciles/uploads and accepts only the existing persisted generation.
+     - Throws: Destination, manifest, transport, baseline compare-and-swap, transaction, and
+       checkpoint failures.
+     */
+    func resumePendingUploadIfPresent(
+        bootstrapState: RemoteSyncBootstrapState,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = RemoteSyncCategory.aiSettings.currentSchemaVersion,
+        acceptanceCheckpoint: @escaping () throws -> Void
+    ) async throws -> RemoteSyncAISettingsPatchUploadReport? {
+        let deviceFolderID = try Self.validatedDeviceFolderID(from: bootstrapState)
+        guard let pendingUpload = try settingsStore.performAtomicBatch(in: modelContext, {
+            try loadPendingUpload(settingsStore: settingsStore)
+        }) else {
+            return nil
+        }
+        guard pendingUpload.schemaVersion == schemaVersion,
+              pendingUpload.deviceFolderID == deviceFolderID else {
+            throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+        }
+        return try await finishPendingUpload(
+            pendingUpload,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            acceptanceCheckpoint: acceptanceCheckpoint
+        )
+    }
+
+    /**
+     Executes AI settings upload with a deterministic final local-acceptance checkpoint.
+
+     - Parameters:
+       - bootstrapState: Ready AI settings category bootstrap state.
+       - modelContext: Clean context containing synchronized AI models and settings rows.
+       - settingsStore: Store constructed from the supplied context.
+       - schemaVersion: Exact Android Room schema version; values other than v23 fail closed.
+       - acceptanceCheckpoint: Callback after acceptance mutations and before transaction commit.
+     - Returns: Accepted generation report, or `nil` for an unchanged baselined projection.
+     - Side effects: Records mutations, creates or resumes a durable outbox, performs remote I/O, and
+       atomically publishes accepted synchronization metadata.
+     - Throws: Strict reads, journal, schema, settings, filesystem, transport, reconciliation, and
+       checkpoint failures without advancing accepted state.
+     */
+    func uploadPendingPatch(
+        bootstrapState: RemoteSyncBootstrapState,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int = RemoteSyncCategory.aiSettings.currentSchemaVersion,
+        acceptanceCheckpoint: @escaping () throws -> Void
+    ) async throws -> RemoteSyncAISettingsPatchUploadReport? {
+        let deviceFolderID = try Self.validatedDeviceFolderID(from: bootstrapState)
+        guard schemaVersion == RemoteSyncCategory.aiSettings.currentSchemaVersion else {
+            throw RemoteSyncAISettingsPatchUploadError.unsupportedSchemaVersion(schemaVersion)
+        }
+
+        if let resumed = try await resumePendingUploadIfPresent(
+            bootstrapState: bootstrapState,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            schemaVersion: schemaVersion,
+            acceptanceCheckpoint: acceptanceCheckpoint
+        ) {
+            return resumed
+        }
+
+        let hasPendingMutations = try settingsStore.performAtomicBatch(in: modelContext) {
+            let mutationJournal = RemoteSyncMutationJournalService(nowProvider: nowProvider)
+            try mutationJournal.recordLocalChanges(
+                for: .aiSettings,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            return try !mutationJournal.pendingMutations(
+                for: .aiSettings,
+                settingsStore: settingsStore
+            ).isEmpty
+        }
+        guard hasPendingMutations else {
+            return nil
+        }
+
+        let highestRemotePatchNumber = try await highestRemotePatchNumber(in: deviceFolderID)
+        let generation: UploadGeneration? = try settingsStore.performAtomicBatch(in: modelContext) {
+            let sourceDevice = Self.sourceDeviceName(from: deviceFolderID)
+            let mutationJournal = RemoteSyncMutationJournalService(nowProvider: nowProvider)
+            try mutationJournal.recordLocalChanges(
+                for: .aiSettings,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            let pendingMutations = try mutationJournal.pendingMutations(
+                for: .aiSettings,
+                settingsStore: settingsStore
+            )
+            let snapshot = try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            let previousBaseline = try snapshotService.storedAcceptedBaseline(settingsStore: settingsStore)
+            let acceptedBaseline = try snapshotService.acceptedBaseline(from: snapshot)
+            let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+            let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+            let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+            let existingEntriesByKey = Dictionary(
+                uniqueKeysWithValues: try logEntryStore.entriesStrict(for: .aiSettings).map {
+                    (logEntryStore.key(for: .aiSettings, entry: $0), $0)
+                }
+            )
+            let patchStatuses = try patchStatusStore.statusesStrict(for: .aiSettings)
+            let progressState = RemoteSyncStateStore(settingsStore: settingsStore)
+                .progressState(for: .aiSettings)
+            let timestamp = try RemoteSyncLogicalSequence.nextTimestamp(
+                now: nowProvider(),
+                highWatermarks: existingEntriesByKey.values.map(\.lastUpdated)
+                    + patchStatuses.map(\.appliedDate)
+                    + [progressState.lastPatchWritten, progressState.lastSynchronized].compactMap { $0 }
+            )
+            var acceptedRowsByKey = Dictionary(
+                uniqueKeysWithValues: (previousBaseline?.rowIdentities ?? []).map { ($0.key, $0) }
+            )
+            for (key, entry) in existingEntriesByKey
+            where entry.type != .delete
+                && Self.supportedTableNameSet.contains(entry.tableName)
+                && currentRowExists(forKey: key, in: snapshot) {
+                acceptedRowsByKey[key] = RemoteSyncAISettingsAcceptedRowIdentity(
+                    key: key,
+                    tableName: entry.tableName,
+                    entityID1: entry.entityID1,
+                    entityID2: entry.entityID2
+                )
+            }
+
+            let changeSet = try buildChangeSet(
+                snapshot: snapshot,
+                existingEntriesByKey: existingEntriesByKey,
+                acceptedRowsByKey: acceptedRowsByKey,
+                fingerprintStore: fingerprintStore,
+                pendingMutations: pendingMutations,
+                timestamp: timestamp,
+                sourceDevice: sourceDevice
+            )
+            if changeSet.logEntries.isEmpty {
+                if previousBaseline == nil {
+                    try snapshotService.acceptBaseline(acceptedBaseline, settingsStore: settingsStore)
+                }
+                return nil
+            }
+
+            let highestAcceptedPatchNumber = patchStatuses
+                .filter { $0.sourceDevice == sourceDevice }
+                .map(\.patchNumber)
+                .max() ?? 0
+            let patchNumber: Int64
+            do {
+                patchNumber = try RemoteSyncPublicationIdentity.nextPatchNumber(
+                    after: [highestAcceptedPatchNumber, highestRemotePatchNumber]
+                )
+            } catch {
+                throw RemoteSyncAISettingsPatchUploadError.patchNumberOverflow
+            }
+            return UploadGeneration(
+                sourceSnapshot: snapshot,
+                acceptedBaseline: acceptedBaseline,
+                expectedAcceptedBaselineRevision: previousBaseline?.revision,
+                expectedAcceptedBaselineExists: previousBaseline != nil,
+                changeSet: changeSet,
+                patchNumber: patchNumber,
+                sourceDevice: sourceDevice,
+                timestamp: timestamp
+            )
+        }
+
+        guard let generation else { return nil }
+        let patchFileName = "\(generation.patchNumber).\(schemaVersion).sqlite3.gz"
+        let databaseURL = temporaryURL(prefix: "remote-sync-ai-settings-upload-", suffix: ".sqlite3")
+        defer { try? fileManager.removeItem(at: databaseURL) }
+
+        try writePatchDatabase(
+            at: databaseURL,
+            schemaVersion: schemaVersion,
+            snapshot: generation.sourceSnapshot,
+            changeSet: generation.changeSet
+        )
+        let pendingUpload = try persistPendingUpload(
+            generation: generation,
+            databaseURL: databaseURL,
+            patchFileName: patchFileName,
+            deviceFolderID: deviceFolderID,
+            schemaVersion: schemaVersion,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        return try await finishPendingUpload(
+            pendingUpload,
+            modelContext: modelContext,
+            settingsStore: settingsStore,
+            acceptanceCheckpoint: acceptanceCheckpoint
+        )
+    }
+
+    /**
+     Persists one exact compressed archive and signed acceptance manifest before network upload.
+
+     - Parameters:
+       - generation: Strict immutable sparse-patch generation.
+       - databaseURL: Complete Android Room v23 patch database to compress.
+       - patchFileName: Android-compatible remote patch filename.
+       - deviceFolderID: Permanent remote destination for this generation.
+       - schemaVersion: Exact Android Room schema version.
+       - modelContext: Clean context shared by AI settings and synchronization settings.
+       - settingsStore: Store receiving the pending manifest.
+     - Returns: Complete durable pending generation.
+     - Side effects: Writes one outbox archive and atomically stores its signed manifest.
+     - Throws: Filesystem, compression, encoding, identity, or settings transaction errors; the
+       archive is removed when manifest publication fails.
+     */
+    private func persistPendingUpload(
+        generation: UploadGeneration,
+        databaseURL: URL,
+        patchFileName: String,
+        deviceFolderID: String,
+        schemaVersion: Int,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> PendingUpload {
+        try fileManager.createDirectory(at: outboxDirectory, withIntermediateDirectories: true)
+        let generationID = UUID()
+        let archiveFileName = "ai-settings-\(generationID.uuidString.lowercased()).sqlite3.gz"
+        let archiveURL = outboxDirectory.appendingPathComponent(archiveFileName, isDirectory: false)
+        var keepsArchive = false
+        defer {
+            if !keepsArchive {
+                try? fileManager.removeItem(at: archiveURL)
+            }
+        }
+        let archiveFingerprint = try RemoteSyncArchiveStagingService.gzipPatchDatabase(
+            at: databaseURL,
+            to: archiveURL
+        )
+
+        var pendingUpload = PendingUpload(
+            generationID: generationID,
+            deviceFolderID: deviceFolderID,
+            sourceDevice: generation.sourceDevice,
+            patchNumber: generation.patchNumber,
+            schemaVersion: schemaVersion,
+            patchFileName: patchFileName,
+            archiveFileName: archiveFileName,
+            archiveSHA256: archiveFingerprint.sha256,
+            archiveSize: archiveFingerprint.byteCount,
+            timestamp: generation.timestamp,
+            updatedEntries: generation.changeSet.updatedEntriesByKey.values.sorted(by: Self.logEntrySort),
+            uploadedEntries: generation.changeSet.logEntries,
+            acceptedBaseline: generation.acceptedBaseline,
+            expectedAcceptedBaselineRevision: generation.expectedAcceptedBaselineRevision,
+            expectedAcceptedBaselineExists: generation.expectedAcceptedBaselineExists,
+            upsertCountsByTable: generation.changeSet.upsertCountsByTable,
+            deleteCountsByTable: generation.changeSet.deleteCountsByTable,
+            logEntryCount: generation.changeSet.logEntries.count
+        )
+        pendingUpload.publicationIdentity = try RemoteSyncPublicationIdentity.patch(
+            category: .aiSettings,
+            destinationID: pendingUpload.deviceFolderID,
+            sourceDevice: pendingUpload.sourceDevice,
+            patchNumber: pendingUpload.patchNumber,
+            schemaVersion: pendingUpload.schemaVersion,
+            remoteFileName: pendingUpload.patchFileName,
+            archiveFileName: pendingUpload.archiveFileName,
+            archiveSHA256: pendingUpload.archiveSHA256,
+            archiveSize: pendingUpload.archiveSize,
+            rowCounts: Self.publicationRowCounts(for: pendingUpload),
+            acceptancePayload: pendingUpload
+        )
+        do {
+            try settingsStore.performAtomicBatch(in: modelContext) {
+                guard try loadPendingUpload(settingsStore: settingsStore) == nil else {
+                    throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+                }
+                try storePendingUpload(pendingUpload, settingsStore: settingsStore)
+            }
+        } catch {
+            throw error
+        }
+        keepsArchive = true
+        return pendingUpload
+    }
+
+    /**
+     Reconciles or uploads one persisted generation and publishes local acceptance atomically.
+
+     Existing same-name remote files are downloaded and compared with the durable archive digest.
+     This closes the process-death window after remote commit without regenerating bytes from a live
+     graph that may already have changed.
+
+     - Parameters:
+       - pendingUpload: Durable generation to reconcile and accept.
+       - modelContext: Clean shared SwiftData context.
+       - settingsStore: Store containing pending and accepted synchronization metadata.
+       - acceptanceCheckpoint: Deterministic callback after acceptance mutation and before commit.
+     - Returns: Report describing the exact accepted generation.
+     - Side effects: Lists/downloads/uploads remote data, atomically publishes accepted local state,
+       and removes the outbox archive after commit.
+     - Throws: Missing/conflicting bytes, transport, stale baseline, settings, transaction, or
+       checkpoint errors; the outbox remains resumable on failure.
+     */
+    private func finishPendingUpload(
+        _ pendingUpload: PendingUpload,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        acceptanceCheckpoint: @escaping () throws -> Void
+    ) async throws -> RemoteSyncAISettingsPatchUploadReport {
+        let archiveURL = try pendingArchiveURL(for: pendingUpload)
+        let reconciliation = try await remotePatchReconciler.reconcile(
+            archive: RemoteSyncDurablePatchArchive(
+                fileName: pendingUpload.patchFileName,
+                fileURL: archiveURL,
+                sha256: pendingUpload.archiveSHA256,
+                size: pendingUpload.archiveSize,
+                parentID: pendingUpload.deviceFolderID,
+                contentType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        let acceptedRemoteFile: RemoteSyncFile
+        switch reconciliation {
+        case .created(let file), .matchedExisting(let file):
+            acceptedRemoteFile = file
+        }
+
+        try settingsStore.performAtomicBatch(in: modelContext) {
+            guard try loadPendingUpload(settingsStore: settingsStore) == pendingUpload else {
+                throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+            }
+            try snapshotService.validateAcceptedBaselineRevision(
+                expectedRevision: pendingUpload.expectedAcceptedBaselineRevision,
+                expectedBaselineExists: pendingUpload.expectedAcceptedBaselineExists,
+                settingsStore: settingsStore
+            )
+            let currentSnapshot = try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            try RemoteSyncMutationJournalService().mergeAcceptedLogEntries(
+                acceptedEntries: pendingUpload.updatedEntries,
+                uploadedEntries: pendingUpload.uploadedEntries ?? pendingUpload.updatedEntries.filter {
+                    $0.lastUpdated == pendingUpload.timestamp && $0.sourceDevice == pendingUpload.sourceDevice
+                },
+                acceptedFingerprints: pendingUpload.acceptedBaseline.fingerprintsByKey,
+                currentFingerprints: currentSnapshot.fingerprintsByKey,
+                category: .aiSettings,
+                settingsStore: settingsStore
+            )
+            let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+            _ = try patchStatusStore.statusesStrict(for: .aiSettings)
+            patchStatusStore.addStatus(
+                RemoteSyncPatchStatus(
+                    sourceDevice: pendingUpload.sourceDevice,
+                    patchNumber: pendingUpload.patchNumber,
+                    sizeBytes: acceptedRemoteFile.size,
+                    appliedDate: acceptedRemoteFile.timestamp
+                ),
+                for: .aiSettings
+            )
+            let stateStore = RemoteSyncStateStore(settingsStore: settingsStore)
+            var progressState = stateStore.progressState(for: .aiSettings)
+            progressState.lastPatchWritten = pendingUpload.timestamp
+            stateStore.setProgressState(progressState, for: .aiSettings)
+            try snapshotService.acceptBaseline(
+                pendingUpload.acceptedBaseline,
+                settingsStore: settingsStore
+            )
+            try acceptanceCheckpoint()
+            settingsStore.remove(Self.pendingUploadKey)
+        }
+
+        try? fileManager.removeItem(at: archiveURL)
+        return RemoteSyncAISettingsPatchUploadReport(
+            uploadedFile: acceptedRemoteFile,
+            patchNumber: pendingUpload.patchNumber,
+            tableReports: Self.tableReports(for: pendingUpload),
+            logEntryCount: pendingUpload.logEntryCount,
+            lastUpdated: pendingUpload.timestamp
+        )
+    }
+
+    /**
+     Invalidates an AI settings outbox only after explicit lifecycle destination replacement.
+
+     - Parameters:
+       - pendingUpload: Old destination-bound generation.
+       - modelContext: Clean shared context.
+       - settingsStore: Store containing its manifest.
+     - Side effects: Atomically removes only the pending marker and then removes its archive best effort.
+     - Throws: Manifest validation or settings transaction errors leave state unchanged.
+     */
+    private func invalidatePendingUpload(
+        _ pendingUpload: PendingUpload,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws {
+        try settingsStore.performAtomicBatch(in: modelContext) {
+            guard try loadPendingUpload(settingsStore: settingsStore) == pendingUpload else {
+                throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+            }
+            settingsStore.remove(Self.pendingUploadKey)
+        }
+        if let archiveURL = try? pendingArchiveURL(for: pendingUpload) {
+            try? fileManager.removeItem(at: archiveURL)
+        }
+    }
+
+    /**
+     Reads, validates, and authenticates the pending AI settings manifest.
+
+     - Parameter settingsStore: Store containing the optional pending manifest.
+     - Returns: Validated manifest, or `nil` when no generation exists.
+     - Side effects: Reads one settings value.
+     - Throws: `invalidPendingUpload` for malformed JSON, counts, or publication identity.
+     */
+    private func loadPendingUpload(settingsStore: SettingsStore) throws -> PendingUpload? {
+        guard let payload = settingsStore.getString(Self.pendingUploadKey) else { return nil }
+        guard let data = payload.data(using: .utf8),
+              let pendingUpload = try? JSONDecoder().decode(PendingUpload.self, from: data),
+              Set(pendingUpload.upsertCountsByTable.keys) == Self.supportedTableNameSet,
+              Set(pendingUpload.deleteCountsByTable.keys) == Self.supportedTableNameSet,
+              pendingUpload.upsertCountsByTable.values.allSatisfy({ $0 >= 0 }),
+              pendingUpload.deleteCountsByTable.values.allSatisfy({ $0 >= 0 }),
+              Self.totalOperationCount(for: pendingUpload) == pendingUpload.logEntryCount,
+              let publicationIdentity = pendingUpload.publicationIdentity else {
+            throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+        }
+        var acceptancePayload = pendingUpload
+        acceptancePayload.publicationIdentity = nil
+        do {
+            try publicationIdentity.validate(
+                kind: .patch,
+                category: .aiSettings,
+                destinationID: pendingUpload.deviceFolderID,
+                sourceDevice: pendingUpload.sourceDevice,
+                patchNumber: pendingUpload.patchNumber,
+                schemaVersion: pendingUpload.schemaVersion,
+                remoteFileName: pendingUpload.patchFileName,
+                archiveFileName: pendingUpload.archiveFileName,
+                archiveSHA256: pendingUpload.archiveSHA256,
+                archiveSize: pendingUpload.archiveSize,
+                rowCounts: Self.publicationRowCounts(for: pendingUpload),
+                acceptancePayload: acceptancePayload
+            )
+        } catch {
+            throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+        }
+        return pendingUpload
+    }
+
+    /**
+     Returns all signed operation counts for one AI settings publication.
+
+     - Parameter pendingUpload: Identity-free or decoded outbox envelope.
+     - Returns: Stable count dictionary covering all seven upsert/delete families and log rows.
+     - Side effects: None.
+     - Failure modes: This deterministic projection cannot fail for a validated manifest.
+     */
+    private static func publicationRowCounts(for pendingUpload: PendingUpload) -> [String: Int] {
+        var counts: [String: Int] = ["LogEntry.rows": pendingUpload.logEntryCount]
+        for tableName in supportedTableNames {
+            counts["\(tableName).upserts"] = pendingUpload.upsertCountsByTable[tableName] ?? -1
+            counts["\(tableName).deletes"] = pendingUpload.deleteCountsByTable[tableName] ?? -1
+        }
+        return counts
+    }
+
+    /**
+     Builds deterministic public table reports from one validated manifest.
+
+     - Parameter pendingUpload: Accepted pending generation.
+     - Returns: Seven reports in Android synchronization order.
+     - Side effects: None.
+     - Failure modes: Validated manifests always contain all required counts.
+     */
+    private static func tableReports(
+        for pendingUpload: PendingUpload
+    ) -> [RemoteSyncAISettingsPatchTableReport] {
+        supportedTableNames.map { tableName in
+            RemoteSyncAISettingsPatchTableReport(
+                tableName: tableName,
+                upsertedRowCount: pendingUpload.upsertCountsByTable[tableName] ?? 0,
+                deletedRowCount: pendingUpload.deleteCountsByTable[tableName] ?? 0
+            )
+        }
+    }
+
+    /**
+     Computes the exact operation total without overflowing on a malformed persisted manifest.
+
+     - Parameter pendingUpload: Decoded pending manifest.
+     - Returns: Total upserts plus deletes, or `nil` when integer addition overflows.
+     - Side effects: None.
+     - Failure modes: Overflow is represented as `nil` and causes manifest rejection.
+     */
+    private static func totalOperationCount(for pendingUpload: PendingUpload) -> Int? {
+        var total = 0
+        for value in pendingUpload.upsertCountsByTable.values {
+            let result = total.addingReportingOverflow(value)
+            guard !result.overflow else { return nil }
+            total = result.partialValue
+        }
+        for value in pendingUpload.deleteCountsByTable.values {
+            let result = total.addingReportingOverflow(value)
+            guard !result.overflow else { return nil }
+            total = result.partialValue
+        }
+        return total
+    }
+
+    /**
+     Encodes and stores one complete pending AI settings upload manifest.
+
+     - Parameters:
+       - pendingUpload: Signed durable generation.
+       - settingsStore: Store receiving sorted JSON metadata.
+     - Side effects: Replaces one settings value.
+     - Throws: Encoding or UTF-8 conversion failures as `invalidPendingUpload`.
+     */
+    private func storePendingUpload(
+        _ pendingUpload: PendingUpload,
+        settingsStore: SettingsStore
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(pendingUpload)
+        guard let payload = String(data: data, encoding: .utf8) else {
+            throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+        }
+        settingsStore.setString(Self.pendingUploadKey, value: payload)
+    }
+
+    /**
+     Resolves a safe pending archive basename beneath the configured outbox.
+
+     - Parameter pendingUpload: Validated manifest containing the local archive basename.
+     - Returns: Archive URL constrained beneath `outboxDirectory`.
+     - Side effects: None.
+     - Throws: `invalidPendingUpload` for empty or path-bearing names.
+     */
+    private func pendingArchiveURL(for pendingUpload: PendingUpload) throws -> URL {
+        guard pendingUpload.archiveFileName == URL(fileURLWithPath: pendingUpload.archiveFileName).lastPathComponent,
+              !pendingUpload.archiveFileName.isEmpty else {
+            throw RemoteSyncAISettingsPatchUploadError.invalidPendingUpload
+        }
+        return outboxDirectory.appendingPathComponent(pendingUpload.archiveFileName, isDirectory: false)
+    }
+
+    /**
+     Reads the highest Android patch number already present in one AI settings device folder.
+
+     - Parameter deviceFolderID: Active remote device-folder identifier.
+     - Returns: Highest valid Android patch number, or zero when no patch archive exists.
+     - Side effects: Performs one unfiltered remote folder listing.
+     - Throws: Backend listing failures so generation creation fails closed.
+     */
+    private func highestRemotePatchNumber(in deviceFolderID: String) async throws -> Int64 {
+        try await adapter.listFiles(
+            parentIDs: [deviceFolderID],
+            name: nil,
+            mimeType: nil,
+            modifiedAtLeast: nil
+        )
+        .compactMap { RemoteSyncPatchDiscoveryService.parsePatchFileName($0.name)?.patchNumber }
+        .max() ?? 0
+    }
+
+    /**
+     Resolves the production AI settings outbox beneath Application Support.
+
+     - Parameter fileManager: Filesystem dependency used to locate Application Support.
+     - Returns: Stable category-specific durable outbox directory.
+     - Side effects: None; the directory is created only when a generation is persisted.
+     - Failure modes: Falls back to the process temporary directory when Application Support is absent.
+     */
+    static func defaultOutboxDirectory(fileManager: FileManager) -> URL {
+        let root = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return root
+            .appendingPathComponent("AndBible", isDirectory: true)
+            .appendingPathComponent("RemoteSyncOutbox", isDirectory: true)
+            .appendingPathComponent("ai-settings", isDirectory: true)
+    }
+
+    /**
+     Diffs all seven current row maps against accepted fingerprints and durable tombstone identities.
+
+     - Parameters:
+       - snapshot: Strict complete current AI settings projection.
+       - existingEntriesByKey: Accepted local/remote Android log map.
+       - acceptedRowsByKey: Durable identities for rows accepted in prior generations.
+       - fingerprintStore: Accepted row fingerprint store.
+       - pendingMutations: Mutation-time operations captured before projection.
+       - timestamp: Logical fallback timestamp for legacy unjournaled differences.
+       - sourceDevice: Source device for fallback operations.
+     - Returns: Sparse rows plus preserved upsert/delete log operations.
+     - Side effects: Reads accepted fingerprints; does not mutate persistence.
+     - Throws: Mutation-journal identity or state-fingerprint validation errors.
+     */
+    private func buildChangeSet(
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        acceptedRowsByKey: [String: RemoteSyncAISettingsAcceptedRowIdentity],
+        fingerprintStore: RemoteSyncRowFingerprintStore,
+        pendingMutations: [String: RemoteSyncPendingMutation],
+        timestamp: Int64,
+        sourceDevice: String
+    ) throws -> ChangeSet {
+        var changeSet = ChangeSet(updatedEntriesByKey: existingEntriesByKey)
+
+        let providers = try changedRows(
+            snapshot.providerRowsByKey,
+            tableName: "LlmProviderConfig",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.providerRowsByKey = providers.rowsByKey
+        merge(providers, into: &changeSet)
+
+        let configuredModels = try changedRows(
+            snapshot.configuredModelRowsByKey,
+            tableName: "LlmConfiguredModel",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.configuredModelRowsByKey = configuredModels.rowsByKey
+        merge(configuredModels, into: &changeSet)
+
+        let agentPrompts = try changedRows(
+            snapshot.agentPromptRowsByKey,
+            tableName: "AgentPrompt",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.agentPromptRowsByKey = agentPrompts.rowsByKey
+        merge(agentPrompts, into: &changeSet)
+
+        let globalSettings = try changedRows(
+            snapshot.globalSettingsRowsByKey,
+            tableName: "GlobalAiSettings",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.globalSettingsRowsByKey = globalSettings.rowsByKey
+        merge(globalSettings, into: &changeSet)
+
+        let usageRecords = try changedRows(
+            snapshot.usageRowsByKey,
+            tableName: "LlmUsageRecord",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.usageRowsByKey = usageRecords.rowsByKey
+        merge(usageRecords, into: &changeSet)
+
+        let promptCategories = try changedRows(
+            snapshot.promptCategoryRowsByKey,
+            tableName: "PromptCategory",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.promptCategoryRowsByKey = promptCategories.rowsByKey
+        merge(promptCategories, into: &changeSet)
+
+        let builtinOverrides = try changedRows(
+            snapshot.builtinOverrideRowsByKey,
+            tableName: "BuiltinPromptOverride",
+            id: \.id,
+            snapshot: snapshot,
+            existingEntriesByKey: existingEntriesByKey,
+            fingerprintStore: fingerprintStore,
+            pendingMutations: pendingMutations,
+            timestamp: timestamp,
+            sourceDevice: sourceDevice
+        )
+        changeSet.builtinOverrideRowsByKey = builtinOverrides.rowsByKey
+        merge(builtinOverrides, into: &changeSet)
+
+        var deletionRowsByKey = acceptedRowsByKey
+        for (key, mutation) in pendingMutations where mutation.entry.type == .delete {
+            deletionRowsByKey[key] = RemoteSyncAISettingsAcceptedRowIdentity(
+                key: key,
+                tableName: mutation.entry.tableName,
+                entityID1: mutation.entry.entityID1,
+                entityID2: mutation.entry.entityID2
+            )
+        }
+        for (key, identity) in deletionRowsByKey.sorted(by: { $0.key < $1.key }) {
+            guard Self.supportedTableNameSet.contains(identity.tableName),
+                  !currentRowExists(forKey: key, in: snapshot),
+                  existingEntriesByKey[key]?.type != .delete || pendingMutations[key] != nil else {
+                continue
+            }
+            let deleteEntry = try RemoteSyncMutationJournalService().entryForUpload(
+                key: key,
+                stateFingerprint: nil,
+                type: .delete,
+                category: .aiSettings,
+                pendingMutations: pendingMutations
+            ) ?? RemoteSyncLogEntry(
+                tableName: identity.tableName,
+                entityID1: identity.entityID1,
+                entityID2: identity.entityID2,
+                type: .delete,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            changeSet.logEntries.append(deleteEntry)
+            changeSet.updatedEntriesByKey[key] = deleteEntry
+        }
+
+        changeSet.logEntries.sort(by: Self.logEntrySort)
+        return changeSet
+    }
+
+    /**
+     Collects changed rows for one UUID-keyed synchronized table without altering timestamps.
+
+     - Parameters:
+       - rows: Complete current table projection keyed by Android log identity.
+       - tableName: Exact Android synchronized table name.
+       - id: Stable UUID extractor for the row family.
+       - snapshot: Complete snapshot containing deterministic row fingerprints.
+       - existingEntriesByKey: Accepted Android log map.
+       - fingerprintStore: Accepted fingerprint store.
+       - pendingMutations: Mutation-time journal operations.
+       - timestamp: Logical timestamp used only for unjournaled legacy differences.
+       - sourceDevice: Source device used only for unjournaled legacy differences.
+     - Returns: Sparse rows paired with their exact upsert operations.
+     - Side effects: Reads accepted fingerprints; does not mutate persistence.
+     - Throws: Journal state mismatch errors from `entryForUpload`.
+     */
+    private func changedRows<Row>(
+        _ rows: [String: Row],
+        tableName: String,
+        id: (Row) -> UUID,
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore,
+        pendingMutations: [String: RemoteSyncPendingMutation],
+        timestamp: Int64,
+        sourceDevice: String
+    ) throws -> ChangedRows<Row> {
+        var rowsByKey: [String: Row] = [:]
+        var logEntries: [RemoteSyncLogEntry] = []
+        var entriesByKey: [String: RemoteSyncLogEntry] = [:]
+        for (key, row) in rows.sorted(by: { $0.key < $1.key }) {
+            let hasPendingUpsert = pendingMutations[key]?.entry.type == .upsert
+            guard hasPendingUpsert || shouldUploadCurrentRow(
+                    key: key,
+                    currentFingerprint: snapshot.fingerprintsByKey[key],
+                    existingEntriesByKey: existingEntriesByKey,
+                    fingerprintStore: fingerprintStore
+                  ) else {
+                continue
+            }
+            let entry = try RemoteSyncMutationJournalService().entryForUpload(
+                key: key,
+                stateFingerprint: snapshot.fingerprintsByKey[key],
+                type: .upsert,
+                category: .aiSettings,
+                pendingMutations: pendingMutations
+            ) ?? RemoteSyncLogEntry(
+                tableName: tableName,
+                entityID1: .blob(RemoteSyncAISettingsSnapshotService.uuidBlob(id(row))),
+                entityID2: RemoteSyncAISettingsSnapshotService.emptySecondaryEntityID,
+                type: .upsert,
+                lastUpdated: timestamp,
+                sourceDevice: sourceDevice
+            )
+            rowsByKey[key] = row
+            logEntries.append(entry)
+            entriesByKey[key] = entry
+        }
+        return ChangedRows(
+            rowsByKey: rowsByKey,
+            logEntries: logEntries,
+            entriesByKey: entriesByKey
+        )
+    }
+
+    /**
+     Overlays one table's changed operations onto the generation-wide accepted log map.
+
+     - Parameters:
+       - changedRows: Sparse rows and keyed upsert operations produced for one table.
+       - changeSet: Generation accumulator receiving the operations.
+     - Side effects: Mutates only the in-memory change set.
+     - Failure modes: This deterministic overlay cannot fail.
+     */
+    private func merge<Row>(_ changedRows: ChangedRows<Row>, into changeSet: inout ChangeSet) {
+        changeSet.logEntries.append(contentsOf: changedRows.logEntries)
+        for (key, entry) in changedRows.entriesByKey {
+            changeSet.updatedEntriesByKey[key] = entry
+        }
+    }
+
+    /**
+     Determines whether one current row differs from accepted state.
+
+     - Parameters:
+       - key: Canonical Android log identity key.
+       - currentFingerprint: Fingerprint of the complete current wire row.
+       - existingEntriesByKey: Accepted Android log map.
+       - fingerprintStore: Accepted row fingerprint store.
+     - Returns: `true` when fingerprint state requires an upsert. The caller separately treats a
+       matching mutation-journal marker as authoritative even when replay refreshed the baseline.
+     - Side effects: Reads settings-backed fingerprints.
+     - Failure modes: Missing accepted fingerprints fail dirty rather than suppressing publication.
+     */
+    private func shouldUploadCurrentRow(
+        key: String,
+        currentFingerprint: String?,
+        existingEntriesByKey: [String: RemoteSyncLogEntry],
+        fingerprintStore: RemoteSyncRowFingerprintStore
+    ) -> Bool {
+        guard let currentFingerprint else { return false }
+        guard let existingEntry = existingEntriesByKey[key] else {
+            if let existingFingerprint = fingerprintStore.fingerprint(
+                forLogKey: key,
+                category: .aiSettings
+            ) {
+                return existingFingerprint != currentFingerprint
+            }
+            return true
+        }
+        guard Self.supportedTableNameSet.contains(existingEntry.tableName) else { return false }
+        if existingEntry.type == .delete { return true }
+        guard let existingFingerprint = fingerprintStore.fingerprint(
+            for: .aiSettings,
+            tableName: existingEntry.tableName,
+            entityID1: existingEntry.entityID1,
+            entityID2: existingEntry.entityID2
+        ) else {
+            return true
+        }
+        return existingFingerprint != currentFingerprint
+    }
+
+    /**
+     Checks whether any of the seven synchronized row maps contains one Android log identity.
+
+     - Parameters:
+       - key: Canonical Android log key.
+       - snapshot: Complete current seven-table projection.
+     - Returns: `true` when the identity still has a current row.
+     - Side effects: None.
+     - Failure modes: This dictionary lookup cannot fail.
+     */
+    private func currentRowExists(
+        forKey key: String,
+        in snapshot: RemoteSyncAISettingsCurrentSnapshot
+    ) -> Bool {
+        snapshot.providerRowsByKey[key] != nil
+            || snapshot.configuredModelRowsByKey[key] != nil
+            || snapshot.agentPromptRowsByKey[key] != nil
+            || snapshot.globalSettingsRowsByKey[key] != nil
+            || snapshot.usageRowsByKey[key] != nil
+            || snapshot.promptCategoryRowsByKey[key] != nil
+            || snapshot.builtinOverrideRowsByKey[key] != nil
+    }
+
+    /**
+     Delegates complete Room v23 shell creation and sparse row insertion to the AI database writer.
+
+     - Parameters:
+       - url: Destination for the uncompressed SQLite database.
+       - schemaVersion: Exact Android AI settings schema version.
+       - snapshot: Complete credential-free source projection used to resolve sparse UPSERT rows.
+       - changeSet: Seven-table sparse rows and preserved Android log entries.
+     - Side effects: Creates and writes one SQLite file; `LlmRawLogRecord` remains empty.
+     - Throws: Unsupported schema or database-writer failures.
+     */
+    private func writePatchDatabase(
+        at url: URL,
+        schemaVersion: Int,
+        snapshot: RemoteSyncAISettingsCurrentSnapshot,
+        changeSet: ChangeSet
+    ) throws {
+        guard schemaVersion == RemoteSyncCategory.aiSettings.currentSchemaVersion else {
+            throw RemoteSyncAISettingsPatchUploadError.unsupportedSchemaVersion(schemaVersion)
+        }
+        let report = try databaseWriter.writeSparseDatabase(
+            at: url,
+            snapshot: snapshot,
+            selectedLogEntries: changeSet.logEntries,
+            schemaVersion: schemaVersion
+        )
+        let expected = changeSet.upsertCountsByTable
+        guard report.schemaVersion == schemaVersion,
+              report.providerCount == (expected["LlmProviderConfig"] ?? -1),
+              report.configuredModelCount == (expected["LlmConfiguredModel"] ?? -1),
+              report.agentPromptCount == (expected["AgentPrompt"] ?? -1),
+              report.globalSettingsCount == (expected["GlobalAiSettings"] ?? -1),
+              report.usageRecordCount == (expected["LlmUsageRecord"] ?? -1),
+              report.promptCategoryCount == (expected["PromptCategory"] ?? -1),
+              report.builtinPromptOverrideCount == (expected["BuiltinPromptOverride"] ?? -1),
+              report.logEntryCount == changeSet.logEntries.count,
+              report.rawLogRecordCount == 0 else {
+            throw RemoteSyncAISettingsPatchUploadError.databaseWriteReportMismatch
+        }
+    }
+
+    /**
+     Validates and normalizes the destination folder identifier.
+
+     - Parameter bootstrapState: Category state containing the optional remote folder ID.
+     - Returns: Trimmed nonempty folder identifier.
+     - Side effects: None.
+     - Throws: `missingDeviceFolderID` when no usable destination exists.
+     */
+    private static func validatedDeviceFolderID(
+        from bootstrapState: RemoteSyncBootstrapState
+    ) throws -> String {
+        guard let deviceFolderID = bootstrapState.deviceFolderID?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !deviceFolderID.isEmpty else {
+            throw RemoteSyncAISettingsPatchUploadError.missingDeviceFolderID
+        }
+        return deviceFolderID
+    }
+
+    /** Creates a unique transient file URL without touching the filesystem. */
+    private func temporaryURL(prefix: String, suffix: String) -> URL {
+        temporaryDirectory.appendingPathComponent("\(prefix)\(UUID().uuidString)\(suffix)")
+    }
+
+    /** Derives Android's source-device name from the final destination path component. */
+    private static func sourceDeviceName(from deviceFolderID: String) -> String {
+        let trimmed = deviceFolderID.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmed.split(separator: "/").last.map(String.init) ?? deviceFolderID
+    }
+
+    /** Orders Android log operations deterministically without altering their conflict timestamps. */
+    private static func logEntrySort(_ lhs: RemoteSyncLogEntry, _ rhs: RemoteSyncLogEntry) -> Bool {
+        if lhs.lastUpdated != rhs.lastUpdated { return lhs.lastUpdated < rhs.lastUpdated }
+        if lhs.tableName != rhs.tableName { return lhs.tableName < rhs.tableName }
+        if lhs.type != rhs.type { return lhs.type.rawValue < rhs.type.rawValue }
+        if lhs.sourceDevice != rhs.sourceDevice { return lhs.sourceDevice < rhs.sourceDevice }
+        if lhs.entityID1 != rhs.entityID1 {
+            return sortKey(for: lhs.entityID1) < sortKey(for: rhs.entityID1)
+        }
+        return sortKey(for: lhs.entityID2) < sortKey(for: rhs.entityID2)
+    }
+
+    /** Encodes one SQLite identity into a stable lexical sort key. */
+    private static func sortKey(for value: RemoteSyncSQLiteValue) -> String {
+        switch value.kind {
+        case .null:
+            return "null"
+        case .integer:
+            return "integer:\(value.integerValue ?? 0)"
+        case .real:
+            return "real:\(value.realValue?.bitPattern ?? 0)"
+        case .text:
+            return "text:\(value.textValue ?? "")"
+        case .blob:
+            return "blob:\(value.blobBase64Value ?? "")"
+        }
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsRestoreService.swift
@@ -1,0 +1,1294 @@
+// RemoteSyncAISettingsRestoreService.swift -- Validated Android v23 AI settings restore
+
+import Foundation
+import SQLite3
+import SwiftData
+
+/**
+ Fail-closed errors raised while decoding or replacing Android AI settings.
+
+ Exact schema, Room identity, version, trigger, and bounded-value failures are surfaced directly as
+ `RemoteSyncAndroidDatabaseContractError`; this error type covers row materialization and semantic
+ graph invariants that remain after the shared contract validator succeeds.
+ */
+public enum RemoteSyncAISettingsRestoreError: Error, Equatable {
+    /// The staged file could not be opened or stepped as a readable SQLite database.
+    case invalidSQLiteDatabase
+
+    /// A required column used an unexpected storage class or invalid UTF-8 representation.
+    case invalidColumnValue(table: String, column: String)
+
+    /// A UUID column was not an exact 16-byte Android BLOB.
+    case invalidIdentifierBlob(table: String, column: String)
+
+    /// More than one row used the same Android table primary key.
+    case duplicateIdentifier(table: String, id: UUID)
+
+    /// More than one row used an Android unique composite identity.
+    case duplicateCompositeIdentity(table: String, first: String, second: String)
+
+    /// More than one Android global settings singleton row was present.
+    case duplicateGlobalSettings
+
+    /// A present global settings row did not use Android's fixed singleton UUID.
+    case invalidGlobalSettingsIdentity(UUID)
+
+    /// A row violated one of Android Room's declared foreign keys.
+    case orphanFormalReference(table: String, id: UUID, parentTable: String, parentID: UUID)
+
+    /// A synchronized provider endpoint could contain URL-carried credentials or secret material.
+    case unsafeSynchronizedEndpoint(providerID: UUID)
+
+    /// A SQLite REAL decoded to a non-finite value that SwiftData must not persist.
+    case invalidFloatingPointValue(table: String, id: UUID)
+}
+
+/**
+ Materialized, credential-free contents of one Android `AiSettingsDatabase` v23 file.
+
+ Only Android's seven `AI_SETTINGS` sync tables are represented. Full Android initial backups can
+ contain device-local `LlmRawLogRecord` rows because Android copies the complete Room file; iOS
+ counts and ignores those rows. API credentials have no Room column and no property here. Raw
+ Room-converter strings remain byte-for-byte UTF-8-equivalent to their SQLite values.
+ */
+public struct RemoteSyncAndroidAISettingsSnapshot: Sendable, Equatable {
+    /// Android `LlmProviderConfig` rows without API keys.
+    public let providers: [RemoteSyncAndroidAIProvider]
+
+    /// Android `LlmConfiguredModel` rows.
+    public let configuredModels: [RemoteSyncAndroidAIConfiguredModel]
+
+    /// Android `AgentPrompt` rows with raw converter strings preserved.
+    public let agentPrompts: [RemoteSyncAndroidAIAgentPrompt]
+
+    /// Zero or one Android global settings singleton row.
+    public let globalSettings: [RemoteSyncAndroidGlobalAISettings]
+
+    /// Android per-device model usage rows.
+    public let usageRecords: [RemoteSyncAndroidAIUsageRecord]
+
+    /// Android user-defined prompt category rows.
+    public let promptCategories: [RemoteSyncAndroidAIPromptCategory]
+
+    /// Android built-in prompt model overrides.
+    public let builtinOverrides: [RemoteSyncAndroidAIBuiltinPromptOverride]
+
+    /// Number of bounded incoming device-local raw logs deliberately omitted from the snapshot.
+    public let ignoredIncomingRawLogCount: Int
+
+    /**
+     Creates a typed Android AI settings restore generation.
+
+     - Parameters:
+       - providers: Non-secret provider configuration rows.
+       - configuredModels: Provider-owned configured model rows.
+       - agentPrompts: User prompt rows.
+       - globalSettings: Zero or one fixed-identity singleton row.
+       - usageRecords: Per-device usage rows.
+       - promptCategories: User category rows.
+       - builtinOverrides: Built-in prompt override rows.
+       - ignoredIncomingRawLogCount: Bounded incoming raw-log count omitted from materialization.
+     - Side Effects: none.
+     - Failure modes: This initializer does not validate; restore entry points validate all identities,
+       unique composites, finite values, and formal foreign keys before mutation.
+     */
+    public init(
+        providers: [RemoteSyncAndroidAIProvider],
+        configuredModels: [RemoteSyncAndroidAIConfiguredModel],
+        agentPrompts: [RemoteSyncAndroidAIAgentPrompt],
+        globalSettings: [RemoteSyncAndroidGlobalAISettings],
+        usageRecords: [RemoteSyncAndroidAIUsageRecord],
+        promptCategories: [RemoteSyncAndroidAIPromptCategory],
+        builtinOverrides: [RemoteSyncAndroidAIBuiltinPromptOverride],
+        ignoredIncomingRawLogCount: Int = 0
+    ) {
+        self.providers = providers
+        self.configuredModels = configuredModels
+        self.agentPrompts = agentPrompts
+        self.globalSettings = globalSettings
+        self.usageRecords = usageRecords
+        self.promptCategories = promptCategories
+        self.builtinOverrides = builtinOverrides
+        self.ignoredIncomingRawLogCount = ignoredIncomingRawLogCount
+    }
+}
+
+/** Counts produced by one successful atomic AI settings replacement. */
+public struct RemoteSyncAISettingsRestoreReport: Sendable, Equatable {
+    /// Number of non-secret provider rows restored.
+    public let restoredProviderCount: Int
+
+    /// Number of configured-model rows restored.
+    public let restoredConfiguredModelCount: Int
+
+    /// Number of agent-prompt rows restored.
+    public let restoredAgentPromptCount: Int
+
+    /// Number of global-settings singleton rows restored.
+    public let restoredGlobalSettingsCount: Int
+
+    /// Number of per-device usage rows restored.
+    public let restoredUsageRecordCount: Int
+
+    /// Number of prompt-category rows restored.
+    public let restoredPromptCategoryCount: Int
+
+    /// Number of built-in prompt override rows restored.
+    public let restoredBuiltinPromptOverrideCount: Int
+
+    /// Number of bounded Android raw-log rows ignored during materialization.
+    public let ignoredIncomingRawLogCount: Int
+
+    /// Number of local iOS raw-log rows left untouched by the replacement.
+    public let preservedLocalRawLogCount: Int
+}
+
+/**
+ Reads authenticated Android AI settings Room generations and atomically replaces iOS's synchronized
+ AI models.
+
+ Read behavior:
+ - migrates supported writable staged predecessors through Android's production chain
+ - opens the resulting SQLite file read-only
+ - validates the complete v23 Room schema, identity hash, runtime trigger set, storage classes, and
+   allocation bounds through `RemoteSyncAndroidDatabaseContract`
+ - materializes only the seven Android `AI_SETTINGS` tables
+ - rejects malformed UUIDs, duplicate primary or composite identities, non-finite REALs, and missing
+   parents for Room-declared foreign keys
+ - preserves Android's deliberately logical dangling references for prompt categories, global default
+   models, and usage model identities
+ - bounds and counts `LlmRawLogRecord` rows from Android full-database backups but never decodes or
+   imports them
+ - rejects provider endpoints containing credential-bearing URL components
+ - never accepts a credential input
+
+ Replace behavior:
+ - captures the existing seven-model durable generation before mutation
+ - deletes and recreates only those seven SwiftData model sets
+ - commits through `SettingsStore.performAtomicBatch(in:durableRecovery:_:)`
+ - leaves every local `LLMRawLogRecord` and Keychain credential untouched
+ - restores the prior durable generation through a fresh context if a multi-store commit partially lands
+
+ Failure modes:
+ - no SwiftData mutation begins until the complete incoming graph passes validation
+ - schema and payload contract failures propagate as `RemoteSyncAndroidDatabaseContractError`
+ - decode, identity, foreign-key, fetch, cancellation, save, and durable recovery failures are rethrown
+
+ Concurrency:
+ - the service is not `Sendable`; callers must respect the supplied `ModelContext` confinement
+ - the settings store must own the exact clean context passed to replacement
+ */
+public final class RemoteSyncAISettingsRestoreService {
+    /// Exact Android `AiSettingsDatabase` generation accepted by this reader.
+    public static let supportedAndroidSchemaVersion = 23
+
+    /**
+     Creates an AI settings restore service.
+
+     - Side Effects: none.
+     - Failure modes: This initializer cannot fail.
+     */
+    public init() {}
+
+    /**
+     Reads and validates one staged Android `ai_settings.sqlite3` database.
+
+     - Parameters:
+       - databaseURL: Local file URL for the uncompressed Android Room database.
+       - expectedSourceVersion: Archive-declared Room generation, or `nil` when the staged file is
+         the only source of version authority.
+     - Returns: Deterministically ordered rows from only the seven synchronized AI tables, plus the
+       bounded count of Android raw-log rows deliberately ignored by iOS.
+     - Side Effects:
+       - migrates the writable staged copy through Android's supported Room chain when needed
+       - validates the complete Room v23 schema and row-storage contract
+       - opens the validated staged SQLite database read-only for decoding
+     - Throws:
+       - migration errors for unsupported, mismatched, or unopenable source generations
+       - `RemoteSyncAndroidDatabaseContractError` for noncanonical or out-of-bounds files
+       - `RemoteSyncAISettingsRestoreError` for SQLite stepping, malformed UTF-8/UUID values,
+         duplicate identities, credential-bearing endpoints, non-finite values, or formal
+         foreign-key orphans
+     */
+    public func readSnapshot(
+        from databaseURL: URL,
+        expectedSourceVersion: Int? = nil
+    ) throws -> RemoteSyncAndroidAISettingsSnapshot {
+        try readSnapshot(
+            from: databaseURL,
+            expectedSourceVersion: expectedSourceVersion,
+            requiresCompleteFormalReferences: true
+        )
+    }
+
+    /**
+     Reads one sparse Android AI settings patch without requiring unchanged parent rows in the file.
+
+     Patch databases carry only rows named by their `LogEntry` operations. Formal references are
+     therefore validated against the materialized local-plus-patch graph immediately before publish,
+     rather than against this intentionally incomplete snapshot.
+
+     - Parameters:
+       - databaseURL: Local file URL for the uncompressed Android Room patch database.
+       - expectedSourceVersion: Patch-filename Room generation, or `nil` when the staged file is the
+         only source of version authority.
+     - Returns: Deterministically ordered rows from the seven synchronized AI tables.
+     - Side Effects: Migrates and validates the writable staged copy, then opens it read-only for
+       deterministic row decoding; no local app persistence is mutated.
+     - Throws: Rethrows exact schema, bounds, row decoding, identity, endpoint, and numeric errors.
+     */
+    func readSparsePatchSnapshot(
+        from databaseURL: URL,
+        expectedSourceVersion: Int? = nil
+    ) throws -> RemoteSyncAndroidAISettingsSnapshot {
+        try readSnapshot(
+            from: databaseURL,
+            expectedSourceVersion: expectedSourceVersion,
+            requiresCompleteFormalReferences: false
+        )
+    }
+
+    /** Reads one full or sparse Android AI database under the requested graph-validation policy. */
+    private func readSnapshot(
+        from databaseURL: URL,
+        expectedSourceVersion: Int?,
+        requiresCompleteFormalReferences: Bool
+    ) throws -> RemoteSyncAndroidAISettingsSnapshot {
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(
+            at: databaseURL,
+            expectedSourceVersion: expectedSourceVersion
+        )
+
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(
+            databaseURL.path,
+            &database,
+            SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK, let database else {
+            if let database { sqlite3_close(database) }
+            throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+        }
+        defer { sqlite3_close(database) }
+
+        guard RemoteSyncAndroidDatabaseContract.schemaVersion(for: .aiSettings)
+            == Self.supportedAndroidSchemaVersion else {
+            throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+        }
+        try RemoteSyncAndroidDatabaseContract.validateInboundDatabase(database, category: .aiSettings)
+
+        let snapshot = RemoteSyncAndroidAISettingsSnapshot(
+            providers: try fetchProviders(from: database),
+            configuredModels: try fetchConfiguredModels(from: database),
+            agentPrompts: try fetchAgentPrompts(from: database),
+            globalSettings: try fetchGlobalSettings(from: database),
+            usageRecords: try fetchUsageRecords(from: database),
+            promptCategories: try fetchPromptCategories(from: database),
+            builtinOverrides: try fetchBuiltinPromptOverrides(from: database),
+            ignoredIncomingRawLogCount: try rowCount(in: "LlmRawLogRecord", database: database)
+        )
+        try Self.validate(
+            snapshot,
+            requiresCompleteFormalReferences: requiresCompleteFormalReferences
+        )
+        return Self.sorted(snapshot)
+    }
+
+    /**
+     Reads one staged database and atomically replaces the seven synchronized local AI model sets.
+
+     - Parameters:
+       - databaseURL: Local file URL for an authenticated Android Room generation supported by the
+         production migration chain.
+       - modelContext: Clean context containing AI models and the settings store's local configuration.
+       - settingsStore: Store created with the exact same context.
+     - Returns: Counts for all restored, ignored, and preserved model groups.
+     - Side Effects: Performs one read-only SQLite pass followed by one atomic SwiftData replacement.
+     - Throws: Rethrows every read, validation, context-contract, cancellation, save, or durable
+       recovery failure. Local synchronized rows and raw logs remain unchanged on failure.
+     */
+    public func restore(
+        from databaseURL: URL,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAISettingsRestoreReport {
+        let snapshot = try readSnapshot(from: databaseURL)
+        return try replaceLocalAISettings(
+            from: snapshot,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+    }
+
+    /**
+     Atomically replaces all seven synchronized AI model sets with one validated generation.
+
+     The method is suitable for initial restore and for a fully reconciled patch generation. Local raw
+     model logs are counted but never deleted, inserted, or decoded. Provider credentials remain in the
+     separate device-local credential store and are neither removed nor overwritten.
+
+     - Parameters:
+       - snapshot: Complete Android-shaped generation to publish.
+       - modelContext: Exact clean context shared by the AI models and `settingsStore`.
+       - settingsStore: Settings store that owns `modelContext` and the atomic commit boundary.
+     - Returns: Typed counts after the outer transaction commits successfully.
+     - Side Effects: Deletes and recreates only the seven synchronized SwiftData model sets and saves
+       through one settings-backed atomic transaction.
+     - Throws: Identity, composite, formal-reference, fetch, context, cancellation, save, or durable
+       recovery errors. Any failed publication restores the previous durable generation.
+     */
+    public func replaceLocalAISettings(
+        from snapshot: RemoteSyncAndroidAISettingsSnapshot,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAISettingsRestoreReport {
+        try Self.validate(snapshot, requiresCompleteFormalReferences: true)
+        let durableGraph = try Self.captureDurableGraph(from: modelContext)
+        let preservedRawLogCount = try modelContext.fetchCount(FetchDescriptor<LLMRawLogRecord>())
+
+        return try settingsStore.performAtomicBatch(
+            in: modelContext,
+            durableRecovery: { container in
+                try Self.restoreDurableGraph(durableGraph, in: container)
+            }
+        ) {
+            try Task.checkCancellation()
+            try Self.stage(snapshot, in: modelContext)
+            try Task.checkCancellation()
+            return Self.report(
+                for: snapshot,
+                preservedLocalRawLogCount: preservedRawLogCount
+            )
+        }
+    }
+
+    /** Store-independent value generation used only for partial-commit compensation. */
+    private struct DurableGraph: Equatable {
+        let providers: [RemoteSyncAndroidAIProvider]
+        let configuredModels: [RemoteSyncAndroidAIConfiguredModel]
+        let agentPrompts: [RemoteSyncAndroidAIAgentPrompt]
+        let globalSettings: [RemoteSyncAndroidGlobalAISettings]
+        let usageRecords: [RemoteSyncAndroidAIUsageRecord]
+        let promptCategories: [RemoteSyncAndroidAIPromptCategory]
+        let builtinPromptOverrides: [RemoteSyncAndroidAIBuiltinPromptOverride]
+    }
+
+    /** Builds a successful restore report without querying or mutating persistence. */
+    private static func report(
+        for snapshot: RemoteSyncAndroidAISettingsSnapshot,
+        preservedLocalRawLogCount: Int
+    ) -> RemoteSyncAISettingsRestoreReport {
+        RemoteSyncAISettingsRestoreReport(
+            restoredProviderCount: snapshot.providers.count,
+            restoredConfiguredModelCount: snapshot.configuredModels.count,
+            restoredAgentPromptCount: snapshot.agentPrompts.count,
+            restoredGlobalSettingsCount: snapshot.globalSettings.count,
+            restoredUsageRecordCount: snapshot.usageRecords.count,
+            restoredPromptCategoryCount: snapshot.promptCategories.count,
+            restoredBuiltinPromptOverrideCount: snapshot.builtinOverrides.count,
+            ignoredIncomingRawLogCount: snapshot.ignoredIncomingRawLogCount,
+            preservedLocalRawLogCount: preservedLocalRawLogCount
+        )
+    }
+
+    /**
+     Validates identities and graph semantics not already enforced by the shared SQLite contract.
+
+     Android's logical references intentionally remain unchecked. Formal Room references are checked
+     against the complete staged generation and cause the entire restore to fail before mutation.
+     */
+    private static func validate(
+        _ snapshot: RemoteSyncAndroidAISettingsSnapshot,
+        requiresCompleteFormalReferences: Bool = true
+    ) throws {
+        try requireUniqueIDs(snapshot.providers, table: "LlmProviderConfig", id: \.id)
+        try requireUniqueIDs(snapshot.configuredModels, table: "LlmConfiguredModel", id: \.id)
+        try requireUniqueIDs(snapshot.agentPrompts, table: "AgentPrompt", id: \.id)
+        try requireUniqueIDs(snapshot.globalSettings, table: "GlobalAiSettings", id: \.id)
+        try requireUniqueIDs(snapshot.usageRecords, table: "LlmUsageRecord", id: \.id)
+        try requireUniqueIDs(snapshot.promptCategories, table: "PromptCategory", id: \.id)
+        try requireUniqueIDs(snapshot.builtinOverrides, table: "BuiltinPromptOverride", id: \.id)
+
+        for row in snapshot.providers {
+            guard RemoteSyncAISettingsEndpointPolicy.isCredentialFree(row.endpoint) else {
+                throw RemoteSyncAISettingsRestoreError.unsafeSynchronizedEndpoint(
+                    providerID: row.id
+                )
+            }
+        }
+
+        guard snapshot.globalSettings.count <= 1 else {
+            throw RemoteSyncAISettingsRestoreError.duplicateGlobalSettings
+        }
+        if let global = snapshot.globalSettings.first, global.id != GlobalAISettings.singletonID {
+            throw RemoteSyncAISettingsRestoreError.invalidGlobalSettingsIdentity(global.id)
+        }
+        try requireUniqueComposite(
+            snapshot.configuredModels,
+            table: "LlmConfiguredModel",
+            first: { $0.providerConfigId.uuidString.lowercased() },
+            second: \.modelId
+        )
+        try requireUniqueComposite(
+            snapshot.usageRecords,
+            table: "LlmUsageRecord",
+            first: { $0.configuredModelId.uuidString.lowercased() },
+            second: \.deviceId
+        )
+
+        if requiresCompleteFormalReferences {
+            let providerIDs = Set(snapshot.providers.map(\.id))
+            let configuredModelIDs = Set(snapshot.configuredModels.map(\.id))
+            for row in snapshot.configuredModels where !providerIDs.contains(row.providerConfigId) {
+                throw RemoteSyncAISettingsRestoreError.orphanFormalReference(
+                    table: "LlmConfiguredModel",
+                    id: row.id,
+                    parentTable: "LlmProviderConfig",
+                    parentID: row.providerConfigId
+                )
+            }
+            for row in snapshot.agentPrompts {
+                if let parentID = row.configuredModelId, !configuredModelIDs.contains(parentID) {
+                    throw RemoteSyncAISettingsRestoreError.orphanFormalReference(
+                        table: "AgentPrompt",
+                        id: row.id,
+                        parentTable: "LlmConfiguredModel",
+                        parentID: parentID
+                    )
+                }
+            }
+            for row in snapshot.builtinOverrides {
+                if let parentID = row.configuredModelId, !configuredModelIDs.contains(parentID) {
+                    throw RemoteSyncAISettingsRestoreError.orphanFormalReference(
+                        table: "BuiltinPromptOverride",
+                        id: row.id,
+                        parentTable: "LlmConfiguredModel",
+                        parentID: parentID
+                    )
+                }
+            }
+        }
+        for row in snapshot.configuredModels where !row.inputPricePerMillion.isFinite
+            || !row.outputPricePerMillion.isFinite
+            || !row.cacheCreationPricePerMillion.isFinite
+            || !row.cacheReadPricePerMillion.isFinite {
+            throw RemoteSyncAISettingsRestoreError.invalidFloatingPointValue(
+                table: "LlmConfiguredModel",
+                id: row.id
+            )
+        }
+        for row in snapshot.usageRecords where !row.estimatedCostUsd.isFinite {
+            throw RemoteSyncAISettingsRestoreError.invalidFloatingPointValue(
+                table: "LlmUsageRecord",
+                id: row.id
+            )
+        }
+    }
+
+    /** Rejects repeated primary UUIDs without relying on a trapping dictionary initializer. */
+    private static func requireUniqueIDs<Row>(
+        _ rows: [Row],
+        table: String,
+        id: (Row) -> UUID
+    ) throws {
+        var seen: Set<UUID> = []
+        for row in rows {
+            let value = id(row)
+            guard seen.insert(value).inserted else {
+                throw RemoteSyncAISettingsRestoreError.duplicateIdentifier(table: table, id: value)
+            }
+        }
+    }
+
+    /** Rejects repeated unique-index pairs using a length-delimited identity key. */
+    private static func requireUniqueComposite<Row>(
+        _ rows: [Row],
+        table: String,
+        first: (Row) -> String,
+        second: (Row) -> String
+    ) throws {
+        var seen: Set<String> = []
+        for row in rows {
+            let firstValue = first(row)
+            let secondValue = second(row)
+            let key = "\(firstValue.utf8.count):\(firstValue)\(secondValue.utf8.count):\(secondValue)"
+            guard seen.insert(key).inserted else {
+                throw RemoteSyncAISettingsRestoreError.duplicateCompositeIdentity(
+                    table: table,
+                    first: firstValue,
+                    second: secondValue
+                )
+            }
+        }
+    }
+
+    /** Captures the exact synchronized local generation without reading raw logs or credentials. */
+    private static func captureDurableGraph(from modelContext: ModelContext) throws -> DurableGraph {
+        DurableGraph(
+            providers: try modelContext.fetch(FetchDescriptor<LLMProviderConfig>()).map(providerRow).sorted(by: providerSort),
+            configuredModels: try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).map(configuredModelRow).sorted(by: configuredModelSort),
+            agentPrompts: try modelContext.fetch(FetchDescriptor<AgentPrompt>()).map(agentPromptRow).sorted(by: promptSort),
+            globalSettings: try modelContext.fetch(FetchDescriptor<GlobalAISettings>()).map(globalSettingsRow).sorted { $0.id.uuidString < $1.id.uuidString },
+            usageRecords: try modelContext.fetch(FetchDescriptor<LLMUsageRecord>()).map(usageRow).sorted(by: usageSort),
+            promptCategories: try modelContext.fetch(FetchDescriptor<PromptCategory>()).map(promptCategoryRow).sorted(by: categorySort),
+            builtinPromptOverrides: try modelContext.fetch(FetchDescriptor<BuiltInPromptOverride>()).map(builtinOverrideRow).sorted { $0.id.uuidString < $1.id.uuidString }
+        )
+    }
+
+    /** Restores a partially committed old generation through a fresh graph-only context. */
+    private static func restoreDurableGraph(
+        _ expected: DurableGraph,
+        in container: ModelContainer
+    ) throws {
+        let recoveryContext = ModelContext(container)
+        recoveryContext.autosaveEnabled = false
+        let current = try captureDurableGraph(from: recoveryContext)
+        guard current != expected else { return }
+
+        let snapshot = RemoteSyncAndroidAISettingsSnapshot(
+            providers: expected.providers,
+            configuredModels: expected.configuredModels,
+            agentPrompts: expected.agentPrompts,
+            globalSettings: expected.globalSettings,
+            usageRecords: expected.usageRecords,
+            promptCategories: expected.promptCategories,
+            builtinOverrides: expected.builtinPromptOverrides
+        )
+        try stage(snapshot, in: recoveryContext, checksCancellation: false)
+        try recoveryContext.save()
+    }
+
+    /**
+     Stages one complete seven-model replacement without saving.
+
+     - Parameters:
+       - snapshot: Prevalidated synchronized generation.
+       - modelContext: Context receiving delete and insert operations.
+       - checksCancellation: Whether destructive loops should observe cooperative cancellation.
+     - Side Effects: Deletes and inserts only synchronized AI models; raw logs remain untouched.
+     - Throws: Rethrows fetch failures and, when enabled, `CancellationError`.
+     - Important: The caller owns the save or rollback boundary.
+     */
+    private static func stage(
+        _ snapshot: RemoteSyncAndroidAISettingsSnapshot,
+        in modelContext: ModelContext,
+        checksCancellation: Bool = true
+    ) throws {
+        let existingPrompts = try modelContext.fetch(FetchDescriptor<AgentPrompt>())
+        let existingOverrides = try modelContext.fetch(FetchDescriptor<BuiltInPromptOverride>())
+        let existingUsage = try modelContext.fetch(FetchDescriptor<LLMUsageRecord>())
+        let existingGlobalSettings = try modelContext.fetch(FetchDescriptor<GlobalAISettings>())
+        let existingConfiguredModels = try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>())
+        let existingCategories = try modelContext.fetch(FetchDescriptor<PromptCategory>())
+        let existingProviders = try modelContext.fetch(FetchDescriptor<LLMProviderConfig>())
+
+        for row in existingPrompts { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingOverrides { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingUsage { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingGlobalSettings { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingConfiguredModels { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingCategories { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+        for row in existingProviders { modelContext.delete(row); try cancellationCheck(checksCancellation) }
+
+        for row in snapshot.providers {
+            modelContext.insert(providerModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.configuredModels {
+            modelContext.insert(configuredModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.promptCategories {
+            modelContext.insert(promptCategoryModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.agentPrompts {
+            modelContext.insert(agentPromptModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.globalSettings {
+            modelContext.insert(globalSettingsModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.usageRecords {
+            modelContext.insert(usageModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+        for row in snapshot.builtinOverrides {
+            modelContext.insert(builtinOverrideModel(row))
+            try cancellationCheck(checksCancellation)
+        }
+    }
+
+    /** Performs an optional cooperative cancellation check between destructive mutations. */
+    private static func cancellationCheck(_ enabled: Bool) throws {
+        if enabled { try Task.checkCancellation() }
+    }
+
+    /** Builds a SwiftData provider while retaining unknown raw Android enum values verbatim. */
+    private static func providerModel(_ row: RemoteSyncAndroidAIProvider) -> LLMProviderConfig {
+        let model = LLMProviderConfig(
+            id: row.id,
+            provider: LLMProvider(rawValue: row.providerType) ?? .custom,
+            displayName: row.displayName,
+            endpoint: row.endpoint,
+            apiFormat: row.apiFormat.flatMap(APIFormat.init(rawValue:)),
+            orderNumber: row.orderNumber
+        )
+        model.providerType = row.providerType
+        model.endpoint = row.endpoint
+        model.apiFormatRawValue = row.apiFormat
+        return model
+    }
+
+    /** Builds a SwiftData configured-model row with exact pricing values. */
+    private static func configuredModel(_ row: RemoteSyncAndroidAIConfiguredModel) -> LLMConfiguredModel {
+        LLMConfiguredModel(
+            id: row.id,
+            providerConfigId: row.providerConfigId,
+            modelId: row.modelId,
+            orderNumber: row.orderNumber,
+            inputPricePerMillion: row.inputPricePerMillion,
+            outputPricePerMillion: row.outputPricePerMillion,
+            cacheCreationPricePerMillion: row.cacheCreationPricePerMillion,
+            cacheReadPricePerMillion: row.cacheReadPricePerMillion
+        )
+    }
+
+    /** Builds a SwiftData prompt and then restores every raw converter string without normalization. */
+    private static func agentPromptModel(_ row: RemoteSyncAndroidAIAgentPrompt) -> AgentPrompt {
+        let model = AgentPrompt(
+            id: row.id,
+            name: row.name,
+            description: row.promptDescription,
+            promptTemplate: row.promptTemplate,
+            orderNumber: row.orderNumber,
+            createdAtMilliseconds: row.createdAt,
+            strictContextMatching: row.strictContextMatching,
+            configuredModelId: row.configuredModelId,
+            specifyBeforeRun: row.editBeforeRun,
+            noDocumentCreation: row.noDocumentCreation,
+            maxIterations: row.maxIterations,
+            autoIncludeDocuments: row.autoIncludeDocuments,
+            autoIncludeCommentaries: row.autoIncludeCommentaries,
+            bibleOnly: row.bibleOnly,
+            isTextTransformation: row.isTextTransformation,
+            categoryId: row.categoryId
+        )
+        model.showInRawValue = row.showIn
+        model.permissionModeRawValue = row.permissionMode
+        model.allowedToolsRawValue = row.allowedTools
+        model.deniedToolsRawValue = row.deniedTools
+        return model
+    }
+
+    /** Builds Android's global singleton and preserves all raw converter payloads verbatim. */
+    private static func globalSettingsModel(_ row: RemoteSyncAndroidGlobalAISettings) -> GlobalAISettings {
+        let model = GlobalAISettings(id: row.id)
+        model.agentPermissionModeRawValue = row.agentPermissionMode
+        model.permanentlyAllowedToolsRawValue = row.permanentlyAllowedTools
+        model.permanentlyDeniedToolsRawValue = row.permanentlyDeniedTools
+        model.aiExcludedDocumentsRawValue = row.aiExcludedDocuments
+        model.commentaryMaxResponseTokens = row.commentaryMaxResponseTokens
+        model.hiddenBuiltInPromptsRawValue = row.hiddenBuiltInPrompts
+        model.maxIterations = row.maxIterations
+        model.commentaryDeselectedRawValue = row.commentaryDeselected
+        model.defaultModelId = row.defaultModelId
+        model.aiLanguage = row.aiLanguage
+        model.askModelBeforeRun = row.askModelBeforeRun
+        model.aiDisclaimerAccepted = row.aiDisclaimerAccepted
+        model.hiddenBuiltInCategoriesRawValue = row.hiddenBuiltInCategories
+        model.customAgentSystemPrompt = row.customAgentSystemPrompt
+        model.customTextTransformationSystemPrompt = row.customTextTransformationSystemPrompt
+        model.favoritePromptsRawValue = row.favoritePrompts
+        model.rawLogRetentionDays = row.rawLogRetentionDays
+        model.autoHideAgentLogOnCompletion = row.autoHideAgentLogOnCompletion
+        return model
+    }
+
+    /** Builds one SwiftData per-device cumulative usage row. */
+    private static func usageModel(_ row: RemoteSyncAndroidAIUsageRecord) -> LLMUsageRecord {
+        let model = LLMUsageRecord(
+            id: row.id,
+            configuredModelId: row.configuredModelId,
+            deviceId: row.deviceId
+        )
+        model.inputTokens = row.inputTokens
+        model.outputTokens = row.outputTokens
+        model.cacheCreationTokens = row.cacheCreationTokens
+        model.cacheReadTokens = row.cacheReadTokens
+        model.estimatedCostUSD = row.estimatedCostUsd
+        return model
+    }
+
+    /** Builds one SwiftData user prompt-category row. */
+    private static func promptCategoryModel(_ row: RemoteSyncAndroidAIPromptCategory) -> PromptCategory {
+        PromptCategory(id: row.id, name: row.name, orderNumber: row.orderNumber, hidden: row.hidden)
+    }
+
+    /** Builds one SwiftData built-in prompt override row. */
+    private static func builtinOverrideModel(
+        _ row: RemoteSyncAndroidAIBuiltinPromptOverride
+    ) -> BuiltInPromptOverride {
+        BuiltInPromptOverride(id: row.id, configuredModelId: row.configuredModelId)
+    }
+
+    /** Projects one local provider into its credential-free Android wire row. */
+    private static func providerRow(_ value: LLMProviderConfig) -> RemoteSyncAndroidAIProvider {
+        RemoteSyncAndroidAIProvider(
+            id: value.id,
+            providerType: value.providerType,
+            displayName: value.displayName,
+            endpoint: value.endpoint,
+            apiFormat: value.apiFormatRawValue,
+            orderNumber: value.orderNumber
+        )
+    }
+
+    /** Projects one local configured model into its exact Android wire row. */
+    private static func configuredModelRow(
+        _ value: LLMConfiguredModel
+    ) -> RemoteSyncAndroidAIConfiguredModel {
+        RemoteSyncAndroidAIConfiguredModel(
+            id: value.id,
+            providerConfigId: value.providerConfigId,
+            modelId: value.modelId,
+            orderNumber: value.orderNumber,
+            inputPricePerMillion: value.inputPricePerMillion,
+            outputPricePerMillion: value.outputPricePerMillion,
+            cacheCreationPricePerMillion: value.cacheCreationPricePerMillion,
+            cacheReadPricePerMillion: value.cacheReadPricePerMillion
+        )
+    }
+
+    /** Projects one local prompt without decoding or re-encoding Room converter strings. */
+    private static func agentPromptRow(_ value: AgentPrompt) -> RemoteSyncAndroidAIAgentPrompt {
+        RemoteSyncAndroidAIAgentPrompt(
+            id: value.id,
+            name: value.name,
+            promptDescription: value.promptDescription,
+            promptTemplate: value.promptTemplate,
+            showIn: value.showInRawValue,
+            orderNumber: value.orderNumber,
+            createdAt: value.createdAtMilliseconds,
+            strictContextMatching: value.strictContextMatching,
+            permissionMode: value.permissionModeRawValue,
+            allowedTools: value.allowedToolsRawValue,
+            deniedTools: value.deniedToolsRawValue,
+            configuredModelId: value.configuredModelId,
+            editBeforeRun: value.specifyBeforeRun,
+            noDocumentCreation: value.noDocumentCreation,
+            maxIterations: value.maxIterations,
+            autoIncludeDocuments: value.autoIncludeDocuments,
+            autoIncludeCommentaries: value.autoIncludeCommentaries,
+            bibleOnly: value.bibleOnly,
+            isTextTransformation: value.isTextTransformation,
+            categoryId: value.categoryId
+        )
+    }
+
+    /** Projects one local global singleton without normalizing raw converter strings. */
+    private static func globalSettingsRow(
+        _ value: GlobalAISettings
+    ) -> RemoteSyncAndroidGlobalAISettings {
+        RemoteSyncAndroidGlobalAISettings(
+            id: value.id,
+            agentPermissionMode: value.agentPermissionModeRawValue,
+            permanentlyAllowedTools: value.permanentlyAllowedToolsRawValue,
+            permanentlyDeniedTools: value.permanentlyDeniedToolsRawValue,
+            aiExcludedDocuments: value.aiExcludedDocumentsRawValue,
+            commentaryMaxResponseTokens: value.commentaryMaxResponseTokens,
+            hiddenBuiltInPrompts: value.hiddenBuiltInPromptsRawValue,
+            maxIterations: value.maxIterations,
+            commentaryDeselected: value.commentaryDeselectedRawValue,
+            defaultModelId: value.defaultModelId,
+            aiLanguage: value.aiLanguage,
+            askModelBeforeRun: value.askModelBeforeRun,
+            aiDisclaimerAccepted: value.aiDisclaimerAccepted,
+            hiddenBuiltInCategories: value.hiddenBuiltInCategoriesRawValue,
+            customAgentSystemPrompt: value.customAgentSystemPrompt,
+            customTextTransformationSystemPrompt: value.customTextTransformationSystemPrompt,
+            favoritePrompts: value.favoritePromptsRawValue,
+            rawLogRetentionDays: value.rawLogRetentionDays,
+            autoHideAgentLogOnCompletion: value.autoHideAgentLogOnCompletion
+        )
+    }
+
+    /** Projects one local usage row into Android's cumulative per-device wire row. */
+    private static func usageRow(_ value: LLMUsageRecord) -> RemoteSyncAndroidAIUsageRecord {
+        RemoteSyncAndroidAIUsageRecord(
+            id: value.id,
+            configuredModelId: value.configuredModelId,
+            deviceId: value.deviceId,
+            inputTokens: value.inputTokens,
+            outputTokens: value.outputTokens,
+            cacheCreationTokens: value.cacheCreationTokens,
+            cacheReadTokens: value.cacheReadTokens,
+            estimatedCostUsd: value.estimatedCostUSD
+        )
+    }
+
+    /** Projects one local user category into Android's wire row. */
+    private static func promptCategoryRow(
+        _ value: PromptCategory
+    ) -> RemoteSyncAndroidAIPromptCategory {
+        RemoteSyncAndroidAIPromptCategory(
+            id: value.id,
+            name: value.name,
+            orderNumber: value.orderNumber,
+            hidden: value.hidden
+        )
+    }
+
+    /** Projects one local built-in override into Android's wire row. */
+    private static func builtinOverrideRow(
+        _ value: BuiltInPromptOverride
+    ) -> RemoteSyncAndroidAIBuiltinPromptOverride {
+        RemoteSyncAndroidAIBuiltinPromptOverride(
+            id: value.id,
+            configuredModelId: value.configuredModelId
+        )
+    }
+
+    /** Reads every credential-free provider row in deterministic Android display order. */
+    private func fetchProviders(from database: OpaquePointer) throws -> [RemoteSyncAndroidAIProvider] {
+        let table = "LlmProviderConfig"
+        let statement = try prepare(
+            "SELECT id, providerType, displayName, endpoint, apiFormat, orderNumber FROM LlmProviderConfig;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIProvider] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIProvider(
+                    id: try uuid(statement, 0, table, "id"),
+                    providerType: try text(statement, 1, table, "providerType"),
+                    displayName: try text(statement, 2, table, "displayName"),
+                    endpoint: try optionalText(statement, 3, table, "endpoint"),
+                    apiFormat: try optionalText(statement, 4, table, "apiFormat"),
+                    orderNumber: try int(statement, 5, table, "orderNumber")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads every configured-model row with exact REAL pricing storage. */
+    private func fetchConfiguredModels(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidAIConfiguredModel] {
+        let table = "LlmConfiguredModel"
+        let statement = try prepare(
+            "SELECT id, providerConfigId, modelId, orderNumber, inputPricePerMillion, outputPricePerMillion, cacheCreationPricePerMillion, cacheReadPricePerMillion FROM LlmConfiguredModel;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIConfiguredModel] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIConfiguredModel(
+                    id: try uuid(statement, 0, table, "id"),
+                    providerConfigId: try uuid(statement, 1, table, "providerConfigId"),
+                    modelId: try text(statement, 2, table, "modelId"),
+                    orderNumber: try int(statement, 3, table, "orderNumber"),
+                    inputPricePerMillion: try real(statement, 4, table, "inputPricePerMillion"),
+                    outputPricePerMillion: try real(statement, 5, table, "outputPricePerMillion"),
+                    cacheCreationPricePerMillion: try real(statement, 6, table, "cacheCreationPricePerMillion"),
+                    cacheReadPricePerMillion: try real(statement, 7, table, "cacheReadPricePerMillion")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads every agent prompt while preserving all raw Room-converter strings. */
+    private func fetchAgentPrompts(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidAIAgentPrompt] {
+        let table = "AgentPrompt"
+        let statement = try prepare(
+            "SELECT id, name, description, promptTemplate, showIn, orderNumber, createdAt, strictContextMatching, permissionMode, allowedTools, deniedTools, configuredModelId, editBeforeRun, noDocumentCreation, maxIterations, autoIncludeDocuments, autoIncludeCommentaries, bibleOnly, isTextTransformation, categoryId FROM AgentPrompt;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIAgentPrompt] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIAgentPrompt(
+                    id: try uuid(statement, 0, table, "id"),
+                    name: try text(statement, 1, table, "name"),
+                    promptDescription: try optionalText(statement, 2, table, "description"),
+                    promptTemplate: try text(statement, 3, table, "promptTemplate"),
+                    showIn: try text(statement, 4, table, "showIn"),
+                    orderNumber: try int(statement, 5, table, "orderNumber"),
+                    createdAt: try int64(statement, 6, table, "createdAt"),
+                    strictContextMatching: try bool(statement, 7, table, "strictContextMatching"),
+                    permissionMode: try optionalText(statement, 8, table, "permissionMode"),
+                    allowedTools: try optionalText(statement, 9, table, "allowedTools"),
+                    deniedTools: try optionalText(statement, 10, table, "deniedTools"),
+                    configuredModelId: try optionalUUID(statement, 11, table, "configuredModelId"),
+                    editBeforeRun: try bool(statement, 12, table, "editBeforeRun"),
+                    noDocumentCreation: try bool(statement, 13, table, "noDocumentCreation"),
+                    maxIterations: try optionalInt(statement, 14, table, "maxIterations"),
+                    autoIncludeDocuments: try bool(statement, 15, table, "autoIncludeDocuments"),
+                    autoIncludeCommentaries: try bool(statement, 16, table, "autoIncludeCommentaries"),
+                    bibleOnly: try bool(statement, 17, table, "bibleOnly"),
+                    isTextTransformation: try bool(statement, 18, table, "isTextTransformation"),
+                    categoryId: try optionalUUID(statement, 19, table, "categoryId")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads Android's zero-or-one global settings singleton without converter normalization. */
+    private func fetchGlobalSettings(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidGlobalAISettings] {
+        let table = "GlobalAiSettings"
+        let statement = try prepare(
+            "SELECT id, agentPermissionMode, permanentlyAllowedTools, permanentlyDeniedTools, aiExcludedDocuments, commentaryMaxResponseTokens, hiddenBuiltInPrompts, maxIterations, commentaryDeselected, defaultModelId, aiLanguage, askModelBeforeRun, aiDisclaimerAccepted, hiddenBuiltInCategories, customAgentSystemPrompt, customTextTransformationSystemPrompt, favoritePrompts, rawLogRetentionDays, autoHideAgentLogOnCompletion FROM GlobalAiSettings;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidGlobalAISettings] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidGlobalAISettings(
+                    id: try uuid(statement, 0, table, "id"),
+                    agentPermissionMode: try optionalText(statement, 1, table, "agentPermissionMode"),
+                    permanentlyAllowedTools: try optionalText(statement, 2, table, "permanentlyAllowedTools"),
+                    permanentlyDeniedTools: try optionalText(statement, 3, table, "permanentlyDeniedTools"),
+                    aiExcludedDocuments: try text(statement, 4, table, "aiExcludedDocuments"),
+                    commentaryMaxResponseTokens: try int(statement, 5, table, "commentaryMaxResponseTokens"),
+                    hiddenBuiltInPrompts: try text(statement, 6, table, "hiddenBuiltInPrompts"),
+                    maxIterations: try int(statement, 7, table, "maxIterations"),
+                    commentaryDeselected: try text(statement, 8, table, "commentaryDeselected"),
+                    defaultModelId: try optionalUUID(statement, 9, table, "defaultModelId"),
+                    aiLanguage: try optionalText(statement, 10, table, "aiLanguage"),
+                    askModelBeforeRun: try bool(statement, 11, table, "askModelBeforeRun"),
+                    aiDisclaimerAccepted: try bool(statement, 12, table, "aiDisclaimerAccepted"),
+                    hiddenBuiltInCategories: try text(statement, 13, table, "hiddenBuiltInCategories"),
+                    customAgentSystemPrompt: try optionalText(statement, 14, table, "customAgentSystemPrompt"),
+                    customTextTransformationSystemPrompt: try optionalText(statement, 15, table, "customTextTransformationSystemPrompt"),
+                    favoritePrompts: try text(statement, 16, table, "favoritePrompts"),
+                    rawLogRetentionDays: try optionalInt(statement, 17, table, "rawLogRetentionDays"),
+                    autoHideAgentLogOnCompletion: try bool(statement, 18, table, "autoHideAgentLogOnCompletion")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads every Android per-device cumulative usage row. */
+    private func fetchUsageRecords(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidAIUsageRecord] {
+        let table = "LlmUsageRecord"
+        let statement = try prepare(
+            "SELECT id, configuredModelId, deviceId, inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens, estimatedCostUsd FROM LlmUsageRecord;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIUsageRecord] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIUsageRecord(
+                    id: try uuid(statement, 0, table, "id"),
+                    configuredModelId: try uuid(statement, 1, table, "configuredModelId"),
+                    deviceId: try text(statement, 2, table, "deviceId"),
+                    inputTokens: try int64(statement, 3, table, "inputTokens"),
+                    outputTokens: try int64(statement, 4, table, "outputTokens"),
+                    cacheCreationTokens: try int64(statement, 5, table, "cacheCreationTokens"),
+                    cacheReadTokens: try int64(statement, 6, table, "cacheReadTokens"),
+                    estimatedCostUsd: try real(statement, 7, table, "estimatedCostUsd")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads every user-defined prompt category row. */
+    private func fetchPromptCategories(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidAIPromptCategory] {
+        let table = "PromptCategory"
+        let statement = try prepare(
+            "SELECT id, name, orderNumber, hidden FROM PromptCategory;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIPromptCategory] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIPromptCategory(
+                    id: try uuid(statement, 0, table, "id"),
+                    name: try text(statement, 1, table, "name"),
+                    orderNumber: try int(statement, 2, table, "orderNumber"),
+                    hidden: try bool(statement, 3, table, "hidden")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Reads every built-in prompt model override row. */
+    private func fetchBuiltinPromptOverrides(
+        from database: OpaquePointer
+    ) throws -> [RemoteSyncAndroidAIBuiltinPromptOverride] {
+        let table = "BuiltinPromptOverride"
+        let statement = try prepare(
+            "SELECT id, configuredModelId FROM BuiltinPromptOverride;",
+            in: database
+        )
+        defer { sqlite3_finalize(statement) }
+        var rows: [RemoteSyncAndroidAIBuiltinPromptOverride] = []
+        try forEachRow(statement) {
+            rows.append(
+                RemoteSyncAndroidAIBuiltinPromptOverride(
+                    id: try uuid(statement, 0, table, "id"),
+                    configuredModelId: try optionalUUID(statement, 1, table, "configuredModelId")
+                )
+            )
+        }
+        return rows
+    }
+
+    /** Returns deterministic Android display/storage ordering for a materialized generation. */
+    private static func sorted(
+        _ snapshot: RemoteSyncAndroidAISettingsSnapshot
+    ) -> RemoteSyncAndroidAISettingsSnapshot {
+        RemoteSyncAndroidAISettingsSnapshot(
+            providers: snapshot.providers.sorted(by: providerSort),
+            configuredModels: snapshot.configuredModels.sorted(by: configuredModelSort),
+            agentPrompts: snapshot.agentPrompts.sorted(by: promptSort),
+            globalSettings: snapshot.globalSettings.sorted { $0.id.uuidString < $1.id.uuidString },
+            usageRecords: snapshot.usageRecords.sorted(by: usageSort),
+            promptCategories: snapshot.promptCategories.sorted(by: categorySort),
+            builtinOverrides: snapshot.builtinOverrides.sorted { $0.id.uuidString < $1.id.uuidString },
+            ignoredIncomingRawLogCount: snapshot.ignoredIncomingRawLogCount
+        )
+    }
+
+    /** Prepares one read-only query or reports a fail-closed SQLite error. */
+    private func prepare(_ sql: String, in database: OpaquePointer) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+        }
+        return statement
+    }
+
+    /** Counts one already-bounded Android table without materializing any row payload. */
+    private func rowCount(in table: String, database: OpaquePointer) throws -> Int {
+        let statement = try prepare("SELECT COUNT(*) FROM \(table);", in: database)
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              sqlite3_column_type(statement, 0) == SQLITE_INTEGER,
+              let count = Int(exactly: sqlite3_column_int64(statement, 0)),
+              count >= 0 else {
+            throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+        }
+        return count
+    }
+
+    /** Steps every row and rejects any terminal status other than `SQLITE_DONE`. */
+    private func forEachRow(
+        _ statement: OpaquePointer?,
+        _ body: () throws -> Void
+    ) throws {
+        while true {
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                try body()
+            case SQLITE_DONE:
+                return
+            default:
+                throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+            }
+        }
+    }
+
+    /** Decodes one exact 16-byte Android UUID BLOB. */
+    private func uuid(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> UUID {
+        guard sqlite3_column_type(statement, column) == SQLITE_BLOB,
+              sqlite3_column_bytes(statement, column) == 16,
+              let bytes = sqlite3_column_blob(statement, column),
+              let value = RemoteSyncAISettingsSnapshotService.uuid(
+                  from: Data(bytes: bytes, count: 16)
+              ) else {
+            throw RemoteSyncAISettingsRestoreError.invalidIdentifierBlob(table: table, column: name)
+        }
+        return value
+    }
+
+    /** Decodes a nullable Android UUID while preserving SQL NULL. */
+    private func optionalUUID(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> UUID? {
+        if sqlite3_column_type(statement, column) == SQLITE_NULL { return nil }
+        return try uuid(statement, column, table, name)
+    }
+
+    /** Decodes exact UTF-8 SQLite TEXT, including embedded NUL bytes. */
+    private func text(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> String {
+        guard sqlite3_column_type(statement, column) == SQLITE_TEXT else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        let byteCount = Int(sqlite3_column_bytes(statement, column))
+        if byteCount == 0 { return "" }
+        guard byteCount > 0, let bytes = sqlite3_column_text(statement, column),
+              let value = String(
+                  data: Data(bytes: bytes, count: byteCount),
+                  encoding: .utf8
+              ) else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return value
+    }
+
+    /** Decodes nullable exact UTF-8 SQLite TEXT without collapsing empty to nil. */
+    private func optionalText(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> String? {
+        if sqlite3_column_type(statement, column) == SQLITE_NULL { return nil }
+        return try text(statement, column, table, name)
+    }
+
+    /** Decodes an Android Kotlin `Int` after exact INTEGER storage validation. */
+    private func int(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> Int {
+        let value = try int64(statement, column, table, name)
+        guard let result = Int(exactly: value) else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return result
+    }
+
+    /** Decodes a nullable Android Kotlin `Int` while preserving SQL NULL. */
+    private func optionalInt(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> Int? {
+        if sqlite3_column_type(statement, column) == SQLITE_NULL { return nil }
+        return try int(statement, column, table, name)
+    }
+
+    /** Decodes an exact SQLite INTEGER into Android's signed 64-bit domain. */
+    private func int64(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> Int64 {
+        guard sqlite3_column_type(statement, column) == SQLITE_INTEGER else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return sqlite3_column_int64(statement, column)
+    }
+
+    /** Decodes Android Boolean storage and rejects integers other than zero or one. */
+    private func bool(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> Bool {
+        switch try int64(statement, column, table, name) {
+        case 0: false
+        case 1: true
+        default: throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+    }
+
+    /** Decodes one finite SQLite REAL without accepting INTEGER coercion. */
+    private func real(
+        _ statement: OpaquePointer?,
+        _ column: Int32,
+        _ table: String,
+        _ name: String
+    ) throws -> Double {
+        guard sqlite3_column_type(statement, column) == SQLITE_FLOAT else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        let value = sqlite3_column_double(statement, column)
+        guard value.isFinite else {
+            throw RemoteSyncAISettingsRestoreError.invalidColumnValue(table: table, column: name)
+        }
+        return value
+    }
+
+    private static func providerSort(
+        _ lhs: RemoteSyncAndroidAIProvider,
+        _ rhs: RemoteSyncAndroidAIProvider
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func configuredModelSort(
+        _ lhs: RemoteSyncAndroidAIConfiguredModel,
+        _ rhs: RemoteSyncAndroidAIConfiguredModel
+    ) -> Bool {
+        if lhs.providerConfigId != rhs.providerConfigId {
+            return lhs.providerConfigId.uuidString < rhs.providerConfigId.uuidString
+        }
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.modelId != rhs.modelId { return lhs.modelId < rhs.modelId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func promptSort(
+        _ lhs: RemoteSyncAndroidAIAgentPrompt,
+        _ rhs: RemoteSyncAndroidAIAgentPrompt
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func usageSort(
+        _ lhs: RemoteSyncAndroidAIUsageRecord,
+        _ rhs: RemoteSyncAndroidAIUsageRecord
+    ) -> Bool {
+        if lhs.configuredModelId != rhs.configuredModelId {
+            return lhs.configuredModelId.uuidString < rhs.configuredModelId.uuidString
+        }
+        if lhs.deviceId != rhs.deviceId { return lhs.deviceId < rhs.deviceId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func categorySort(
+        _ lhs: RemoteSyncAndroidAIPromptCategory,
+        _ rhs: RemoteSyncAndroidAIPromptCategory
+    ) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.name != rhs.name { return lhs.name < rhs.name }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsSnapshotService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAISettingsSnapshotService.swift
@@ -1,0 +1,838 @@
+// RemoteSyncAISettingsSnapshotService.swift -- Android-shaped AI settings snapshots for remote sync
+
+import CryptoKit
+import Foundation
+import SwiftData
+
+/** One Android `LlmProviderConfig` row without credentials. */
+public struct RemoteSyncAndroidAIProvider: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let providerType: String
+    public let displayName: String
+    public let endpoint: String?
+    public let apiFormat: String?
+    public let orderNumber: Int
+}
+
+/** One Android `LlmConfiguredModel` row. */
+public struct RemoteSyncAndroidAIConfiguredModel: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let providerConfigId: UUID
+    public let modelId: String
+    public let orderNumber: Int
+    public let inputPricePerMillion: Double
+    public let outputPricePerMillion: Double
+    public let cacheCreationPricePerMillion: Double
+    public let cacheReadPricePerMillion: Double
+}
+
+/** One Android `AgentPrompt` row with Room-converter values preserved verbatim. */
+public struct RemoteSyncAndroidAIAgentPrompt: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public let promptDescription: String?
+    public let promptTemplate: String
+    public let showIn: String
+    public let orderNumber: Int
+    public let createdAt: Int64
+    public let strictContextMatching: Bool
+    public let permissionMode: String?
+    public let allowedTools: String?
+    public let deniedTools: String?
+    public let configuredModelId: UUID?
+    public let editBeforeRun: Bool
+    public let noDocumentCreation: Bool
+    public let maxIterations: Int?
+    public let autoIncludeDocuments: Bool
+    public let autoIncludeCommentaries: Bool
+    public let bibleOnly: Bool
+    public let isTextTransformation: Bool
+    public let categoryId: UUID?
+}
+
+/** Android's singleton `GlobalAiSettings` row. */
+public struct RemoteSyncAndroidGlobalAISettings: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let agentPermissionMode: String?
+    public let permanentlyAllowedTools: String?
+    public let permanentlyDeniedTools: String?
+    public let aiExcludedDocuments: String
+    public let commentaryMaxResponseTokens: Int
+    public let hiddenBuiltInPrompts: String
+    public let maxIterations: Int
+    public let commentaryDeselected: String
+    public let defaultModelId: UUID?
+    public let aiLanguage: String?
+    public let askModelBeforeRun: Bool
+    public let aiDisclaimerAccepted: Bool
+    public let hiddenBuiltInCategories: String
+    public let customAgentSystemPrompt: String?
+    public let customTextTransformationSystemPrompt: String?
+    public let favoritePrompts: String
+    public let rawLogRetentionDays: Int?
+    public let autoHideAgentLogOnCompletion: Bool
+}
+
+/** One Android `LlmUsageRecord` row. */
+public struct RemoteSyncAndroidAIUsageRecord: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let configuredModelId: UUID
+    public let deviceId: String
+    public let inputTokens: Int64
+    public let outputTokens: Int64
+    public let cacheCreationTokens: Int64
+    public let cacheReadTokens: Int64
+    public let estimatedCostUsd: Double
+}
+
+/** One Android `PromptCategory` row. */
+public struct RemoteSyncAndroidAIPromptCategory: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public let orderNumber: Int
+    public let hidden: Bool
+}
+
+/** One Android `BuiltinPromptOverride` row. */
+public struct RemoteSyncAndroidAIBuiltinPromptOverride: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let configuredModelId: UUID?
+}
+
+/**
+ Complete current AI settings projection expressed as Android v23 rows.
+
+ `LLMRawLogRecord` is intentionally absent because Android excludes it from the `AI_SETTINGS`
+ sync-table list. Provider credentials are also absent because they live only in `AICredentialStore`.
+ */
+public struct RemoteSyncAISettingsCurrentSnapshot: Sendable, Equatable {
+    public let providerRowsByKey: [String: RemoteSyncAndroidAIProvider]
+    public let configuredModelRowsByKey: [String: RemoteSyncAndroidAIConfiguredModel]
+    public let agentPromptRowsByKey: [String: RemoteSyncAndroidAIAgentPrompt]
+    public let globalSettingsRowsByKey: [String: RemoteSyncAndroidGlobalAISettings]
+    public let usageRowsByKey: [String: RemoteSyncAndroidAIUsageRecord]
+    public let promptCategoryRowsByKey: [String: RemoteSyncAndroidAIPromptCategory]
+    public let builtinOverrideRowsByKey: [String: RemoteSyncAndroidAIBuiltinPromptOverride]
+    public let fingerprintsByKey: [String: String]
+}
+
+/** Durable Android identity for one accepted AI settings row. */
+struct RemoteSyncAISettingsAcceptedRowIdentity: Codable, Sendable, Equatable {
+    let key: String
+    let tableName: String
+    let entityID1: RemoteSyncSQLiteValue
+    let entityID2: RemoteSyncSQLiteValue
+}
+
+/** Immutable accepted fingerprint and row-identity generation for AI settings. */
+struct RemoteSyncAISettingsAcceptedBaseline: Codable, Sendable, Equatable {
+    let revision: UUID?
+    let fingerprintsByKey: [String: String]
+    let rowIdentities: [RemoteSyncAISettingsAcceptedRowIdentity]
+
+    init(
+        revision: UUID? = UUID(),
+        fingerprintsByKey: [String: String],
+        rowIdentities: [RemoteSyncAISettingsAcceptedRowIdentity]
+    ) {
+        self.revision = revision
+        self.fingerprintsByKey = fingerprintsByKey
+        self.rowIdentities = rowIdentities
+    }
+}
+
+/** Fail-closed AI settings projection and accepted-generation errors. */
+enum RemoteSyncAISettingsSnapshotError: Error, Equatable {
+    case duplicateIdentifier(table: String, id: UUID)
+    case duplicateProviderModel(providerID: UUID, modelID: String)
+    case duplicateUsageRecord(modelID: UUID, deviceID: String)
+    case invalidGlobalSettingsIdentity(UUID)
+    case duplicateGlobalSettings
+    case invalidFloatingPointValue(table: String, id: UUID)
+    case invalidFormalReference(table: String, id: UUID, column: String, referencedID: UUID)
+    case credentialLookupFailed(providerID: UUID)
+    case unsafeSynchronizedEndpoint(providerID: UUID)
+    case missingProjectedFingerprint(String)
+    case invalidStoredBaseline
+    case invalidFingerprintKey(String)
+    case staleAcceptedBaseline
+}
+
+/**
+ Projects SwiftData AI settings into Android's seven synchronized v23 tables.
+
+ Data dependencies:
+ - the seven models in `AIModelRegistration.cloudSyncableModels`
+ - `SettingsStore` for Android-compatible log identity keys and accepted-generation storage
+
+ Side effects:
+ - strict snapshot methods read all seven synchronized SwiftData tables
+ - baseline methods read or replace AI-category fingerprint and identity metadata
+
+ Failure modes:
+ - duplicate Android identities, invalid singleton rows, non-finite prices, fetch failures, malformed
+   accepted state, and stale publication revisions fail before data is published
+
+ Important:
+ - `LLMRawLogRecord` can never enter a snapshot
+ - `AICredentialStore` is read only to reject endpoints that embed the provider's local credential;
+   credential values are never projected or fingerprinted
+ */
+public final class RemoteSyncAISettingsSnapshotService {
+    static let acceptedBaselineKey = "remote_sync.accepted_baseline.ai_settings"
+    static let emptySecondaryEntityID = RemoteSyncSQLiteValue.text("")
+
+    private let strictSnapshotCheckpoint: () throws -> Void
+    private let credentialForProvider: (UUID) throws -> String?
+    private let encoder: JSONEncoder
+
+    /**
+     Creates a production snapshot service with device-local Keychain credential inspection.
+
+     - Side Effects: Construction creates a Keychain-backed reader; snapshots perform one lookup per
+       provider without modifying credentials.
+     - Failure modes: Snapshot projection fails closed when Keychain cannot distinguish a missing
+       credential from an access or payload error.
+     */
+    public init() {
+        let credentialStore = AICredentialStore.keychain()
+        strictSnapshotCheckpoint = {}
+        credentialForProvider = { try credentialStore.credentialStrict(for: $0) }
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    /**
+     Creates a service with deterministic strict-read and credential dependencies for tests.
+
+     - Parameters:
+       - strictSnapshotCheckpoint: Callback invoked before graph projection.
+       - credentialForProvider: Device-local credential lookup used only for endpoint leak checks.
+     - Side Effects: none until snapshot projection invokes the supplied closures.
+     - Failure modes: Rethrows checkpoint and credential lookup errors.
+     */
+    init(
+        strictSnapshotCheckpoint: @escaping () throws -> Void = {},
+        credentialForProvider: @escaping (UUID) throws -> String?
+    ) {
+        self.strictSnapshotCheckpoint = strictSnapshotCheckpoint
+        self.credentialForProvider = credentialForProvider
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    /**
+     Strictly projects all synchronized AI rows into deterministic Android identities.
+
+     - Parameters:
+       - modelContext: Context containing AI settings models.
+       - settingsStore: Settings store used to build category log keys.
+     - Returns: Complete Android-shaped AI settings snapshot.
+     - Side Effects: Reads all seven synchronized model tables.
+     - Throws: Fetch, checkpoint, duplicate-identity, singleton, or fingerprint errors.
+     */
+    public func snapshotCurrentStateStrict(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAISettingsCurrentSnapshot {
+        try strictSnapshotCheckpoint()
+        let providers = try modelContext.fetch(FetchDescriptor<LLMProviderConfig>())
+        let configuredModels = try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>())
+        let prompts = try modelContext.fetch(FetchDescriptor<AgentPrompt>())
+        let globalSettings = try modelContext.fetch(FetchDescriptor<GlobalAISettings>())
+        let usageRecords = try modelContext.fetch(FetchDescriptor<LLMUsageRecord>())
+        let promptCategories = try modelContext.fetch(FetchDescriptor<PromptCategory>())
+        let builtinOverrides = try modelContext.fetch(FetchDescriptor<BuiltInPromptOverride>())
+
+        if globalSettings.count > 1 {
+            throw RemoteSyncAISettingsSnapshotError.duplicateGlobalSettings
+        }
+        if let row = globalSettings.first, row.id != GlobalAISettings.singletonID {
+            throw RemoteSyncAISettingsSnapshotError.invalidGlobalSettingsIdentity(row.id)
+        }
+
+        let logStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        var providerRowsByKey: [String: RemoteSyncAndroidAIProvider] = [:]
+        var configuredModelRowsByKey: [String: RemoteSyncAndroidAIConfiguredModel] = [:]
+        var agentPromptRowsByKey: [String: RemoteSyncAndroidAIAgentPrompt] = [:]
+        var globalSettingsRowsByKey: [String: RemoteSyncAndroidGlobalAISettings] = [:]
+        var usageRowsByKey: [String: RemoteSyncAndroidAIUsageRecord] = [:]
+        var promptCategoryRowsByKey: [String: RemoteSyncAndroidAIPromptCategory] = [:]
+        var builtinOverrideRowsByKey: [String: RemoteSyncAndroidAIBuiltinPromptOverride] = [:]
+        var fingerprintsByKey: [String: String] = [:]
+        var providerModelKeys: Set<String> = []
+        var usageCompositeKeys: Set<String> = []
+
+        /** Inserts one UUID-keyed row after enforcing Android identity and fingerprint uniqueness. */
+        func insert<Row: Encodable>(
+            _ row: Row,
+            id: UUID,
+            tableName: String,
+            into rows: inout [String: Row]
+        ) throws {
+            let key = Self.logKey(tableName: tableName, id: id, logStore: logStore)
+            guard rows[key] == nil else {
+                throw RemoteSyncAISettingsSnapshotError.duplicateIdentifier(table: tableName, id: id)
+            }
+            rows[key] = row
+            fingerprintsByKey[key] = try fingerprintHex(for: row, tableName: tableName, id: id)
+        }
+
+        for value in providers.sorted(by: Self.providerSort) {
+            let knownCredential: String?
+            do {
+                knownCredential = try credentialForProvider(value.id)
+            } catch {
+                throw RemoteSyncAISettingsSnapshotError.credentialLookupFailed(
+                    providerID: value.id
+                )
+            }
+            guard RemoteSyncAISettingsEndpointPolicy.isCredentialFree(
+                value.endpoint,
+                knownCredential: knownCredential
+            ) else {
+                throw RemoteSyncAISettingsSnapshotError.unsafeSynchronizedEndpoint(
+                    providerID: value.id
+                )
+            }
+            let row = RemoteSyncAndroidAIProvider(
+                id: value.id,
+                providerType: value.providerType,
+                displayName: value.displayName,
+                endpoint: value.endpoint,
+                apiFormat: value.apiFormatRawValue,
+                orderNumber: value.orderNumber
+            )
+            try insert(row, id: row.id, tableName: "LlmProviderConfig", into: &providerRowsByKey)
+        }
+
+        for value in configuredModels.sorted(by: Self.configuredModelSort) {
+            guard value.inputPricePerMillion.isFinite,
+                  value.outputPricePerMillion.isFinite,
+                  value.cacheCreationPricePerMillion.isFinite,
+                  value.cacheReadPricePerMillion.isFinite else {
+                throw RemoteSyncAISettingsSnapshotError.invalidFloatingPointValue(
+                    table: "LlmConfiguredModel",
+                    id: value.id
+                )
+            }
+            let compositeKey = "\(value.providerConfigId.uuidString.lowercased())\u{0}\(value.modelId)"
+            guard providerModelKeys.insert(compositeKey).inserted else {
+                throw RemoteSyncAISettingsSnapshotError.duplicateProviderModel(
+                    providerID: value.providerConfigId,
+                    modelID: value.modelId
+                )
+            }
+            let row = RemoteSyncAndroidAIConfiguredModel(
+                id: value.id,
+                providerConfigId: value.providerConfigId,
+                modelId: value.modelId,
+                orderNumber: value.orderNumber,
+                inputPricePerMillion: value.inputPricePerMillion,
+                outputPricePerMillion: value.outputPricePerMillion,
+                cacheCreationPricePerMillion: value.cacheCreationPricePerMillion,
+                cacheReadPricePerMillion: value.cacheReadPricePerMillion
+            )
+            try insert(row, id: row.id, tableName: "LlmConfiguredModel", into: &configuredModelRowsByKey)
+        }
+
+        for value in prompts.sorted(by: Self.promptSort) {
+            let row = RemoteSyncAndroidAIAgentPrompt(
+                id: value.id,
+                name: value.name,
+                promptDescription: value.promptDescription,
+                promptTemplate: value.promptTemplate,
+                showIn: value.showInRawValue,
+                orderNumber: value.orderNumber,
+                createdAt: value.createdAtMilliseconds,
+                strictContextMatching: value.strictContextMatching,
+                permissionMode: value.permissionModeRawValue,
+                allowedTools: value.allowedToolsRawValue,
+                deniedTools: value.deniedToolsRawValue,
+                configuredModelId: value.configuredModelId,
+                editBeforeRun: value.specifyBeforeRun,
+                noDocumentCreation: value.noDocumentCreation,
+                maxIterations: value.maxIterations,
+                autoIncludeDocuments: value.autoIncludeDocuments,
+                autoIncludeCommentaries: value.autoIncludeCommentaries,
+                bibleOnly: value.bibleOnly,
+                isTextTransformation: value.isTextTransformation,
+                categoryId: value.categoryId
+            )
+            try insert(row, id: row.id, tableName: "AgentPrompt", into: &agentPromptRowsByKey)
+        }
+
+        for value in globalSettings {
+            let row = RemoteSyncAndroidGlobalAISettings(
+                id: value.id,
+                agentPermissionMode: value.agentPermissionModeRawValue,
+                permanentlyAllowedTools: value.permanentlyAllowedToolsRawValue,
+                permanentlyDeniedTools: value.permanentlyDeniedToolsRawValue,
+                aiExcludedDocuments: value.aiExcludedDocumentsRawValue,
+                commentaryMaxResponseTokens: value.commentaryMaxResponseTokens,
+                hiddenBuiltInPrompts: value.hiddenBuiltInPromptsRawValue,
+                maxIterations: value.maxIterations,
+                commentaryDeselected: value.commentaryDeselectedRawValue,
+                defaultModelId: value.defaultModelId,
+                aiLanguage: value.aiLanguage,
+                askModelBeforeRun: value.askModelBeforeRun,
+                aiDisclaimerAccepted: value.aiDisclaimerAccepted,
+                hiddenBuiltInCategories: value.hiddenBuiltInCategoriesRawValue,
+                customAgentSystemPrompt: value.customAgentSystemPrompt,
+                customTextTransformationSystemPrompt: value.customTextTransformationSystemPrompt,
+                favoritePrompts: value.favoritePromptsRawValue,
+                rawLogRetentionDays: value.rawLogRetentionDays,
+                autoHideAgentLogOnCompletion: value.autoHideAgentLogOnCompletion
+            )
+            try insert(row, id: row.id, tableName: "GlobalAiSettings", into: &globalSettingsRowsByKey)
+        }
+
+        for value in usageRecords.sorted(by: Self.usageSort) {
+            guard value.estimatedCostUSD.isFinite else {
+                throw RemoteSyncAISettingsSnapshotError.invalidFloatingPointValue(
+                    table: "LlmUsageRecord",
+                    id: value.id
+                )
+            }
+            let compositeKey = "\(value.configuredModelId.uuidString.lowercased())\u{0}\(value.deviceId)"
+            guard usageCompositeKeys.insert(compositeKey).inserted else {
+                throw RemoteSyncAISettingsSnapshotError.duplicateUsageRecord(
+                    modelID: value.configuredModelId,
+                    deviceID: value.deviceId
+                )
+            }
+            let row = RemoteSyncAndroidAIUsageRecord(
+                id: value.id,
+                configuredModelId: value.configuredModelId,
+                deviceId: value.deviceId,
+                inputTokens: value.inputTokens,
+                outputTokens: value.outputTokens,
+                cacheCreationTokens: value.cacheCreationTokens,
+                cacheReadTokens: value.cacheReadTokens,
+                estimatedCostUsd: value.estimatedCostUSD
+            )
+            try insert(row, id: row.id, tableName: "LlmUsageRecord", into: &usageRowsByKey)
+        }
+
+        for value in promptCategories.sorted(by: Self.categorySort) {
+            let row = RemoteSyncAndroidAIPromptCategory(
+                id: value.id,
+                name: value.name,
+                orderNumber: value.orderNumber,
+                hidden: value.hidden
+            )
+            try insert(row, id: row.id, tableName: "PromptCategory", into: &promptCategoryRowsByKey)
+        }
+
+        for value in builtinOverrides.sorted(by: { $0.id.uuidString < $1.id.uuidString }) {
+            let row = RemoteSyncAndroidAIBuiltinPromptOverride(
+                id: value.id,
+                configuredModelId: value.configuredModelId
+            )
+            try insert(row, id: row.id, tableName: "BuiltinPromptOverride", into: &builtinOverrideRowsByKey)
+        }
+
+        let providerIDs = Set(providerRowsByKey.values.map(\.id))
+        for row in configuredModelRowsByKey.values where !providerIDs.contains(row.providerConfigId) {
+            throw RemoteSyncAISettingsSnapshotError.invalidFormalReference(
+                table: "LlmConfiguredModel",
+                id: row.id,
+                column: "providerConfigId",
+                referencedID: row.providerConfigId
+            )
+        }
+        let configuredModelIDs = Set(configuredModelRowsByKey.values.map(\.id))
+        for row in agentPromptRowsByKey.values {
+            if let configuredModelId = row.configuredModelId,
+               !configuredModelIDs.contains(configuredModelId) {
+                throw RemoteSyncAISettingsSnapshotError.invalidFormalReference(
+                    table: "AgentPrompt",
+                    id: row.id,
+                    column: "configuredModelId",
+                    referencedID: configuredModelId
+                )
+            }
+        }
+        for row in builtinOverrideRowsByKey.values {
+            if let configuredModelId = row.configuredModelId,
+               !configuredModelIDs.contains(configuredModelId) {
+                throw RemoteSyncAISettingsSnapshotError.invalidFormalReference(
+                    table: "BuiltinPromptOverride",
+                    id: row.id,
+                    column: "configuredModelId",
+                    referencedID: configuredModelId
+                )
+            }
+        }
+
+        return RemoteSyncAISettingsCurrentSnapshot(
+            providerRowsByKey: providerRowsByKey,
+            configuredModelRowsByKey: configuredModelRowsByKey,
+            agentPromptRowsByKey: agentPromptRowsByKey,
+            globalSettingsRowsByKey: globalSettingsRowsByKey,
+            usageRowsByKey: usageRowsByKey,
+            promptCategoryRowsByKey: promptCategoryRowsByKey,
+            builtinOverrideRowsByKey: builtinOverrideRowsByKey,
+            fingerprintsByKey: fingerprintsByKey
+        )
+    }
+
+    /** Converts a strict snapshot into an immutable accepted generation. */
+    func acceptedBaseline(
+        from snapshot: RemoteSyncAISettingsCurrentSnapshot
+    ) throws -> RemoteSyncAISettingsAcceptedBaseline {
+        let identities = acceptedRowIdentities(from: snapshot)
+        for identity in identities where snapshot.fingerprintsByKey[identity.key] == nil {
+            throw RemoteSyncAISettingsSnapshotError.missingProjectedFingerprint(identity.key)
+        }
+        return RemoteSyncAISettingsAcceptedBaseline(
+            fingerprintsByKey: snapshot.fingerprintsByKey,
+            rowIdentities: identities
+        )
+    }
+
+    /** Reads the accepted AI settings generation, failing on malformed persisted JSON. */
+    func storedAcceptedBaseline(
+        settingsStore: SettingsStore
+    ) throws -> RemoteSyncAISettingsAcceptedBaseline? {
+        guard let payload = settingsStore.getString(Self.acceptedBaselineKey) else {
+            return nil
+        }
+        guard let data = payload.data(using: .utf8),
+              let baseline = try? JSONDecoder().decode(RemoteSyncAISettingsAcceptedBaseline.self, from: data) else {
+            throw RemoteSyncAISettingsSnapshotError.invalidStoredBaseline
+        }
+        return baseline
+    }
+
+    /** Verifies that an outbox still targets the accepted generation used during projection. */
+    func validateAcceptedBaselineRevision(
+        expectedRevision: UUID?,
+        expectedBaselineExists: Bool,
+        settingsStore: SettingsStore
+    ) throws {
+        let current = try storedAcceptedBaseline(settingsStore: settingsStore)
+        guard (current != nil) == expectedBaselineExists,
+              current?.revision == expectedRevision else {
+            throw RemoteSyncAISettingsSnapshotError.staleAcceptedBaseline
+        }
+    }
+
+    /** Replaces AI settings fingerprints and accepted row identities atomically with the caller. */
+    func acceptBaseline(
+        _ baseline: RemoteSyncAISettingsAcceptedBaseline,
+        settingsStore: SettingsStore
+    ) throws {
+        let fingerprints = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        let logStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
+        let fingerprintPrefix = fingerprints.prefix(for: .aiSettings)
+        let logPrefix = logStore.prefix(for: .aiSettings)
+
+        fingerprints.clearCategory(.aiSettings)
+        for (logKey, fingerprint) in baseline.fingerprintsByKey.sorted(by: { $0.key < $1.key }) {
+            guard logKey.hasPrefix(logPrefix) else {
+                throw RemoteSyncAISettingsSnapshotError.invalidFingerprintKey(logKey)
+            }
+            settingsStore.setString(
+                "\(fingerprintPrefix)\(logKey.dropFirst(logPrefix.count))",
+                value: fingerprint
+            )
+        }
+
+        let data = try encoder.encode(baseline)
+        guard let payload = String(data: data, encoding: .utf8) else {
+            throw RemoteSyncAISettingsSnapshotError.invalidStoredBaseline
+        }
+        settingsStore.setString(Self.acceptedBaselineKey, value: payload)
+    }
+
+    /** Strictly refreshes the accepted baseline from the current SwiftData graph. */
+    func refreshBaselineFingerprintsStrict(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws {
+        let snapshot = try snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        try acceptBaseline(try acceptedBaseline(from: snapshot), settingsStore: settingsStore)
+    }
+
+    /** Returns the Android identity manifest for every row in one snapshot. */
+    private func acceptedRowIdentities(
+        from snapshot: RemoteSyncAISettingsCurrentSnapshot
+    ) -> [RemoteSyncAISettingsAcceptedRowIdentity] {
+        var result: [RemoteSyncAISettingsAcceptedRowIdentity] = []
+
+        /** Appends identities for one UUID-keyed Android table map. */
+        func append<Row>(_ rows: [String: Row], tableName: String, id: (Row) -> UUID) {
+            for (key, row) in rows {
+                result.append(
+                    RemoteSyncAISettingsAcceptedRowIdentity(
+                        key: key,
+                        tableName: tableName,
+                        entityID1: .blob(Self.uuidBlob(id(row))),
+                        entityID2: Self.emptySecondaryEntityID
+                    )
+                )
+            }
+        }
+
+        append(snapshot.providerRowsByKey, tableName: "LlmProviderConfig", id: \.id)
+        append(snapshot.configuredModelRowsByKey, tableName: "LlmConfiguredModel", id: \.id)
+        append(snapshot.agentPromptRowsByKey, tableName: "AgentPrompt", id: \.id)
+        append(snapshot.globalSettingsRowsByKey, tableName: "GlobalAiSettings", id: \.id)
+        append(snapshot.usageRowsByKey, tableName: "LlmUsageRecord", id: \.id)
+        append(snapshot.promptCategoryRowsByKey, tableName: "PromptCategory", id: \.id)
+        append(snapshot.builtinOverrideRowsByKey, tableName: "BuiltinPromptOverride", id: \.id)
+        return result.sorted { $0.key < $1.key }
+    }
+
+    /** Produces Android's raw 16-byte UUID representation. */
+    static func uuidBlob(_ uuid: UUID) -> Data {
+        withUnsafeBytes(of: uuid.uuid) { Data($0) }
+    }
+
+    /** Decodes a 16-byte Android UUID blob. */
+    static func uuid(from data: Data) -> UUID? {
+        guard data.count == 16 else { return nil }
+        return data.withUnsafeBytes { bytes -> UUID? in
+            guard bytes.count == 16 else { return nil }
+            return UUID(uuid: (
+                bytes[0], bytes[1], bytes[2], bytes[3],
+                bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[8], bytes[9], bytes[10], bytes[11],
+                bytes[12], bytes[13], bytes[14], bytes[15]
+            ))
+        }
+    }
+
+    /** Builds the canonical settings-backed log key for one UUID row. */
+    static func logKey(
+        tableName: String,
+        id: UUID,
+        logStore: RemoteSyncLogEntryStore
+    ) -> String {
+        logStore.key(
+            for: .aiSettings,
+            tableName: tableName,
+            entityID1: .blob(uuidBlob(id)),
+            entityID2: emptySecondaryEntityID
+        )
+    }
+
+    /** Encodes one row deterministically and hashes its complete non-secret wire state. */
+    private func fingerprintHex<Row: Encodable>(
+        for row: Row,
+        tableName: String,
+        id: UUID
+    ) throws -> String {
+        do {
+            let data = try encoder.encode(row)
+            let digest = SHA256.hash(data: data)
+            return digest.map { String(format: "%02x", $0) }.joined()
+        } catch {
+            throw RemoteSyncAISettingsSnapshotError.invalidFloatingPointValue(
+                table: tableName,
+                id: id
+            )
+        }
+    }
+
+    private static func providerSort(_ lhs: LLMProviderConfig, _ rhs: LLMProviderConfig) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func configuredModelSort(
+        _ lhs: LLMConfiguredModel,
+        _ rhs: LLMConfiguredModel
+    ) -> Bool {
+        if lhs.providerConfigId != rhs.providerConfigId {
+            return lhs.providerConfigId.uuidString < rhs.providerConfigId.uuidString
+        }
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.modelId != rhs.modelId { return lhs.modelId < rhs.modelId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func promptSort(_ lhs: AgentPrompt, _ rhs: AgentPrompt) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.createdAtMilliseconds != rhs.createdAtMilliseconds {
+            return lhs.createdAtMilliseconds < rhs.createdAtMilliseconds
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func usageSort(_ lhs: LLMUsageRecord, _ rhs: LLMUsageRecord) -> Bool {
+        if lhs.configuredModelId != rhs.configuredModelId {
+            return lhs.configuredModelId.uuidString < rhs.configuredModelId.uuidString
+        }
+        if lhs.deviceId != rhs.deviceId { return lhs.deviceId < rhs.deviceId }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func categorySort(_ lhs: PromptCategory, _ rhs: PromptCategory) -> Bool {
+        if lhs.orderNumber != rhs.orderNumber { return lhs.orderNumber < rhs.orderNumber }
+        if lhs.name != rhs.name { return lhs.name < rhs.name }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}
+
+/** Credential boundary shared by outbound snapshots and inbound AI settings restore. */
+enum RemoteSyncAISettingsEndpointPolicy {
+    /// Normalized short query names that conventionally carry authentication material.
+    private static let credentialQueryNames: Set<String> = [
+        "accesskey",
+        "accesstoken",
+        "apikey",
+        "auth",
+        "authorization",
+        "authtoken",
+        "code",
+        "credential",
+        "credentials",
+        "key",
+        "password",
+        "passwd",
+        "secret",
+        "sig",
+        "signature",
+        "token",
+    ]
+
+    /// Longer markers rejected anywhere inside a normalized query or path component name.
+    private static let credentialNameFragments = [
+        "accesskey",
+        "accesstoken",
+        "apikey",
+        "authorization",
+        "authtoken",
+        "credential",
+        "password",
+        "secret",
+        "securitytoken",
+        "sessiontoken",
+        "signature",
+    ]
+
+    /// Prefix and minimum token lengths that distinguish credentials from short routing labels.
+    private static let credentialValuePrefixRules: [(prefix: String, minimumLength: Int)] = [
+        ("aiza", 24),
+        ("akia", 20),
+        ("github_pat_", 24),
+        ("ghp_", 24),
+        ("rk-", 20),
+        ("sk-", 20),
+        ("sk_", 20),
+        ("xoxa-", 20),
+        ("xoxb-", 20),
+        ("xoxp-", 20),
+        ("xoxr-", 20),
+        ("xoxs-", 20),
+    ]
+
+    /**
+     Returns whether one optional provider endpoint is safe to synchronize as non-secret state.
+
+     - Parameters:
+       - endpoint: Persisted custom endpoint string, or `nil` for known providers.
+       - knownCredential: Device-local provider credential, when available on the sending device.
+     - Returns: `false` for URL user-info, fragments, signed/auth query families, credential-bearing
+       path labels, realistic token values, or any recursively decoded endpoint form that embeds the
+       provider's exact local credential. Hostnames and short routing labels are not token-scanned.
+     - Side Effects: none.
+     - Failure modes: Endpoints that `URLComponents` cannot parse fail closed before publication.
+     */
+    static func isCredentialFree(
+        _ endpoint: String?,
+        knownCredential: String? = nil
+    ) -> Bool {
+        guard let endpoint else { return true }
+        if let knownCredential, !knownCredential.isEmpty {
+            guard !percentDecodedForms(endpoint).contains(where: {
+                $0.contains(knownCredential)
+            }) else {
+                return false
+            }
+        }
+        guard let components = URLComponents(string: endpoint) else { return false }
+        guard components.user == nil,
+              components.password == nil,
+              components.fragment == nil else {
+            return false
+        }
+        let pathComponents = components.percentEncodedPath.split(separator: "/")
+        guard !pathComponents.contains(where: { component in
+            let value = String(component)
+            return isCredentialName(value)
+                || containsRecognizableCredentialValue(in: value)
+        }) else {
+            return false
+        }
+        return !(components.queryItems ?? []).contains { item in
+            isCredentialName(item.name)
+                || containsRecognizableCredentialValue(in: item.value ?? "")
+        }
+    }
+
+    /** Normalizes common punctuation and case differences in one query key. */
+    private static func normalizedQueryName(_ value: String) -> String {
+        value.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+
+    /** Classifies exact and vendor-prefixed authentication field names after punctuation removal. */
+    private static func isCredentialName(_ value: String) -> Bool {
+        percentDecodedForms(value).contains { form in
+            let normalized = normalizedQueryName(form)
+            return credentialQueryNames.contains(normalized)
+                || credentialNameFragments.contains(where: normalized.contains)
+        }
+    }
+
+    /** Detects realistic opaque token forms through every reversible percent-decoding layer. */
+    private static func containsRecognizableCredentialValue(in value: String) -> Bool {
+        percentDecodedForms(value).contains { form in
+            let lowercased = form.lowercased()
+            if lowercased.contains("bearer ") {
+                return true
+            }
+            let tokens = lowercased.split { character in
+                !(character.isLetter
+                    || character.isNumber
+                    || character == "-"
+                    || character == "_"
+                    || character == ".")
+            }
+            return tokens.contains { token in
+                credentialValuePrefixRules.contains(where: { rule in
+                    token.hasPrefix(rule.prefix) && token.count >= rule.minimumLength
+                })
+                    || (token.hasPrefix("eyj")
+                        && token.count >= 24
+                        && token.filter { $0 == "." }.count == 2)
+            }
+        }
+    }
+
+    /**
+     Produces every successively decoded representation until percent decoding reaches a fixed point.
+
+     Each successful non-identity decode shortens the input, so the byte-count bound guarantees
+     deterministic termination without imposing a bypassable fixed nesting depth.
+     */
+    private static func percentDecodedForms(_ value: String) -> [String] {
+        var forms = [value]
+        var current = value
+        for _ in 0..<value.utf8.count {
+            guard let decoded = current.removingPercentEncoding,
+                  decoded != current else {
+                break
+            }
+            forms.append(decoded)
+            current = decoded
+        }
+        return forms
+    }
+}

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAndroidDatabaseContract.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncAndroidDatabaseContract.swift
@@ -32,13 +32,14 @@ enum RemoteSyncAndroidDatabaseContractError: Error, Equatable {
  Defines the exact Android Room database contract for every iOS-supported remote-sync category.
 
  The versions, identity hashes, tables, indexes, foreign keys, views, defaults, and primary keys are
- transcribed from Android's checked-in Room schema exports. Initial and sparse databases must both be
- valid Room databases because Android opens every downloaded patch through its production Room
- factory before attaching it for reconciliation.
+ transcribed from Android's Room schema exports. The one omitted AI v12 export is reconstructed from
+ exported v11, Android's exact migration, and Room's compiler identity algorithm. Initial and sparse
+ databases must both be valid Room databases because Android opens every downloaded patch through
+ its production Room factory before attaching it for reconciliation.
  */
 enum RemoteSyncAndroidDatabaseContract {
-    /** Immutable Room identity and canonical-schema digest for one exported workspace generation. */
-    private struct WorkspaceSourceAuthority {
+    /** Immutable Room identity and canonical-schema digest for one exported predecessor generation. */
+    private struct RoomSourceAuthority {
         /// Room identity written by Android's generated schema export.
         let identityHash: String
 
@@ -61,6 +62,7 @@ enum RemoteSyncAndroidDatabaseContract {
         case .readingPlans: 1
         case .myDocuments: 4
         case .progress: 9
+        case .aiSettings: 23
         }
     }
 
@@ -79,6 +81,7 @@ enum RemoteSyncAndroidDatabaseContract {
         case .readingPlans: "d465b2a4bc2012fff3a69d3eaff9b5ff"
         case .myDocuments: "3f0946602099d896c8d47129233c1794"
         case .progress: "76330d8367020840e56e6b92d921522a"
+        case .aiSettings: "c5b1820fd3dfb0390fa3122d2d6e139f"
         }
     }
 
@@ -105,6 +108,8 @@ enum RemoteSyncAndroidDatabaseContract {
             myDocumentsSchemaSQL
         case .progress:
             progressSchemaSQL
+        case .aiSettings:
+            aiSettingsSchemaSQL
         }
     }
 
@@ -228,6 +233,50 @@ enum RemoteSyncAndroidDatabaseContract {
         return runtimeTriggerNames
     }
 
+    /**
+     Validates one advertised AI settings predecessor against its exported Room generation.
+
+     - Parameters:
+       - database: Open staged AI settings database.
+       - sourceVersion: Advertised Android Room generation.
+     - Returns: Exact validated runtime trigger names, which migration may safely remove.
+     - Side Effects: Reads SQLite metadata and computes an in-memory schema digest only.
+     - Throws: Typed version, identity, trigger, or schema errors before migration mutates the file.
+     */
+    static func validateAISettingsSourceDatabase(
+        _ database: OpaquePointer,
+        sourceVersion: Int
+    ) throws -> Set<String> {
+        guard let authority = aiSettingsSourceAuthorities[sourceVersion] else {
+            throw RemoteSyncAndroidDatabaseContractError.invalidUserVersion(
+                expected: schemaVersion(for: .aiSettings),
+                actual: sourceVersion
+            )
+        }
+        let actualVersion = try integerPragma("user_version", in: database)
+        guard actualVersion == sourceVersion else {
+            throw RemoteSyncAndroidDatabaseContractError.invalidUserVersion(
+                expected: sourceVersion,
+                actual: actualVersion
+            )
+        }
+        try validateIdentity(in: database, expectedHash: authority.identityHash)
+        let runtimeTriggerNames = try validatedRuntimeSyncTriggerNames(
+            in: database,
+            category: .aiSettings
+        )
+        let actualDigest = try schemaSHA256(
+            in: database,
+            excludingObjects: runtimeTriggerNames
+        )
+        guard actualDigest == authority.schemaSHA256 else {
+            throw RemoteSyncAndroidDatabaseContractError.schemaMismatch(
+                "ai-settings-v\(sourceVersion)"
+            )
+        }
+        return runtimeTriggerNames
+    }
+
     /** Validates bounded row and scalar domains before any caller materializes database content. */
     private static func validatePayloadBounds(
         in database: OpaquePointer,
@@ -339,9 +388,145 @@ enum RemoteSyncAndroidDatabaseContract {
                 ],
                 in: database
             )
+        case .aiSettings:
+            try validateAISettingsPayloadBounds(in: database)
         case .bookmarks, .myDocuments:
             break
         }
+    }
+
+    /** Validates Android AI settings row domains without materializing unbounded prompt content. */
+    private static func validateAISettingsPayloadBounds(in database: OpaquePointer) throws {
+        let uuidTables = [
+            "LlmProviderConfig",
+            "LlmConfiguredModel",
+            "AgentPrompt",
+            "GlobalAiSettings",
+            "LlmUsageRecord",
+            "LlmRawLogRecord",
+            "PromptCategory",
+            "BuiltinPromptOverride",
+        ]
+        for table in uuidTables {
+            let maximumRows: Int64
+            switch table {
+            case "GlobalAiSettings":
+                maximumRows = 1
+            case "LlmRawLogRecord":
+                maximumRows = 100_000
+            default:
+                maximumRows = 100_000
+            }
+            try requireRowCount(table, maximum: maximumRows, in: database)
+            try requireBlobUUID(table, column: "id", in: database)
+        }
+        try requireFixedBlobIdentifier(
+            "GlobalAiSettings",
+            column: "id",
+            hexadecimal: "A1000000000000000000000000000001",
+            in: database
+        )
+
+        try requireBoundedText("LlmProviderConfig", column: "providerType", maximum: 128, permitsEmpty: false, in: database)
+        try requireBoundedText("LlmProviderConfig", column: "displayName", maximum: 1_048_576, permitsEmpty: true, in: database)
+        try requireNullableText("LlmProviderConfig", column: "endpoint", maximum: 1_048_576, in: database)
+        try requireNullableText("LlmProviderConfig", column: "apiFormat", maximum: 128, in: database)
+        try requireInt32("LlmProviderConfig", column: "orderNumber", in: database)
+
+        try requireBlobUUID("LlmConfiguredModel", column: "providerConfigId", in: database)
+        try requireBoundedText("LlmConfiguredModel", column: "modelId", maximum: 1_048_576, permitsEmpty: true, in: database)
+        try requireInt32("LlmConfiguredModel", column: "orderNumber", in: database)
+        for column in [
+            "inputPricePerMillion",
+            "outputPricePerMillion",
+            "cacheCreationPricePerMillion",
+            "cacheReadPricePerMillion",
+        ] {
+            try requireNonnegativeFiniteReal("LlmConfiguredModel", column: column, in: database)
+        }
+
+        for column in ["name", "promptTemplate", "showIn"] {
+            try requireBoundedText("AgentPrompt", column: column, maximum: 16_777_216, permitsEmpty: true, in: database)
+        }
+        for column in ["description", "permissionMode", "allowedTools", "deniedTools"] {
+            try requireNullableText("AgentPrompt", column: column, maximum: 16_777_216, in: database)
+        }
+        try requireInt32("AgentPrompt", column: "orderNumber", in: database)
+        try requireInteger("AgentPrompt", column: "createdAt", in: database)
+        try requireNullableBlobUUID("AgentPrompt", column: "configuredModelId", in: database)
+        try requireNullableBlobUUID("AgentPrompt", column: "categoryId", in: database)
+        try requireNullableInt32("AgentPrompt", column: "maxIterations", in: database)
+        for column in [
+            "strictContextMatching",
+            "editBeforeRun",
+            "noDocumentCreation",
+            "autoIncludeDocuments",
+            "autoIncludeCommentaries",
+            "bibleOnly",
+            "isTextTransformation",
+        ] {
+            try requireBoolean("AgentPrompt", column: column, in: database)
+        }
+
+        for column in [
+            "agentPermissionMode",
+            "permanentlyAllowedTools",
+            "permanentlyDeniedTools",
+            "aiLanguage",
+            "customAgentSystemPrompt",
+            "customTextTransformationSystemPrompt",
+        ] {
+            try requireNullableText("GlobalAiSettings", column: column, maximum: 16_777_216, in: database)
+        }
+        for column in [
+            "aiExcludedDocuments",
+            "hiddenBuiltInPrompts",
+            "commentaryDeselected",
+            "hiddenBuiltInCategories",
+            "favoritePrompts",
+        ] {
+            try requireBoundedText("GlobalAiSettings", column: column, maximum: 16_777_216, permitsEmpty: true, in: database)
+        }
+        try requireInt32("GlobalAiSettings", column: "commentaryMaxResponseTokens", in: database)
+        try requireInt32("GlobalAiSettings", column: "maxIterations", in: database)
+        try requireNullableInt32("GlobalAiSettings", column: "rawLogRetentionDays", in: database)
+        try requireNullableBlobUUID("GlobalAiSettings", column: "defaultModelId", in: database)
+        for column in ["askModelBeforeRun", "aiDisclaimerAccepted", "autoHideAgentLogOnCompletion"] {
+            try requireBoolean("GlobalAiSettings", column: column, in: database)
+        }
+
+        try requireBlobUUID("LlmUsageRecord", column: "configuredModelId", in: database)
+        try requireBoundedText("LlmUsageRecord", column: "deviceId", maximum: 512, permitsEmpty: true, in: database)
+        for column in ["inputTokens", "outputTokens", "cacheCreationTokens", "cacheReadTokens"] {
+            try requireInteger("LlmUsageRecord", column: column, range: 0...Int64.max, in: database)
+        }
+        try requireNonnegativeFiniteReal("LlmUsageRecord", column: "estimatedCostUsd", in: database)
+
+        try requireBoundedText("PromptCategory", column: "name", maximum: 1_048_576, permitsEmpty: true, in: database)
+        try requireInt32("PromptCategory", column: "orderNumber", in: database)
+        try requireBoolean("PromptCategory", column: "hidden", in: database)
+        try requireNullableBlobUUID("BuiltinPromptOverride", column: "configuredModelId", in: database)
+
+        try rejectAny(
+            "SELECT 1 FROM LlmRawLogRecord WHERE length(logData) > 67108864 LIMIT 1",
+            error: .fieldTooLarge(table: "LlmRawLogRecord", column: "logData"),
+            in: database
+        )
+        try validateSyncMetadataBounds(
+            nativeTables: [
+                "LlmProviderConfig",
+                "LlmConfiguredModel",
+                "AgentPrompt",
+                "GlobalAiSettings",
+                "LlmUsageRecord",
+                "PromptCategory",
+                "BuiltinPromptOverride",
+            ],
+            fixedIdentifiers: [
+                "GlobalAiSettings": "A1000000000000000000000000000001"
+            ],
+            in: database
+        )
     }
 
     /** Validates exact Android workspace row storage classes and bounded materialization sizes. */
@@ -780,6 +965,20 @@ enum RemoteSyncAndroidDatabaseContract {
         )
     }
 
+    /** Requires exact SQLite REAL storage within the nonnegative finite IEEE-754 domain. */
+    private static func requireNonnegativeFiniteReal(
+        _ table: String,
+        column: String,
+        in database: OpaquePointer
+    ) throws {
+        let identifier = sqlIdentifier(column)
+        try rejectAny(
+            "SELECT 1 FROM \(sqlIdentifier(table)) WHERE typeof(\(identifier)) != 'real' OR \(identifier) < 0.0 OR \(identifier) > 1.7976931348623157e308 LIMIT 1",
+            error: .invalidRowValue(table: table, column: column),
+            in: database
+        )
+    }
+
     /** Requires every non-null value in one column to use exact SQLite REAL storage. */
     private static func requireNullableReal(
         _ table: String,
@@ -1050,6 +1249,16 @@ enum RemoteSyncAndroidDatabaseContract {
                 ("MemorizationTarget", "id", nil),
                 ("GlobalReadingProgressSettings", "id", nil),
             ]
+        case .aiSettings:
+            return [
+                ("LlmProviderConfig", "id", nil),
+                ("LlmConfiguredModel", "id", nil),
+                ("AgentPrompt", "id", nil),
+                ("GlobalAiSettings", "id", nil),
+                ("LlmUsageRecord", "id", nil),
+                ("PromptCategory", "id", nil),
+                ("BuiltinPromptOverride", "id", nil),
+            ]
         case .bookmarks, .readingPlans, .myDocuments:
             return []
         }
@@ -1138,9 +1347,9 @@ enum RemoteSyncAndroidDatabaseContract {
      Builds Room-equivalent semantic signatures for every non-internal SQLite schema object.
 
      Table columns are keyed independently of physical `cid` order, matching Room's `TableInfo`
-     comparison. Defaults remain exact except `PageManager.jsState`, whose Android 4-to-5 migration
-     explicitly adds `DEFAULT NULL` while later generated exports omit that semantically equivalent
-     clause. Raw table SQL is also tokenized for material features omitted by SQLite PRAGMAs,
+     comparison. Defaults remain exact except where Android migrations add a compatibility default
+     that a later generated entity export omits; Room treats those migrated and fresh-install forms
+     as equivalent. Raw table SQL is also tokenized for material features omitted by SQLite PRAGMAs,
      including collations, checks, conflict clauses, deferrability, autoincrement, strict tables, and
      `WITHOUT ROWID`.
 
@@ -1192,8 +1401,8 @@ enum RemoteSyncAndroidDatabaseContract {
                     }
                     var semanticColumn = Array(row.dropFirst())
                     let columnName = try serializedTextValue(row[1])
-                    if semanticColumn[3] == "t:NULL",
-                       defaultNullEquivalentColumns.contains("\(name).\(columnName)") {
+                    let columnKey = "\(name).\(columnName)"
+                    if defaultAbsentEquivalentValues[columnKey]?.contains(semanticColumn[3]) == true {
                         semanticColumn[3] = "n:"
                     }
                     return semanticColumn
@@ -1244,8 +1453,13 @@ enum RemoteSyncAndroidDatabaseContract {
         return signatures
     }
 
-    /** Computes a stable SHA-256 over length-delimited canonical schema signatures. */
-    private static func schemaSHA256(
+    /**
+     Computes a stable SHA-256 over length-delimited canonical schema signatures.
+
+     Staged-database migrators use this internal authority digest before changing predecessor files;
+     tests derive the pinned values from Android's checked-in Room exports.
+     */
+    static func schemaSHA256(
         in database: OpaquePointer,
         excludingObjects: Set<String>
     ) throws -> String {
@@ -1470,11 +1684,28 @@ enum RemoteSyncAndroidDatabaseContract {
     private static let progressSettingsIdentifierHex =
         "B2000000000000000000000000000001"
 
-    /// Sole documented default-null equivalence produced by Android's workspace migration chain.
-    private static let defaultNullEquivalentColumns: Set<String> = ["PageManager.jsState"]
+    /// Exact historical migration defaults that Room accepts as equivalent to no entity default.
+    private static let defaultAbsentEquivalentValues: [String: Set<String>] = [
+        "PageManager.jsState": ["t:NULL"],
+        "GlobalAiSettings.hiddenBuiltInPrompts": ["t:''"],
+        "GlobalAiSettings.commentaryDeselected": ["t:''"],
+        "GlobalAiSettings.hiddenBuiltInCategories": ["t:''"],
+        "GlobalAiSettings.favoritePrompts": ["t:''"],
+        "LlmProviderConfig.endpoint": ["t:NULL"],
+        "LlmProviderConfig.apiFormat": ["t:NULL"],
+        "LlmRawLogRecord.promptId": ["t:NULL"],
+        "LlmRawLogRecord.promptName": ["t:''"],
+        "LlmRawLogRecord.promptDescription": ["t:NULL"],
+        "LlmRawLogRecord.configuredModelId": ["t:NULL"],
+        "LlmRawLogRecord.modelName": ["t:''"],
+        "LlmRawLogRecord.providerType": ["t:''"],
+        "LlmRawLogRecord.timestamp": ["t:0"],
+        "LlmRawLogRecord.totalInputTokens": ["t:0"],
+        "LlmRawLogRecord.totalOutputTokens": ["t:0"],
+    ]
 
     /// Source-derived Room identities and canonical schema digests for supported workspace versions.
-    private static let workspaceSourceAuthorities: [Int: WorkspaceSourceAuthority] = [
+    private static let workspaceSourceAuthorities: [Int: RoomSourceAuthority] = [
         1: .init(identityHash: "4bf98e71faae835422c6aad319b3c3e6", schemaSHA256: "99057f0bb023884c8712d504809d48e4b681d62a3508aa9ba25af8f8a7dd8a4a"),
         2: .init(identityHash: "4bf98e71faae835422c6aad319b3c3e6", schemaSHA256: "99057f0bb023884c8712d504809d48e4b681d62a3508aa9ba25af8f8a7dd8a4a"),
         3: .init(identityHash: "039ea7732752b2ad4b4ef67168479e0d", schemaSHA256: "19580320104c86a1f6b1b3d0c5970c2c09a822ea554e10c9c86d4837e658f328"),
@@ -1497,6 +1728,33 @@ enum RemoteSyncAndroidDatabaseContract {
         22: .init(identityHash: "4a38e9989c3075a4382c417b41f0c4a6", schemaSHA256: "02bf74d0597649e20e8e687fb5ee5987048a0ed246022bb4832c70cddcacc904"),
         23: .init(identityHash: "7ba9fd73c4f856535b0ccf704686a631", schemaSHA256: "c9c377e975adaeb46be155fab7595019195c56bcf4c7994f7a9c7a54f517c6b2"),
         24: .init(identityHash: "59b8635a1eb5125e32e2789eedd02ab2", schemaSHA256: "033e08ef59637066efeeb2dec2dbbb5e6bb7700e41f48930ef099d421b96387a"),
+    ]
+
+    /// Exported or exactly derived Room identities and schema digests for AI settings generations.
+    private static let aiSettingsSourceAuthorities: [Int: RoomSourceAuthority] = [
+        1: .init(identityHash: "9acb139ce0350ae8d45abe791a34d5a6", schemaSHA256: "8317465a0a2d4ce6f303c1edb132bb363a81cbbf0eeada2179f0cc8c7e187152"),
+        2: .init(identityHash: "959f762d0c6e5b46c0e2972d78da075b", schemaSHA256: "76437b02a23a03083fc290649609f03bf2eee7f51bb36a7f30aa4ff762af8594"),
+        3: .init(identityHash: "8c4ba2db34ea934850985ef133401c84", schemaSHA256: "ebfa80f29e704e4213aad749dab68a43e809aa870d02c3ac1acd9d675a1b63f1"),
+        4: .init(identityHash: "f2617a01e732d92655cc482da61ab59b", schemaSHA256: "79f66898cc6ab75b22a1469be7eedefca7cdf38ef45c4180561005be0d976174"),
+        5: .init(identityHash: "79f56a8289168f6c523498ee304a77f7", schemaSHA256: "02f5f5b27e4dc1d04b90999833f4e3940aff25a4fb17dbd379d89f42c5728108"),
+        6: .init(identityHash: "44771286d77cd66ed6bd171f22b85f48", schemaSHA256: "00372b77b0cf8d17fd1efc13cd965196981685688765665568f34cc63bfa473f"),
+        7: .init(identityHash: "d7f999f5bfbe041800525de7ea079ced", schemaSHA256: "d3819c99432c935ce64086ebdd5459cfa70be782eda0dc6a664097ba9c056420"),
+        8: .init(identityHash: "beaee5ab47416e0e33fe1b5648280860", schemaSHA256: "92c6f887f5e6d2242ece2fd1d08c09d9746c8616d7bdd7046791cc270249ca51"),
+        9: .init(identityHash: "c72ce2565d4b73f61bfe567e97dfc07f", schemaSHA256: "f1f098dfc7889eeed4a7e8c7abf4e6c55891aa6ae95a7259c66e2049dba29165"),
+        10: .init(identityHash: "4ac43f9df1b74a5aeb31ad2928ec31d9", schemaSHA256: "93297f28c42cf45ef5f8391740abbbea64d5e7f1ed49fda97ae2f1ec5b0bd632"),
+        11: .init(identityHash: "ba66632b571047b0d26b028d68a09fd4", schemaSHA256: "d76f70c62584fb144a0b345d973d26603b24102c039f5c4bee023c6712146340"),
+        12: .init(identityHash: "ce84fdcfd2da69ec7a3dbb0a48598c5b", schemaSHA256: "1fcdbebe0865065824e82c0a995c7c216bce2de8e483f90f6daec3746aa39149"),
+        13: .init(identityHash: "7f78373ef09d4a39963a6d36fb1af07c", schemaSHA256: "8025bb17bd61933adaa64434a2479ea09579ae4494b576259d1c62bc2ed3c640"),
+        14: .init(identityHash: "a58582f787ab00d65317d194b512d65d", schemaSHA256: "26a16acf0751f124dfe3315c966f2011803535dfce863b35bf991914df6bbe65"),
+        15: .init(identityHash: "74162a4c9fee3d05e66dea913f3a8ecc", schemaSHA256: "fe2dd0d8b2ad5660576b195c937744fbc8e2f8fbbaf30751eabeb4f37a9ba8f5"),
+        16: .init(identityHash: "44ee4b49c2dc4b97f4d47d5d05f9c106", schemaSHA256: "90bf4c6f2794dcc2271c8e2bbaf02ff5699f28237e24d1f3b96057b0042f2a32"),
+        17: .init(identityHash: "db8c5d0eaebf6bb8660ad4bffdd5e634", schemaSHA256: "c90ed042f68c6b84ceae4d0d87449930c141e080dd5983419745337a1c86b15d"),
+        18: .init(identityHash: "94c3097da2ba84700e7a99b45be93354", schemaSHA256: "472beb6e51dc3cf12877d9c014263ad2cdd5c40492c00d4d3697f01e77152175"),
+        19: .init(identityHash: "9ebbedb251fc0892363a38ef2f3aa314", schemaSHA256: "bb099daf645b7909bff6c3f3cc1c5ec12c0b8a573d7f91e0f9a9431729266006"),
+        20: .init(identityHash: "2fb949a3f2269f9ea913d71ec86e9a2c", schemaSHA256: "f777f05ca16b0982802cd559d935a43761e9d2ad8fda5d1302863f5df53f2cab"),
+        21: .init(identityHash: "78dc0aed47cda9c269d076d4bff4353e", schemaSHA256: "1b8a59bcc8acb858597ab678088ed7e23cd33d6bc57809696e009e0b6973bdd0"),
+        22: .init(identityHash: "cd5d541ba5aee11ecf5cf66642675607", schemaSHA256: "6893f3914273d7b6cb22147d0faf5f4b190df3c24abbe285b22a8b3129076093"),
+        23: .init(identityHash: "c5b1820fd3dfb0390fa3122d2d6e139f", schemaSHA256: "43904463fc915222308d336b104b42f042178d53602eef65f6de5c196da0f7f9"),
     ]
 
     /// Shared Android Room sync metadata tables and indexes.
@@ -1553,6 +1811,35 @@ enum RemoteSyncAndroidDatabaseContract {
     CREATE VIEW `AiCachedPageWithContent` AS SELECT c.pageId, c.sourcePromptId, c.sourceContext, c.kjvOrdinalStart, c.kjvOrdinalEnd, c.contextHash, c.usedWriteTools, c.sourceModelName, c.sourceBookInitials, c.sourceBookKey, p.title, p.pageKey, p.contentType, p.documentId, p.orderNumber, p.createdAt, p.updatedAt, p.languageCode, cnt.content FROM AiPageCacheEntry c INNER JOIN MyDocumentPage p ON c.pageId = p.id LEFT OUTER JOIN MyDocumentPageContent cnt ON p.id = cnt.pageId;
     CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT);
     INSERT OR REPLACE INTO room_master_table (id, identity_hash) VALUES (42, '3f0946602099d896c8d47129233c1794');
+    """
+
+    /// Complete Android `AiSettingsDatabase` version 23 schema.
+    private static let aiSettingsSchemaSQL = """
+    PRAGMA user_version = 23;
+    CREATE TABLE IF NOT EXISTS `AgentPrompt` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL );
+    CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `AgentPrompt` (`orderNumber`);
+    CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `AgentPrompt` (`createdAt`);
+    CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `AgentPrompt` (`configuredModelId`);
+    CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `AgentPrompt` (`categoryId`);
+    CREATE TABLE IF NOT EXISTS `LlmProviderConfig` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`));
+    CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `LlmProviderConfig` (`orderNumber`);
+    CREATE TABLE IF NOT EXISTS `LlmConfiguredModel` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE );
+    CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `LlmConfiguredModel` (`providerConfigId`);
+    CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `LlmConfiguredModel` (`providerConfigId`, `modelId`);
+    CREATE TABLE IF NOT EXISTS `GlobalAiSettings` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, `rawLogRetentionDays` INTEGER DEFAULT 30, `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`));
+    CREATE TABLE IF NOT EXISTS `LlmUsageRecord` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`));
+    CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `LlmUsageRecord` (`configuredModelId`);
+    CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `LlmUsageRecord` (`configuredModelId`, `deviceId`);
+    CREATE TABLE IF NOT EXISTS `LlmRawLogRecord` (`id` BLOB NOT NULL, `promptId` BLOB, `promptName` TEXT NOT NULL, `promptDescription` TEXT, `configuredModelId` BLOB, `modelName` TEXT NOT NULL, `providerType` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `totalInputTokens` INTEGER NOT NULL, `totalOutputTokens` INTEGER NOT NULL, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`));
+    CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `LlmRawLogRecord` (`timestamp`);
+    CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `LlmRawLogRecord` (`promptId`);
+    CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `LlmRawLogRecord` (`configuredModelId`);
+    CREATE TABLE IF NOT EXISTS `PromptCategory` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`));
+    CREATE TABLE IF NOT EXISTS `BuiltinPromptOverride` (`id` BLOB NOT NULL, `configuredModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL );
+    CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `BuiltinPromptOverride` (`configuredModelId`);
+    \(syncMetadataSQL)
+    CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT);
+    INSERT OR REPLACE INTO room_master_table (id, identity_hash) VALUES (42, 'c5b1820fd3dfb0390fa3122d2d6e139f');
     """
 
     /// Complete Android `WorkspaceDatabase` version 24 schema.

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncArchiveStagingService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncArchiveStagingService.swift
@@ -159,7 +159,7 @@ public final class RemoteSyncArchiveStagingService {
        - throws `RemoteSyncArchiveStagingError.decompressionFailed` when gzip extraction fails
        - throws `RemoteSyncArchiveStagingError.invalidSQLiteDatabase` when the extracted file is not a readable SQLite database
        - throws `RemoteSyncArchiveStagingError.incompatibleInitialBackupVersion` when the extracted
-         database generation is not an authoritative workspace source or needs a newer schema
+         database generation is not an authoritative migratable source or needs a newer schema
          version than `currentSchemaVersion`
      */
     public func downloadInitialBackup(
@@ -194,7 +194,11 @@ public final class RemoteSyncArchiveStagingService {
             let schemaVersion = try Self.sqliteUserVersion(at: databaseURL)
             let isUnsupportedWorkspaceGeneration = category == .workspaces
                 && !RemoteSyncWorkspaceDatabaseMigrator.supportsSourceVersion(schemaVersion)
-            if schemaVersion > currentSchemaVersion || isUnsupportedWorkspaceGeneration {
+            let isUnsupportedAISettingsGeneration = category == .aiSettings
+                && !RemoteSyncAISettingsDatabaseMigrator.supportsSourceVersion(schemaVersion)
+            if schemaVersion > currentSchemaVersion
+                || isUnsupportedWorkspaceGeneration
+                || isUnsupportedAISettingsGeneration {
                 throw RemoteSyncArchiveStagingError.incompatibleInitialBackupVersion(schemaVersion)
             }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupRestoreService.swift
@@ -23,6 +23,9 @@ public enum RemoteSyncInitialBackupRestoreReport: Sendable, Equatable {
     /// Successful restore report for the My Documents sync category.
     case myDocuments(RemoteSyncMyDocumentRestoreReport)
 
+    /// Successful restore report for the AI Settings sync category.
+    case aiSettings(RemoteSyncAISettingsRestoreReport)
+
     /// Successful restore report for the Progress sync category.
     case progress(AndroidDatabaseBackupProgressReport)
 }
@@ -40,6 +43,8 @@ through one generic SQLite importer.
  - `RemoteSyncReadingPlanRestoreService` restores staged Android `readingplans.sqlite3` backups
  - `RemoteSyncWorkspaceRestoreService` restores staged Android `workspaces.sqlite3` backups
  - `RemoteSyncMyDocumentRestoreService` restores staged Android `mydocuments.sqlite3` backups
+ - `RemoteSyncAISettingsRestoreService` restores seven non-secret AI settings tables while
+   preserving device-local raw logs and credentials
  - `RemoteSyncInitialBackupMetadataRestoreService` preserves staged Android `LogEntry` and
    `SyncStatus` rows needed for later patch replay
  - `RemoteSyncBookmarkSnapshotService` refreshes outbound bookmark fingerprint baselines after
@@ -75,11 +80,13 @@ public final class RemoteSyncInitialBackupRestoreService {
     private let readingPlanRestoreService: RemoteSyncReadingPlanRestoreService
     private let workspaceRestoreService: RemoteSyncWorkspaceRestoreService
     private let myDocumentRestoreService: RemoteSyncMyDocumentRestoreService
+    private let aiSettingsRestoreService: RemoteSyncAISettingsRestoreService
     private let metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService
     private let bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService
     private let workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService
     private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
     private let myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService
+    private let aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService
     private let progressSnapshotService: RemoteSyncProgressSnapshotService
 
     /**
@@ -90,6 +97,7 @@ public final class RemoteSyncInitialBackupRestoreService {
        - readingPlanRestoreService: Restore service used for the reading-plan category.
        - workspaceRestoreService: Restore service used for the workspace category.
        - myDocumentRestoreService: Restore service used for the My Documents category.
+       - aiSettingsRestoreService: Restore service used for the non-secret AI Settings category.
        - metadataRestoreService: Restore service used to preserve Android `LogEntry` and `SyncStatus`
          rows after content restore succeeds.
        - bookmarkSnapshotService: Snapshot service used to refresh outbound bookmark fingerprint
@@ -99,6 +107,8 @@ public final class RemoteSyncInitialBackupRestoreService {
        - readingPlanSnapshotService: Snapshot service used to refresh outbound reading-plan
          fingerprint baselines after successful remote restores.
        - myDocumentSnapshotService: Snapshot service used to refresh outbound My Documents
+         fingerprint baselines after successful remote restores.
+       - aiSettingsSnapshotService: Snapshot service used to refresh outbound AI Settings
          fingerprint baselines after successful remote restores.
        - progressSnapshotService: Snapshot service used to refresh outbound Progress fingerprint
          baselines after successful remote restores.
@@ -110,22 +120,26 @@ public final class RemoteSyncInitialBackupRestoreService {
         readingPlanRestoreService: RemoteSyncReadingPlanRestoreService = RemoteSyncReadingPlanRestoreService(),
         workspaceRestoreService: RemoteSyncWorkspaceRestoreService = RemoteSyncWorkspaceRestoreService(),
         myDocumentRestoreService: RemoteSyncMyDocumentRestoreService = RemoteSyncMyDocumentRestoreService(),
+        aiSettingsRestoreService: RemoteSyncAISettingsRestoreService = RemoteSyncAISettingsRestoreService(),
         metadataRestoreService: RemoteSyncInitialBackupMetadataRestoreService = RemoteSyncInitialBackupMetadataRestoreService(),
         bookmarkSnapshotService: RemoteSyncBookmarkSnapshotService = RemoteSyncBookmarkSnapshotService(),
         workspaceSnapshotService: RemoteSyncWorkspaceSnapshotService = RemoteSyncWorkspaceSnapshotService(),
         readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(),
         myDocumentSnapshotService: RemoteSyncMyDocumentSnapshotService = RemoteSyncMyDocumentSnapshotService(),
+        aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService(),
         progressSnapshotService: RemoteSyncProgressSnapshotService = RemoteSyncProgressSnapshotService()
     ) {
         self.bookmarkRestoreService = bookmarkRestoreService
         self.readingPlanRestoreService = readingPlanRestoreService
         self.workspaceRestoreService = workspaceRestoreService
         self.myDocumentRestoreService = myDocumentRestoreService
+        self.aiSettingsRestoreService = aiSettingsRestoreService
         self.metadataRestoreService = metadataRestoreService
         self.bookmarkSnapshotService = bookmarkSnapshotService
         self.workspaceSnapshotService = workspaceSnapshotService
         self.readingPlanSnapshotService = readingPlanSnapshotService
         self.myDocumentSnapshotService = myDocumentSnapshotService
+        self.aiSettingsSnapshotService = aiSettingsSnapshotService
         self.progressSnapshotService = progressSnapshotService
     }
 
@@ -213,6 +227,15 @@ public final class RemoteSyncInitialBackupRestoreService {
         } else {
             workspaceSnapshot = nil
         }
+        let aiSettingsSnapshot: RemoteSyncAndroidAISettingsSnapshot?
+        if category == .aiSettings {
+            aiSettingsSnapshot = try aiSettingsRestoreService.readSnapshot(
+                from: stagedBackup.databaseFileURL,
+                expectedSourceVersion: stagedBackup.schemaVersion
+            )
+        } else {
+            aiSettingsSnapshot = nil
+        }
         if category == .progress {
             try Self.validateProgressDatabaseBeforeMetadata(
                 at: stagedBackup.databaseFileURL
@@ -270,6 +293,16 @@ public final class RemoteSyncInitialBackupRestoreService {
                         settingsStore: settingsStore
                     )
                     report = .myDocuments(myDocumentReport)
+                case .aiSettings:
+                    guard let aiSettingsSnapshot else {
+                        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+                    }
+                    let aiSettingsReport = try aiSettingsRestoreService.replaceLocalAISettings(
+                        from: aiSettingsSnapshot,
+                        modelContext: modelContext,
+                        settingsStore: settingsStore
+                    )
+                    report = .aiSettings(aiSettingsReport)
                 case .progress:
                     let progressReport = try AndroidDatabaseBackupProgressMapper.apply(
                         from: stagedBackup.databaseFileURL,
@@ -282,6 +315,10 @@ public final class RemoteSyncInitialBackupRestoreService {
                 _ = metadataRestoreService.replaceLocalMetadata(
                     from: metadataSnapshot,
                     category: category,
+                    settingsStore: settingsStore
+                )
+                RemoteSyncMutationJournalService().clearPendingMutations(
+                    for: category,
                     settingsStore: settingsStore
                 )
                 if category == .bookmarks {
@@ -301,6 +338,11 @@ public final class RemoteSyncInitialBackupRestoreService {
                     )
                 } else if category == .myDocuments {
                     try myDocumentSnapshotService.refreshBaselineFingerprintsThrowing(
+                        modelContext: modelContext,
+                        settingsStore: settingsStore
+                    )
+                } else if category == .aiSettings {
+                    try aiSettingsSnapshotService.refreshBaselineFingerprintsStrict(
                         modelContext: modelContext,
                         settingsStore: settingsStore
                     )

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -136,6 +136,7 @@ public final class RemoteSyncInitialBackupUploadService {
         case bookmarks(RemoteSyncBookmarkAcceptedBaseline)
         case workspaces(RemoteSyncWorkspaceAcceptedGeneration)
         case myDocuments(RemoteSyncMyDocumentAcceptedBaseline)
+        case aiSettings(RemoteSyncAISettingsAcceptedBaseline)
         case progress(RemoteSyncProgressAcceptedGeneration)
     }
 
@@ -195,8 +196,30 @@ public final class RemoteSyncInitialBackupUploadService {
             return .workspaces
         case .myDocuments:
             return .myDocuments
+        case .aiSettings:
+            return .aiSettings
         case .progress:
             return .progress
+        }
+    }
+
+    /** Returns the exact row fingerprints carried by one immutable initial-backup generation. */
+    private static func fingerprints(
+        for generation: AcceptedFingerprintGeneration
+    ) -> [String: String] {
+        switch generation {
+        case .readingPlans(let value):
+            return value.fingerprintsByKey
+        case .bookmarks(let value):
+            return value.fingerprintsByKey
+        case .workspaces(let value):
+            return value.fingerprintsByKey
+        case .myDocuments(let value):
+            return value.fingerprintsByKey
+        case .aiSettings(let value):
+            return value.fingerprintsByKey
+        case .progress(let value):
+            return value.fingerprintsByKey
         }
     }
 
@@ -846,6 +869,8 @@ public final class RemoteSyncInitialBackupUploadService {
             tableNames = generation.rowsByKey.values.map(\.tableName)
         case .myDocuments(let baseline):
             tableNames = baseline.rowIdentities.map(\.tableName)
+        case .aiSettings(let baseline):
+            tableNames = baseline.rowIdentities.map(\.tableName)
         case .progress(let generation):
             tableNames = generation.rowsByKey.values.map(\.tableName)
         }
@@ -904,6 +929,12 @@ public final class RemoteSyncInitialBackupUploadService {
                     )
                 case .myDocuments:
                     builtBackup = try buildMyDocumentInitialBackup(
+                        modelContext: modelContext,
+                        settingsStore: settingsStore,
+                        schemaVersion: schemaVersion
+                    )
+                case .aiSettings:
+                    builtBackup = try buildAISettingsInitialBackup(
                         modelContext: modelContext,
                         settingsStore: settingsStore,
                         schemaVersion: schemaVersion
@@ -1007,12 +1038,23 @@ public final class RemoteSyncInitialBackupUploadService {
                         baseline,
                         settingsStore: settingsStore
                     )
+                case .aiSettings(let baseline):
+                    try RemoteSyncAISettingsSnapshotService().acceptBaseline(
+                        baseline,
+                        settingsStore: settingsStore
+                    )
                 case .progress(let generation):
                     try RemoteSyncProgressSnapshotService().acceptBaselineFingerprints(
                         generation,
                         settingsStore: settingsStore
                     )
                 }
+                try RemoteSyncMutationJournalService().clearPendingMutationsAcceptedByBaseline(
+                    Self.fingerprints(for: acceptedInitialBackup.fingerprintGeneration),
+                    for: category,
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                )
                 try acceptedBaselineMutations()
             }
         } catch {
@@ -1456,6 +1498,61 @@ public final class RemoteSyncInitialBackupUploadService {
                 acceptedInitialBackup: AcceptedInitialBackup(
                     timestamp: acceptedTimestamp,
                     fingerprintGeneration: .myDocuments(acceptedBaseline),
+                    workspaceHistoryAliases: []
+                )
+            )
+        } catch {
+            try? fileManager.removeItem(at: databaseURL)
+            throw error
+        }
+    }
+
+    /**
+     Builds one full Android AI settings database from the seven synchronized non-secret tables.
+
+     - Parameters:
+       - modelContext: SwiftData context that owns the current AI settings graph.
+       - settingsStore: Local settings store backing sync metadata and the accepted baseline.
+       - schemaVersion: Exact Android Room version written into the database; only v23 is supported.
+     - Returns: Temporary SQLite database and the immutable accepted generation represented by it.
+     - Side Effects: Strictly reads the AI graph and writes one temporary Android-shaped database.
+     - Throws: Rethrows snapshot-integrity, schema, SQLite, filesystem, and timestamp failures; no
+       credential value or raw model log is read or written.
+     */
+    private func buildAISettingsInitialBackup(
+        modelContext: ModelContext,
+        settingsStore: SettingsStore,
+        schemaVersion: Int
+    ) throws -> BuiltInitialBackup {
+        guard schemaVersion == RemoteSyncAndroidDatabaseContract.schemaVersion(for: .aiSettings) else {
+            throw RemoteSyncInitialBackupUploadError.unsupportedSchemaVersion(
+                category: .aiSettings,
+                version: schemaVersion
+            )
+        }
+
+        let snapshotService = RemoteSyncAISettingsSnapshotService()
+        let snapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let acceptedBaseline = try snapshotService.acceptedBaseline(from: snapshot)
+        let acceptedTimestamp = try nextAcceptedTimestamp(
+            for: .aiSettings,
+            settingsStore: settingsStore
+        )
+        let databaseURL = temporaryURL(prefix: "remote-sync-ai-settings-initial-", suffix: ".sqlite3")
+        do {
+            _ = try RemoteSyncAISettingsDatabaseWriter(fileManager: fileManager).writeFullDatabase(
+                at: databaseURL,
+                snapshot: snapshot,
+                schemaVersion: schemaVersion
+            )
+            return BuiltInitialBackup(
+                databaseURL: databaseURL,
+                acceptedInitialBackup: AcceptedInitialBackup(
+                    timestamp: acceptedTimestamp,
+                    fingerprintGeneration: .aiSettings(acceptedBaseline),
                     workspaceHistoryAliases: []
                 )
             )

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncInitialBackupUploadService.swift
@@ -253,6 +253,7 @@ public final class RemoteSyncInitialBackupUploadService {
     private let retryDirectory: URL
     private let nowProvider: () -> Int64
     private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
+    private let aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService
 
     /**
      Creates an initial-backup upload service for one remote backend.
@@ -261,6 +262,7 @@ public final class RemoteSyncInitialBackupUploadService {
        - adapter: Remote backend adapter used for initial-backup uploads.
        - deviceIdentifier: Stable device identifier used for patch-zero bookkeeping.
        - readingPlanSnapshotService: Snapshot service bound to this device's custom-plan directory.
+       - aiSettingsSnapshotService: Snapshot service bound to the device-local credential reader.
        - userPlanDirectory: Local custom-definition directory used by snapshot recovery.
        - fileManager: File manager used for temporary staging and cleanup.
        - temporaryDirectory: Optional staging directory override.
@@ -274,6 +276,7 @@ public final class RemoteSyncInitialBackupUploadService {
         adapter: any RemoteSyncAdapting,
         deviceIdentifier: String,
         readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService? = nil,
+        aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService(),
         userPlanDirectory: URL = ReadingPlanService.defaultUserReadingPlanDirectory(),
         fileManager: FileManager = .default,
         temporaryDirectory: URL? = nil,
@@ -287,6 +290,7 @@ public final class RemoteSyncInitialBackupUploadService {
                 userPlanDirectory: userPlanDirectory,
                 fileManager: fileManager
             )
+        self.aiSettingsSnapshotService = aiSettingsSnapshotService
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
         self.retryDirectory = retryDirectory
@@ -316,6 +320,7 @@ public final class RemoteSyncInitialBackupUploadService {
         adapter = nil
         deviceIdentifier = "manual-database-backup-export"
         readingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(fileManager: fileManager)
+        aiSettingsSnapshotService = RemoteSyncAISettingsSnapshotService()
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
         retryDirectory = self.temporaryDirectory
@@ -1049,7 +1054,9 @@ public final class RemoteSyncInitialBackupUploadService {
                         settingsStore: settingsStore
                     )
                 }
-                try RemoteSyncMutationJournalService().clearPendingMutationsAcceptedByBaseline(
+                try RemoteSyncMutationJournalService(
+                    aiSettingsSnapshotService: aiSettingsSnapshotService
+                ).clearPendingMutationsAcceptedByBaseline(
                     Self.fingerprints(for: acceptedInitialBackup.fingerprintGeneration),
                     for: category,
                     modelContext: modelContext,
@@ -1531,12 +1538,11 @@ public final class RemoteSyncInitialBackupUploadService {
             )
         }
 
-        let snapshotService = RemoteSyncAISettingsSnapshotService()
-        let snapshot = try snapshotService.snapshotCurrentStateStrict(
+        let snapshot = try aiSettingsSnapshotService.snapshotCurrentStateStrict(
             modelContext: modelContext,
             settingsStore: settingsStore
         )
-        let acceptedBaseline = try snapshotService.acceptedBaseline(from: snapshot)
+        let acceptedBaseline = try aiSettingsSnapshotService.acceptedBaseline(from: snapshot)
         let acceptedTimestamp = try nextAcceptedTimestamp(
             for: .aiSettings,
             settingsStore: settingsStore

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMutationJournalService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMutationJournalService.swift
@@ -64,7 +64,7 @@ private struct RemoteSyncPreparedMutation {
  Records Android-compatible `LogEntry` rows when local stores persist user mutations.
 
  Android installs Room triggers on every syncable table, so pending changes exist before transport
- begins. iOS projects the same five category graphs at each database-store save boundary, compares
+ begins. iOS projects the same category graphs at each database-store save boundary, compares
  them with the last accepted generation, and writes deterministic local log entries in the same
  transaction as the graph/settings mutation. Upload acceptance can then merge a newer in-flight
  journal entry instead of replacing it with the generation that finished transport.
@@ -350,6 +350,69 @@ final class RemoteSyncMutationJournalService {
     }
 
     /**
+     Removes every pending mutation marker for a category without decoding abandoned payloads.
+
+     Full remote restore and explicit reset replace or abandon the complete accepted generation, so
+     no prior local marker remains meaningful. Raw prefix removal also lets reset recover from a
+     malformed marker that strict synchronization would otherwise reject.
+
+     - Parameters:
+       - category: Category whose pending mutation generation is being abandoned.
+       - settingsStore: Store containing category-scoped marker rows.
+     - Side Effects: Removes every settings row under the category marker prefix.
+     - Failure modes: None; settings removal is staged in the caller's transaction.
+     */
+    func clearPendingMutations(
+        for category: RemoteSyncCategory,
+        settingsStore: SettingsStore
+    ) {
+        for entry in settingsStore.entries(withPrefix: markerPrefix(for: category)) {
+            settingsStore.remove(entry.key)
+        }
+    }
+
+    /**
+     Clears only pending mutations represented by an accepted full-backup snapshot.
+
+     Initial upload can suspend after capturing its immutable archive. A marker is accepted only when
+     its exact fingerprint matches both that archive and the current graph; later edits and deletions
+     therefore survive as the next sparse generation.
+
+     - Parameters:
+       - acceptedFingerprints: Exact row fingerprints carried by the accepted initial backup.
+       - category: Category whose initial generation was accepted.
+       - modelContext: Current graph context, or the settings context for progress.
+       - settingsStore: Store containing pending mutation markers.
+     - Side Effects: Strictly reads current category state and removes only fully accepted markers.
+     - Throws: Rethrows strict projection or marker decoding failures before caller commit.
+     */
+    func clearPendingMutationsAcceptedByBaseline(
+        _ acceptedFingerprints: [String: String],
+        for category: RemoteSyncCategory,
+        modelContext: ModelContext,
+        settingsStore: SettingsStore
+    ) throws {
+        let currentFingerprints = try projection(
+            for: category,
+            modelContext: category == .progress ? nil : modelContext,
+            settingsStore: settingsStore,
+            stagedDeletedIdentities: []
+        ).currentFingerprints
+        let markers = try pendingMutations(for: category, settingsStore: settingsStore)
+        let logPrefix = RemoteSyncLogEntryStore(settingsStore: settingsStore).prefix(for: category)
+
+        for (key, marker) in markers {
+            guard marker.stateFingerprint == acceptedFingerprints[key],
+                  currentFingerprints[key] == acceptedFingerprints[key] else {
+                continue
+            }
+            settingsStore.remove(
+                markerKey(forLogKey: key, category: category, logPrefix: logPrefix)
+            )
+        }
+    }
+
+    /**
      Resolves the mutation-time log row for one exact outbound row generation.
 
      - Parameters:
@@ -558,6 +621,32 @@ final class RemoteSyncMutationJournalService {
                 acceptedRows: accepted?.rowsByKey ?? [:],
                 suppressedKeys: snapshot.suppressedKeys
             )
+
+        case .aiSettings:
+            guard let modelContext else {
+                throw SettingsStoreAtomicBatchError.modelContextMismatch
+            }
+            let service = RemoteSyncAISettingsSnapshotService()
+            let snapshot = try service.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+            let current = try service.acceptedBaseline(from: snapshot)
+            let accepted = try service.storedAcceptedBaseline(settingsStore: settingsStore)
+            return excludingStagedDeletions(
+                from: RemoteSyncMutationProjection(
+                    currentFingerprints: snapshot.fingerprintsByKey,
+                    currentRowsByKey: Dictionary(uniqueKeysWithValues: current.rowIdentities.map {
+                        ($0.key, Self.identity(from: $0))
+                    }),
+                    acceptedFingerprints: accepted?.fingerprintsByKey ?? [:],
+                    acceptedRowsByKey: Dictionary(uniqueKeysWithValues: (accepted?.rowIdentities ?? []).map {
+                        ($0.key, Self.identity(from: $0))
+                    }),
+                    suppressedKeys: []
+                ),
+                stagedDeletedIdentities: stagedDeletedIdentities
+            )
         }
     }
 
@@ -743,6 +832,28 @@ final class RemoteSyncMutationJournalService {
 
         case .progress:
             break
+
+        case .aiSettings:
+            for model in deletedModels {
+                switch model {
+                case let row as LLMProviderConfig:
+                    append("LlmProviderConfig", row.id)
+                case let row as LLMConfiguredModel:
+                    append("LlmConfiguredModel", row.id)
+                case let row as AgentPrompt:
+                    append("AgentPrompt", row.id)
+                case let row as GlobalAISettings:
+                    append("GlobalAiSettings", row.id)
+                case let row as LLMUsageRecord:
+                    append("LlmUsageRecord", row.id)
+                case let row as PromptCategory:
+                    append("PromptCategory", row.id)
+                case let row as BuiltInPromptOverride:
+                    append("BuiltinPromptOverride", row.id)
+                default:
+                    continue
+                }
+            }
         }
 
         return identities
@@ -913,6 +1024,17 @@ final class RemoteSyncMutationJournalService {
 
     private static func identity(
         from value: RemoteSyncProgressAcceptedRowIdentity
+    ) -> RemoteSyncMutationRowIdentity {
+        RemoteSyncMutationRowIdentity(
+            tableName: value.tableName,
+            entityID1: value.entityID1,
+            entityID2: value.entityID2
+        )
+    }
+
+    /** Adapts one accepted AI settings identity into the shared journal projection. */
+    private static func identity(
+        from value: RemoteSyncAISettingsAcceptedRowIdentity
     ) -> RemoteSyncMutationRowIdentity {
         RemoteSyncMutationRowIdentity(
             tableName: value.tableName,

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMutationJournalService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMutationJournalService.swift
@@ -95,16 +95,28 @@ final class RemoteSyncMutationJournalService {
 
     private let nowProvider: () -> Int64
     private let readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService
+    private let aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
-    /** Creates a mutation journal with an exact clock and reading-plan definition source. */
+    /**
+     Creates a mutation journal with exact category snapshot dependencies.
+
+     - Parameters:
+       - nowProvider: Android-compatible logical timestamp source.
+       - readingPlanSnapshotService: Reading-plan projector bound to custom definition storage.
+       - aiSettingsSnapshotService: AI projector bound to the device-local credential reader.
+     - Side Effects: none until a category projection is requested.
+     - Failure Modes: Construction cannot fail; strict projectors preserve their own failures.
+     */
     init(
         nowProvider: @escaping () -> Int64 = { AndroidTimestamp.currentMilliseconds() },
-        readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService()
+        readingPlanSnapshotService: RemoteSyncReadingPlanSnapshotService = RemoteSyncReadingPlanSnapshotService(),
+        aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService()
     ) {
         self.nowProvider = nowProvider
         self.readingPlanSnapshotService = readingPlanSnapshotService
+        self.aiSettingsSnapshotService = aiSettingsSnapshotService
         encoder.outputFormatting = [.sortedKeys]
     }
 
@@ -118,6 +130,7 @@ final class RemoteSyncMutationJournalService {
      - Parameters:
        - category: Remote-sync category mutated by the database store.
        - modelContext: Context containing the already-staged graph mutation.
+       - aiSettingsSnapshotService: AI projector bound to the caller's credential reader.
      - Side Effects:
        - processes pending SwiftData changes so strict snapshot fetches exclude staged deletions
        - commits graph and journal together, or directly saves graph-only test schemas
@@ -125,7 +138,8 @@ final class RemoteSyncMutationJournalService {
      */
     static func savePendingGraphChanges(
         for category: RemoteSyncCategory,
-        modelContext: ModelContext
+        modelContext: ModelContext,
+        aiSettingsSnapshotService: RemoteSyncAISettingsSnapshotService = RemoteSyncAISettingsSnapshotService()
     ) throws {
         guard modelContext.container.schema.entitiesByName["Setting"] != nil else {
             try modelContext.save()
@@ -134,7 +148,9 @@ final class RemoteSyncMutationJournalService {
 
         let settingsStore = SettingsStore(modelContext: modelContext)
         modelContext.processPendingChanges()
-        let journal = RemoteSyncMutationJournalService()
+        let journal = RemoteSyncMutationJournalService(
+            aiSettingsSnapshotService: aiSettingsSnapshotService
+        )
         let stagedDeletedIdentities = try journal.stagedDeletedIdentities(
             for: category,
             modelContext: modelContext,
@@ -626,13 +642,14 @@ final class RemoteSyncMutationJournalService {
             guard let modelContext else {
                 throw SettingsStoreAtomicBatchError.modelContextMismatch
             }
-            let service = RemoteSyncAISettingsSnapshotService()
-            let snapshot = try service.snapshotCurrentStateStrict(
+            let snapshot = try aiSettingsSnapshotService.snapshotCurrentStateStrict(
                 modelContext: modelContext,
                 settingsStore: settingsStore
             )
-            let current = try service.acceptedBaseline(from: snapshot)
-            let accepted = try service.storedAcceptedBaseline(settingsStore: settingsStore)
+            let current = try aiSettingsSnapshotService.acceptedBaseline(from: snapshot)
+            let accepted = try aiSettingsSnapshotService.storedAcceptedBaseline(
+                settingsStore: settingsStore
+            )
             return excludingStagedDeletions(
                 from: RemoteSyncMutationProjection(
                     currentFingerprints: snapshot.fingerprintsByKey,

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncPatchDiscoveryService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncPatchDiscoveryService.swift
@@ -166,7 +166,7 @@ public final class RemoteSyncPatchDiscoveryService {
      - Failure modes:
        - throws `RemoteSyncPatchDiscoveryError.missingSyncFolderID` when bootstrap state is incomplete
        - throws `RemoteSyncPatchDiscoveryError.incompatiblePatchVersion` when a remote patch targets
-         a newer schema version than `currentSchemaVersion`
+         a newer schema version or an unexported migratable generation
        - throws `RemoteSyncPatchDiscoveryError.patchFilesSkipped` when any required patch is missing
        - rethrows backend transport errors from the adapter
      */
@@ -247,8 +247,13 @@ public final class RemoteSyncPatchDiscoveryService {
                 && !RemoteSyncWorkspaceDatabaseMigrator.supportsSourceVersion(
                     parsedPatch.schemaVersion
                 )
+            let isUnsupportedAISettingsGeneration = category == .aiSettings
+                && !RemoteSyncAISettingsDatabaseMigrator.supportsSourceVersion(
+                    parsedPatch.schemaVersion
+                )
             if parsedPatch.schemaVersion > currentSchemaVersion
-                || isUnsupportedWorkspaceGeneration {
+                || isUnsupportedWorkspaceGeneration
+                || isUnsupportedAISettingsGeneration {
                 throw RemoteSyncPatchDiscoveryError.incompatiblePatchVersion(parsedPatch.schemaVersion)
             }
             if folderState.appliedPatchNumbers.contains(parsedPatch.patchNumber) {

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncResetService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncResetService.swift
@@ -26,6 +26,8 @@ public final class RemoteSyncResetService {
                 return RemoteSyncMyDocumentPatchUploadService.pendingUploadKey
             case .progress:
                 return RemoteSyncProgressPatchUploadService.pendingPatchSettingKey
+            case .aiSettings:
+                return RemoteSyncAISettingsPatchUploadService.pendingUploadKey
             }
         }
 
@@ -42,6 +44,8 @@ public final class RemoteSyncResetService {
                 return RemoteSyncMyDocumentSnapshotService.acceptedBaselineKey
             case .progress:
                 return RemoteSyncProgressSnapshotService.acceptedBaselineKey
+            case .aiSettings:
+                return RemoteSyncAISettingsSnapshotService.acceptedBaselineKey
             }
         }
     }
@@ -95,6 +99,7 @@ public final class RemoteSyncResetService {
             .workspaces: RemoteSyncWorkspacePatchUploadService.defaultOutboxDirectory(fileManager: fileManager),
             .readingPlans: RemoteSyncReadingPlanPatchUploadService.defaultOutboxDirectory(fileManager: fileManager),
             .myDocuments: RemoteSyncMyDocumentPatchUploadService.defaultOutboxDirectory(fileManager: fileManager),
+            .aiSettings: RemoteSyncAISettingsPatchUploadService.defaultOutboxDirectory(fileManager: fileManager),
             .progress: RemoteSyncProgressPatchUploadService.defaultOutboxDirectory(fileManager: fileManager),
         ]
         self.initialUploadRetryDirectory = initialUploadRetryDirectory
@@ -151,6 +156,7 @@ public final class RemoteSyncResetService {
         let patchStatusStore = RemoteSyncPatchStatusStore(settingsStore: settingsStore)
         let logEntryStore = RemoteSyncLogEntryStore(settingsStore: settingsStore)
         let fingerprintStore = RemoteSyncRowFingerprintStore(settingsStore: settingsStore)
+        let mutationJournal = RemoteSyncMutationJournalService()
 
         try settingsStore.performAtomicBatch {
             for category in RemoteSyncCategory.allCases {
@@ -159,6 +165,10 @@ public final class RemoteSyncResetService {
                 patchStatusStore.clearCategory(category)
                 logEntryStore.clearCategory(category)
                 fingerprintStore.clearCategory(category)
+                mutationJournal.clearPendingMutations(
+                    for: category,
+                    settingsStore: settingsStore
+                )
                 settingsStore.remove(MetadataKey.pendingPublication(for: category))
                 settingsStore.remove(MetadataKey.acceptedBaseline(for: category))
             }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSettingsStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSettingsStore.swift
@@ -216,11 +216,33 @@ public protocol SecretStoring: AnyObject {
 }
 
 /**
+ Optional strict-read capability for secret stores that can distinguish absence from backend failure.
+
+ Security-sensitive publication paths use this contract to fail closed when Keychain is unavailable,
+ while ordinary credential consumers may continue using `SecretStoring.secret(forKey:)` compatibility
+ semantics. Implementations perform no writes and must return `nil` only for a confirmed missing item.
+ */
+public protocol StrictSecretReading: AnyObject {
+    /**
+     Reads a secret while preserving backend and payload failures.
+
+     - Parameter key: Logical secret identifier.
+     - Returns: Stored UTF-8 secret text, or `nil` only when the item does not exist.
+     - Side Effects: Reads from the concrete secret backend.
+     - Throws: Backend-specific lookup or payload-decoding errors.
+     */
+    func secretStrict(forKey key: String) throws -> String?
+}
+
+/**
  Errors emitted by the Keychain-backed secret store.
  */
 public enum KeychainSecretStoreError: Error, Equatable {
     /// Keychain returned an unexpected status code.
     case unexpectedStatus(OSStatus)
+
+    /// Keychain returned a success payload that was not UTF-8 secret data.
+    case invalidPayload
 }
 
 /**
@@ -229,7 +251,7 @@ public enum KeychainSecretStoreError: Error, Equatable {
  This store is intentionally local-only. Secrets such as WebDAV passwords must never be synced
  through SwiftData or `UserDefaults`.
  */
-public final class KeychainSecretStore: SecretStoring {
+public final class KeychainSecretStore: SecretStoring, StrictSecretReading {
     /// Keychain service namespace shared by all secrets in this store instance.
     private let service: String
 
@@ -256,6 +278,20 @@ public final class KeychainSecretStore: SecretStoring {
        - returns `nil` when Keychain lookup fails or the payload is not UTF-8 text
      */
     public func secret(forKey key: String) -> String? {
+        try? secretStrict(forKey: key)
+    }
+
+    /**
+     Reads a Keychain secret without collapsing access or payload errors into absence.
+
+     - Parameter key: Logical secret identifier stored as the Keychain account.
+     - Returns: UTF-8 secret text, or `nil` only when Keychain confirms the item is absent.
+     - Side Effects: Performs one Keychain lookup through `SecItemCopyMatching`.
+     - Throws:
+       - `KeychainSecretStoreError.unexpectedStatus` for access and backend failures
+       - `KeychainSecretStoreError.invalidPayload` for non-data or non-UTF-8 success payloads
+     */
+    public func secretStrict(forKey key: String) throws -> String? {
         var query = baseQuery(forKey: key)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -263,8 +299,14 @@ public final class KeychainSecretStore: SecretStoring {
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         guard status != errSecItemNotFound else { return nil }
-        guard status == errSecSuccess, let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        guard status == errSecSuccess else {
+            throw KeychainSecretStoreError.unexpectedStatus(status)
+        }
+        guard let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            throw KeychainSecretStoreError.invalidPayload
+        }
+        return value
     }
 
     /**
@@ -664,6 +706,9 @@ public final class RemoteSyncSettingsStore {
      - Failure modes: This helper cannot fail.
      */
     private func legacySyncEnabledKey(for category: RemoteSyncCategory) -> String {
-        "\(Keys.legacySyncCategoryPrefix)\(category.rawValue)"
+        if category == .aiSettings {
+            return "gdrive_llmprocessing"
+        }
+        return "\(Keys.legacySyncCategoryPrefix)\(category.rawValue)"
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncStateStore.swift
@@ -6,7 +6,7 @@ import Foundation
  Identifies the logical data categories Android syncs as separate patch streams.
 
  Android's `SyncableDatabaseDefinition` uses independent categories for bookmarks, workspaces,
- reading plans, and My Documents. The iOS remote-sync implementation preserves that separation so
+ reading plans, My Documents, Progress, and AI settings. The iOS implementation preserves that separation so
  remote folder naming, bootstrap state, and patch progress can be tracked per category instead of
  collapsing all user data into one opaque sync stream.
  */
@@ -26,6 +26,9 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
     /// Reading and memorization progress data.
     case progress = "progress"
 
+    /// Non-secret AI prompts, provider configuration, model metadata, preferences, and usage.
+    case aiSettings = "ai_settings"
+
     /**
      Categories currently backed by iOS sync engines and eligible for lifecycle sweeps.
 
@@ -33,7 +36,7 @@ public enum RemoteSyncCategory: String, CaseIterable, Sendable {
      syncable, so visible settings rows are curated separately by the UI presentation layer.
      */
     public static var activeSyncCases: [RemoteSyncCategory] {
-        [.bookmarks, .workspaces, .readingPlans, .myDocuments, .progress]
+        [.bookmarks, .workspaces, .readingPlans, .myDocuments, .aiSettings, .progress]
     }
 
     /// Highest Android SQLite schema version iOS can currently read and write for this category.

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncSynchronizationService.swift
@@ -38,6 +38,9 @@ public enum RemoteSyncCategoryPatchReplayReport: Sendable, Equatable {
     /// My Documents-category patch replay summary.
     case myDocuments(RemoteSyncMyDocumentPatchApplyReport)
 
+    /// AI Settings-category patch replay summary.
+    case aiSettings(RemoteSyncAISettingsPatchApplyReport)
+
     /// Progress-category patch replay summary.
     case progress(RemoteSyncProgressPatchApplyReport)
 }
@@ -60,6 +63,9 @@ public enum RemoteSyncCategoryPatchUploadReport: Sendable, Equatable {
 
     /// My Documents-category outbound patch upload summary.
     case myDocuments(RemoteSyncMyDocumentPatchUploadReport)
+
+    /// AI Settings-category outbound patch upload summary.
+    case aiSettings(RemoteSyncAISettingsPatchUploadReport)
 
     /// Progress-category outbound patch upload summary.
     case progress(RemoteSyncProgressPatchUploadReport)
@@ -183,6 +189,8 @@ public enum RemoteSyncSynchronizationOutcome: Sendable, Equatable {
  - `RemoteSyncReadingPlanPatchUploadService` exports and uploads outbound sparse reading-plan patches
  - `RemoteSyncMyDocumentPatchApplyService` replays inbound sparse My Documents patches
  - `RemoteSyncMyDocumentPatchUploadService` exports and uploads outbound sparse My Documents patches
+ - `RemoteSyncAISettingsPatchApplyService` replays inbound non-secret AI settings patches
+ - `RemoteSyncAISettingsPatchUploadService` exports non-secret AI settings patches
  - `RemoteSyncStateStore` persists Android-aligned bootstrap and progress metadata locally
  - `RemoteSyncPatchStatusStore` records patch zero after remote initial-backup adoption, matching Android
 
@@ -191,7 +199,7 @@ public enum RemoteSyncSynchronizationOutcome: Sendable, Equatable {
  - may restore a full staged initial backup into local SwiftData
  - may export and upload a full staged initial backup from local SwiftData into a fresh remote folder
  - may replay staged remote patches into local SwiftData and local-only fidelity stores
- - may upload one outbound sparse bookmark, workspace, reading-plan, or My Documents patch and rewrite local baseline metadata after success
+ - may upload one outbound sparse category patch and rewrite local baseline metadata after success
  - persists bootstrap, patch-status, and progress metadata through `SettingsStore`
  - creates and removes temporary staged archive files beneath the configured temporary directory
 
@@ -220,6 +228,8 @@ public final class RemoteSyncSynchronizationService {
     private let workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService
     private let myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService
     private let myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService
+    private let aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService
+    private let aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService
     private let progressPatchApplyService: RemoteSyncProgressPatchApplyService
     private let progressPatchUploadService: RemoteSyncProgressPatchUploadService
     private let fileManager: FileManager
@@ -243,6 +253,8 @@ public final class RemoteSyncSynchronizationService {
        - workspacePatchUploadService: Workspace outbound patch upload service.
        - myDocumentPatchApplyService: My Documents patch replay service.
        - myDocumentPatchUploadService: My Documents outbound patch upload service.
+       - aiSettingsPatchApplyService: AI Settings patch replay service.
+       - aiSettingsPatchUploadService: AI Settings outbound patch upload service.
        - progressPatchApplyService: Progress patch replay service.
        - progressPatchUploadService: Progress outbound patch upload service.
        - fileManager: File manager used for staging cleanup.
@@ -265,6 +277,8 @@ public final class RemoteSyncSynchronizationService {
         workspacePatchUploadService: RemoteSyncWorkspacePatchUploadService? = nil,
         myDocumentPatchApplyService: RemoteSyncMyDocumentPatchApplyService = RemoteSyncMyDocumentPatchApplyService(),
         myDocumentPatchUploadService: RemoteSyncMyDocumentPatchUploadService? = nil,
+        aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService = RemoteSyncAISettingsPatchApplyService(),
+        aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService? = nil,
         progressPatchApplyService: RemoteSyncProgressPatchApplyService = RemoteSyncProgressPatchApplyService(),
         progressPatchUploadService: RemoteSyncProgressPatchUploadService? = nil,
         fileManager: FileManager = .default,
@@ -304,6 +318,12 @@ public final class RemoteSyncSynchronizationService {
         self.myDocumentPatchApplyService = myDocumentPatchApplyService
         self.myDocumentPatchUploadService = myDocumentPatchUploadService
             ?? RemoteSyncMyDocumentPatchUploadService(
+                adapter: adapter,
+                nowProvider: nowProvider
+            )
+        self.aiSettingsPatchApplyService = aiSettingsPatchApplyService
+        self.aiSettingsPatchUploadService = aiSettingsPatchUploadService
+            ?? RemoteSyncAISettingsPatchUploadService(
                 adapter: adapter,
                 nowProvider: nowProvider
             )
@@ -1031,6 +1051,12 @@ public final class RemoteSyncSynchronizationService {
                 modelContext: modelContext,
                 settingsStore: settingsStore
             ).map(RemoteSyncCategoryPatchUploadReport.myDocuments)
+        case .aiSettings:
+            return try await aiSettingsPatchUploadService.resumePendingUploadIfPresent(
+                bootstrapState: bootstrapState,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            ).map(RemoteSyncCategoryPatchUploadReport.aiSettings)
         case .progress:
             return try await progressPatchUploadService.resumePendingPatchIfPresent(
                 bootstrapState: bootstrapState,
@@ -1087,6 +1113,14 @@ public final class RemoteSyncSynchronizationService {
         case .myDocuments:
             return .myDocuments(
                 try myDocumentPatchApplyService.applyPatchArchives(
+                    stagedArchives,
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                )
+            )
+        case .aiSettings:
+            return .aiSettings(
+                try aiSettingsPatchApplyService.applyPatchArchives(
                     stagedArchives,
                     modelContext: modelContext,
                     settingsStore: settingsStore
@@ -1160,6 +1194,15 @@ public final class RemoteSyncSynchronizationService {
                 settingsStore: settingsStore
             ) {
                 return .myDocuments(report)
+            }
+            return nil
+        case .aiSettings:
+            if let report = try await aiSettingsPatchUploadService.uploadPendingPatch(
+                bootstrapState: bootstrapState,
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            ) {
+                return .aiSettings(report)
             }
             return nil
         case .progress:

--- a/Sources/BibleCore/Tests/BibleCoreTests/AIPromptAndModelBehaviorTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AIPromptAndModelBehaviorTests.swift
@@ -336,11 +336,13 @@ final class AIPromptAndModelBehaviorTests: XCTestCase {
     }
 
     /**
-     Verifies configured-model deletion clears prompt, default, override, and usage references.
+     Verifies configured-model deletion clears formal references but preserves usage history.
 
-     Failure means a settings edit could leave synced rows pointing at a deleted model.
+     Android retains `LlmUsageRecord` through model deletion because its model identity is a logical
+     reference rather than a foreign key. Failure means iOS either leaves formal dependents invalid
+     or destroys synchronized historical usage that Android retains.
      */
-    func testDeletingConfiguredModelClearsEveryDependentReference() throws {
+    func testDeletingConfiguredModelClearsFormalReferencesAndPreservesUsageHistory() throws {
         let container = try makeAIContainer()
         let store = AISettingsStore(modelContext: ModelContext(container))
         let provider = LLMProviderConfig(provider: .openAI, displayName: "OpenAI")
@@ -371,7 +373,8 @@ final class AIPromptAndModelBehaviorTests: XCTestCase {
         XCTAssertNil(prompt.configuredModelId)
         XCTAssertNil(settings.defaultModelId)
         XCTAssertNil(try store.builtInOverride(id: builtInID)?.configuredModelId)
-        XCTAssertTrue(try store.usageRecords().isEmpty)
+        let retainedUsage = try XCTUnwrap(store.usageRecords().first)
+        XCTAssertEqual(retainedUsage.configuredModelId, model.id)
     }
 
     /**

--- a/Sources/BibleCore/Tests/BibleCoreTests/AISettingsStoreModelFailoverTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AISettingsStoreModelFailoverTests.swift
@@ -1,0 +1,187 @@
+import SwiftData
+import XCTest
+@testable import BibleCore
+
+/**
+ Protects Android's configured-model identity and first-remaining default promotion at persistence.
+
+ Each test uses an isolated in-memory AI schema and performs no Keychain, CloudKit, filesystem, or
+ network work. Failure means model management can leave the global default empty or select a model
+ that differs from Android's persisted ordering.
+ */
+@MainActor
+final class AISettingsStoreModelFailoverTests: XCTestCase {
+    /**
+     Verifies deleting the current default promotes the globally first surviving configured model.
+
+     The expected survivor belongs to another provider and has the lowest `orderNumber`; insertion
+     order deliberately differs. Failure means `deleteModel` is using provider scope, insertion
+     order, or `nil` instead of Android's first remaining global model.
+     */
+    func testDeletingDefaultModelPromotesFirstRemainingModel() throws {
+        let container = try makeModelFailoverContainer()
+        let store = AISettingsStore(modelContext: ModelContext(container))
+        let firstProvider = LLMProviderConfig(provider: .openAI, displayName: "OpenAI")
+        let secondProvider = LLMProviderConfig(provider: .gemini, displayName: "Gemini")
+        try store.insertProvider(firstProvider)
+        try store.insertProvider(secondProvider)
+
+        let deletedDefault = LLMConfiguredModel(
+            providerConfigId: firstProvider.id,
+            modelId: "deleted-default",
+            orderNumber: 20
+        )
+        let laterSurvivor = LLMConfiguredModel(
+            providerConfigId: firstProvider.id,
+            modelId: "later-survivor",
+            orderNumber: 8
+        )
+        let expectedDefault = LLMConfiguredModel(
+            providerConfigId: secondProvider.id,
+            modelId: "first-survivor",
+            orderNumber: 2
+        )
+        try store.insertModel(deletedDefault)
+        try store.insertModel(laterSurvivor)
+        try store.insertModel(expectedDefault)
+        let settings = try store.globalSettings()
+        settings.defaultModelId = deletedDefault.id
+        try store.save()
+
+        try store.deleteModel(id: deletedDefault.id)
+
+        XCTAssertEqual(settings.defaultModelId, expectedDefault.id)
+        XCTAssertEqual(try store.allModels().map(\.id), [expectedDefault.id, laterSurvivor.id])
+    }
+
+    /**
+     Verifies deleting a provider that owns the default promotes the first model outside it.
+
+     Two provider-owned rows are removed together while surviving rows have distinct persisted
+     order values. Failure means provider deletion clears the default or chooses a row that is also
+     being deleted.
+     */
+    func testDeletingDefaultProviderPromotesFirstModelFromRemainingProviders() throws {
+        let container = try makeModelFailoverContainer()
+        let store = AISettingsStore(modelContext: ModelContext(container))
+        let deletedProvider = LLMProviderConfig(provider: .openAI, displayName: "OpenAI")
+        let survivingProvider = LLMProviderConfig(provider: .anthropic, displayName: "Anthropic")
+        try store.insertProvider(deletedProvider)
+        try store.insertProvider(survivingProvider)
+
+        let deletedDefault = LLMConfiguredModel(
+            providerConfigId: deletedProvider.id,
+            modelId: "deleted-default",
+            orderNumber: 0
+        )
+        let deletedSibling = LLMConfiguredModel(
+            providerConfigId: deletedProvider.id,
+            modelId: "deleted-sibling",
+            orderNumber: 1
+        )
+        let laterSurvivor = LLMConfiguredModel(
+            providerConfigId: survivingProvider.id,
+            modelId: "later-survivor",
+            orderNumber: 9
+        )
+        let expectedDefault = LLMConfiguredModel(
+            providerConfigId: survivingProvider.id,
+            modelId: "first-survivor",
+            orderNumber: 3
+        )
+        try store.insertModel(deletedDefault)
+        try store.insertModel(deletedSibling)
+        try store.insertModel(laterSurvivor)
+        try store.insertModel(expectedDefault)
+        let settings = try store.globalSettings()
+        settings.defaultModelId = deletedDefault.id
+        try store.save()
+
+        try store.deleteProvider(id: deletedProvider.id)
+
+        XCTAssertEqual(settings.defaultModelId, expectedDefault.id)
+        XCTAssertNil(try store.provider(id: deletedProvider.id))
+        XCTAssertEqual(try store.allModels().map(\.id), [expectedDefault.id, laterSurvivor.id])
+    }
+
+    /**
+     Verifies deleting a non-default model does not disturb the selected global default.
+
+     Failure means routine cleanup can unexpectedly switch models even though Android promotes only
+     when the deleted row is the current default.
+     */
+    func testDeletingNonDefaultModelPreservesCurrentDefault() throws {
+        let container = try makeModelFailoverContainer()
+        let store = AISettingsStore(modelContext: ModelContext(container))
+        let provider = LLMProviderConfig(provider: .openAI, displayName: "OpenAI")
+        try store.insertProvider(provider)
+        let deletedModel = LLMConfiguredModel(
+            providerConfigId: provider.id,
+            modelId: "deleted",
+            orderNumber: 0
+        )
+        let selectedModel = LLMConfiguredModel(
+            providerConfigId: provider.id,
+            modelId: "selected",
+            orderNumber: 1
+        )
+        try store.insertModel(deletedModel)
+        try store.insertModel(selectedModel)
+        let settings = try store.globalSettings()
+        settings.defaultModelId = selectedModel.id
+        try store.save()
+
+        try store.deleteModel(id: deletedModel.id)
+
+        XCTAssertEqual(settings.defaultModelId, selectedModel.id)
+    }
+
+    /**
+     Verifies model insertion enforces Android's provider/model composite uniqueness.
+
+     An identical identifier remains valid under another provider, while a duplicate under the same
+     provider must fail before insertion. Failure means iOS can create rows Android's Room schema
+     rejects and make later default promotion ambiguous.
+     */
+    func testInsertModelRejectsDuplicateIdentifierOnlyWithinSameProvider() throws {
+        let container = try makeModelFailoverContainer()
+        let store = AISettingsStore(modelContext: ModelContext(container))
+        let firstProvider = LLMProviderConfig(provider: .openAI, displayName: "OpenAI")
+        let secondProvider = LLMProviderConfig(provider: .openRouter, displayName: "OpenRouter")
+        try store.insertProvider(firstProvider)
+        try store.insertProvider(secondProvider)
+        try store.insertModel(
+            LLMConfiguredModel(providerConfigId: firstProvider.id, modelId: "shared/model")
+        )
+        try store.insertModel(
+            LLMConfiguredModel(providerConfigId: secondProvider.id, modelId: "shared/model")
+        )
+
+        XCTAssertThrowsError(
+            try store.insertModel(
+                LLMConfiguredModel(providerConfigId: firstProvider.id, modelId: "shared/model")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? AISettingsStoreError,
+                .modelAlreadyExists(providerID: firstProvider.id, modelID: "shared/model")
+            )
+        }
+        XCTAssertEqual(try store.allModels().count, 2)
+    }
+}
+
+/**
+ Builds an isolated in-memory container with every production AI model registration.
+
+ - Returns: A transient SwiftData container suitable for `AISettingsStore` mutation tests.
+ - Side effects: Allocates process-local in-memory persistence only.
+ - Throws: Schema or model-container initialization errors.
+ */
+@MainActor
+private func makeModelFailoverContainer() throws -> ModelContainer {
+    let models = AIModelRegistration.cloudSyncableModels + AIModelRegistration.localOnlyModels
+    let schema = Schema(models)
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    return try ModelContainer(for: schema, configurations: [configuration])
+}

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsDatabaseMigrationTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsDatabaseMigrationTests.swift
@@ -1,0 +1,680 @@
+// RemoteSyncAISettingsDatabaseMigrationTests.swift -- Android AI settings Room migration parity
+
+import Foundation
+import SQLite3
+import XCTest
+@testable import BibleCore
+
+/** Proves staged AI settings databases follow Android's authoritative Room migration contract. */
+final class RemoteSyncAISettingsDatabaseMigrationTests: XCTestCase {
+    /** Minimal generated Room export shape needed to materialize one authoritative generation. */
+    private struct RoomSchemaExport: Decodable {
+        let database: Database
+
+        struct Database: Decodable {
+            let version: Int
+            let identityHash: String
+            let entities: [Entity]
+            let views: [View]?
+            let setupQueries: [String]
+        }
+
+        struct Entity: Decodable {
+            let tableName: String
+            let createSql: String
+            let indices: [Index]?
+        }
+
+        struct Index: Decodable {
+            let createSql: String
+        }
+
+        struct View: Decodable {
+            let viewName: String
+            let createSql: String
+        }
+    }
+
+    /** Typed fixture and SQLite failures used only by migration tests. */
+    private enum TestError: Error {
+        case invalidFixture(String)
+        case sqlite(String)
+    }
+
+    /** Migrates every exported or exactly derived Android predecessor through Room v23. */
+    func testEveryExportedAISettingsGenerationMigratesToExactRoomVersion23() throws {
+        let fixtureVersions = try Set(fixtureVersions())
+        XCTAssertEqual(
+            fixtureVersions.subtracting([17]).union([12]),
+            RemoteSyncAISettingsDatabaseMigrator.supportedSourceVersions
+        )
+        XCTAssertFalse(fixtureVersions.contains(12))
+        XCTAssertTrue(fixtureVersions.contains(17))
+
+        for version in RemoteSyncAISettingsDatabaseMigrator.supportedSourceVersions.sorted() {
+            try XCTContext.runActivity(named: "ai-settings-v\(version)-to-v23") { _ in
+                let databaseURL = try makeFixtureDatabase(version: version)
+                defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+                do {
+                    try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(
+                        at: databaseURL,
+                        expectedSourceVersion: version
+                    )
+                } catch {
+                    XCTFail("AI settings v\(version) migration failed: \(error)")
+                    return
+                }
+
+                try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+                    XCTAssertEqual(try scalarInteger("PRAGMA user_version;", in: database), 23)
+                    XCTAssertEqual(
+                        try scalarText(
+                            "SELECT identity_hash FROM room_master_table WHERE id = 42;",
+                            in: database
+                        ),
+                        RemoteSyncAndroidDatabaseContract.identityHash(for: .aiSettings)
+                    )
+                    XCTAssertNoThrow(
+                        try RemoteSyncAndroidDatabaseContract.validateInboundDatabase(
+                            database,
+                            category: .aiSettings
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     Verifies the missing v12 export is reconstructed only from Android's authoritative inputs.
+
+     Android v12 is exported remotely even though its Room JSON was not checked in. The fixture
+     starts from the exact v11 export, applies Android's two 11-to-12 `ALTER TABLE` statements, and
+     pins the Room 2.7.2 compiler identity plus the production canonical-schema digest. Failure means
+     iOS could reject a source Android itself migrates or accept an invented predecessor shape.
+     */
+    func testDerivedVersion12AuthorityMatchesAndroidMigrationAndRoomIdentity() throws {
+        let databaseURL = try makeFixtureDatabase(version: 12)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(try scalarInteger("PRAGMA user_version;", in: database), 12)
+            XCTAssertEqual(
+                try scalarText(
+                    "SELECT identity_hash FROM room_master_table WHERE id = 42;",
+                    in: database
+                ),
+                "ce84fdcfd2da69ec7a3dbb0a48598c5b"
+            )
+            XCTAssertEqual(
+                try RemoteSyncAndroidDatabaseContract.schemaSHA256(
+                    in: database,
+                    excludingObjects: []
+                ),
+                "1fcdbebe0865065824e82c0a995c7c216bce2de8e483f90f6daec3746aa39149"
+            )
+        }
+    }
+
+    /**
+     Compares every Swift migration statement with SQL extracted from the pinned Android Kotlin.
+
+     The Python authority guard regenerates `AiSettingsMigrationSQL.json` semantically from each
+     Android `db.execSQL` call. This test independently normalizes the executable Swift arrays and
+     compares all 22 ordered edges. Failure means the hand-transcribed iOS chain drifted even when
+     both source files remain individually valid.
+     */
+    func testSwiftMigrationStatementsMatchPinnedAndroidKotlinSQL() throws {
+        let fixtureURL = fixtureRoot
+            .deletingLastPathComponent()
+            .appendingPathComponent("AiSettingsMigrationSQL.json")
+        let expected = try JSONDecoder().decode(
+            [String: [String]].self,
+            from: Data(contentsOf: fixtureURL)
+        )
+
+        for version in 1...22 {
+            XCTAssertEqual(
+                RemoteSyncAISettingsDatabaseMigrator.migrationStatements(from: version).map(
+                    normalizeMigrationSQL
+                ),
+                expected[String(version)],
+                "Migration SQL drift at Android edge \(version)..\(version + 1)"
+            )
+        }
+    }
+
+    /** Rejects unversioned, Android-unmigratable, and future generations without mutation. */
+    func testUnsupportedAISettingsSourceGenerationsAreNotMigrated() throws {
+        for version in [0, 17, 24] {
+            try XCTContext.runActivity(named: "unsupported-ai-settings-v\(version)") { _ in
+                let databaseURL = try makeFixtureDatabase(version: version == 17 ? 17 : 23)
+                defer { try? FileManager.default.removeItem(at: databaseURL) }
+                if version != 17 {
+                    try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READWRITE) { database in
+                        try execute("PRAGMA user_version = \(version);", in: database)
+                    }
+                }
+
+                XCTAssertThrowsError(
+                    try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(
+                        at: databaseURL
+                    )
+                ) { error in
+                    XCTAssertEqual(
+                        error as? RemoteSyncAISettingsDatabaseMigrationError,
+                        .unsupportedSourceVersion(version)
+                    )
+                }
+                try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+                    XCTAssertEqual(
+                        try scalarInteger("PRAGMA user_version;", in: database),
+                        Int64(version)
+                    )
+                    if version == 17 {
+                        XCTAssertEqual(
+                            try scalarInteger(
+                                "SELECT COUNT(*) FROM pragma_table_info('GlobalAiSettings') WHERE name = 'builtInPromptCategories';",
+                                in: database
+                            ),
+                            1
+                        )
+                        XCTAssertEqual(
+                            try scalarInteger(
+                                "SELECT COUNT(*) FROM pragma_table_info('GlobalAiSettings') WHERE name = 'hiddenBuiltInCategories';",
+                                in: database
+                            ),
+                            0
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /** Requires archive metadata to agree with the staged source before migration begins. */
+    func testExpectedSourceVersionMismatchFailsWithoutMutation() throws {
+        let databaseURL = try makeFixtureDatabase(version: 22)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        XCTAssertThrowsError(
+            try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(
+                at: databaseURL,
+                expectedSourceVersion: 21
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncAISettingsDatabaseMigrationError,
+                .sourceVersionMismatch(expected: 21, actual: 22)
+            )
+        }
+        try assertVersion22RemainsUnmigrated(at: databaseURL)
+    }
+
+    /** Rejects predecessor identity and schema corruption before any migration statement runs. */
+    func testPredecessorIdentityAndSchemaAreValidatedBeforeMigration() throws {
+        let identityURL = try makeFixtureDatabase(version: 22)
+        defer { try? FileManager.default.removeItem(at: identityURL) }
+        try withDatabase(at: identityURL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                "UPDATE room_master_table SET identity_hash = 'wrong' WHERE id = 42;",
+                in: database
+            )
+        }
+        XCTAssertThrowsError(
+            try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(
+                at: identityURL
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncAndroidDatabaseContractError,
+                .invalidIdentityHash
+            )
+        }
+        try assertVersion22RemainsUnmigrated(at: identityURL)
+
+        let schemaURL = try makeFixtureDatabase(version: 22)
+        defer { try? FileManager.default.removeItem(at: schemaURL) }
+        try withDatabase(at: schemaURL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute("DROP INDEX index_BuiltinPromptOverride_configuredModelId;", in: database)
+        }
+        XCTAssertThrowsError(
+            try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: schemaURL)
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncAndroidDatabaseContractError,
+                .schemaMismatch("ai-settings-v22")
+            )
+        }
+        try assertVersion22RemainsUnmigrated(at: schemaURL)
+    }
+
+    /** Preserves Android's destructive v8 model migration and its explicit data-loss contract. */
+    func testVersion8ProviderAndPromptSurviveWhileUnmappableUsageIsDropped() throws {
+        let databaseURL = try makeFixtureDatabase(version: 8)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                """
+                INSERT INTO LlmProviderConfig (
+                    id, providerType, displayName, endpoint, apiFormat, defaultModel, isDefault,
+                    orderNumber, customInputPrice, customOutputPrice
+                ) VALUES (
+                    X'00000000000000000000000000000001', 'OPENAI', 'Legacy provider',
+                    'https://example.test/v1', 'OPENAI', 'legacy-model', 1, 7, 1.25, 2.5
+                );
+                INSERT INTO AgentPrompt (
+                    id, name, promptTemplate, showIn, providerConfigId, modelOverride
+                ) VALUES (
+                    X'00000000000000000000000000000002', 'Legacy prompt', 'Explain', 'BIBLE',
+                    X'00000000000000000000000000000001', 'legacy-model'
+                );
+                INSERT INTO LlmUsageRecord (
+                    id, providerConfigId, deviceId, inputTokens, outputTokens
+                ) VALUES (
+                    X'00000000000000000000000000000003',
+                    X'00000000000000000000000000000001', 'legacy-device', 12, 34
+                );
+                """,
+                in: database
+            )
+        }
+
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: databaseURL)
+
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(try scalarInteger("SELECT COUNT(*) FROM LlmProviderConfig;", in: database), 1)
+            XCTAssertEqual(try scalarText("SELECT displayName FROM LlmProviderConfig;", in: database), "Legacy provider")
+            XCTAssertEqual(try scalarText("SELECT endpoint FROM LlmProviderConfig;", in: database), "https://example.test/v1")
+            XCTAssertEqual(try scalarInteger("SELECT COUNT(*) FROM AgentPrompt;", in: database), 1)
+            XCTAssertEqual(
+                try scalarInteger("SELECT configuredModelId IS NULL FROM AgentPrompt;", in: database),
+                1
+            )
+            XCTAssertEqual(try scalarInteger("SELECT COUNT(*) FROM LlmConfiguredModel;", in: database), 0)
+            XCTAssertEqual(try scalarInteger("SELECT COUNT(*) FROM LlmUsageRecord;", in: database), 0)
+        }
+    }
+
+    /** Applies Android's two commentary-default normalizations and late global-setting defaults. */
+    func testCommentaryAndLateGlobalDefaultsMatchAndroidMigrations() throws {
+        let version4URL = try makeFixtureDatabase(version: 4)
+        defer { try? FileManager.default.removeItem(at: version4URL) }
+        try withDatabase(at: version4URL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                """
+                INSERT INTO GlobalAiSettings (
+                    id, aiExcludedDocuments, commentaryMaxResponseTokens
+                ) VALUES (
+                    X'A1000000000000000000000000000001', '', 0
+                );
+                """,
+                in: database
+            )
+        }
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: version4URL)
+        try withDatabase(at: version4URL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(
+                try scalarInteger("SELECT commentaryMaxResponseTokens FROM GlobalAiSettings;", in: database),
+                15_000
+            )
+            XCTAssertEqual(
+                try scalarInteger("SELECT rawLogRetentionDays FROM GlobalAiSettings;", in: database),
+                30
+            )
+            XCTAssertEqual(
+                try scalarInteger("SELECT autoHideAgentLogOnCompletion FROM GlobalAiSettings;", in: database),
+                0
+            )
+        }
+
+        let version9URL = try makeFixtureDatabase(version: 9)
+        defer { try? FileManager.default.removeItem(at: version9URL) }
+        try withDatabase(at: version9URL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                """
+                INSERT INTO GlobalAiSettings (
+                    id, aiExcludedDocuments, commentaryMaxResponseTokens,
+                    hiddenBuiltInPrompts, commentaryDeselected
+                ) VALUES (
+                    X'A1000000000000000000000000000001', '', 4000, '', ''
+                );
+                """,
+                in: database
+            )
+        }
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: version9URL)
+        try withDatabase(at: version9URL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(
+                try scalarInteger("SELECT commentaryMaxResponseTokens FROM GlobalAiSettings;", in: database),
+                15_000
+            )
+        }
+    }
+
+    /** Creates Android's v21 raw-log and v22 override tables while preserving their local-only role. */
+    func testLateAISettingsTablesAndDefaultsAreCreatedExactly() throws {
+        let databaseURL = try makeFixtureDatabase(version: 20)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                """
+                INSERT INTO GlobalAiSettings (
+                    id, aiExcludedDocuments, hiddenBuiltInPrompts, commentaryDeselected,
+                    hiddenBuiltInCategories, favoritePrompts
+                ) VALUES (
+                    X'A1000000000000000000000000000001', '', '', '', '', ''
+                );
+                """,
+                in: database
+            )
+        }
+
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: databaseURL)
+
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'LlmRawLogRecord';",
+                    in: database
+                ),
+                1
+            )
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'BuiltinPromptOverride';",
+                    in: database
+                ),
+                1
+            )
+            XCTAssertEqual(
+                try scalarInteger("SELECT rawLogRetentionDays FROM GlobalAiSettings;", in: database),
+                30
+            )
+            XCTAssertEqual(
+                try scalarInteger("SELECT autoHideAgentLogOnCompletion FROM GlobalAiSettings;", in: database),
+                0
+            )
+        }
+    }
+
+    /** Suppresses production-shaped sync triggers while data-changing AI migrations execute. */
+    func testMigrationSuppressesRuntimeTriggersWithoutCreatingLogEntries() throws {
+        let databaseURL = try makeFixtureDatabase(version: 4)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+        let existingTables: Set<String> = [
+            "AgentPrompt",
+            "LlmProviderConfig",
+            "GlobalAiSettings",
+            "LlmUsageRecord",
+        ]
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READWRITE) { database in
+            try execute(
+                """
+                INSERT INTO GlobalAiSettings (
+                    id, aiExcludedDocuments, commentaryMaxResponseTokens
+                ) VALUES (
+                    X'A1000000000000000000000000000001', '', 0
+                );
+                """,
+                in: database
+            )
+            for statement in AndroidRuntimeSyncTriggerFixture.statements(
+                for: .aiSettings,
+                deviceIdentifier: "migration-device",
+                existingTables: existingTables
+            ) {
+                try execute(statement, in: database)
+            }
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger';",
+                    in: database
+                ),
+                12
+            )
+        }
+
+        try RemoteSyncAISettingsDatabaseMigrator.migrateAndValidateStagedDatabase(at: databaseURL)
+
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(try scalarInteger("SELECT COUNT(*) FROM LogEntry;", in: database), 0)
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger';",
+                    in: database
+                ),
+                0
+            )
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM SyncConfiguration WHERE keyName = 'triggersDisabled';",
+                    in: database
+                ),
+                0
+            )
+        }
+    }
+
+    /** Runs an older staged generation through the production restore reader before decoding rows. */
+    func testRestoreReaderMigratesAdvertisedSourceBeforeDecoding() throws {
+        let databaseURL = try makeFixtureDatabase(version: 22)
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let snapshot = try RemoteSyncAISettingsRestoreService().readSnapshot(
+            from: databaseURL,
+            expectedSourceVersion: 22
+        )
+
+        XCTAssertTrue(snapshot.providers.isEmpty)
+        XCTAssertTrue(snapshot.configuredModels.isEmpty)
+        XCTAssertTrue(snapshot.agentPrompts.isEmpty)
+        XCTAssertTrue(snapshot.globalSettings.isEmpty)
+        XCTAssertTrue(snapshot.usageRecords.isEmpty)
+        XCTAssertTrue(snapshot.promptCategories.isEmpty)
+        XCTAssertTrue(snapshot.builtinOverrides.isEmpty)
+        XCTAssertEqual(try readUserVersion(at: databaseURL), 23)
+    }
+
+    /** Proves a rejected v22 source never gains the v23 global-setting column. */
+    private func assertVersion22RemainsUnmigrated(at databaseURL: URL) throws {
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            XCTAssertEqual(try scalarInteger("PRAGMA user_version;", in: database), 22)
+            XCTAssertEqual(
+                try scalarInteger(
+                    "SELECT COUNT(*) FROM pragma_table_info('GlobalAiSettings') WHERE name = 'autoHideAgentLogOnCompletion';",
+                    in: database
+                ),
+                0
+            )
+        }
+    }
+
+    /** Reads one SQLite user-version from a staged file after production migration. */
+    private func readUserVersion(at databaseURL: URL) throws -> Int64 {
+        var version = Int64.min
+        try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READONLY) { database in
+            version = try scalarInteger("PRAGMA user_version;", in: database)
+        }
+        return version
+    }
+
+    /** Collapses formatting-only whitespace to match the Android-authority extraction fixture. */
+    private func normalizeMigrationSQL(_ sql: String) -> String {
+        sql.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
+    /** Returns all numeric authoritative AI settings fixture versions in deterministic order. */
+    private func fixtureVersions() throws -> [Int] {
+        let files = try FileManager.default.contentsOfDirectory(
+            at: fixtureRoot,
+            includingPropertiesForKeys: nil
+        )
+        return try files.filter { $0.pathExtension == "json" }.map { file in
+            guard let version = Int(file.deletingPathExtension().lastPathComponent) else {
+                throw TestError.invalidFixture(file.lastPathComponent)
+            }
+            return version
+        }.sorted()
+    }
+
+    /** Creates one temporary SQLite database from an Android export or the exact derived v12 step. */
+    private func makeFixtureDatabase(version: Int) throws -> URL {
+        if version == 12 {
+            let databaseURL = try makeFixtureDatabase(version: 11)
+            do {
+                try withDatabase(at: databaseURL, flags: SQLITE_OPEN_READWRITE) { database in
+                    try execute(
+                        "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0;",
+                        in: database
+                    )
+                    try execute(
+                        "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0;",
+                        in: database
+                    )
+                    try execute(
+                        "UPDATE room_master_table SET identity_hash = 'ce84fdcfd2da69ec7a3dbb0a48598c5b' WHERE id = 42;",
+                        in: database
+                    )
+                    try execute("PRAGMA user_version = 12;", in: database)
+                }
+                return databaseURL
+            } catch {
+                try? FileManager.default.removeItem(at: databaseURL)
+                throw error
+            }
+        }
+        let fixtureURL = fixtureRoot.appendingPathComponent("\(version).json")
+        let fixture = try JSONDecoder().decode(
+            RoomSchemaExport.self,
+            from: Data(contentsOf: fixtureURL)
+        )
+        guard fixture.database.version == version else {
+            throw TestError.invalidFixture("AI settings v\(version) version mismatch")
+        }
+
+        let databaseURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ai-settings-room-v\(version)-\(UUID().uuidString).sqlite3"
+        )
+        do {
+            try withDatabase(
+                at: databaseURL,
+                flags: SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            ) { database in
+                for entity in fixture.database.entities {
+                    try execute(
+                        entity.createSql.replacingOccurrences(
+                            of: "${TABLE_NAME}",
+                            with: entity.tableName
+                        ),
+                        in: database
+                    )
+                    for index in entity.indices ?? [] {
+                        try execute(
+                            index.createSql.replacingOccurrences(
+                                of: "${TABLE_NAME}",
+                                with: entity.tableName
+                            ),
+                            in: database
+                        )
+                    }
+                }
+                for view in fixture.database.views ?? [] {
+                    try execute(
+                        view.createSql.replacingOccurrences(
+                            of: "${VIEW_NAME}",
+                            with: view.viewName
+                        ),
+                        in: database
+                    )
+                }
+                for query in fixture.database.setupQueries {
+                    try execute(query, in: database)
+                }
+                try execute("PRAGMA user_version = \(version);", in: database)
+            }
+            return databaseURL
+        } catch {
+            try? FileManager.default.removeItem(at: databaseURL)
+            throw error
+        }
+    }
+
+    /** Opens one SQLite file for a scoped test operation and always closes it. */
+    private func withDatabase(
+        at url: URL,
+        flags: Int32,
+        body: (OpaquePointer) throws -> Void
+    ) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &database, flags, nil) == SQLITE_OK,
+              let database else {
+            if let database { sqlite3_close(database) }
+            throw TestError.sqlite("could not open \(url.path)")
+        }
+        defer { sqlite3_close(database) }
+        try body(database)
+    }
+
+    /** Executes one fixture statement with SQLite's diagnostic on failure. */
+    private func execute(_ sql: String, in database: OpaquePointer) throws {
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        guard result == SQLITE_OK else {
+            let message = errorMessage.map { String(cString: $0) }
+                ?? String(cString: sqlite3_errmsg(database))
+            sqlite3_free(errorMessage)
+            throw TestError.sqlite(message)
+        }
+    }
+
+    /** Reads one required integer scalar from a query that must return exactly one row. */
+    private func scalarInteger(_ sql: String, in database: OpaquePointer) throws -> Int64 {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw TestError.sqlite(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              sqlite3_column_type(statement, 0) == SQLITE_INTEGER else {
+            throw TestError.sqlite("missing integer scalar")
+        }
+        let value = sqlite3_column_int64(statement, 0)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw TestError.sqlite("integer scalar returned multiple rows")
+        }
+        return value
+    }
+
+    /** Reads one required UTF-8 scalar from a query that must return exactly one row. */
+    private func scalarText(_ sql: String, in database: OpaquePointer) throws -> String {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw TestError.sqlite(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW,
+              sqlite3_column_type(statement, 0) == SQLITE_TEXT,
+              let pointer = sqlite3_column_text(statement, 0) else {
+            throw TestError.sqlite("missing text scalar")
+        }
+        let value = String(cString: pointer)
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw TestError.sqlite("text scalar returned multiple rows")
+        }
+        return value
+    }
+
+    /// Directory containing exact Android `AiSettingsDatabase` generated exports.
+    private var fixtureRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures", isDirectory: true)
+            .appendingPathComponent("AndroidRoomSchemas", isDirectory: true)
+            .appendingPathComponent("AiSettingsDatabase", isDirectory: true)
+    }
+}

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsTests.swift
@@ -1,0 +1,2621 @@
+import Foundation
+import SQLite3
+import SwiftData
+import XCTest
+@testable import BibleCore
+
+/// Deterministic interruption injected after remote publication but before local outbox acceptance.
+private enum SimulatedAISettingsAcceptanceError: Error, Equatable {
+    /// Represents a process failure at the final local acceptance boundary.
+    case interruptedBeforeAcceptance
+}
+
+/// Deterministic strict-secret backend failure used to prove snapshot publication fails closed.
+private enum SimulatedAICredentialLookupError: Error, Equatable {
+    /// Represents a Keychain access failure that must not be interpreted as a missing credential.
+    case unavailable
+}
+
+/**
+ Secret-store double whose compatibility lookup collapses failure while strict lookup preserves it.
+
+ The mismatch models production Keychain compatibility behavior and proves AI sync selects the
+ strict capability. It stores no values and performs no filesystem, Keychain, or network work.
+ */
+private final class StrictReadFailingAISecretStore: SecretStoring, StrictSecretReading {
+    /** Returns `nil` to model the legacy compatibility lookup's fail-open shape. */
+    func secret(forKey key: String) -> String? {
+        nil
+    }
+
+    /** Throws the deterministic backend error expected to abort synchronized snapshot projection. */
+    func secretStrict(forKey key: String) throws -> String? {
+        throw SimulatedAICredentialLookupError.unavailable
+    }
+
+    /** Rejects unexpected writes because this fixture is read-only. */
+    func setSecret(_ value: String, forKey key: String) throws {
+        XCTFail("Strict-read failure fixture must not receive writes")
+    }
+
+    /** Rejects unexpected deletes because this fixture is read-only. */
+    func removeSecret(forKey key: String) throws {
+        XCTFail("Strict-read failure fixture must not receive deletes")
+    }
+}
+
+/// Local fixture identities shared by the Android v23 AI settings round-trip assertions.
+private struct AISettingsSyncFixtureIDs {
+    let provider: UUID
+    let configuredModel: UUID
+    let agentPrompt: UUID
+    let usageRecord: UUID
+    let promptCategory: UUID
+    let builtinOverride: UUID
+    let rawLog: UUID
+}
+
+/**
+ Protects Android v23 AI settings remote-sync behavior across SQLite publication and SwiftData replay.
+
+ The suite uses in-memory SwiftData stores, temporary SQLite/gzip files, an in-memory credential
+ backend, and an in-memory remote adapter. It performs no network, CloudKit, Keychain, or durable
+ user-data writes. Every test anchors Android's seven-table `AI_SETTINGS` contract while proving raw
+ logs and credentials remain device-local.
+ */
+@MainActor
+final class RemoteSyncAISettingsTests: XCTestCase {
+    /**
+     Proves all seven Android-synchronized tables survive a full writer/read/restore cycle exactly.
+
+     The source also contains a raw model log and provider credential, while the destination starts
+     with a different raw log, credential, and stale synchronized row. A successful result requires
+     all seven synchronized rows to replace the stale graph, an empty outbound raw-log table, no
+     secret or local raw payload bytes in iOS output, bounded ignoring of one Android-origin raw log,
+     and preservation of destination-local state. A failure indicates data loss, secret leakage, or
+     drift from Android's v23 initial-backup contract.
+     */
+    func testAndroidV23DatabaseRoundTripRestoresAllSynchronizedTablesAndPreservesLocalState() throws {
+        let sourceContainer = try makeAISettingsSyncContainer()
+        let sourceContext = ModelContext(sourceContainer)
+        let sourceSettingsStore = SettingsStore(modelContext: sourceContext)
+        let fixtureIDs = try insertCompleteAISettingsFixture(into: sourceContext)
+        let secretStore = InMemorySecretStore()
+        let credentialStore = AICredentialStore(secretStore: secretStore)
+        let credential = "test-only-provider-secret-7d873b"
+        try credentialStore.setCredential(credential, for: fixtureIDs.provider)
+
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { credentialStore.credential(for: $0) }
+        )
+        let sourceSnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        let directoryURL = try makeAISettingsTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let databaseURL = directoryURL.appendingPathComponent("ai_settings.sqlite3")
+
+        let writeReport = try RemoteSyncAISettingsDatabaseWriter().writeFullDatabase(
+            at: databaseURL,
+            snapshot: sourceSnapshot
+        )
+
+        XCTAssertEqual(writeReport.schemaVersion, 23)
+        XCTAssertEqual(writeReport.providerCount, 1)
+        XCTAssertEqual(writeReport.configuredModelCount, 1)
+        XCTAssertEqual(writeReport.agentPromptCount, 1)
+        XCTAssertEqual(writeReport.globalSettingsCount, 1)
+        XCTAssertEqual(writeReport.usageRecordCount, 1)
+        XCTAssertEqual(writeReport.promptCategoryCount, 1)
+        XCTAssertEqual(writeReport.builtinPromptOverrideCount, 1)
+        XCTAssertEqual(writeReport.logEntryCount, 0)
+        XCTAssertEqual(writeReport.rawLogRecordCount, 0)
+        XCTAssertEqual(
+            try sqliteInteger("SELECT COUNT(*) FROM LlmRawLogRecord;", databaseURL: databaseURL),
+            0
+        )
+
+        let databaseData = try Data(contentsOf: databaseURL)
+        XCTAssertNil(databaseData.range(of: Data(credential.utf8)))
+        XCTAssertNil(databaseData.range(of: Data("source-device-local-raw-log".utf8)))
+        try insertAndroidRawLogFixture(into: databaseURL)
+
+        let restoreService = RemoteSyncAISettingsRestoreService()
+        let decodedSnapshot = try restoreService.readSnapshot(from: databaseURL)
+        XCTAssertEqual(Set(decodedSnapshot.providers.map(\.id)), [fixtureIDs.provider])
+        XCTAssertEqual(Set(decodedSnapshot.configuredModels.map(\.id)), [fixtureIDs.configuredModel])
+        XCTAssertEqual(Set(decodedSnapshot.agentPrompts.map(\.id)), [fixtureIDs.agentPrompt])
+        XCTAssertEqual(decodedSnapshot.globalSettings.map(\.id), [GlobalAISettings.singletonID])
+        XCTAssertEqual(Set(decodedSnapshot.usageRecords.map(\.id)), [fixtureIDs.usageRecord])
+        XCTAssertEqual(Set(decodedSnapshot.promptCategories.map(\.id)), [fixtureIDs.promptCategory])
+        XCTAssertEqual(Set(decodedSnapshot.builtinOverrides.map(\.id)), [fixtureIDs.builtinOverride])
+        XCTAssertEqual(decodedSnapshot.ignoredIncomingRawLogCount, 1)
+
+        let destinationContainer = try makeAISettingsSyncContainer()
+        let destinationContext = ModelContext(destinationContainer)
+        let destinationSettingsStore = SettingsStore(modelContext: destinationContext)
+        let staleProviderID = UUID(uuidString: "a2000000-0000-0000-0000-000000000099")!
+        destinationContext.insert(
+            LLMProviderConfig(
+                id: staleProviderID,
+                provider: .openAI,
+                displayName: "Stale provider"
+            )
+        )
+        let localRawLog = LLMRawLogRecord(
+            id: UUID(uuidString: "a8000000-0000-0000-0000-000000000099")!,
+            promptName: "Destination local log",
+            modelName: "local-model",
+            providerType: "OPENAI",
+            timestampMilliseconds: 999,
+            logData: Data("destination-device-local-raw-log".utf8)
+        )
+        destinationContext.insert(localRawLog)
+        try destinationContext.save()
+        let destinationSecrets = InMemorySecretStore()
+        let destinationCredentials = AICredentialStore(secretStore: destinationSecrets)
+        try destinationCredentials.setCredential("destination-local-secret", for: fixtureIDs.provider)
+
+        let restoreReport = try restoreService.restore(
+            from: databaseURL,
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+
+        XCTAssertEqual(restoreReport.restoredProviderCount, 1)
+        XCTAssertEqual(restoreReport.restoredConfiguredModelCount, 1)
+        XCTAssertEqual(restoreReport.restoredAgentPromptCount, 1)
+        XCTAssertEqual(restoreReport.restoredGlobalSettingsCount, 1)
+        XCTAssertEqual(restoreReport.restoredUsageRecordCount, 1)
+        XCTAssertEqual(restoreReport.restoredPromptCategoryCount, 1)
+        XCTAssertEqual(restoreReport.restoredBuiltinPromptOverrideCount, 1)
+        XCTAssertEqual(restoreReport.ignoredIncomingRawLogCount, 1)
+        XCTAssertEqual(restoreReport.preservedLocalRawLogCount, 1)
+        XCTAssertEqual(
+            try destinationContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [localRawLog.id]
+        )
+        XCTAssertEqual(
+            destinationCredentials.credential(for: fixtureIDs.provider),
+            "destination-local-secret"
+        )
+        XCTAssertFalse(
+            try destinationContext.fetch(FetchDescriptor<LLMProviderConfig>())
+                .contains(where: { $0.id == staleProviderID })
+        )
+
+        let restoredSnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        XCTAssertEqual(restoredSnapshot, sourceSnapshot)
+    }
+
+    /**
+     Verifies raw-log and credential-only changes are invisible to both snapshots and mutation logs.
+
+     An accepted empty baseline is established before writing one Keychain-shaped credential and one
+     local raw log. Neither may create an AI sync operation. A later provider insert must create
+     exactly one provider UPSERT, proving the empty journal was caused by exclusion rather than a
+     disabled journal. A failure means device-local or secret state can leak into remote sync.
+     */
+    func testRawLogsAndCredentialsAreExcludedFromSnapshotsAndMutationJournal() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let secrets = InMemorySecretStore()
+        let credentialStore = AICredentialStore(secretStore: secrets)
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { credentialStore.credential(for: $0) }
+        )
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let providerID = UUID(uuidString: "b2000000-0000-0000-0000-000000000001")!
+        try credentialStore.setCredential("never-sync-this-secret", for: providerID)
+        let aiStore = AISettingsStore(modelContext: modelContext)
+        try aiStore.insertRawLog(
+            LLMRawLogRecord(
+                id: UUID(uuidString: "b8000000-0000-0000-0000-000000000001")!,
+                promptName: "Local-only",
+                modelName: "device-model",
+                providerType: "CUSTOM",
+                timestampMilliseconds: 10,
+                logData: Data("never-sync-this-log".utf8)
+            )
+        )
+
+        let localOnlySnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        XCTAssertTrue(localOnlySnapshot.providerRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.configuredModelRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.agentPromptRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.globalSettingsRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.usageRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.promptCategoryRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.builtinOverrideRowsByKey.isEmpty)
+        XCTAssertTrue(localOnlySnapshot.fingerprintsByKey.isEmpty)
+        XCTAssertTrue(
+            try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings)
+                .isEmpty
+        )
+        XCTAssertTrue(
+            try RemoteSyncMutationJournalService()
+                .pendingMutations(for: .aiSettings, settingsStore: settingsStore)
+                .isEmpty
+        )
+        XCTAssertEqual(credentialStore.credential(for: providerID), "never-sync-this-secret")
+
+        try aiStore.insertProvider(
+            LLMProviderConfig(
+                id: providerID,
+                provider: .custom,
+                displayName: "Synchronized provider",
+                endpoint: "https://example.invalid/v1",
+                apiFormat: .openAI
+            )
+        )
+
+        let entries = try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+            .entriesStrict(for: .aiSettings)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.tableName, "LlmProviderConfig")
+        XCTAssertEqual(entries.first?.type, .upsert)
+        XCTAssertFalse(entries.contains(where: { $0.tableName == "LlmRawLogRecord" }))
+        let pending = try RemoteSyncMutationJournalService()
+            .pendingMutations(for: .aiSettings, settingsStore: settingsStore)
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending.values.first?.entry.tableName, "LlmProviderConfig")
+    }
+
+    /**
+     Verifies custom endpoint routing survives sync while credential-bearing endpoint forms fail closed.
+
+     Android stores custom endpoint queries as ordinary provider state, so benign deployment routing
+     must remain serializable. User-info, signed URL fields, OAuth codes, recognizable opaque tokens,
+     credential-bearing path labels, and the exact device-local Keychain value must fail before
+     snapshot publication.
+     */
+    func testEndpointPolicyPreservesRoutingQueriesWithoutSerializingCredentials() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "b2000000-0000-0000-0000-000000000002")!
+        let localCredential = "device-local-provider-secret"
+        let provider = LLMProviderConfig(
+            id: providerID,
+            provider: .custom,
+            displayName: "Query-routed provider",
+            endpoint: "https://llm.example.invalid/v1?region=eu&deployment=study",
+            apiFormat: .openAI
+        )
+        modelContext.insert(provider)
+        try modelContext.save()
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { id in id == providerID ? localCredential : nil }
+        )
+
+        let safeSnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        XCTAssertEqual(
+            safeSnapshot.providerRowsByKey.values.first?.endpoint,
+            "https://llm.example.invalid/v1?region=eu&deployment=study"
+        )
+
+        provider.endpoint = "https://llm.example.invalid/proxy/\(localCredential)/v1"
+        XCTAssertThrowsError(
+            try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncAISettingsSnapshotError,
+                .unsafeSynchronizedEndpoint(providerID: providerID)
+            )
+        }
+
+        let unsafeEndpoints = [
+            "https://llm.example.invalid/v1?api_key=remote-secret",
+            "https://llm.example.invalid/v1?X-Amz-Credential=remote-secret",
+            "https://llm.example.invalid/v1?X-Amz-Signature=remote-signature",
+            "https://llm.example.invalid/v1?x-goog-signature=remote-signature",
+            "https://llm.example.invalid/v1?code=oauth-code",
+            "https://llm.example.invalid/credential/remote-secret/v1",
+            "https://llm.example.invalid/v1?deployment=sk-remote-secret-value-1234567890",
+            "https://llm.example.invalid/v1?deployment=sk%252Dremote%252Dsecret%252Dvalue%252D1234567890",
+            "https://llm.example.invalid/v1?deployment=device%252Dlocal%252Dprovider%252Dsecret",
+        ]
+        for unsafeEndpoint in unsafeEndpoints {
+            provider.endpoint = unsafeEndpoint
+            XCTAssertThrowsError(
+                try snapshotService.snapshotCurrentStateStrict(
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                ),
+                "Accepted credential-bearing endpoint: \(unsafeEndpoint)"
+            ) { error in
+                XCTAssertEqual(
+                    error as? RemoteSyncAISettingsSnapshotError,
+                    .unsafeSynchronizedEndpoint(providerID: providerID)
+                )
+            }
+        }
+
+        let benignRoutingValues = [
+            "aiza-route",
+            "akia-route",
+            "github_pat_route",
+            "ghp_route",
+            "rk-route",
+            "sk-route",
+            "sk_route",
+            "xoxa-route",
+            "xoxb-route",
+            "xoxp-route",
+            "xoxr-route",
+            "xoxs-route",
+        ]
+        for routingValue in benignRoutingValues {
+            provider.endpoint = "https://llm.example.invalid/\(routingValue)/v1?deployment=\(routingValue)"
+            XCTAssertNoThrow(
+                try snapshotService.snapshotCurrentStateStrict(
+                    modelContext: modelContext,
+                    settingsStore: settingsStore
+                ),
+                "Rejected benign routing label: \(routingValue)"
+            )
+        }
+        provider.endpoint = "https://sk-provider-routing-name-that-is-not-a-token.example.invalid/v1"
+        XCTAssertNoThrow(
+            try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        )
+    }
+
+    /**
+     Verifies strict credential lookup failures abort projection instead of enabling publication.
+
+     The injected backend deliberately returns `nil` through the compatibility read but throws from
+     its strict read, mirroring a Keychain access failure such as `errSecInteractionNotAllowed`.
+     Snapshot projection must surface a provider-scoped typed failure before endpoint bytes can reach
+     either a full or sparse Android database writer. The in-memory store performs no durable writes.
+     */
+    func testCredentialLookupFailureAbortsSnapshotProjection() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "b2000000-0000-0000-0000-000000000003")!
+        modelContext.insert(
+            LLMProviderConfig(
+                id: providerID,
+                provider: .custom,
+                displayName: "Unavailable credential backend",
+                endpoint: "https://llm.example.invalid/v1?deployment=u7KM3rQ9Zp2V5nX8",
+                apiFormat: .openAI
+            )
+        )
+        try modelContext.save()
+        let credentialStore = AICredentialStore(
+            secretStore: StrictReadFailingAISecretStore()
+        )
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { try credentialStore.credentialStrict(for: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncAISettingsSnapshotError,
+                .credentialLookupFailed(providerID: providerID)
+            )
+        }
+    }
+
+    /**
+     Protects Android's strict `incoming.lastUpdated > local.lastUpdated` conflict rule.
+
+     The first remote provider UPSERT has an equal timestamp and must be skipped regardless of its
+     source device. A second otherwise-identical UPSERT is one millisecond newer and must replace the
+     local row. Failure means iOS has introduced a source-device tie-break or weakened Android's
+     whole-row last-write conflict contract.
+     */
+    func testPatchConflictAcceptsOnlyStrictlyGreaterLastUpdated() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "c2000000-0000-0000-0000-000000000001")!
+        modelContext.insert(
+            LLMProviderConfig(
+                id: providerID,
+                provider: .openAI,
+                displayName: "Local provider"
+            )
+        )
+        try modelContext.save()
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).addEntry(
+            aiSettingsLogEntry(
+                tableName: "LlmProviderConfig",
+                id: providerID,
+                type: .upsert,
+                lastUpdated: 500,
+                sourceDevice: "ios-device"
+            ),
+            for: .aiSettings
+        )
+
+        let remoteSnapshot = try makeProviderSnapshot(
+            id: providerID,
+            displayName: "Remote provider"
+        )
+        let equalArchive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: providerID,
+                    type: .upsert,
+                    lastUpdated: 500,
+                    sourceDevice: "android-z"
+                )
+            ],
+            sourceDevice: "android-z",
+            patchNumber: 1,
+            fileTimestamp: 500
+        )
+        defer { try? FileManager.default.removeItem(at: equalArchive.archiveFileURL) }
+
+        let applyService = RemoteSyncAISettingsPatchApplyService()
+        let equalReport = try applyService.applyPatchArchives(
+            [equalArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(equalReport.appliedLogEntryCount, 0)
+        XCTAssertEqual(equalReport.skippedLogEntryCount, 1)
+        XCTAssertEqual(
+            try XCTUnwrap(modelContext.fetch(FetchDescriptor<LLMProviderConfig>()).first).displayName,
+            "Local provider"
+        )
+
+        let newerArchive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: providerID,
+                    type: .upsert,
+                    lastUpdated: 501,
+                    sourceDevice: "android-a"
+                )
+            ],
+            sourceDevice: "android-a",
+            patchNumber: 2,
+            fileTimestamp: 501
+        )
+        defer { try? FileManager.default.removeItem(at: newerArchive.archiveFileURL) }
+
+        let newerReport = try applyService.applyPatchArchives(
+            [newerArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(newerReport.appliedLogEntryCount, 1)
+        XCTAssertEqual(newerReport.skippedLogEntryCount, 0)
+        XCTAssertEqual(
+            try XCTUnwrap(modelContext.fetch(FetchDescriptor<LLMProviderConfig>()).first).displayName,
+            "Remote provider"
+        )
+        let acceptedEntry = try XCTUnwrap(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings)
+                .first(where: { $0.tableName == "LlmProviderConfig" })
+        )
+        XCTAssertEqual(acceptedEntry.lastUpdated, 501)
+        XCTAssertEqual(acceptedEntry.sourceDevice, "android-a")
+    }
+
+    /**
+     Verifies one provider tombstone reproduces Android's post-patch foreign-key cleanup.
+
+     Removing the provider must prune its formally dependent model, model-bound prompt, and built-in
+     override. Android's logical references must remain: usage and global default keep the deleted
+     model UUID, and a prompt with a missing category but no model dependency survives. The accepted
+     provider tombstone must also remain as the conflict watermark. Failure means iOS either retains
+     formal orphans or invents stronger relationships than Android declares.
+     */
+    func testProviderTombstonePrunesFormalDependentsWhileLogicalReferencesSurvive() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "d2000000-0000-0000-0000-000000000001")!
+        let modelID = UUID(uuidString: "d3000000-0000-0000-0000-000000000001")!
+        let formalPromptID = UUID(uuidString: "d4000000-0000-0000-0000-000000000001")!
+        let logicalPromptID = UUID(uuidString: "d4000000-0000-0000-0000-000000000002")!
+        let usageID = UUID(uuidString: "d6000000-0000-0000-0000-000000000001")!
+        let overrideID = UUID(uuidString: "d7000000-0000-0000-0000-000000000001")!
+        let missingCategoryID = UUID(uuidString: "d5000000-0000-0000-0000-000000000099")!
+
+        modelContext.insert(
+            LLMProviderConfig(id: providerID, provider: .openAI, displayName: "Delete me")
+        )
+        modelContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: providerID,
+                modelId: "deleted-model"
+            )
+        )
+        modelContext.insert(
+            AgentPrompt(
+                id: formalPromptID,
+                name: "Formal model prompt",
+                promptTemplate: "Use model",
+                configuredModelId: modelID
+            )
+        )
+        modelContext.insert(
+            AgentPrompt(
+                id: logicalPromptID,
+                name: "Logical category prompt",
+                promptTemplate: "Keep category identity",
+                categoryId: missingCategoryID
+            )
+        )
+        let globalSettings = GlobalAISettings()
+        globalSettings.defaultModelId = modelID
+        modelContext.insert(globalSettings)
+        let usage = LLMUsageRecord(id: usageID, configuredModelId: modelID, deviceId: "ios-device")
+        usage.inputTokens = 42
+        modelContext.insert(usage)
+        modelContext.insert(BuiltInPromptOverride(id: overrideID, configuredModelId: modelID))
+        try modelContext.save()
+
+        let emptySnapshot = try makeEmptyAISettingsSnapshot()
+        let deleteArchive = try makeAISettingsPatchArchive(
+            snapshot: emptySnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: providerID,
+                    type: .delete,
+                    lastUpdated: 1_000,
+                    sourceDevice: "android-device"
+                )
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 1_000
+        )
+        defer { try? FileManager.default.removeItem(at: deleteArchive.archiveFileURL) }
+
+        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [deleteArchive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedLogEntryCount, 1)
+        XCTAssertEqual(report.providerCount, 0)
+        XCTAssertEqual(report.configuredModelCount, 0)
+        XCTAssertEqual(report.agentPromptCount, 1)
+        XCTAssertEqual(report.globalSettingsCount, 1)
+        XCTAssertEqual(report.usageRecordCount, 1)
+        XCTAssertEqual(report.builtinOverrideCount, 0)
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<LLMProviderConfig>()).isEmpty)
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).isEmpty)
+        XCTAssertEqual(
+            try modelContext.fetch(FetchDescriptor<AgentPrompt>()).map(\.id),
+            [logicalPromptID]
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(modelContext.fetch(FetchDescriptor<AgentPrompt>()).first).categoryId,
+            missingCategoryID
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(modelContext.fetch(FetchDescriptor<GlobalAISettings>()).first).defaultModelId,
+            modelID
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(modelContext.fetch(FetchDescriptor<LLMUsageRecord>()).first).configuredModelId,
+            modelID
+        )
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<BuiltInPromptOverride>()).isEmpty)
+
+        let tombstone = try XCTUnwrap(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings)
+                .first(where: { $0.tableName == "LlmProviderConfig" })
+        )
+        XCTAssertEqual(tombstone.type, .delete)
+        XCTAssertEqual(tombstone.lastUpdated, 1_000)
+    }
+
+    /**
+     Verifies Android metadata-only UPSERTs advance conflict state without requiring payload rows.
+
+     Android retains `LogEntry` after formal-FK cleanup and can later publish that watermark without
+     the deleted row. Replay must accept the metadata, leave the graph unchanged, and continue the
+     patch batch. Failure means a normal Android sparse patch aborts iOS synchronization.
+     */
+    func testMetadataOnlyUpsertAdvancesWatermarkWithoutCreatingPayload() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let promptID = UUID(uuidString: "d4000000-0000-0000-0000-000000000010")!
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: makeEmptyAISettingsSnapshot(),
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "AgentPrompt",
+                    id: promptID,
+                    type: .upsert,
+                    lastUpdated: 1_100,
+                    sourceDevice: "android-device"
+                )
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 1_100
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+
+        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [archive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedLogEntryCount, 1)
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<AgentPrompt>()).isEmpty)
+        let acceptedEntry = try XCTUnwrap(
+            RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings)
+                .first(where: { $0.tableName == "AgentPrompt" })
+        )
+        XCTAssertEqual(acceptedEntry.type, .upsert)
+        XCTAssertEqual(acceptedEntry.lastUpdated, 1_100)
+    }
+
+    /**
+     Pins Android's table-local FK cleanup order when one patch reparents a model.
+
+     Provider deletion runs before the model UPSERT, but Android does not inspect model FKs until
+     the model table phase. The model can therefore move to a surviving provider before prompt FKs
+     are checked, preserving its unchanged prompt. Failure means iOS prunes repairable child rows
+     earlier than Android.
+     */
+    func testProviderDeletionAllowsLaterModelReparentingBeforePromptCleanup() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let oldProviderID = UUID(uuidString: "d2000000-0000-0000-0000-000000000020")!
+        let newProviderID = UUID(uuidString: "d2000000-0000-0000-0000-000000000021")!
+        let modelID = UUID(uuidString: "d3000000-0000-0000-0000-000000000020")!
+        let promptID = UUID(uuidString: "d4000000-0000-0000-0000-000000000020")!
+        modelContext.insert(
+            LLMProviderConfig(id: oldProviderID, provider: .openAI, displayName: "Old")
+        )
+        modelContext.insert(
+            LLMProviderConfig(id: newProviderID, provider: .anthropic, displayName: "New")
+        )
+        modelContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: oldProviderID,
+                modelId: "reparented-model"
+            )
+        )
+        modelContext.insert(
+            AgentPrompt(
+                id: promptID,
+                name: "Keep me",
+                promptTemplate: "Use the repaired model",
+                configuredModelId: modelID
+            )
+        )
+        try modelContext.save()
+
+        let remoteContainer = try makeAISettingsSyncContainer()
+        let remoteContext = ModelContext(remoteContainer)
+        remoteContext.insert(
+            LLMProviderConfig(id: newProviderID, provider: .anthropic, displayName: "New")
+        )
+        remoteContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: newProviderID,
+                modelId: "reparented-model"
+            )
+        )
+        try remoteContext.save()
+        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+            modelContext: remoteContext,
+            settingsStore: SettingsStore(modelContext: remoteContext)
+        )
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: oldProviderID,
+                    type: .delete,
+                    lastUpdated: 1_200,
+                    sourceDevice: "android-device"
+                ),
+                aiSettingsLogEntry(
+                    tableName: "LlmConfiguredModel",
+                    id: modelID,
+                    type: .upsert,
+                    lastUpdated: 1_201,
+                    sourceDevice: "android-device"
+                ),
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 1_201
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+
+        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [archive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertNil(try modelContext.fetch(FetchDescriptor<LLMProviderConfig>())
+            .first(where: { $0.id == oldProviderID }))
+        XCTAssertEqual(try XCTUnwrap(modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).first)
+            .providerConfigId, newProviderID)
+        XCTAssertEqual(try modelContext.fetch(FetchDescriptor<AgentPrompt>()).map(\.id), [promptID])
+    }
+
+    /**
+     Ensures FK-cleanup metadata never becomes a newer synthetic local tombstone.
+
+     The first patch removes a provider and carries a metadata-only model UPSERT, leaving Android's
+     accepted watermark but no model row. A later unrelated global-setting edit must upload only
+     that edit. Failure means iOS can erase a valid model recreated elsewhere after the cleanup.
+     */
+    func testForeignKeyCleanupDoesNotGenerateSyntheticDeletionOnNextUpload() async throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "d2000000-0000-0000-0000-000000000030")!
+        let modelID = UUID(uuidString: "d3000000-0000-0000-0000-000000000030")!
+        modelContext.insert(
+            LLMProviderConfig(id: providerID, provider: .openAI, displayName: "Removed")
+        )
+        modelContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: providerID,
+                modelId: "removed-model"
+            )
+        )
+        try modelContext.save()
+
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: makeEmptyAISettingsSnapshot(),
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: providerID,
+                    type: .delete,
+                    lastUpdated: 1_300,
+                    sourceDevice: "android-device"
+                ),
+                aiSettingsLogEntry(
+                    tableName: "LlmConfiguredModel",
+                    id: modelID,
+                    type: .upsert,
+                    lastUpdated: 1_301,
+                    sourceDevice: "android-device"
+                ),
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 1_301
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [archive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        XCTAssertTrue(try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).isEmpty)
+
+        let aiStore = AISettingsStore(modelContext: modelContext)
+        let globalSettings = try aiStore.globalSettings()
+        globalSettings.aiLanguage = "fi-FI"
+        try aiStore.save()
+
+        let adapter = RemoteSyncDurableOutboxTestAdapter(uploadMetadata: [.init(timestamp: 1_400)])
+        let directoryURL = try makeAISettingsTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let uploadService = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            temporaryDirectory: directoryURL,
+            outboxDirectory: directoryURL.appendingPathComponent("outbox", isDirectory: true),
+            nowProvider: { 1_400 }
+        )
+        let optionalReport = try await uploadService.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(
+                syncFolderID: "/org.andbible.ios-sync-ai_settings",
+                deviceFolderID: "/org.andbible.ios-sync-ai_settings/ios-device",
+                secretFileName: "device-known-ios-device-secret",
+                phase: .ready
+            ),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let report = try XCTUnwrap(optionalReport)
+
+        XCTAssertEqual(
+            report.tableReports.first(where: { $0.tableName == "LlmConfiguredModel" })?.deletedRowCount,
+            0
+        )
+        XCTAssertEqual(
+            report.tableReports.first(where: { $0.tableName == "GlobalAiSettings" })?.upsertedRowCount,
+            1
+        )
+    }
+
+    /**
+     Proves a sparse child-row patch resolves formal parents from the existing local generation.
+
+     Android patch databases include only changed rows, so an updated configured model can appear
+     without its unchanged provider. Replay must merge first and evaluate foreign keys against the
+     complete graph. A failure means valid Android sparse patches are incorrectly rejected as
+     standalone restore snapshots.
+     */
+    func testSparseConfiguredModelUpdateUsesExistingLocalProvider() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "e2000000-0000-0000-0000-000000000001")!
+        let modelID = UUID(uuidString: "e3000000-0000-0000-0000-000000000001")!
+        modelContext.insert(
+            LLMProviderConfig(id: providerID, provider: .anthropic, displayName: "Anthropic")
+        )
+        modelContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: providerID,
+                modelId: "claude-before",
+                orderNumber: 1
+            )
+        )
+        try modelContext.save()
+
+        let remoteContainer = try makeAISettingsSyncContainer()
+        let remoteContext = ModelContext(remoteContainer)
+        remoteContext.insert(
+            LLMProviderConfig(id: providerID, provider: .anthropic, displayName: "Anthropic")
+        )
+        remoteContext.insert(
+            LLMConfiguredModel(
+                id: modelID,
+                providerConfigId: providerID,
+                modelId: "claude-after",
+                orderNumber: 2,
+                inputPricePerMillion: 3,
+                outputPricePerMillion: 15
+            )
+        )
+        try remoteContext.save()
+        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+            modelContext: remoteContext,
+            settingsStore: SettingsStore(modelContext: remoteContext)
+        )
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmConfiguredModel",
+                    id: modelID,
+                    type: .upsert,
+                    lastUpdated: 2_000,
+                    sourceDevice: "android-device"
+                )
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 2_000
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+
+        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [archive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        XCTAssertEqual(report.appliedLogEntryCount, 1)
+        XCTAssertEqual(report.providerCount, 1)
+        XCTAssertEqual(report.configuredModelCount, 1)
+        let model = try XCTUnwrap(modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).first)
+        XCTAssertEqual(model.providerConfigId, providerID)
+        XCTAssertEqual(model.modelId, "claude-after")
+        XCTAssertEqual(model.orderNumber, 2)
+        XCTAssertEqual(model.inputPricePerMillion, 3)
+        XCTAssertEqual(model.outputPricePerMillion, 15)
+    }
+
+    /**
+     Pins SQLite's primary-identity behavior for Android's two composite unique indexes.
+
+     Android patch replay uses `ON CONFLICT DO UPDATE` without assigning the primary `id` column.
+     Incoming model and usage rows therefore update the rows already occupying their composite keys
+     while retaining the local primary UUIDs. A failure means iOS changes stable identities and can
+     disconnect references even though Android would preserve them.
+     */
+    func testCompositeUniqueConflictsPreserveExistingPrimaryIdentities() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "e4000000-0000-0000-0000-000000000001")!
+        let localModelID = UUID(uuidString: "e5000000-0000-0000-0000-000000000001")!
+        let remoteModelID = UUID(uuidString: "e5000000-0000-0000-0000-000000000002")!
+        let localUsageID = UUID(uuidString: "e6000000-0000-0000-0000-000000000001")!
+        let remoteUsageID = UUID(uuidString: "e6000000-0000-0000-0000-000000000002")!
+        modelContext.insert(
+            LLMProviderConfig(id: providerID, provider: .openAI, displayName: "OpenAI")
+        )
+        modelContext.insert(
+            LLMConfiguredModel(
+                id: localModelID,
+                providerConfigId: providerID,
+                modelId: "shared-model",
+                orderNumber: 1
+            )
+        )
+        let localUsage = LLMUsageRecord(
+            id: localUsageID,
+            configuredModelId: localModelID,
+            deviceId: "shared-device"
+        )
+        localUsage.inputTokens = 10
+        modelContext.insert(localUsage)
+        try modelContext.save()
+
+        let remoteContainer = try makeAISettingsSyncContainer()
+        let remoteContext = ModelContext(remoteContainer)
+        remoteContext.insert(
+            LLMProviderConfig(id: providerID, provider: .openAI, displayName: "OpenAI")
+        )
+        remoteContext.insert(
+            LLMConfiguredModel(
+                id: remoteModelID,
+                providerConfigId: providerID,
+                modelId: "shared-model",
+                orderNumber: 9,
+                inputPricePerMillion: 2,
+                outputPricePerMillion: 8
+            )
+        )
+        let remoteUsage = LLMUsageRecord(
+            id: remoteUsageID,
+            configuredModelId: localModelID,
+            deviceId: "shared-device"
+        )
+        remoteUsage.inputTokens = 99
+        remoteUsage.outputTokens = 55
+        remoteUsage.estimatedCostUSD = 1.5
+        remoteContext.insert(remoteUsage)
+        try remoteContext.save()
+
+        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+            modelContext: remoteContext,
+            settingsStore: SettingsStore(modelContext: remoteContext)
+        )
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmConfiguredModel",
+                    id: remoteModelID,
+                    type: .upsert,
+                    lastUpdated: 3_000,
+                    sourceDevice: "android-device"
+                ),
+                aiSettingsLogEntry(
+                    tableName: "LlmUsageRecord",
+                    id: remoteUsageID,
+                    type: .upsert,
+                    lastUpdated: 3_001,
+                    sourceDevice: "android-device"
+                ),
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 1,
+            fileTimestamp: 3_001
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+
+        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+            [archive],
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let models = try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>())
+        let usages = try modelContext.fetch(FetchDescriptor<LLMUsageRecord>())
+        XCTAssertEqual(models.map(\.id), [localModelID])
+        XCTAssertEqual(models.first?.orderNumber, 9)
+        XCTAssertEqual(models.first?.inputPricePerMillion, 2)
+        XCTAssertEqual(models.first?.outputPricePerMillion, 8)
+        XCTAssertEqual(usages.map(\.id), [localUsageID])
+        XCTAssertEqual(usages.first?.inputTokens, 99)
+        XCTAssertEqual(usages.first?.outputTokens, 55)
+        XCTAssertEqual(usages.first?.estimatedCostUSD, 1.5)
+    }
+
+    /**
+     Verifies an already-uploaded generation remains durable when local acceptance is interrupted.
+
+     The first call publishes immutable bytes and fails at the injected pre-commit checkpoint. The
+     manifest and archive must remain available for restart. Resumption must reconcile the same remote
+     object, accept it without a second upload, and clear the outbox. Failure means transport success
+     can lose local mutation state or duplicate Android patch files after a crash.
+     */
+    func testInterruptedLocalAcceptanceResumesDurableOutboxWithoutReupload() async throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        try AISettingsStore(modelContext: modelContext).insertProvider(
+            LLMProviderConfig(
+                id: UUID(uuidString: "f2000000-0000-0000-0000-000000000001")!,
+                provider: .openAI,
+                displayName: "OpenAI"
+            )
+        )
+
+        let adapter = RemoteSyncDurableOutboxTestAdapter(
+            uploadMetadata: [.init(timestamp: 3_000)]
+        )
+        let directoryURL = try makeAISettingsTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let service = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            temporaryDirectory: directoryURL,
+            outboxDirectory: directoryURL.appendingPathComponent("outbox", isDirectory: true),
+            nowProvider: { 2_000 }
+        )
+        let bootstrapState = RemoteSyncBootstrapState(
+            syncFolderID: "/org.andbible.ios-sync-ai_settings",
+            deviceFolderID: "/org.andbible.ios-sync-ai_settings/ios-device",
+            secretFileName: "device-known-ios-device-secret",
+            phase: .ready
+        )
+
+        do {
+            _ = try await service.uploadPendingPatch(
+                bootstrapState: bootstrapState,
+                modelContext: modelContext,
+                settingsStore: settingsStore,
+                acceptanceCheckpoint: {
+                    throw SimulatedAISettingsAcceptanceError.interruptedBeforeAcceptance
+                }
+            )
+            XCTFail("Expected local acceptance interruption")
+        } catch {
+            XCTAssertEqual(
+                error as? SimulatedAISettingsAcceptanceError,
+                .interruptedBeforeAcceptance
+            )
+        }
+
+        XCTAssertNotNil(
+            settingsStore.getString(RemoteSyncAISettingsPatchUploadService.pendingUploadKey)
+        )
+        let uploadsBeforeResume = await adapter.uploads()
+        XCTAssertEqual(uploadsBeforeResume.count, 1)
+
+        let resumedReport = try await service.resumePendingUploadIfPresent(
+            bootstrapState: bootstrapState,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let report = try XCTUnwrap(resumedReport)
+
+        XCTAssertEqual(report.patchNumber, 1)
+        XCTAssertEqual(report.logEntryCount, 1)
+        XCTAssertEqual(
+            report.tableReports.first(where: { $0.tableName == "LlmProviderConfig" })?.upsertedRowCount,
+            1
+        )
+        XCTAssertNil(settingsStore.getString(RemoteSyncAISettingsPatchUploadService.pendingUploadKey))
+        let uploadsAfterResume = await adapter.uploads()
+        XCTAssertEqual(uploadsAfterResume.count, 1)
+    }
+
+    /**
+     Verifies replay cannot absorb a local mutation by refreshing its accepted fingerprint baseline.
+
+     The fixture records a mutation-time journal entry, then simulates inbound replay refreshing the
+     baseline to that same live row before outbound publication. The pending marker must still force an
+     UPSERT with its original timestamp and must clear only after remote and local acceptance succeed.
+     */
+    func testPendingMutationUploadsAfterReplayRefreshesMatchingBaseline() async throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let providerID = UUID(uuidString: "f2000000-0000-0000-0000-000000000002")!
+        let provider = LLMProviderConfig(
+            id: providerID,
+            provider: .openAI,
+            displayName: "Before edit"
+        )
+        modelContext.insert(provider)
+        try modelContext.save()
+        let snapshotService = RemoteSyncAISettingsSnapshotService(credentialForProvider: { _ in nil })
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        provider.displayName = "Edited during synchronization"
+        try AISettingsStore(modelContext: modelContext).save()
+        let journalService = RemoteSyncMutationJournalService()
+        let pendingBeforeReplay = try journalService.pendingMutations(
+            for: .aiSettings,
+            settingsStore: settingsStore
+        )
+        let pendingEntry = try XCTUnwrap(pendingBeforeReplay.values.first?.entry)
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        let adapter = RemoteSyncDurableOutboxTestAdapter(uploadMetadata: [.init(timestamp: 4_000)])
+        let directoryURL = try makeAISettingsTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let service = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            snapshotService: snapshotService,
+            temporaryDirectory: directoryURL,
+            outboxDirectory: directoryURL.appendingPathComponent("outbox", isDirectory: true),
+            nowProvider: { 3_000 }
+        )
+        let optionalReport = try await service.uploadPendingPatch(
+            bootstrapState: RemoteSyncBootstrapState(
+                syncFolderID: "/org.andbible.ios-sync-ai_settings",
+                deviceFolderID: "/org.andbible.ios-sync-ai_settings/ios-device",
+                secretFileName: "device-known-ios-device-secret",
+                phase: .ready
+            ),
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let report = try XCTUnwrap(optionalReport)
+
+        XCTAssertEqual(report.logEntryCount, 1)
+        XCTAssertEqual(
+            report.tableReports.first(where: { $0.tableName == "LlmProviderConfig" })?.upsertedRowCount,
+            1
+        )
+        XCTAssertEqual(
+            try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings)
+                .first(where: { $0.tableName == "LlmProviderConfig" }),
+            pendingEntry
+        )
+        XCTAssertTrue(
+            try journalService.pendingMutations(for: .aiSettings, settingsStore: settingsStore).isEmpty
+        )
+    }
+
+    /**
+     Verifies initial-backup acceptance clears represented markers but preserves edits made in flight.
+
+     The initial generation captures the first provider state. A second local save replaces the marker
+     before acceptance; cleanup against the older generation must retain it. Cleanup against the exact
+     current generation then removes it, proving restart/reset metadata cannot remain perpetually dirty.
+     */
+    func testInitialBaselineMarkerCleanupPreservesOnlyLaterMutations() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let snapshotService = RemoteSyncAISettingsSnapshotService(credentialForProvider: { _ in nil })
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let provider = LLMProviderConfig(
+            id: UUID(uuidString: "f2000000-0000-0000-0000-000000000003")!,
+            provider: .openAI,
+            displayName: "Initial archive value"
+        )
+        let aiStore = AISettingsStore(modelContext: modelContext)
+        try aiStore.insertProvider(provider)
+        let initialSnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+
+        provider.displayName = "Edited during upload"
+        try aiStore.save()
+        let journalService = RemoteSyncMutationJournalService()
+        try journalService.clearPendingMutationsAcceptedByBaseline(
+            initialSnapshot.fingerprintsByKey,
+            for: .aiSettings,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        XCTAssertEqual(
+            try journalService.pendingMutations(for: .aiSettings, settingsStore: settingsStore).count,
+            1
+        )
+
+        let currentSnapshot = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        try journalService.clearPendingMutationsAcceptedByBaseline(
+            currentSnapshot.fingerprintsByKey,
+            for: .aiSettings,
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        XCTAssertTrue(
+            try journalService.pendingMutations(for: .aiSettings, settingsStore: settingsStore).isEmpty
+        )
+    }
+
+    /**
+     Verifies the public upload entry point rejects non-v23 requests before remote discovery.
+
+     The valid ready bootstrap state isolates schema validation from missing-destination errors. A
+     failure means callers can receive an internal writer failure or perform remote I/O for a schema
+     Android cannot consume.
+     */
+    func testUploadRejectsUnsupportedSchemaWithPublicError() async throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let adapter = RemoteSyncMockAdapter()
+        let service = RemoteSyncAISettingsPatchUploadService(adapter: adapter)
+        let bootstrapState = RemoteSyncBootstrapState(
+            syncFolderID: "/org.andbible.ios-sync-ai_settings",
+            deviceFolderID: "/org.andbible.ios-sync-ai_settings/ios-device",
+            secretFileName: "device-known-ios-device-secret",
+            phase: .ready
+        )
+
+        do {
+            _ = try await service.uploadPendingPatch(
+                bootstrapState: bootstrapState,
+                modelContext: modelContext,
+                settingsStore: settingsStore,
+                schemaVersion: 22
+            )
+            XCTFail("Expected an unsupported AI settings schema error")
+        } catch {
+            XCTAssertEqual(
+                error as? RemoteSyncAISettingsPatchUploadError,
+                .unsupportedSchemaVersion(22)
+            )
+        }
+        let events = await adapter.eventsSnapshot()
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    /**
+     Proves the active AI Settings toggle reaches real initial upload and adoption through lifecycle sync.
+
+     Device A enables only `AI_SETTINGS`; the lifecycle runner must discover no remote folder,
+     create it, and publish a complete Android v23 `initial.sqlite3.gz`. Device B enables the same
+     category, receives the remote-adoption decision, and resumes through the lifecycle continuation
+     to restore all seven synchronized tables. Device B begins with its own credential and raw log,
+     which must survive the destructive initial replacement. Fixed adapter queues and clocks make
+     every bootstrap, upload, and download boundary deterministic. A failure means the visible
+     active toggle is not connected to the category's production bootstrap path. Temporary staging
+     and durable-outbox directories are removed at completion.
+     */
+    func testLifecycleCreatesAndAdoptsAISettingsInitialBackupWithoutLocalSecretLoss() async throws {
+        let syncFolderID = "/org.andbible.ios-sync-ai_settings"
+        let sourceDeviceFolderID = "\(syncFolderID)/ios-source"
+        let destinationDeviceFolderID = "\(syncFolderID)/ios-destination"
+        let sourceMarker = "device-known-ios-source-secret"
+        let destinationMarker = "device-known-ios-destination-secret"
+        let sourceDirectory = try makeAISettingsTemporaryDirectory()
+        let destinationDirectory = try makeAISettingsTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: sourceDirectory)
+            try? FileManager.default.removeItem(at: destinationDirectory)
+        }
+
+        let sourceContainer = try makeAISettingsSyncContainer()
+        let sourceConfigurationContext = ModelContext(sourceContainer)
+        let sourceSettingsStore = SettingsStore(modelContext: sourceConfigurationContext)
+        let sourceSecrets = InMemorySecretStore()
+        let sourceRemoteSettings = RemoteSyncSettingsStore(
+            settingsStore: sourceSettingsStore,
+            secretStore: sourceSecrets
+        )
+        sourceRemoteSettings.selectedBackend = .nextCloud
+        try sourceRemoteSettings.saveWebDAVConfiguration(
+            WebDAVSyncConfiguration(
+                serverURL: "https://nextcloud.example.com",
+                username: "source",
+                folderPath: nil
+            ),
+            password: "source-webdav-password"
+        )
+        sourceRemoteSettings.setSyncEnabled(true, for: .aiSettings)
+        let fixtureIDs = try insertCompleteAISettingsFixture(into: sourceConfigurationContext)
+        let sourceCredentials = AICredentialStore(secretStore: sourceSecrets)
+        try sourceCredentials.setCredential("source-provider-secret", for: fixtureIDs.provider)
+
+        let adapter = RemoteSyncMockAdapter()
+        await adapter.setMakeKnownResponse(sourceMarker)
+        await adapter.enqueueListFilesResult([])
+        await adapter.enqueueCreateFolderResult(
+            RemoteSyncFile(
+                id: syncFolderID,
+                name: "org.andbible.ios-sync-ai_settings",
+                size: 0,
+                timestamp: 1_000,
+                parentID: "/",
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        )
+        await adapter.enqueueCreateFolderResult(
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 1_100,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        )
+        await adapter.enqueueListFilesResult([])
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(syncFolderID)/initial.sqlite3.gz",
+                name: "initial.sqlite3.gz",
+                size: 0,
+                timestamp: 3_000,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 1_100,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ])
+        await adapter.enqueueListFilesResult([])
+
+        let sourceCoordinator = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-source",
+            initialBackupUploadService: RemoteSyncInitialBackupUploadService(
+                adapter: adapter,
+                deviceIdentifier: "ios-source",
+                temporaryDirectory: sourceDirectory,
+                retryDirectory: sourceDirectory.appendingPathComponent("initial-outbox", isDirectory: true),
+                nowProvider: { 2_000 }
+            ),
+            aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService(
+                adapter: adapter,
+                temporaryDirectory: sourceDirectory,
+                outboxDirectory: sourceDirectory.appendingPathComponent("patch-outbox", isDirectory: true),
+                nowProvider: { 2_000 }
+            ),
+            temporaryDirectory: sourceDirectory,
+            nowProvider: { 2_000 }
+        )
+        let sourceLifecycle = RemoteSyncLifecycleService(
+            modelContainer: sourceContainer,
+            bundleIdentifier: "org.andbible.ios",
+            synchronizationServiceFactory: { _ in sourceCoordinator },
+            remoteSettingsStoreFactory: {
+                RemoteSyncSettingsStore(settingsStore: $0, secretStore: sourceSecrets)
+            },
+            nowProvider: { 2_000 }
+        )
+
+        var sourceReport: RemoteSyncCategorySynchronizationReport?
+        sourceLifecycle.onCategorySynchronized = { sourceReport = $0 }
+        let didCreateSource = await sourceLifecycle.synchronizeIfNeeded(force: true)
+        XCTAssertTrue(didCreateSource)
+        XCTAssertEqual(sourceReport?.category, .aiSettings)
+        XCTAssertNil(sourceReport?.patchUploadReport)
+        let sourceUploads = await adapter.uploadedFilesSnapshot()
+        let initialUpload = try XCTUnwrap(sourceUploads.first)
+        XCTAssertEqual(sourceUploads.count, 1)
+        XCTAssertEqual(initialUpload.name, "initial.sqlite3.gz")
+
+        let destinationContainer = try makeAISettingsSyncContainer()
+        let destinationConfigurationContext = ModelContext(destinationContainer)
+        let destinationSettingsStore = SettingsStore(modelContext: destinationConfigurationContext)
+        let destinationSecrets = InMemorySecretStore()
+        let destinationRemoteSettings = RemoteSyncSettingsStore(
+            settingsStore: destinationSettingsStore,
+            secretStore: destinationSecrets
+        )
+        destinationRemoteSettings.selectedBackend = .nextCloud
+        try destinationRemoteSettings.saveWebDAVConfiguration(
+            WebDAVSyncConfiguration(
+                serverURL: "https://nextcloud.example.com",
+                username: "destination",
+                folderPath: nil
+            ),
+            password: "destination-webdav-password"
+        )
+        destinationRemoteSettings.setSyncEnabled(true, for: .aiSettings)
+        let destinationCredentials = AICredentialStore(secretStore: destinationSecrets)
+        try destinationCredentials.setCredential("destination-provider-secret", for: fixtureIDs.provider)
+        let destinationRawLog = LLMRawLogRecord(
+            id: UUID(uuidString: "f8000000-0000-0000-0000-000000000020")!,
+            promptName: "Destination lifecycle log",
+            modelName: "local-model",
+            providerType: "CUSTOM",
+            timestampMilliseconds: 4_000,
+            logData: Data("destination-lifecycle-raw-log".utf8)
+        )
+        destinationConfigurationContext.insert(destinationRawLog)
+        try destinationConfigurationContext.save()
+
+        let syncFolder = RemoteSyncFile(
+            id: syncFolderID,
+            name: "org.andbible.ios-sync-ai_settings",
+            size: 0,
+            timestamp: 1_000,
+            parentID: "/",
+            mimeType: NextCloudSyncAdapter.folderMimeType
+        )
+        let initialFile = RemoteSyncFile(
+            id: "\(syncFolderID)/initial.sqlite3.gz",
+            name: "initial.sqlite3.gz",
+            size: Int64(initialUpload.data.count),
+            timestamp: 3_000,
+            parentID: syncFolderID,
+            mimeType: initialUpload.contentType
+        )
+        await adapter.setDownloadData(initialUpload.data, forID: initialFile.id)
+        await adapter.enqueueListFilesResult([syncFolder])
+        await adapter.setMakeKnownResponse(destinationMarker)
+        await adapter.enqueueCreateFolderResult(
+            RemoteSyncFile(
+                id: destinationDeviceFolderID,
+                name: "ios-destination",
+                size: 0,
+                timestamp: 4_100,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        )
+        await adapter.enqueueListFilesResult([initialFile])
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 1_100,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            ),
+            RemoteSyncFile(
+                id: destinationDeviceFolderID,
+                name: "ios-destination",
+                size: 0,
+                timestamp: 4_100,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            ),
+        ])
+        await adapter.enqueueListFilesResult([])
+        await adapter.enqueueListFilesResult([])
+
+        let destinationCoordinator = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-destination",
+            initialBackupUploadService: RemoteSyncInitialBackupUploadService(
+                adapter: adapter,
+                deviceIdentifier: "ios-destination",
+                temporaryDirectory: destinationDirectory,
+                retryDirectory: destinationDirectory.appendingPathComponent("initial-outbox", isDirectory: true),
+                nowProvider: { 5_000 }
+            ),
+            aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService(
+                adapter: adapter,
+                temporaryDirectory: destinationDirectory,
+                outboxDirectory: destinationDirectory.appendingPathComponent("patch-outbox", isDirectory: true),
+                nowProvider: { 5_000 }
+            ),
+            temporaryDirectory: destinationDirectory,
+            nowProvider: { 5_000 }
+        )
+        let destinationLifecycle = RemoteSyncLifecycleService(
+            modelContainer: destinationContainer,
+            bundleIdentifier: "org.andbible.ios",
+            synchronizationServiceFactory: { _ in destinationCoordinator },
+            remoteSettingsStoreFactory: {
+                RemoteSyncSettingsStore(settingsStore: $0, secretStore: destinationSecrets)
+            },
+            nowProvider: { 5_000 }
+        )
+
+        var adoptionCandidate: RemoteSyncBootstrapCandidate?
+        destinationLifecycle.onInteractionRequired = { category, outcome in
+            guard category == .aiSettings,
+                  case .requiresRemoteAdoption(let candidate) = outcome else {
+                return
+            }
+            adoptionCandidate = candidate
+        }
+        let didSynchronizeBeforeAdoption = await destinationLifecycle.synchronizeIfNeeded(force: true)
+        XCTAssertFalse(didSynchronizeBeforeAdoption)
+        XCTAssertEqual(adoptionCandidate?.remoteFolderID, syncFolderID)
+        let didAdoptDestination = await destinationLifecycle.adoptRemoteFolderAndSynchronize(
+            try XCTUnwrap(adoptionCandidate)
+        )
+        XCTAssertTrue(didAdoptDestination)
+
+        let destinationVerificationContext = ModelContext(destinationContainer)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<LLMProviderConfig>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<LLMConfiguredModel>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<AgentPrompt>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<GlobalAISettings>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<LLMUsageRecord>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<PromptCategory>()).count, 1)
+        XCTAssertEqual(try destinationVerificationContext.fetch(FetchDescriptor<BuiltInPromptOverride>()).count, 1)
+        XCTAssertEqual(
+            try destinationVerificationContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [destinationRawLog.id]
+        )
+        XCTAssertEqual(
+            destinationCredentials.credential(for: fixtureIDs.provider),
+            "destination-provider-secret"
+        )
+    }
+
+    /**
+     Proves two ready devices converge through the production AI settings synchronization route.
+
+     Device A starts from an accepted empty baseline, creates one row in each of Android's seven
+     `AI_SETTINGS` tables, and publishes one sparse v23 patch through
+     `RemoteSyncSynchronizationService`. Device B starts from the same empty synchronized baseline
+     plus a local credential and raw log, then discovers, downloads, and replays that exact archive
+     through a second coordinator instance. Device A then updates its provider and deletes its
+     prompt; a second pair of coordinator passes must publish and replay only those changes. The
+     destination then synchronizes once more without local edits and must neither upload an echo nor
+     rediscover accepted patches. Fixed clocks and queued adapter responses make upload-before-list
+     ordering deterministic. A failure means the category can pass isolated writer/replay tests while
+     remaining disconnected, destructive, or self-amplifying in repeated top-level sync. Temporary
+     outbox and staging directories are removed when the test completes.
+     */
+    func testSynchronizationCoordinatorConvergesAISettingsAcrossTwoDevicesWithoutLocalSecretLoss() async throws {
+        let sourceContainer = try makeAISettingsSyncContainer()
+        let sourceContext = ModelContext(sourceContainer)
+        let sourceSettingsStore = SettingsStore(modelContext: sourceContext)
+        let sourceSecrets = InMemorySecretStore()
+        let sourceCredentials = AICredentialStore(secretStore: sourceSecrets)
+        let sourceSnapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { sourceCredentials.credential(for: $0) }
+        )
+        try sourceSnapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        let fixtureIDs = try insertCompleteAISettingsFixture(into: sourceContext)
+        try sourceCredentials.setCredential("source-device-secret", for: fixtureIDs.provider)
+
+        let destinationContainer = try makeAISettingsSyncContainer()
+        let destinationContext = ModelContext(destinationContainer)
+        let destinationSettingsStore = SettingsStore(modelContext: destinationContext)
+        let destinationSecrets = InMemorySecretStore()
+        let destinationCredentials = AICredentialStore(secretStore: destinationSecrets)
+        let destinationSnapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { destinationCredentials.credential(for: $0) }
+        )
+        try destinationSnapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        try destinationCredentials.setCredential("destination-device-secret", for: fixtureIDs.provider)
+        let destinationRawLog = LLMRawLogRecord(
+            id: UUID(uuidString: "f8000000-0000-0000-0000-000000000010")!,
+            promptName: "Destination-only run",
+            modelName: "local-model",
+            providerType: "CUSTOM",
+            timestampMilliseconds: 8_000,
+            logData: Data("destination-only-raw-log".utf8)
+        )
+        destinationContext.insert(destinationRawLog)
+        try destinationContext.save()
+
+        let syncFolderID = "/org.andbible.ios-sync-ai_settings"
+        let sourceDeviceFolderID = "\(syncFolderID)/ios-source"
+        let destinationDeviceFolderID = "\(syncFolderID)/ios-destination"
+        let sourceMarker = "device-known-ios-source-secret"
+        let destinationMarker = "device-known-ios-destination-secret"
+        RemoteSyncStateStore(settingsStore: sourceSettingsStore).setBootstrapState(
+            RemoteSyncBootstrapState(
+                syncFolderID: syncFolderID,
+                deviceFolderID: sourceDeviceFolderID,
+                secretFileName: sourceMarker,
+                phase: .ready
+            ),
+            for: .aiSettings
+        )
+        RemoteSyncStateStore(settingsStore: destinationSettingsStore).setBootstrapState(
+            RemoteSyncBootstrapState(
+                syncFolderID: syncFolderID,
+                deviceFolderID: destinationDeviceFolderID,
+                secretFileName: destinationMarker,
+                phase: .ready
+            ),
+            for: .aiSettings
+        )
+
+        let adapter = RemoteSyncMockAdapter()
+        await adapter.setKnownResponse(
+            true,
+            forSyncFolderID: syncFolderID,
+            secretFileName: sourceMarker
+        )
+        await adapter.setKnownResponse(
+            true,
+            forSyncFolderID: syncFolderID,
+            secretFileName: destinationMarker
+        )
+        await adapter.enqueueListFilesResult([])
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(sourceDeviceFolderID)/1.23.sqlite3.gz",
+                name: "1.23.sqlite3.gz",
+                size: 0,
+                timestamp: 6_000,
+                parentID: sourceDeviceFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        await adapter.enqueueListFilesResult([])
+
+        let sourceDirectory = try makeAISettingsTemporaryDirectory()
+        let destinationDirectory = try makeAISettingsTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: sourceDirectory)
+            try? FileManager.default.removeItem(at: destinationDirectory)
+        }
+        let sourcePatchUploadService = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            snapshotService: sourceSnapshotService,
+            temporaryDirectory: sourceDirectory,
+            outboxDirectory: sourceDirectory.appendingPathComponent("outbox", isDirectory: true),
+            nowProvider: { 5_000 }
+        )
+        let sourceService = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-source",
+            aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService(
+                snapshotService: sourceSnapshotService,
+                temporaryDirectory: sourceDirectory
+            ),
+            aiSettingsPatchUploadService: sourcePatchUploadService,
+            temporaryDirectory: sourceDirectory,
+            nowProvider: { 5_000 }
+        )
+
+        let sourceOutcome = try await sourceService.synchronize(
+            .aiSettings,
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        guard case .synchronized(let sourceReport) = sourceOutcome,
+              case .aiSettings(let uploadReport)? = sourceReport.patchUploadReport else {
+            return XCTFail("Expected device A to publish one AI settings patch")
+        }
+        XCTAssertEqual(sourceReport.category, .aiSettings)
+        XCTAssertEqual(sourceReport.discoveredPatchCount, 0)
+        XCTAssertEqual(uploadReport.patchNumber, 1)
+        XCTAssertEqual(uploadReport.logEntryCount, 7)
+        XCTAssertEqual(uploadReport.tableReports.map(\.upsertedRowCount), Array(repeating: 1, count: 7))
+
+        let uploadedFiles = await adapter.uploadedFilesSnapshot()
+        let uploadedPatch = try XCTUnwrap(uploadedFiles.first)
+        XCTAssertEqual(uploadedFiles.count, 1)
+        XCTAssertEqual(uploadedPatch.name, "1.23.sqlite3.gz")
+        let patchFile = RemoteSyncFile(
+            id: "\(sourceDeviceFolderID)/\(uploadedPatch.name)",
+            name: uploadedPatch.name,
+            size: Int64(uploadedPatch.data.count),
+            timestamp: 6_000,
+            parentID: sourceDeviceFolderID,
+            mimeType: uploadedPatch.contentType
+        )
+        await adapter.setDownloadData(uploadedPatch.data, forID: patchFile.id)
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 5_500,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ])
+        await adapter.enqueueListFilesResult([patchFile])
+
+        let destinationPatchUploadService = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            snapshotService: destinationSnapshotService,
+            temporaryDirectory: destinationDirectory,
+            outboxDirectory: destinationDirectory.appendingPathComponent("outbox", isDirectory: true),
+            nowProvider: { 7_000 }
+        )
+        let destinationService = RemoteSyncSynchronizationService(
+            adapter: adapter,
+            bundleIdentifier: "org.andbible.ios",
+            deviceIdentifier: "ios-destination",
+            aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService(
+                snapshotService: destinationSnapshotService,
+                temporaryDirectory: destinationDirectory
+            ),
+            aiSettingsPatchUploadService: destinationPatchUploadService,
+            temporaryDirectory: destinationDirectory,
+            nowProvider: { 7_000 }
+        )
+
+        let destinationOutcome = try await destinationService.synchronize(
+            .aiSettings,
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        guard case .synchronized(let destinationReport) = destinationOutcome,
+              case .aiSettings(let replayReport)? = destinationReport.patchReplayReport else {
+            return XCTFail("Expected device B to replay device A's AI settings patch")
+        }
+        XCTAssertEqual(destinationReport.category, .aiSettings)
+        XCTAssertEqual(destinationReport.discoveredPatchCount, 1)
+        XCTAssertNil(destinationReport.patchUploadReport)
+        XCTAssertEqual(replayReport.appliedPatchCount, 1)
+        XCTAssertEqual(replayReport.appliedLogEntryCount, 7)
+        XCTAssertEqual(replayReport.skippedLogEntryCount, 0)
+        XCTAssertEqual(replayReport.providerCount, 1)
+        XCTAssertEqual(replayReport.configuredModelCount, 1)
+        XCTAssertEqual(replayReport.agentPromptCount, 1)
+        XCTAssertEqual(replayReport.globalSettingsCount, 1)
+        XCTAssertEqual(replayReport.usageRecordCount, 1)
+        XCTAssertEqual(replayReport.promptCategoryCount, 1)
+        XCTAssertEqual(replayReport.builtinOverrideCount, 1)
+
+        let sourceSnapshot = try sourceSnapshotService.snapshotCurrentStateStrict(
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        let destinationSnapshot = try destinationSnapshotService.snapshotCurrentStateStrict(
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        XCTAssertEqual(destinationSnapshot, sourceSnapshot)
+        XCTAssertEqual(
+            try destinationContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [destinationRawLog.id]
+        )
+        XCTAssertEqual(
+            destinationCredentials.credential(for: fixtureIDs.provider),
+            "destination-device-secret"
+        )
+
+        let sourceProvider = try XCTUnwrap(
+            try sourceContext.fetch(FetchDescriptor<LLMProviderConfig>()).first
+        )
+        let sourcePrompt = try XCTUnwrap(
+            try sourceContext.fetch(FetchDescriptor<AgentPrompt>()).first
+        )
+        sourceProvider.displayName = "Updated on device A"
+        try AISettingsStore(modelContext: sourceContext).deletePrompt(sourcePrompt)
+
+        await adapter.enqueueListFilesResult([patchFile])
+        await adapter.enqueueUploadResult(
+            RemoteSyncFile(
+                id: "\(sourceDeviceFolderID)/2.23.sqlite3.gz",
+                name: "2.23.sqlite3.gz",
+                size: 0,
+                timestamp: 9_000,
+                parentID: sourceDeviceFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        )
+        await adapter.enqueueListFilesResult([])
+
+        let secondSourceOutcome = try await sourceService.synchronize(
+            .aiSettings,
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        guard case .synchronized(let secondSourceReport) = secondSourceOutcome,
+              case .aiSettings(let secondUploadReport)? = secondSourceReport.patchUploadReport else {
+            return XCTFail("Expected device A to publish its update and tombstone")
+        }
+        XCTAssertEqual(secondUploadReport.patchNumber, 2)
+        XCTAssertEqual(secondUploadReport.logEntryCount, 2)
+        XCTAssertEqual(
+            secondUploadReport.tableReports.first(where: {
+                $0.tableName == "LlmProviderConfig"
+            })?.upsertedRowCount,
+            1
+        )
+        XCTAssertEqual(
+            secondUploadReport.tableReports.first(where: {
+                $0.tableName == "AgentPrompt"
+            })?.deletedRowCount,
+            1
+        )
+
+        let allUploadedFiles = await adapter.uploadedFilesSnapshot()
+        XCTAssertEqual(allUploadedFiles.count, 2)
+        let uploadedSecondPatch = allUploadedFiles[1]
+        let secondPatchFile = RemoteSyncFile(
+            id: "\(sourceDeviceFolderID)/\(uploadedSecondPatch.name)",
+            name: uploadedSecondPatch.name,
+            size: Int64(uploadedSecondPatch.data.count),
+            timestamp: 9_000,
+            parentID: sourceDeviceFolderID,
+            mimeType: uploadedSecondPatch.contentType
+        )
+        await adapter.setDownloadData(uploadedSecondPatch.data, forID: secondPatchFile.id)
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 5_500,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ])
+        await adapter.enqueueListFilesResult([patchFile, secondPatchFile])
+
+        let secondDestinationOutcome = try await destinationService.synchronize(
+            .aiSettings,
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        guard case .synchronized(let secondDestinationReport) = secondDestinationOutcome,
+              case .aiSettings(let secondReplayReport)? = secondDestinationReport.patchReplayReport else {
+            return XCTFail("Expected device B to replay device A's second patch")
+        }
+        XCTAssertEqual(secondDestinationReport.discoveredPatchCount, 1)
+        XCTAssertNil(secondDestinationReport.patchUploadReport)
+        XCTAssertEqual(secondReplayReport.appliedPatchCount, 1)
+        XCTAssertEqual(secondReplayReport.appliedLogEntryCount, 2)
+        XCTAssertEqual(secondReplayReport.skippedLogEntryCount, 0)
+        XCTAssertEqual(secondReplayReport.agentPromptCount, 0)
+        XCTAssertEqual(
+            try XCTUnwrap(destinationContext.fetch(FetchDescriptor<LLMProviderConfig>()).first)
+                .displayName,
+            "Updated on device A"
+        )
+        XCTAssertTrue(try destinationContext.fetch(FetchDescriptor<AgentPrompt>()).isEmpty)
+
+        let updatedSourceSnapshot = try sourceSnapshotService.snapshotCurrentStateStrict(
+            modelContext: sourceContext,
+            settingsStore: sourceSettingsStore
+        )
+        let updatedDestinationSnapshot = try destinationSnapshotService.snapshotCurrentStateStrict(
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        XCTAssertEqual(updatedDestinationSnapshot, updatedSourceSnapshot)
+        XCTAssertEqual(
+            try destinationContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [destinationRawLog.id]
+        )
+        XCTAssertEqual(
+            destinationCredentials.credential(for: fixtureIDs.provider),
+            "destination-device-secret"
+        )
+
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: sourceDeviceFolderID,
+                name: "ios-source",
+                size: 0,
+                timestamp: 5_500,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ])
+        await adapter.enqueueListFilesResult([patchFile, secondPatchFile])
+
+        let settledDestinationOutcome = try await destinationService.synchronize(
+            .aiSettings,
+            modelContext: destinationContext,
+            settingsStore: destinationSettingsStore
+        )
+        guard case .synchronized(let settledDestinationReport) = settledDestinationOutcome else {
+            return XCTFail("Expected device B's settled synchronization to complete")
+        }
+        XCTAssertEqual(settledDestinationReport.discoveredPatchCount, 0)
+        XCTAssertNil(settledDestinationReport.patchReplayReport)
+        XCTAssertNil(settledDestinationReport.patchUploadReport)
+        let settledUploads = await adapter.uploadedFilesSnapshot()
+        XCTAssertEqual(settledUploads.count, 2)
+    }
+
+    /**
+     Verifies cancellation at the final replay publication boundary rolls back every local mutation.
+
+     The local generation contains a complete synchronized graph, accepted fingerprints, conflict
+     metadata, an applied-patch status, a credential, and a raw log. A valid newer provider patch is
+     fully decoded and staged before the injected second checkpoint throws `CancellationError` from
+     inside the atomic publication transaction. The graph and all sync metadata must equal their
+     pre-replay values, while device-local credential and raw-log state must remain untouched. A
+     failure means cancellation can expose a mixed generation that Android would never publish.
+     */
+    func testPatchReplayCancellationBeforePublishRollsBackGraphMetadataAndLocalState() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let fixtureIDs = try insertCompleteAISettingsFixture(into: modelContext)
+        let credentialStore = AICredentialStore(secretStore: InMemorySecretStore())
+        try credentialStore.setCredential("destination-only-secret", for: fixtureIDs.provider)
+
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { credentialStore.credential(for: $0) }
+        )
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let localLogEntry = aiSettingsLogEntry(
+            tableName: "LlmProviderConfig",
+            id: fixtureIDs.provider,
+            type: .upsert,
+            lastUpdated: 1_000,
+            sourceDevice: "ios-local"
+        )
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [localLogEntry],
+            for: .aiSettings
+        )
+        let localPatchStatus = RemoteSyncPatchStatus(
+            sourceDevice: "earlier-android",
+            patchNumber: 1,
+            sizeBytes: 321,
+            appliedDate: 1_500
+        )
+        RemoteSyncPatchStatusStore(settingsStore: settingsStore).addStatus(
+            localPatchStatus,
+            for: .aiSettings
+        )
+
+        let remoteSnapshot = try makeProviderSnapshot(
+            id: fixtureIDs.provider,
+            displayName: "Remote provider value"
+        )
+        let archive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: fixtureIDs.provider,
+                    type: .upsert,
+                    lastUpdated: 2_000,
+                    sourceDevice: "android-device"
+                )
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 2,
+            fileTimestamp: 2_000
+        )
+        defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
+
+        let graphBeforeReplay = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let baselineBeforeReplay = settingsStore.getString(
+            RemoteSyncAISettingsSnapshotService.acceptedBaselineKey
+        )
+        let logsBeforeReplay = try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+            .entriesStrict(for: .aiSettings)
+        let statusesBeforeReplay = try RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+            .statusesStrict(for: .aiSettings)
+        var checkpointCount = 0
+
+        XCTAssertThrowsError(
+            try RemoteSyncAISettingsPatchApplyService(
+                snapshotService: snapshotService
+            ).applyPatchArchives(
+                [archive],
+                modelContext: modelContext,
+                settingsStore: settingsStore,
+                publishCheckpoint: {
+                    checkpointCount += 1
+                    if checkpointCount == 2 {
+                        throw CancellationError()
+                    }
+                }
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        XCTAssertEqual(checkpointCount, 2)
+        XCTAssertEqual(
+            try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            ),
+            graphBeforeReplay
+        )
+        XCTAssertEqual(
+            settingsStore.getString(RemoteSyncAISettingsSnapshotService.acceptedBaselineKey),
+            baselineBeforeReplay
+        )
+        XCTAssertEqual(
+            try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings),
+            logsBeforeReplay
+        )
+        XCTAssertEqual(
+            try RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+                .statusesStrict(for: .aiSettings),
+            statusesBeforeReplay
+        )
+        XCTAssertEqual(
+            try modelContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [fixtureIDs.rawLog]
+        )
+        XCTAssertEqual(
+            credentialStore.credential(for: fixtureIDs.provider),
+            "destination-only-secret"
+        )
+    }
+
+    /**
+     Verifies a malformed later archive prevents publication of every earlier patch in the batch.
+
+     The first archive is a valid newer provider UPSERT and the second has valid remote metadata but
+     malformed gzip bytes. Replay must throw the precise bounded-file error before its one atomic
+     publication, leaving the graph, accepted baseline, conflict log, patch statuses, credential,
+     and raw log byte-for-byte equivalent to the pre-replay generation. A failure means one corrupt
+     device stream can partially commit preceding Android patches.
+     */
+    func testCorruptSecondPatchRollsBackEntireAISettingsReplayBatch() throws {
+        let container = try makeAISettingsSyncContainer()
+        let modelContext = ModelContext(container)
+        let settingsStore = SettingsStore(modelContext: modelContext)
+        let fixtureIDs = try insertCompleteAISettingsFixture(into: modelContext)
+        let credentialStore = AICredentialStore(secretStore: InMemorySecretStore())
+        try credentialStore.setCredential("destination-only-secret", for: fixtureIDs.provider)
+
+        let snapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { credentialStore.credential(for: $0) }
+        )
+        try snapshotService.refreshBaselineFingerprintsStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let localLogEntry = aiSettingsLogEntry(
+            tableName: "LlmProviderConfig",
+            id: fixtureIDs.provider,
+            type: .upsert,
+            lastUpdated: 1_000,
+            sourceDevice: "ios-local"
+        )
+        RemoteSyncLogEntryStore(settingsStore: settingsStore).replaceEntries(
+            [localLogEntry],
+            for: .aiSettings
+        )
+        let localPatchStatus = RemoteSyncPatchStatus(
+            sourceDevice: "earlier-android",
+            patchNumber: 1,
+            sizeBytes: 321,
+            appliedDate: 1_500
+        )
+        RemoteSyncPatchStatusStore(settingsStore: settingsStore).addStatus(
+            localPatchStatus,
+            for: .aiSettings
+        )
+
+        let remoteSnapshot = try makeProviderSnapshot(
+            id: fixtureIDs.provider,
+            displayName: "Remote provider value"
+        )
+        let validArchive = try makeAISettingsPatchArchive(
+            snapshot: remoteSnapshot,
+            logEntries: [
+                aiSettingsLogEntry(
+                    tableName: "LlmProviderConfig",
+                    id: fixtureIDs.provider,
+                    type: .upsert,
+                    lastUpdated: 2_000,
+                    sourceDevice: "android-device"
+                )
+            ],
+            sourceDevice: "android-device",
+            patchNumber: 2,
+            fileTimestamp: 2_000
+        )
+        let malformedArchiveURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("android-ai-settings-malformed-\(UUID().uuidString).sqlite3.gz")
+        let malformedArchiveData = Data(repeating: 0x7f, count: 18)
+        try malformedArchiveData.write(to: malformedArchiveURL, options: .atomic)
+        let malformedArchive = RemoteSyncStagedPatchArchive(
+            patch: RemoteSyncDiscoveredPatch(
+                sourceDevice: "second-android-device",
+                patchNumber: 1,
+                schemaVersion: RemoteSyncCategory.aiSettings.currentSchemaVersion,
+                file: RemoteSyncFile(
+                    id: "/org.andbible.ios-sync-ai_settings/second-android-device/1.23.sqlite3.gz",
+                    name: "1.23.sqlite3.gz",
+                    size: Int64(malformedArchiveData.count),
+                    timestamp: 2_500,
+                    parentID: "/org.andbible.ios-sync-ai_settings/second-android-device",
+                    mimeType: NextCloudSyncAdapter.gzipMimeType
+                )
+            ),
+            archiveFileURL: malformedArchiveURL
+        )
+        defer {
+            try? FileManager.default.removeItem(at: validArchive.archiveFileURL)
+            try? FileManager.default.removeItem(at: malformedArchiveURL)
+        }
+
+        let graphBeforeReplay = try snapshotService.snapshotCurrentStateStrict(
+            modelContext: modelContext,
+            settingsStore: settingsStore
+        )
+        let baselineBeforeReplay = settingsStore.getString(
+            RemoteSyncAISettingsSnapshotService.acceptedBaselineKey
+        )
+        let logsBeforeReplay = try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+            .entriesStrict(for: .aiSettings)
+        let statusesBeforeReplay = try RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+            .statusesStrict(for: .aiSettings)
+
+        XCTAssertThrowsError(
+            try RemoteSyncAISettingsPatchApplyService(
+                snapshotService: snapshotService
+            ).applyPatchArchives(
+                [validArchive, malformedArchive],
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            )
+        ) { error in
+            XCTAssertEqual(error as? RemoteSyncBoundedFileError, .malformedGzip)
+        }
+
+        XCTAssertEqual(
+            try snapshotService.snapshotCurrentStateStrict(
+                modelContext: modelContext,
+                settingsStore: settingsStore
+            ),
+            graphBeforeReplay
+        )
+        XCTAssertEqual(
+            settingsStore.getString(RemoteSyncAISettingsSnapshotService.acceptedBaselineKey),
+            baselineBeforeReplay
+        )
+        XCTAssertEqual(
+            try RemoteSyncLogEntryStore(settingsStore: settingsStore)
+                .entriesStrict(for: .aiSettings),
+            logsBeforeReplay
+        )
+        XCTAssertEqual(
+            try RemoteSyncPatchStatusStore(settingsStore: settingsStore)
+                .statusesStrict(for: .aiSettings),
+            statusesBeforeReplay
+        )
+        XCTAssertEqual(
+            try modelContext.fetch(FetchDescriptor<LLMRawLogRecord>()).map(\.id),
+            [fixtureIDs.rawLog]
+        )
+        XCTAssertEqual(
+            credentialStore.credential(for: fixtureIDs.provider),
+            "destination-only-secret"
+        )
+    }
+}
+
+/**
+ Creates an isolated SwiftData container for all AI sync models plus local settings metadata.
+
+ - Returns: Empty in-memory store containing seven synchronized AI models, raw logs, and `Setting`.
+ - Side effects: Allocates transient in-process SwiftData storage only.
+ - Throws: Rethrows schema or model-container initialization failures.
+ */
+@MainActor
+private func makeAISettingsSyncContainer() throws -> ModelContainer {
+    let schema = Schema(
+        AIModelRegistration.cloudSyncableModels
+            + AIModelRegistration.localOnlyModels
+            + [Setting.self]
+    )
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    return try ModelContainer(for: schema, configurations: [configuration])
+}
+
+/**
+ Inserts one value-rich row in each synchronized Android table plus one device-local raw log.
+
+ - Parameter modelContext: Empty AI settings test context receiving the fixture.
+ - Returns: Stable identities used to verify every restored table.
+ - Side effects: Inserts eight SwiftData rows and saves the context once without journaling.
+ - Throws: Rethrows SwiftData save failures.
+ */
+@MainActor
+private func insertCompleteAISettingsFixture(
+    into modelContext: ModelContext
+) throws -> AISettingsSyncFixtureIDs {
+    let ids = AISettingsSyncFixtureIDs(
+        provider: UUID(uuidString: "a2000000-0000-0000-0000-000000000001")!,
+        configuredModel: UUID(uuidString: "a3000000-0000-0000-0000-000000000001")!,
+        agentPrompt: UUID(uuidString: "a4000000-0000-0000-0000-000000000001")!,
+        usageRecord: UUID(uuidString: "a6000000-0000-0000-0000-000000000001")!,
+        promptCategory: UUID(uuidString: "a5000000-0000-0000-0000-000000000001")!,
+        builtinOverride: UUID(uuidString: "a7000000-0000-0000-0000-000000000001")!,
+        rawLog: UUID(uuidString: "a8000000-0000-0000-0000-000000000001")!
+    )
+
+    modelContext.insert(
+        LLMProviderConfig(
+            id: ids.provider,
+            provider: .custom,
+            displayName: "Private compatible provider",
+            endpoint: "https://llm.example.invalid/v1",
+            apiFormat: .anthropic,
+            orderNumber: 4
+        )
+    )
+    modelContext.insert(
+        LLMConfiguredModel(
+            id: ids.configuredModel,
+            providerConfigId: ids.provider,
+            modelId: "model/with unicode λ",
+            orderNumber: 3,
+            inputPricePerMillion: 1.25,
+            outputPricePerMillion: 5.5,
+            cacheCreationPricePerMillion: 0.75,
+            cacheReadPricePerMillion: 0.125
+        )
+    )
+    modelContext.insert(
+        PromptCategory(
+            id: ids.promptCategory,
+            name: "Study, custom",
+            orderNumber: 8,
+            hidden: true
+        )
+    )
+    modelContext.insert(
+        AgentPrompt(
+            id: ids.agentPrompt,
+            name: "Compare translations",
+            description: "Preserve Android converter values",
+            promptTemplate: "Compare {{selection}}\nwithout truncation.",
+            showIn: [.verseSelection, .workspaceMenu],
+            orderNumber: 6,
+            createdAtMilliseconds: 1_725_000_000_123,
+            strictContextMatching: false,
+            permissionMode: .askOncePerRun,
+            allowedTools: [.getVerseContent, .searchBible],
+            deniedTools: [.createBookmark],
+            configuredModelId: ids.configuredModel,
+            specifyBeforeRun: true,
+            noDocumentCreation: true,
+            maxIterations: 7,
+            autoIncludeDocuments: true,
+            autoIncludeCommentaries: true,
+            bibleOnly: true,
+            isTextTransformation: false,
+            categoryId: ids.promptCategory
+        )
+    )
+    let globalSettings = GlobalAISettings()
+    globalSettings.agentPermissionModeRawValue = AIPermissionMode.denyAll.rawValue
+    globalSettings.permanentlyAllowedToolsRawValue = #"["GET_VERSE_CONTENT"]"#
+    globalSettings.permanentlyDeniedToolsRawValue = #"["CREATE_BOOKMARK"]"#
+    globalSettings.aiExcludedDocumentsRawValue = #"["KJV","NET"]"#
+    globalSettings.commentaryMaxResponseTokens = 12_345
+    globalSettings.hiddenBuiltInPromptsRawValue = #"["11111111-1111-1111-1111-111111111111"]"#
+    globalSettings.maxIterations = 9
+    globalSettings.commentaryDeselectedRawValue = #"["MHCC"]"#
+    globalSettings.defaultModelId = ids.configuredModel
+    globalSettings.aiLanguage = "fi-FI"
+    globalSettings.askModelBeforeRun = true
+    globalSettings.aiDisclaimerAccepted = true
+    globalSettings.hiddenBuiltInCategoriesRawValue = #"["22222222-2222-2222-2222-222222222222"]"#
+    globalSettings.customAgentSystemPrompt = "Use installed documents first."
+    globalSettings.customTextTransformationSystemPrompt = "Return only transformed text."
+    globalSettings.favoritePromptsRawValue = #"["33333333-3333-3333-3333-333333333333"]"#
+    globalSettings.rawLogRetentionDays = 14
+    globalSettings.autoHideAgentLogOnCompletion = true
+    modelContext.insert(globalSettings)
+
+    let usage = LLMUsageRecord(
+        id: ids.usageRecord,
+        configuredModelId: ids.configuredModel,
+        deviceId: "ios-test-device"
+    )
+    usage.inputTokens = 101
+    usage.outputTokens = 202
+    usage.cacheCreationTokens = 303
+    usage.cacheReadTokens = 404
+    usage.estimatedCostUSD = 1.2345
+    modelContext.insert(usage)
+    modelContext.insert(
+        BuiltInPromptOverride(
+            id: ids.builtinOverride,
+            configuredModelId: ids.configuredModel
+        )
+    )
+    modelContext.insert(
+        LLMRawLogRecord(
+            id: ids.rawLog,
+            promptId: ids.agentPrompt,
+            promptName: "Device-local run",
+            promptDescription: "Must not leave this device",
+            configuredModelId: ids.configuredModel,
+            modelName: "model/with unicode λ",
+            providerType: "CUSTOM",
+            timestampMilliseconds: 1_725_000_000_999,
+            totalInputTokens: 10,
+            totalOutputTokens: 20,
+            estimatedCostUSD: 0.001,
+            logData: Data("source-device-local-raw-log".utf8),
+            iterationCount: 2,
+            wasError: false
+        )
+    )
+    try modelContext.save()
+    return ids
+}
+
+/**
+ Builds a complete strict snapshot containing one provider and no dependent rows.
+
+ - Parameters:
+   - id: Stable provider UUID used by patch log metadata.
+   - displayName: Provider value expected after an accepted UPSERT.
+ - Returns: Credential-free Android-shaped current snapshot.
+ - Side effects: Allocates and reads a transient SwiftData container.
+ - Throws: Rethrows container, save, or strict snapshot failures.
+ */
+@MainActor
+private func makeProviderSnapshot(
+    id: UUID,
+    displayName: String
+) throws -> RemoteSyncAISettingsCurrentSnapshot {
+    let container = try makeAISettingsSyncContainer()
+    let context = ModelContext(container)
+    context.insert(LLMProviderConfig(id: id, provider: .openAI, displayName: displayName))
+    try context.save()
+    return try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+        modelContext: context,
+        settingsStore: SettingsStore(modelContext: context)
+    )
+}
+
+/**
+ Builds an empty complete strict snapshot suitable for a delete-only sparse patch.
+
+ - Returns: Android-shaped snapshot with no synchronized rows or fingerprints.
+ - Side effects: Allocates and reads a transient SwiftData container.
+ - Throws: Rethrows container or strict snapshot failures.
+ */
+@MainActor
+private func makeEmptyAISettingsSnapshot() throws -> RemoteSyncAISettingsCurrentSnapshot {
+    let container = try makeAISettingsSyncContainer()
+    let context = ModelContext(container)
+    return try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+        modelContext: context,
+        settingsStore: SettingsStore(modelContext: context)
+    )
+}
+
+/**
+ Creates one canonical UUID-keyed Android AI settings log entry.
+
+ - Parameters:
+   - tableName: One of Android's seven synchronized AI table names.
+   - id: UUID stored as Android's exact 16-byte BLOB primary identifier.
+   - type: UPSERT or DELETE operation.
+   - lastUpdated: Conflict timestamp in epoch milliseconds.
+   - sourceDevice: Originating Android-compatible device identifier.
+ - Returns: Log entry with Android's empty-text secondary identifier.
+ - Side effects: none.
+ - Failure modes: This helper cannot fail.
+ */
+private func aiSettingsLogEntry(
+    tableName: String,
+    id: UUID,
+    type: RemoteSyncLogEntryType,
+    lastUpdated: Int64,
+    sourceDevice: String
+) -> RemoteSyncLogEntry {
+    RemoteSyncLogEntry(
+        tableName: tableName,
+        entityID1: .blob(aiSettingsUUIDBlob(id)),
+        entityID2: .text(""),
+        type: type,
+        lastUpdated: lastUpdated,
+        sourceDevice: sourceDevice
+    )
+}
+
+/**
+ Encodes a UUID using Android Room's raw 16-byte UUID converter representation.
+
+ - Parameter id: UUID to encode without textual normalization.
+ - Returns: Sixteen bytes in the UUID tuple's canonical order.
+ - Side effects: none.
+ - Failure modes: This helper cannot fail.
+ */
+private func aiSettingsUUIDBlob(_ id: UUID) -> Data {
+    withUnsafeBytes(of: id.uuid) { Data($0) }
+}
+
+/**
+ Writes and gzip-stages one sparse Android v23 AI settings patch.
+
+ - Parameters:
+   - snapshot: Complete source generation used to resolve selected UPSERT rows.
+   - logEntries: Exact sparse operations and conflict metadata.
+   - sourceDevice: Device folder name owning the patch stream.
+   - patchNumber: Monotonic patch number within that stream.
+   - fileTimestamp: Remote metadata timestamp recorded in patch status.
+ - Returns: Staged archive whose temporary gzip file remains caller-owned.
+ - Side effects: Creates, reads, and removes a temporary SQLite file, then writes one gzip archive.
+ - Throws: Rethrows writer, compression, and filesystem failures.
+ */
+private func makeAISettingsPatchArchive(
+    snapshot: RemoteSyncAISettingsCurrentSnapshot,
+    logEntries: [RemoteSyncLogEntry],
+    sourceDevice: String,
+    patchNumber: Int64,
+    fileTimestamp: Int64
+) throws -> RemoteSyncStagedPatchArchive {
+    let databaseURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("android-ai-settings-patch-\(UUID().uuidString).sqlite3")
+    defer { try? FileManager.default.removeItem(at: databaseURL) }
+    _ = try RemoteSyncAISettingsDatabaseWriter().writeSparseDatabase(
+        at: databaseURL,
+        snapshot: snapshot,
+        selectedLogEntries: logEntries
+    )
+    let archiveData = try RemoteSyncArchiveStagingService.gzip(Data(contentsOf: databaseURL))
+    let archiveURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("android-ai-settings-patch-\(UUID().uuidString).sqlite3.gz")
+    try archiveData.write(to: archiveURL, options: .atomic)
+    let parentID = "/org.andbible.ios-sync-ai_settings/\(sourceDevice)"
+    return RemoteSyncStagedPatchArchive(
+        patch: RemoteSyncDiscoveredPatch(
+            sourceDevice: sourceDevice,
+            patchNumber: patchNumber,
+            schemaVersion: RemoteSyncCategory.aiSettings.currentSchemaVersion,
+            file: RemoteSyncFile(
+                id: "\(parentID)/\(patchNumber).sqlite3.gz",
+                name: "\(patchNumber).sqlite3.gz",
+                size: Int64(archiveData.count),
+                timestamp: fileTimestamp,
+                parentID: parentID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        ),
+        archiveFileURL: archiveURL
+    )
+}
+
+/**
+ Creates one unique temporary directory for AI settings file and outbox tests.
+
+ - Returns: Existing empty directory beneath the process temporary root.
+ - Side effects: Creates one filesystem directory; callers remove it with their test cleanup.
+ - Throws: Rethrows directory creation failures.
+ */
+private func makeAISettingsTemporaryDirectory() throws -> URL {
+    let directoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("remote-sync-ai-settings-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true
+    )
+    return directoryURL
+}
+
+/**
+ Reads one required SQLite integer scalar from a published test database.
+
+ - Parameters:
+   - sql: Single-row integer query.
+   - databaseURL: Existing SQLite file opened read-only.
+ - Returns: First column of the first result row.
+ - Side effects: Opens, prepares, steps, finalizes, and closes a read-only SQLite connection.
+ - Throws: `RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase` for any open or query failure.
+ */
+private func sqliteInteger(_ sql: String, databaseURL: URL) throws -> Int64 {
+    var database: OpaquePointer?
+    guard sqlite3_open_v2(
+        databaseURL.path,
+        &database,
+        SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX,
+        nil
+    ) == SQLITE_OK, let database else {
+        if let database { sqlite3_close(database) }
+        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(database) }
+
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+          let statement else {
+        sqlite3_finalize(statement)
+        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW,
+          sqlite3_column_type(statement, 0) == SQLITE_INTEGER else {
+        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+    }
+    return sqlite3_column_int64(statement, 0)
+}
+
+/**
+ Adds one raw-log row that Android's whole-database initial upload can legitimately contain.
+
+ - Parameter databaseURL: Existing exact Android v23 AI database opened for one fixture mutation.
+ - Side effects: Inserts one bounded `LlmRawLogRecord` row and closes the SQLite connection.
+ - Throws: `RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase` if open or insertion fails.
+ */
+private func insertAndroidRawLogFixture(into databaseURL: URL) throws {
+    var database: OpaquePointer?
+    guard sqlite3_open_v2(
+        databaseURL.path,
+        &database,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+        nil
+    ) == SQLITE_OK, let database else {
+        if let database { sqlite3_close(database) }
+        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+    }
+    defer { sqlite3_close(database) }
+
+    let sql = """
+    INSERT INTO LlmRawLogRecord (
+        id, promptId, promptName, promptDescription, configuredModelId, modelName, providerType,
+        timestamp, totalInputTokens, totalOutputTokens, estimatedCostUsd, logData, iterationCount,
+        wasError
+    ) VALUES (
+        X'A8000000000000000000000000000099', NULL, 'Android local run', NULL, NULL,
+        'android-model', 'CUSTOM', 1725000000999, 10, 20, 0.001,
+        X'616E64726F69642D6F726967696E2D7261772D6C6F67', 2, 0
+    );
+    """
+    guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
+        throw RemoteSyncAISettingsRestoreError.invalidSQLiteDatabase
+    }
+}

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAISettingsTests.swift
@@ -17,6 +17,17 @@ private enum SimulatedAICredentialLookupError: Error, Equatable {
 }
 
 /**
+ Creates an AI settings projector that deterministically reports no device-local credentials.
+
+ - Returns: Strict snapshot service suitable for credential-free synchronization fixtures.
+ - Side effects: none.
+ - Failure modes: The injected lookup does not throw.
+ */
+private func makeCredentialFreeAISettingsSnapshotService() -> RemoteSyncAISettingsSnapshotService {
+    RemoteSyncAISettingsSnapshotService(credentialForProvider: { _ in nil })
+}
+
+/**
  Secret-store double whose compatibility lookup collapses failure while strict lookup preserves it.
 
  The mismatch models production Keychain compatibility behavior and proves AI sync selects the
@@ -216,7 +227,10 @@ final class RemoteSyncAISettingsTests: XCTestCase {
 
         let providerID = UUID(uuidString: "b2000000-0000-0000-0000-000000000001")!
         try credentialStore.setCredential("never-sync-this-secret", for: providerID)
-        let aiStore = AISettingsStore(modelContext: modelContext)
+        let aiStore = AISettingsStore(
+            modelContext: modelContext,
+            remoteSyncSnapshotService: snapshotService
+        )
         try aiStore.insertRawLog(
             LLMRawLogRecord(
                 id: UUID(uuidString: "b8000000-0000-0000-0000-000000000001")!,
@@ -246,7 +260,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
                 .isEmpty
         )
         XCTAssertTrue(
-            try RemoteSyncMutationJournalService()
+            try RemoteSyncMutationJournalService(aiSettingsSnapshotService: snapshotService)
                 .pendingMutations(for: .aiSettings, settingsStore: settingsStore)
                 .isEmpty
         )
@@ -268,7 +282,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         XCTAssertEqual(entries.first?.tableName, "LlmProviderConfig")
         XCTAssertEqual(entries.first?.type, .upsert)
         XCTAssertFalse(entries.contains(where: { $0.tableName == "LlmRawLogRecord" }))
-        let pending = try RemoteSyncMutationJournalService()
+        let pending = try RemoteSyncMutationJournalService(
+            aiSettingsSnapshotService: snapshotService
+        )
             .pendingMutations(for: .aiSettings, settingsStore: settingsStore)
         XCTAssertEqual(pending.count, 1)
         XCTAssertEqual(pending.values.first?.entry.tableName, "LlmProviderConfig")
@@ -479,7 +495,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: equalArchive.archiveFileURL) }
 
-        let applyService = RemoteSyncAISettingsPatchApplyService()
+        let applyService = RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        )
         let equalReport = try applyService.applyPatchArchives(
             [equalArchive],
             modelContext: modelContext,
@@ -605,7 +623,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: deleteArchive.archiveFileURL) }
 
-        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        let report = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        ).applyPatchArchives(
             [deleteArchive],
             modelContext: modelContext,
             settingsStore: settingsStore
@@ -676,7 +696,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
 
-        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        let report = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        ).applyPatchArchives(
             [archive],
             modelContext: modelContext,
             settingsStore: settingsStore
@@ -745,7 +767,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             )
         )
         try remoteContext.save()
-        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+        let remoteSnapshot = try makeCredentialFreeAISettingsSnapshotService().snapshotCurrentStateStrict(
             modelContext: remoteContext,
             settingsStore: SettingsStore(modelContext: remoteContext)
         )
@@ -773,7 +795,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
 
-        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        _ = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        ).applyPatchArchives(
             [archive],
             modelContext: modelContext,
             settingsStore: settingsStore
@@ -834,14 +858,20 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             fileTimestamp: 1_301
         )
         defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
-        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        let snapshotService = makeCredentialFreeAISettingsSnapshotService()
+        _ = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: snapshotService
+        ).applyPatchArchives(
             [archive],
             modelContext: modelContext,
             settingsStore: settingsStore
         )
         XCTAssertTrue(try modelContext.fetch(FetchDescriptor<LLMConfiguredModel>()).isEmpty)
 
-        let aiStore = AISettingsStore(modelContext: modelContext)
+        let aiStore = AISettingsStore(
+            modelContext: modelContext,
+            remoteSyncSnapshotService: snapshotService
+        )
         let globalSettings = try aiStore.globalSettings()
         globalSettings.aiLanguage = "fi-FI"
         try aiStore.save()
@@ -851,6 +881,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let uploadService = RemoteSyncAISettingsPatchUploadService(
             adapter: adapter,
+            snapshotService: snapshotService,
             temporaryDirectory: directoryURL,
             outboxDirectory: directoryURL.appendingPathComponent("outbox", isDirectory: true),
             nowProvider: { 1_400 }
@@ -920,7 +951,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             )
         )
         try remoteContext.save()
-        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+        let remoteSnapshot = try makeCredentialFreeAISettingsSnapshotService().snapshotCurrentStateStrict(
             modelContext: remoteContext,
             settingsStore: SettingsStore(modelContext: remoteContext)
         )
@@ -941,7 +972,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
 
-        let report = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        let report = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        ).applyPatchArchives(
             [archive],
             modelContext: modelContext,
             settingsStore: settingsStore
@@ -1021,7 +1054,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         remoteContext.insert(remoteUsage)
         try remoteContext.save()
 
-        let remoteSnapshot = try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+        let remoteSnapshot = try makeCredentialFreeAISettingsSnapshotService().snapshotCurrentStateStrict(
             modelContext: remoteContext,
             settingsStore: SettingsStore(modelContext: remoteContext)
         )
@@ -1049,7 +1082,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: archive.archiveFileURL) }
 
-        _ = try RemoteSyncAISettingsPatchApplyService().applyPatchArchives(
+        _ = try RemoteSyncAISettingsPatchApplyService(
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        ).applyPatchArchives(
             [archive],
             modelContext: modelContext,
             settingsStore: settingsStore
@@ -1079,7 +1114,11 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         let container = try makeAISettingsSyncContainer()
         let modelContext = ModelContext(container)
         let settingsStore = SettingsStore(modelContext: modelContext)
-        try AISettingsStore(modelContext: modelContext).insertProvider(
+        let snapshotService = makeCredentialFreeAISettingsSnapshotService()
+        try AISettingsStore(
+            modelContext: modelContext,
+            remoteSyncSnapshotService: snapshotService
+        ).insertProvider(
             LLMProviderConfig(
                 id: UUID(uuidString: "f2000000-0000-0000-0000-000000000001")!,
                 provider: .openAI,
@@ -1094,6 +1133,7 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directoryURL) }
         let service = RemoteSyncAISettingsPatchUploadService(
             adapter: adapter,
+            snapshotService: snapshotService,
             temporaryDirectory: directoryURL,
             outboxDirectory: directoryURL.appendingPathComponent("outbox", isDirectory: true),
             nowProvider: { 2_000 }
@@ -1172,8 +1212,13 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         )
 
         provider.displayName = "Edited during synchronization"
-        try AISettingsStore(modelContext: modelContext).save()
-        let journalService = RemoteSyncMutationJournalService()
+        try AISettingsStore(
+            modelContext: modelContext,
+            remoteSyncSnapshotService: snapshotService
+        ).save()
+        let journalService = RemoteSyncMutationJournalService(
+            aiSettingsSnapshotService: snapshotService
+        )
         let pendingBeforeReplay = try journalService.pendingMutations(
             for: .aiSettings,
             settingsStore: settingsStore
@@ -1243,7 +1288,10 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             provider: .openAI,
             displayName: "Initial archive value"
         )
-        let aiStore = AISettingsStore(modelContext: modelContext)
+        let aiStore = AISettingsStore(
+            modelContext: modelContext,
+            remoteSyncSnapshotService: snapshotService
+        )
         try aiStore.insertProvider(provider)
         let initialSnapshot = try snapshotService.snapshotCurrentStateStrict(
             modelContext: modelContext,
@@ -1252,7 +1300,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
 
         provider.displayName = "Edited during upload"
         try aiStore.save()
-        let journalService = RemoteSyncMutationJournalService()
+        let journalService = RemoteSyncMutationJournalService(
+            aiSettingsSnapshotService: snapshotService
+        )
         try journalService.clearPendingMutationsAcceptedByBaseline(
             initialSnapshot.fingerprintsByKey,
             for: .aiSettings,
@@ -1291,7 +1341,10 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         let modelContext = ModelContext(container)
         let settingsStore = SettingsStore(modelContext: modelContext)
         let adapter = RemoteSyncMockAdapter()
-        let service = RemoteSyncAISettingsPatchUploadService(adapter: adapter)
+        let service = RemoteSyncAISettingsPatchUploadService(
+            adapter: adapter,
+            snapshotService: makeCredentialFreeAISettingsSnapshotService()
+        )
         let bootstrapState = RemoteSyncBootstrapState(
             syncFolderID: "/org.andbible.ios-sync-ai_settings",
             deviceFolderID: "/org.andbible.ios-sync-ai_settings/ios-device",
@@ -1363,6 +1416,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         let fixtureIDs = try insertCompleteAISettingsFixture(into: sourceConfigurationContext)
         let sourceCredentials = AICredentialStore(secretStore: sourceSecrets)
         try sourceCredentials.setCredential("source-provider-secret", for: fixtureIDs.provider)
+        let sourceSnapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { sourceCredentials.credential(for: $0) }
+        )
 
         let adapter = RemoteSyncMockAdapter()
         await adapter.setMakeKnownResponse(sourceMarker)
@@ -1414,15 +1470,24 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             adapter: adapter,
             bundleIdentifier: "org.andbible.ios",
             deviceIdentifier: "ios-source",
+            initialBackupRestoreService: RemoteSyncInitialBackupRestoreService(
+                aiSettingsSnapshotService: sourceSnapshotService
+            ),
             initialBackupUploadService: RemoteSyncInitialBackupUploadService(
                 adapter: adapter,
                 deviceIdentifier: "ios-source",
+                aiSettingsSnapshotService: sourceSnapshotService,
                 temporaryDirectory: sourceDirectory,
                 retryDirectory: sourceDirectory.appendingPathComponent("initial-outbox", isDirectory: true),
                 nowProvider: { 2_000 }
             ),
+            aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService(
+                snapshotService: sourceSnapshotService,
+                temporaryDirectory: sourceDirectory
+            ),
             aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService(
                 adapter: adapter,
+                snapshotService: sourceSnapshotService,
                 temporaryDirectory: sourceDirectory,
                 outboxDirectory: sourceDirectory.appendingPathComponent("patch-outbox", isDirectory: true),
                 nowProvider: { 2_000 }
@@ -1471,6 +1536,9 @@ final class RemoteSyncAISettingsTests: XCTestCase {
         destinationRemoteSettings.setSyncEnabled(true, for: .aiSettings)
         let destinationCredentials = AICredentialStore(secretStore: destinationSecrets)
         try destinationCredentials.setCredential("destination-provider-secret", for: fixtureIDs.provider)
+        let destinationSnapshotService = RemoteSyncAISettingsSnapshotService(
+            credentialForProvider: { destinationCredentials.credential(for: $0) }
+        )
         let destinationRawLog = LLMRawLogRecord(
             id: UUID(uuidString: "f8000000-0000-0000-0000-000000000020")!,
             promptName: "Destination lifecycle log",
@@ -1537,15 +1605,24 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             adapter: adapter,
             bundleIdentifier: "org.andbible.ios",
             deviceIdentifier: "ios-destination",
+            initialBackupRestoreService: RemoteSyncInitialBackupRestoreService(
+                aiSettingsSnapshotService: destinationSnapshotService
+            ),
             initialBackupUploadService: RemoteSyncInitialBackupUploadService(
                 adapter: adapter,
                 deviceIdentifier: "ios-destination",
+                aiSettingsSnapshotService: destinationSnapshotService,
                 temporaryDirectory: destinationDirectory,
                 retryDirectory: destinationDirectory.appendingPathComponent("initial-outbox", isDirectory: true),
                 nowProvider: { 5_000 }
             ),
+            aiSettingsPatchApplyService: RemoteSyncAISettingsPatchApplyService(
+                snapshotService: destinationSnapshotService,
+                temporaryDirectory: destinationDirectory
+            ),
             aiSettingsPatchUploadService: RemoteSyncAISettingsPatchUploadService(
                 adapter: adapter,
+                snapshotService: destinationSnapshotService,
                 temporaryDirectory: destinationDirectory,
                 outboxDirectory: destinationDirectory.appendingPathComponent("patch-outbox", isDirectory: true),
                 nowProvider: { 5_000 }
@@ -1834,7 +1911,10 @@ final class RemoteSyncAISettingsTests: XCTestCase {
             try sourceContext.fetch(FetchDescriptor<AgentPrompt>()).first
         )
         sourceProvider.displayName = "Updated on device A"
-        try AISettingsStore(modelContext: sourceContext).deletePrompt(sourcePrompt)
+        try AISettingsStore(
+            modelContext: sourceContext,
+            remoteSyncSnapshotService: sourceSnapshotService
+        ).deletePrompt(sourcePrompt)
 
         await adapter.enqueueListFilesResult([patchFile])
         await adapter.enqueueUploadResult(
@@ -2414,7 +2494,7 @@ private func makeProviderSnapshot(
     let context = ModelContext(container)
     context.insert(LLMProviderConfig(id: id, provider: .openAI, displayName: displayName))
     try context.save()
-    return try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+    return try makeCredentialFreeAISettingsSnapshotService().snapshotCurrentStateStrict(
         modelContext: context,
         settingsStore: SettingsStore(modelContext: context)
     )
@@ -2431,7 +2511,7 @@ private func makeProviderSnapshot(
 private func makeEmptyAISettingsSnapshot() throws -> RemoteSyncAISettingsCurrentSnapshot {
     let container = try makeAISettingsSyncContainer()
     let context = ModelContext(container)
-    return try RemoteSyncAISettingsSnapshotService().snapshotCurrentStateStrict(
+    return try makeCredentialFreeAISettingsSnapshotService().snapshotCurrentStateStrict(
         modelContext: context,
         settingsStore: SettingsStore(modelContext: context)
     )

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAndroidRoomSchemaContractTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncAndroidRoomSchemaContractTests.swift
@@ -57,7 +57,7 @@ final class RemoteSyncAndroidRoomSchemaContractTests: XCTestCase {
     }
 
     /**
-     Verifies all five iOS database shells are structurally identical to Android Room exports.
+     Verifies all six iOS database shells are structurally identical to Android Room exports.
 
      Each case checks the Android export format, schema version, Room identity hash, complete table
      DDL, explicit index DDL, and view DDL after removing only SQLite-insignificant formatting and
@@ -69,6 +69,7 @@ final class RemoteSyncAndroidRoomSchemaContractTests: XCTestCase {
             FixtureCase(category: .workspaces, fileName: "WorkspaceDatabase-v24.json"),
             FixtureCase(category: .readingPlans, fileName: "ReadingPlanDatabase-v1.json"),
             FixtureCase(category: .myDocuments, fileName: "MyDocumentDatabase-v4.json"),
+            FixtureCase(category: .aiSettings, fileName: "AiSettingsDatabase-v23.json"),
             FixtureCase(category: .progress, fileName: "ProgressDatabase-v9.json")
         ]
 
@@ -900,7 +901,7 @@ enum AndroidRuntimeSyncTriggerFixture {
      Returns the exact trigger statements Android generates for one supported sync category.
 
      - Parameters:
-       - category: Workspace or Progress database category.
+       - category: Workspace, Progress, or AI settings database category.
        - deviceIdentifier: Stable source-device literal embedded in every generated trigger.
        - existingTables: Optional predecessor table set used to model older Workspace generations.
      - Returns: Three trigger statements per Android syncable table.
@@ -928,6 +929,16 @@ enum AndroidRuntimeSyncTriggerFixture {
                 ("ChapterReadHistory", "id", nil),
                 ("MemorizationTarget", "id", nil),
                 ("GlobalReadingProgressSettings", "id", nil),
+            ]
+        case .aiSettings:
+            definitions = [
+                ("LlmProviderConfig", "id", nil),
+                ("LlmConfiguredModel", "id", nil),
+                ("AgentPrompt", "id", nil),
+                ("GlobalAiSettings", "id", nil),
+                ("LlmUsageRecord", "id", nil),
+                ("PromptCategory", "id", nil),
+                ("BuiltinPromptOverride", "id", nil),
             ]
         case .bookmarks, .readingPlans, .myDocuments:
             return []

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncStateTests.swift
@@ -544,35 +544,44 @@ final class RemoteSyncStateTests: XCTestCase {
         XCTAssertFalse(store.isSyncEnabled(for: .workspaces))
         XCTAssertFalse(store.isSyncEnabled(for: .readingPlans))
         XCTAssertFalse(store.isSyncEnabled(for: .myDocuments))
+        XCTAssertFalse(store.isSyncEnabled(for: .aiSettings))
 
         store.setSyncEnabled(true, for: .bookmarks)
         store.setSyncEnabled(true, for: .readingPlans)
         store.setSyncEnabled(false, for: .workspaces)
         store.setSyncEnabled(true, for: .myDocuments)
+        store.setSyncEnabled(true, for: .aiSettings)
 
         XCTAssertEqual(settingsStore.getString("sync_enable_bookmarks"), "true")
         XCTAssertEqual(settingsStore.getString("sync_enable_workspaces"), "false")
         XCTAssertEqual(settingsStore.getString("sync_enable_readingplans"), "true")
         XCTAssertEqual(settingsStore.getString("sync_enable_mydocuments"), "true")
+        XCTAssertEqual(settingsStore.getString("sync_enable_ai_settings"), "true")
         XCTAssertTrue(store.isSyncEnabled(for: .bookmarks))
         XCTAssertFalse(store.isSyncEnabled(for: .workspaces))
         XCTAssertTrue(store.isSyncEnabled(for: .readingPlans))
         XCTAssertTrue(store.isSyncEnabled(for: .myDocuments))
+        XCTAssertTrue(store.isSyncEnabled(for: .aiSettings))
     }
 
     func testRemoteSyncSettingsStoreReadsLegacyCategoryToggleKeys() throws {
         let settingsStore = try makeInMemorySettingsStore()
         settingsStore.setString("gdrive_mydocuments", value: "true")
+        settingsStore.setString("gdrive_llmprocessing", value: "true")
         let store = RemoteSyncSettingsStore(
             settingsStore: settingsStore,
             secretStore: InMemorySecretStore()
         )
 
         XCTAssertTrue(store.isSyncEnabled(for: .myDocuments))
+        XCTAssertTrue(store.isSyncEnabled(for: .aiSettings))
 
         store.setSyncEnabled(false, for: .myDocuments)
         XCTAssertEqual(settingsStore.getString("sync_enable_mydocuments"), "false")
         XCTAssertFalse(store.isSyncEnabled(for: .myDocuments))
+        store.setSyncEnabled(false, for: .aiSettings)
+        XCTAssertEqual(settingsStore.getString("sync_enable_ai_settings"), "false")
+        XCTAssertFalse(store.isSyncEnabled(for: .aiSettings))
     }
 
     func testRemoteSyncSettingsStoreGeneratesStableLowercaseDeviceIdentifier() throws {
@@ -693,10 +702,10 @@ final class RemoteSyncStateTests: XCTestCase {
         )
     }
 
-    func testRemoteSyncCategoryActiveSyncCasesExposeMyDocuments() {
+    func testRemoteSyncCategoryActiveSyncCasesExposeAllAndroidDatabaseCategories() {
         XCTAssertEqual(
             RemoteSyncCategory.activeSyncCases,
-            [.bookmarks, .workspaces, .readingPlans, .myDocuments, .progress]
+            [.bookmarks, .workspaces, .readingPlans, .myDocuments, .aiSettings, .progress]
         )
     }
 
@@ -1596,6 +1605,46 @@ final class RemoteSyncStateTests: XCTestCase {
         }
     }
 
+    /** Rejects the transient AI v17 patch shape that Android itself cannot migrate forward. */
+    func testRemoteSyncPatchDiscoveryRejectsUnsupportedAISettingsGeneration() async throws {
+        let statusStore = RemoteSyncPatchStatusStore(settingsStore: try makeInMemorySettingsStore())
+        let adapter = RemoteSyncMockAdapter()
+        let syncFolderID = "/org.andbible.ios-sync-ai-settings"
+        let deviceFolderID = "\(syncFolderID)/device-a"
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: deviceFolderID,
+                name: "device-a",
+                size: 0,
+                timestamp: 1_000,
+                parentID: syncFolderID,
+                mimeType: NextCloudSyncAdapter.folderMimeType
+            )
+        ])
+        await adapter.enqueueListFilesResult([
+            RemoteSyncFile(
+                id: "\(deviceFolderID)/1.17.sqlite3.gz",
+                name: "1.17.sqlite3.gz",
+                size: 333,
+                timestamp: 2_000,
+                parentID: deviceFolderID,
+                mimeType: NextCloudSyncAdapter.gzipMimeType
+            )
+        ])
+
+        let service = RemoteSyncPatchDiscoveryService(adapter: adapter, statusStore: statusStore)
+        await XCTAssertThrowsErrorAsync(
+            try await service.discoverPendingPatches(
+                for: .aiSettings,
+                bootstrapState: RemoteSyncBootstrapState(syncFolderID: syncFolderID),
+                progressState: RemoteSyncProgressState(),
+                currentSchemaVersion: 23
+            )
+        ) { error in
+            XCTAssertEqual(error as? RemoteSyncPatchDiscoveryError, .incompatiblePatchVersion(17))
+        }
+    }
+
     func testRemoteSyncArchiveStagingDownloadsInitialBackupAndExtractsSQLiteFile() async throws {
         let adapter = RemoteSyncMockAdapter()
         let initialDatabaseURL = try makeTemporarySQLiteDatabase(userVersion: 3)
@@ -1688,6 +1737,39 @@ final class RemoteSyncStateTests: XCTestCase {
             XCTAssertEqual(
                 error as? RemoteSyncArchiveStagingError,
                 .incompatibleInitialBackupVersion(10)
+            )
+        }
+    }
+
+    /** Rejects an initial AI settings generation outside the authenticated migration source set. */
+    func testRemoteSyncArchiveStagingRejectsUnsupportedAISettingsGeneration() async throws {
+        let adapter = RemoteSyncMockAdapter()
+        let initialDatabaseURL = try makeTemporarySQLiteDatabase(userVersion: 17)
+        defer { try? FileManager.default.removeItem(at: initialDatabaseURL) }
+        let initialArchiveData = try RemoteSyncArchiveStagingService.gzip(
+            Data(contentsOf: initialDatabaseURL)
+        )
+        let remoteID = "/org.andbible.ios-sync-ai-settings/initial.sqlite3.gz"
+        await adapter.setDownloadData(initialArchiveData, forID: remoteID)
+
+        let service = RemoteSyncArchiveStagingService(adapter: adapter)
+        await XCTAssertThrowsErrorAsync(
+            try await service.downloadInitialBackup(
+                RemoteSyncFile(
+                    id: remoteID,
+                    name: "initial.sqlite3.gz",
+                    size: Int64(initialArchiveData.count),
+                    timestamp: 1_000,
+                    parentID: "/org.andbible.ios-sync-ai-settings",
+                    mimeType: NextCloudSyncAdapter.gzipMimeType
+                ),
+                category: .aiSettings,
+                currentSchemaVersion: 23
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? RemoteSyncArchiveStagingError,
+                .incompatibleInitialBackupVersion(17)
             )
         }
     }

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase-v23.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase-v23.json
@@ -1,0 +1,931 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "c5b1820fd3dfb0390fa3122d2d6e139f",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, `rawLogRetentionDays` INTEGER DEFAULT 30, `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favoritePrompts",
+            "columnName": "favoritePrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawLogRetentionDays",
+            "columnName": "rawLogRetentionDays",
+            "affinity": "INTEGER",
+            "defaultValue": "30"
+          },
+          {
+            "fieldPath": "autoHideAgentLogOnCompletion",
+            "columnName": "autoHideAgentLogOnCompletion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmRawLogRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `promptId` BLOB, `promptName` TEXT NOT NULL, `promptDescription` TEXT, `configuredModelId` BLOB, `modelName` TEXT NOT NULL, `providerType` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `totalInputTokens` INTEGER NOT NULL, `totalOutputTokens` INTEGER NOT NULL, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptId",
+            "columnName": "promptId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "promptName",
+            "columnName": "promptName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptDescription",
+            "columnName": "promptDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalInputTokens",
+            "columnName": "totalInputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalOutputTokens",
+            "columnName": "totalOutputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "logData",
+            "columnName": "logData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iterationCount",
+            "columnName": "iterationCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "wasError",
+            "columnName": "wasError",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmRawLogRecord_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_promptId",
+            "unique": false,
+            "columnNames": [
+              "promptId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `${TABLE_NAME}` (`promptId`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BuiltinPromptOverride",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_BuiltinPromptOverride_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c5b1820fd3dfb0390fa3122d2d6e139f')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/1.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/1.json
@@ -1,0 +1,359 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "9acb139ce0350ae8d45abe791a34d5a6",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9acb139ce0350ae8d45abe791a34d5a6')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/10.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/10.json
@@ -1,0 +1,620 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "4ac43f9df1b74a5aeb31ad2928ec31d9",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4ac43f9df1b74a5aeb31ad2928ec31d9')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/11.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/11.json
@@ -1,0 +1,626 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "ba66632b571047b0d26b028d68a09fd4",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba66632b571047b0d26b028d68a09fd4')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/13.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/13.json
@@ -1,0 +1,647 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "7f78373ef09d4a39963a6d36fb1af07c",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7f78373ef09d4a39963a6d36fb1af07c')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/14.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/14.json
@@ -1,0 +1,654 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "a58582f787ab00d65317d194b512d65d",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a58582f787ab00d65317d194b512d65d')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/15.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/15.json
@@ -1,0 +1,661 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "74162a4c9fee3d05e66dea913f3a8ecc",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '74162a4c9fee3d05e66dea913f3a8ecc')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/16.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/16.json
@@ -1,0 +1,668 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "44ee4b49c2dc4b97f4d47d5d05f9c106",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '44ee4b49c2dc4b97f4d47d5d05f9c106')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/17.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/17.json
@@ -1,0 +1,720 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "db8c5d0eaebf6bb8660ad4bffdd5e634",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `builtInPromptCategories` TEXT DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "builtInPromptCategories",
+            "columnName": "builtInPromptCategories",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'db8c5d0eaebf6bb8660ad4bffdd5e634')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/18.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/18.json
@@ -1,0 +1,727 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "94c3097da2ba84700e7a99b45be93354",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '94c3097da2ba84700e7a99b45be93354')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/19.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/19.json
@@ -1,0 +1,739 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "9ebbedb251fc0892363a38ef2f3aa314",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9ebbedb251fc0892363a38ef2f3aa314')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/2.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/2.json
@@ -1,0 +1,366 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "959f762d0c6e5b46c0e2972d78da075b",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "editBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '959f762d0c6e5b46c0e2972d78da075b')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/20.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/20.json
@@ -1,0 +1,745 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "2fb949a3f2269f9ea913d71ec86e9a2c",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favoritePrompts",
+            "columnName": "favoritePrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2fb949a3f2269f9ea913d71ec86e9a2c')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/21.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/21.json
@@ -1,0 +1,876 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "78dc0aed47cda9c269d076d4bff4353e",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, `rawLogRetentionDays` INTEGER DEFAULT 30, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favoritePrompts",
+            "columnName": "favoritePrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawLogRetentionDays",
+            "columnName": "rawLogRetentionDays",
+            "affinity": "INTEGER",
+            "defaultValue": "30"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmRawLogRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `promptId` BLOB, `promptName` TEXT NOT NULL, `promptDescription` TEXT, `configuredModelId` BLOB, `modelName` TEXT NOT NULL, `providerType` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `totalInputTokens` INTEGER NOT NULL, `totalOutputTokens` INTEGER NOT NULL, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptId",
+            "columnName": "promptId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "promptName",
+            "columnName": "promptName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptDescription",
+            "columnName": "promptDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalInputTokens",
+            "columnName": "totalInputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalOutputTokens",
+            "columnName": "totalOutputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "logData",
+            "columnName": "logData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iterationCount",
+            "columnName": "iterationCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "wasError",
+            "columnName": "wasError",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmRawLogRecord_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_promptId",
+            "unique": false,
+            "columnNames": [
+              "promptId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `${TABLE_NAME}` (`promptId`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '78dc0aed47cda9c269d076d4bff4353e')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/22.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/22.json
@@ -1,0 +1,924 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "cd5d541ba5aee11ecf5cf66642675607",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, `rawLogRetentionDays` INTEGER DEFAULT 30, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favoritePrompts",
+            "columnName": "favoritePrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawLogRetentionDays",
+            "columnName": "rawLogRetentionDays",
+            "affinity": "INTEGER",
+            "defaultValue": "30"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmRawLogRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `promptId` BLOB, `promptName` TEXT NOT NULL, `promptDescription` TEXT, `configuredModelId` BLOB, `modelName` TEXT NOT NULL, `providerType` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `totalInputTokens` INTEGER NOT NULL, `totalOutputTokens` INTEGER NOT NULL, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptId",
+            "columnName": "promptId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "promptName",
+            "columnName": "promptName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptDescription",
+            "columnName": "promptDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalInputTokens",
+            "columnName": "totalInputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalOutputTokens",
+            "columnName": "totalOutputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "logData",
+            "columnName": "logData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iterationCount",
+            "columnName": "iterationCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "wasError",
+            "columnName": "wasError",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmRawLogRecord_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_promptId",
+            "unique": false,
+            "columnNames": [
+              "promptId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `${TABLE_NAME}` (`promptId`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BuiltinPromptOverride",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_BuiltinPromptOverride_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cd5d541ba5aee11ecf5cf66642675607')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/23.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/23.json
@@ -1,0 +1,931 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "c5b1820fd3dfb0390fa3122d2d6e139f",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0, `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0, `bibleOnly` INTEGER NOT NULL DEFAULT 0, `isTextTransformation` INTEGER NOT NULL DEFAULT 0, `categoryId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "autoIncludeDocuments",
+            "columnName": "autoIncludeDocuments",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "autoIncludeCommentaries",
+            "columnName": "autoIncludeCommentaries",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bibleOnly",
+            "columnName": "bibleOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isTextTransformation",
+            "columnName": "isTextTransformation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_AgentPrompt_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, `aiLanguage` TEXT DEFAULT NULL, `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0, `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0, `hiddenBuiltInCategories` TEXT NOT NULL, `customAgentSystemPrompt` TEXT DEFAULT NULL, `customTextTransformationSystemPrompt` TEXT DEFAULT NULL, `favoritePrompts` TEXT NOT NULL, `rawLogRetentionDays` INTEGER DEFAULT 30, `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "15000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiLanguage",
+            "columnName": "aiLanguage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "askModelBeforeRun",
+            "columnName": "askModelBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aiDisclaimerAccepted",
+            "columnName": "aiDisclaimerAccepted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hiddenBuiltInCategories",
+            "columnName": "hiddenBuiltInCategories",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customAgentSystemPrompt",
+            "columnName": "customAgentSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "customTextTransformationSystemPrompt",
+            "columnName": "customTextTransformationSystemPrompt",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "favoritePrompts",
+            "columnName": "favoritePrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawLogRetentionDays",
+            "columnName": "rawLogRetentionDays",
+            "affinity": "INTEGER",
+            "defaultValue": "30"
+          },
+          {
+            "fieldPath": "autoHideAgentLogOnCompletion",
+            "columnName": "autoHideAgentLogOnCompletion",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmRawLogRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `promptId` BLOB, `promptName` TEXT NOT NULL, `promptDescription` TEXT, `configuredModelId` BLOB, `modelName` TEXT NOT NULL, `providerType` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `totalInputTokens` INTEGER NOT NULL, `totalOutputTokens` INTEGER NOT NULL, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptId",
+            "columnName": "promptId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "promptName",
+            "columnName": "promptName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptDescription",
+            "columnName": "promptDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "modelName",
+            "columnName": "modelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalInputTokens",
+            "columnName": "totalInputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalOutputTokens",
+            "columnName": "totalOutputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "logData",
+            "columnName": "logData",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iterationCount",
+            "columnName": "iterationCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "wasError",
+            "columnName": "wasError",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmRawLogRecord_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_promptId",
+            "unique": false,
+            "columnNames": [
+              "promptId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `${TABLE_NAME}` (`promptId`)"
+          },
+          {
+            "name": "index_LlmRawLogRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "PromptCategory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "BuiltinPromptOverride",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_BuiltinPromptOverride_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c5b1820fd3dfb0390fa3122d2d6e139f')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/3.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/3.json
@@ -1,0 +1,373 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "8c4ba2db34ea934850985ef133401c84",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "editBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c4ba2db34ea934850985ef133401c84')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/4.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/4.json
@@ -1,0 +1,535 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f2617a01e732d92655cc482da61ab59b",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "editBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, `customInputPrice` REAL NOT NULL DEFAULT 0.0, `customOutputPrice` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInputPrice",
+            "columnName": "customInputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "customOutputPrice",
+            "columnName": "customOutputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_providerConfigId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `${TABLE_NAME}` (`providerConfigId`, `deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f2617a01e732d92655cc482da61ab59b')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/5.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/5.json
@@ -1,0 +1,535 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "79f56a8289168f6c523498ee304a77f7",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "editBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, `customInputPrice` REAL NOT NULL DEFAULT 0.0, `customOutputPrice` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInputPrice",
+            "columnName": "customInputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "customOutputPrice",
+            "columnName": "customOutputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "4000"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_providerConfigId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `${TABLE_NAME}` (`providerConfigId`, `deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '79f56a8289168f6c523498ee304a77f7')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/6.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/6.json
@@ -1,0 +1,541 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "44771286d77cd66ed6bd171f22b85f48",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "editBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, `customInputPrice` REAL NOT NULL DEFAULT 0.0, `customOutputPrice` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInputPrice",
+            "columnName": "customInputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "customOutputPrice",
+            "columnName": "customOutputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000, `hiddenBuiltInPrompts` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "4000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_providerConfigId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `${TABLE_NAME}` (`providerConfigId`, `deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '44771286d77cd66ed6bd171f22b85f48')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/7.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/7.json
@@ -1,0 +1,554 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "d7f999f5bfbe041800525de7ea079ced",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, `customInputPrice` REAL NOT NULL DEFAULT 0.0, `customOutputPrice` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInputPrice",
+            "columnName": "customInputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "customOutputPrice",
+            "columnName": "customOutputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "4000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_providerConfigId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `${TABLE_NAME}` (`providerConfigId`, `deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd7f999f5bfbe041800525de7ea079ced')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/8.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/8.json
@@ -1,0 +1,560 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "beaee5ab47416e0e33fe1b5648280860",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `modelOverride` TEXT DEFAULT NULL, `providerConfigId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "modelOverride",
+            "columnName": "modelOverride",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `defaultModel` TEXT, `isDefault` INTEGER NOT NULL DEFAULT 0, `orderNumber` INTEGER NOT NULL DEFAULT 0, `customInputPrice` REAL NOT NULL DEFAULT 0.0, `customOutputPrice` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultModel",
+            "columnName": "defaultModel",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customInputPrice",
+            "columnName": "customInputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "customOutputPrice",
+            "columnName": "customOutputPrice",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "4000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_providerConfigId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `${TABLE_NAME}` (`providerConfigId`, `deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'beaee5ab47416e0e33fe1b5648280860')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/9.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsDatabase/9.json
@@ -1,0 +1,620 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "c72ce2565d4b73f61bfe567e97dfc07f",
+    "entities": [
+      {
+        "tableName": "AgentPrompt",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "promptTemplate",
+            "columnName": "promptTemplate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showIn",
+            "columnName": "showIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "strictContextMatching",
+            "columnName": "strictContextMatching",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "permissionMode",
+            "columnName": "permissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "allowedTools",
+            "columnName": "allowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "deniedTools",
+            "columnName": "deniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "specifyBeforeRun",
+            "columnName": "editBeforeRun",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "noDocumentCreation",
+            "columnName": "noDocumentCreation",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AgentPrompt_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          },
+          {
+            "name": "index_AgentPrompt_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_AgentPrompt_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmConfiguredModel",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "configuredModelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LlmProviderConfig",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT, `apiFormat` TEXT, `orderNumber` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerType",
+            "columnName": "providerType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpoint",
+            "columnName": "endpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiFormat",
+            "columnName": "apiFormat",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmProviderConfig_orderNumber",
+            "unique": false,
+            "columnNames": [
+              "orderNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `${TABLE_NAME}` (`orderNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LlmConfiguredModel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`), FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerConfigId",
+            "columnName": "providerConfigId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "modelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "inputPricePerMillion",
+            "columnName": "inputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "outputPricePerMillion",
+            "columnName": "outputPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheCreationPricePerMillion",
+            "columnName": "cacheCreationPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "cacheReadPricePerMillion",
+            "columnName": "cacheReadPricePerMillion",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId",
+            "unique": false,
+            "columnNames": [
+              "providerConfigId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `${TABLE_NAME}` (`providerConfigId`)"
+          },
+          {
+            "name": "index_LlmConfiguredModel_providerConfigId_modelId",
+            "unique": true,
+            "columnNames": [
+              "providerConfigId",
+              "modelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `${TABLE_NAME}` (`providerConfigId`, `modelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LlmProviderConfig",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "providerConfigId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalAiSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "agentPermissionMode",
+            "columnName": "agentPermissionMode",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyAllowedTools",
+            "columnName": "permanentlyAllowedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "permanentlyDeniedTools",
+            "columnName": "permanentlyDeniedTools",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "aiExcludedDocuments",
+            "columnName": "aiExcludedDocuments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryMaxResponseTokens",
+            "columnName": "commentaryMaxResponseTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "4000"
+          },
+          {
+            "fieldPath": "hiddenBuiltInPrompts",
+            "columnName": "hiddenBuiltInPrompts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxIterations",
+            "columnName": "maxIterations",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "10"
+          },
+          {
+            "fieldPath": "commentaryDeselected",
+            "columnName": "commentaryDeselected",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultModelId",
+            "columnName": "defaultModelId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LlmUsageRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configuredModelId",
+            "columnName": "configuredModelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputTokens",
+            "columnName": "inputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheCreationTokens",
+            "columnName": "cacheCreationTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "cacheReadTokens",
+            "columnName": "cacheReadTokens",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "estimatedCostUsd",
+            "columnName": "estimatedCostUsd",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LlmUsageRecord_configuredModelId",
+            "unique": false,
+            "columnNames": [
+              "configuredModelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `${TABLE_NAME}` (`configuredModelId`)"
+          },
+          {
+            "name": "index_LlmUsageRecord_configuredModelId_deviceId",
+            "unique": true,
+            "columnNames": [
+              "configuredModelId",
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `${TABLE_NAME}` (`configuredModelId`, `deviceId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c72ce2565d4b73f61bfe567e97dfc07f')"
+    ]
+  }
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrationSQL.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrationSQL.json
@@ -1,0 +1,110 @@
+{
+  "1": [
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `editBeforeRun` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "10": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiLanguage` TEXT DEFAULT NULL"
+  ],
+  "11": [
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "12": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "13": [
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `bibleOnly` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "14": [
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `isTextTransformation` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "15": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "16": [
+    "CREATE TABLE IF NOT EXISTS `PromptCategory` ( `id` BLOB NOT NULL PRIMARY KEY, `name` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0 )",
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `categoryId` BLOB DEFAULT NULL",
+    "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `AgentPrompt` (`categoryId`)"
+  ],
+  "17": [
+    "ALTER TABLE `PromptCategory` ADD COLUMN `hidden` INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInCategories` TEXT NOT NULL DEFAULT ''"
+  ],
+  "18": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `customAgentSystemPrompt` TEXT DEFAULT NULL",
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `customTextTransformationSystemPrompt` TEXT DEFAULT NULL"
+  ],
+  "19": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `favoritePrompts` TEXT NOT NULL DEFAULT ''"
+  ],
+  "2": [
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `noDocumentCreation` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "20": [
+    "CREATE TABLE IF NOT EXISTS `LlmRawLogRecord` ( `id` BLOB NOT NULL PRIMARY KEY, `promptId` BLOB DEFAULT NULL, `promptName` TEXT NOT NULL DEFAULT '', `promptDescription` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `modelName` TEXT NOT NULL DEFAULT '', `providerType` TEXT NOT NULL DEFAULT '', `timestamp` INTEGER NOT NULL DEFAULT 0, `totalInputTokens` INTEGER NOT NULL DEFAULT 0, `totalOutputTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, `logData` BLOB NOT NULL, `iterationCount` INTEGER NOT NULL DEFAULT 0, `wasError` INTEGER NOT NULL DEFAULT 0 )",
+    "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `LlmRawLogRecord` (`timestamp`)",
+    "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `LlmRawLogRecord` (`promptId`)",
+    "CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `LlmRawLogRecord` (`configuredModelId`)",
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `rawLogRetentionDays` INTEGER DEFAULT 30"
+  ],
+  "21": [
+    "CREATE TABLE IF NOT EXISTS `BuiltinPromptOverride` ( `id` BLOB NOT NULL PRIMARY KEY, `configuredModelId` BLOB DEFAULT NULL, FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+    "CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `BuiltinPromptOverride` (`configuredModelId`)"
+  ],
+  "22": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0"
+  ],
+  "3": [
+    "CREATE TABLE IF NOT EXISTS `GlobalAiSettings` ( `id` BLOB NOT NULL PRIMARY KEY, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 0 )",
+    "CREATE TABLE IF NOT EXISTS `LlmUsageRecord` ( `id` BLOB NOT NULL PRIMARY KEY, `providerConfigId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0, FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+    "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `LlmUsageRecord` (`providerConfigId`)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `LlmUsageRecord` (`providerConfigId`, `deviceId`)",
+    "ALTER TABLE `LlmProviderConfig` ADD COLUMN `customInputPrice` REAL NOT NULL DEFAULT 0.0",
+    "ALTER TABLE `LlmProviderConfig` ADD COLUMN `customOutputPrice` REAL NOT NULL DEFAULT 0.0"
+  ],
+  "4": [
+    "CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` ( `id` BLOB NOT NULL PRIMARY KEY, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000 )",
+    "INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`) SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, CASE WHEN `commentaryMaxResponseTokens` = 0 THEN 4000 ELSE `commentaryMaxResponseTokens` END FROM `GlobalAiSettings`",
+    "DROP TABLE `GlobalAiSettings`",
+    "ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`"
+  ],
+  "5": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInPrompts` TEXT NOT NULL DEFAULT ''"
+  ],
+  "6": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `maxIterations` INTEGER NOT NULL DEFAULT 10",
+    "ALTER TABLE `AgentPrompt` ADD COLUMN `maxIterations` INTEGER DEFAULT NULL"
+  ],
+  "7": [
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `commentaryDeselected` TEXT NOT NULL DEFAULT ''"
+  ],
+  "8": [
+    "CREATE TABLE IF NOT EXISTS `LlmConfiguredModel` ( `id` BLOB NOT NULL PRIMARY KEY, `providerConfigId` BLOB NOT NULL, `modelId` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0, `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0, FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+    "CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `LlmConfiguredModel` (`providerConfigId`)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `LlmConfiguredModel` (`providerConfigId`, `modelId`)",
+    "CREATE TABLE IF NOT EXISTS `LlmProviderConfig_new` ( `id` BLOB NOT NULL PRIMARY KEY, `providerType` TEXT NOT NULL, `displayName` TEXT NOT NULL, `endpoint` TEXT DEFAULT NULL, `apiFormat` TEXT DEFAULT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0 )",
+    "INSERT INTO `LlmProviderConfig_new` (`id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber`) SELECT `id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber` FROM `LlmProviderConfig`",
+    "DROP TABLE `LlmProviderConfig`",
+    "ALTER TABLE `LlmProviderConfig_new` RENAME TO `LlmProviderConfig`",
+    "CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `LlmProviderConfig` (`orderNumber`)",
+    "CREATE TABLE IF NOT EXISTS `AgentPrompt_new` ( `id` BLOB NOT NULL PRIMARY KEY, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `promptTemplate` TEXT NOT NULL, `showIn` TEXT NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `createdAt` INTEGER NOT NULL DEFAULT 0, `strictContextMatching` INTEGER NOT NULL DEFAULT 1, `permissionMode` TEXT DEFAULT NULL, `allowedTools` TEXT DEFAULT NULL, `deniedTools` TEXT DEFAULT NULL, `configuredModelId` BLOB DEFAULT NULL, `editBeforeRun` INTEGER NOT NULL DEFAULT 0, `noDocumentCreation` INTEGER NOT NULL DEFAULT 0, `maxIterations` INTEGER DEFAULT NULL, FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+    "INSERT INTO `AgentPrompt_new` (`id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, `configuredModelId`, `editBeforeRun`, `noDocumentCreation`, `maxIterations`) SELECT `id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, NULL, `editBeforeRun`, `noDocumentCreation`, `maxIterations` FROM `AgentPrompt`",
+    "DROP TABLE `AgentPrompt`",
+    "ALTER TABLE `AgentPrompt_new` RENAME TO `AgentPrompt`",
+    "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `AgentPrompt` (`orderNumber`)",
+    "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `AgentPrompt` (`createdAt`)",
+    "CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `AgentPrompt` (`configuredModelId`)",
+    "CREATE TABLE IF NOT EXISTS `LlmUsageRecord_new` ( `id` BLOB NOT NULL PRIMARY KEY, `configuredModelId` BLOB NOT NULL, `deviceId` TEXT NOT NULL, `inputTokens` INTEGER NOT NULL DEFAULT 0, `outputTokens` INTEGER NOT NULL DEFAULT 0, `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0, `cacheReadTokens` INTEGER NOT NULL DEFAULT 0, `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0 )",
+    "DROP TABLE `LlmUsageRecord`",
+    "ALTER TABLE `LlmUsageRecord_new` RENAME TO `LlmUsageRecord`",
+    "CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `LlmUsageRecord` (`configuredModelId`)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `LlmUsageRecord` (`configuredModelId`, `deviceId`)",
+    "ALTER TABLE `GlobalAiSettings` ADD COLUMN `defaultModelId` BLOB DEFAULT NULL"
+  ],
+  "9": [
+    "CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` ( `id` BLOB NOT NULL PRIMARY KEY, `agentPermissionMode` TEXT DEFAULT NULL, `permanentlyAllowedTools` TEXT DEFAULT NULL, `permanentlyDeniedTools` TEXT DEFAULT NULL, `aiExcludedDocuments` TEXT NOT NULL, `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000, `hiddenBuiltInPrompts` TEXT NOT NULL, `maxIterations` INTEGER NOT NULL DEFAULT 10, `commentaryDeselected` TEXT NOT NULL, `defaultModelId` BLOB DEFAULT NULL )",
+    "INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`, `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId`) SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, CASE WHEN `commentaryMaxResponseTokens` = 4000 THEN 15000 ELSE `commentaryMaxResponseTokens` END, `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId` FROM `GlobalAiSettings`",
+    "DROP TABLE `GlobalAiSettings`",
+    "ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`"
+  ]
+}

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrationUtilities.kt
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrationUtilities.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023-2024 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package net.bible.android.database.migrations
+
+import android.util.Log
+import androidx.room.migration.Migration as RoomMigration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+abstract class Migration(startVersion: Int, endVersion: Int): RoomMigration(startVersion, endVersion) {
+    abstract fun doMigrate(db: SupportSQLiteDatabase)
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        Log.i(TAG, "Migrating from version $startVersion to $endVersion")
+        disableSyncTriggers(db)
+        try {
+            doMigrate(db)
+        } finally {
+            enableSyncTriggers(db)
+        }
+    }
+}
+
+/**
+ * Disable sync triggers during migrations to prevent unnecessary LogEntry rows
+ * from data-shuffling operations (e.g. column migrations with UPDATE statements).
+ * SyncConfiguration table may not exist yet in early migrations, so we check first.
+ */
+private fun disableSyncTriggers(db: SupportSQLiteDatabase) {
+    if (hasSyncConfigurationTable(db)) {
+        db.execSQL("INSERT OR REPLACE INTO SyncConfiguration (keyName, booleanValue) VALUES ('triggersDisabled', 1)")
+    }
+}
+
+private fun enableSyncTriggers(db: SupportSQLiteDatabase) {
+    if (hasSyncConfigurationTable(db)) {
+        db.execSQL("DELETE FROM SyncConfiguration WHERE keyName = 'triggersDisabled'")
+    }
+}
+
+private fun hasSyncConfigurationTable(db: SupportSQLiteDatabase): Boolean {
+    db.query("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='SyncConfiguration'").use { cursor ->
+        return cursor.moveToFirst() && cursor.getInt(0) > 0
+    }
+}
+
+fun makeMigration(versionRange: IntRange, migration: (db: SupportSQLiteDatabase) -> Unit): Migration =
+    object: Migration(versionRange.first, versionRange.last) {
+        override fun doMigrate(db: SupportSQLiteDatabase) {
+            migration.invoke(db)
+        }
+    }

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrations.kt
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/AiSettingsMigrations.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2024-2026 Sykerö Software / Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package net.bible.android.database.migrations
+
+import androidx.room.migration.Migration
+
+private val addEditBeforeRun = makeMigration(1..2) { db ->
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `editBeforeRun` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addNoDocumentCreation = makeMigration(2..3) { db ->
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `noDocumentCreation` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addGlobalAiSettingsAndUsage = makeMigration(3..4) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `GlobalAiSettings` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `agentPermissionMode` TEXT DEFAULT NULL,
+        `permanentlyAllowedTools` TEXT DEFAULT NULL,
+        `permanentlyDeniedTools` TEXT DEFAULT NULL,
+        `aiExcludedDocuments` TEXT NOT NULL,
+        `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 0
+    )""")
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `LlmUsageRecord` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `providerConfigId` BLOB NOT NULL,
+        `deviceId` TEXT NOT NULL,
+        `inputTokens` INTEGER NOT NULL DEFAULT 0,
+        `outputTokens` INTEGER NOT NULL DEFAULT 0,
+        `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0,
+        `cacheReadTokens` INTEGER NOT NULL DEFAULT 0,
+        `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0,
+        FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+    )""")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId` ON `LlmUsageRecord` (`providerConfigId`)")
+    db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_providerConfigId_deviceId` ON `LlmUsageRecord` (`providerConfigId`, `deviceId`)")
+    db.execSQL("ALTER TABLE `LlmProviderConfig` ADD COLUMN `customInputPrice` REAL NOT NULL DEFAULT 0.0")
+    db.execSQL("ALTER TABLE `LlmProviderConfig` ADD COLUMN `customOutputPrice` REAL NOT NULL DEFAULT 0.0")
+}
+
+private val setCommentaryTokenDefault = makeMigration(4..5) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `agentPermissionMode` TEXT DEFAULT NULL,
+        `permanentlyAllowedTools` TEXT DEFAULT NULL,
+        `permanentlyDeniedTools` TEXT DEFAULT NULL,
+        `aiExcludedDocuments` TEXT NOT NULL,
+        `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 4000
+    )""")
+    db.execSQL("""INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`)
+        SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`,
+            CASE WHEN `commentaryMaxResponseTokens` = 0 THEN 4000 ELSE `commentaryMaxResponseTokens` END
+        FROM `GlobalAiSettings`""")
+    db.execSQL("DROP TABLE `GlobalAiSettings`")
+    db.execSQL("ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`")
+}
+
+private val addHiddenBuiltInPrompts = makeMigration(5..6) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInPrompts` TEXT NOT NULL DEFAULT ''")
+}
+
+private val addMaxIterations = makeMigration(6..7) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `maxIterations` INTEGER NOT NULL DEFAULT 10")
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `maxIterations` INTEGER DEFAULT NULL")
+}
+
+private val addCommentaryDeselected = makeMigration(7..8) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `commentaryDeselected` TEXT NOT NULL DEFAULT ''")
+}
+
+private val addConfiguredModels = makeMigration(8..9) { db ->
+    // 1. Create LlmConfiguredModel table
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `LlmConfiguredModel` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `providerConfigId` BLOB NOT NULL,
+        `modelId` TEXT NOT NULL,
+        `orderNumber` INTEGER NOT NULL DEFAULT 0,
+        `inputPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+        `outputPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+        `cacheCreationPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+        `cacheReadPricePerMillion` REAL NOT NULL DEFAULT 0.0,
+        FOREIGN KEY(`providerConfigId`) REFERENCES `LlmProviderConfig`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+    )""")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId` ON `LlmConfiguredModel` (`providerConfigId`)")
+    db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmConfiguredModel_providerConfigId_modelId` ON `LlmConfiguredModel` (`providerConfigId`, `modelId`)")
+
+    // 2. Rebuild LlmProviderConfig without removed columns (defaultModel, isDefault, customInputPrice, customOutputPrice)
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `LlmProviderConfig_new` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `providerType` TEXT NOT NULL,
+        `displayName` TEXT NOT NULL,
+        `endpoint` TEXT DEFAULT NULL,
+        `apiFormat` TEXT DEFAULT NULL,
+        `orderNumber` INTEGER NOT NULL DEFAULT 0
+    )""")
+    db.execSQL("""INSERT INTO `LlmProviderConfig_new` (`id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber`)
+        SELECT `id`, `providerType`, `displayName`, `endpoint`, `apiFormat`, `orderNumber` FROM `LlmProviderConfig`""")
+    db.execSQL("DROP TABLE `LlmProviderConfig`")
+    db.execSQL("ALTER TABLE `LlmProviderConfig_new` RENAME TO `LlmProviderConfig`")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmProviderConfig_orderNumber` ON `LlmProviderConfig` (`orderNumber`)")
+
+    // 3. Rebuild AgentPrompt: replace providerConfigId + modelOverride with configuredModelId
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `AgentPrompt_new` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `name` TEXT NOT NULL,
+        `description` TEXT DEFAULT NULL,
+        `promptTemplate` TEXT NOT NULL,
+        `showIn` TEXT NOT NULL,
+        `orderNumber` INTEGER NOT NULL DEFAULT 0,
+        `createdAt` INTEGER NOT NULL DEFAULT 0,
+        `strictContextMatching` INTEGER NOT NULL DEFAULT 1,
+        `permissionMode` TEXT DEFAULT NULL,
+        `allowedTools` TEXT DEFAULT NULL,
+        `deniedTools` TEXT DEFAULT NULL,
+        `configuredModelId` BLOB DEFAULT NULL,
+        `editBeforeRun` INTEGER NOT NULL DEFAULT 0,
+        `noDocumentCreation` INTEGER NOT NULL DEFAULT 0,
+        `maxIterations` INTEGER DEFAULT NULL,
+        FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+    )""")
+    db.execSQL("""INSERT INTO `AgentPrompt_new` (`id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, `configuredModelId`, `editBeforeRun`, `noDocumentCreation`, `maxIterations`)
+        SELECT `id`, `name`, `description`, `promptTemplate`, `showIn`, `orderNumber`, `createdAt`, `strictContextMatching`, `permissionMode`, `allowedTools`, `deniedTools`, NULL, `editBeforeRun`, `noDocumentCreation`, `maxIterations` FROM `AgentPrompt`""")
+    db.execSQL("DROP TABLE `AgentPrompt`")
+    db.execSQL("ALTER TABLE `AgentPrompt_new` RENAME TO `AgentPrompt`")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_AgentPrompt_orderNumber` ON `AgentPrompt` (`orderNumber`)")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_AgentPrompt_createdAt` ON `AgentPrompt` (`createdAt`)")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_AgentPrompt_configuredModelId` ON `AgentPrompt` (`configuredModelId`)")
+
+    // 4. Rebuild LlmUsageRecord: replace providerConfigId with configuredModelId
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `LlmUsageRecord_new` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `configuredModelId` BLOB NOT NULL,
+        `deviceId` TEXT NOT NULL,
+        `inputTokens` INTEGER NOT NULL DEFAULT 0,
+        `outputTokens` INTEGER NOT NULL DEFAULT 0,
+        `cacheCreationTokens` INTEGER NOT NULL DEFAULT 0,
+        `cacheReadTokens` INTEGER NOT NULL DEFAULT 0,
+        `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0
+    )""")
+    // Old usage records are dropped (no way to map providerConfigId → configuredModelId)
+    db.execSQL("DROP TABLE `LlmUsageRecord`")
+    db.execSQL("ALTER TABLE `LlmUsageRecord_new` RENAME TO `LlmUsageRecord`")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId` ON `LlmUsageRecord` (`configuredModelId`)")
+    db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_LlmUsageRecord_configuredModelId_deviceId` ON `LlmUsageRecord` (`configuredModelId`, `deviceId`)")
+
+    // 5. Add defaultModelId to GlobalAiSettings
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `defaultModelId` BLOB DEFAULT NULL")
+}
+
+private val raiseCommentaryTokenDefault = makeMigration(9..10) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `GlobalAiSettings_new` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `agentPermissionMode` TEXT DEFAULT NULL,
+        `permanentlyAllowedTools` TEXT DEFAULT NULL,
+        `permanentlyDeniedTools` TEXT DEFAULT NULL,
+        `aiExcludedDocuments` TEXT NOT NULL,
+        `commentaryMaxResponseTokens` INTEGER NOT NULL DEFAULT 15000,
+        `hiddenBuiltInPrompts` TEXT NOT NULL,
+        `maxIterations` INTEGER NOT NULL DEFAULT 10,
+        `commentaryDeselected` TEXT NOT NULL,
+        `defaultModelId` BLOB DEFAULT NULL
+    )""")
+    db.execSQL("""INSERT INTO `GlobalAiSettings_new` (`id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`, `commentaryMaxResponseTokens`, `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId`)
+        SELECT `id`, `agentPermissionMode`, `permanentlyAllowedTools`, `permanentlyDeniedTools`, `aiExcludedDocuments`,
+            CASE WHEN `commentaryMaxResponseTokens` = 4000 THEN 15000 ELSE `commentaryMaxResponseTokens` END,
+            `hiddenBuiltInPrompts`, `maxIterations`, `commentaryDeselected`, `defaultModelId`
+        FROM `GlobalAiSettings`""")
+    db.execSQL("DROP TABLE `GlobalAiSettings`")
+    db.execSQL("ALTER TABLE `GlobalAiSettings_new` RENAME TO `GlobalAiSettings`")
+}
+
+private val addAiLanguage = makeMigration(10..11) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiLanguage` TEXT DEFAULT NULL")
+}
+
+private val addAutoIncludeFields = makeMigration(11..12) { db ->
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0")
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addAskModelBeforeRun = makeMigration(12..13) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `askModelBeforeRun` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addBibleOnly = makeMigration(13..14) { db ->
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `bibleOnly` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addIsTextTransformation = makeMigration(14..15) { db ->
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `isTextTransformation` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addAiDisclaimerAccepted = makeMigration(15..16) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `aiDisclaimerAccepted` INTEGER NOT NULL DEFAULT 0")
+}
+
+private val addPromptCategories = makeMigration(16..17) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `PromptCategory` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `name` TEXT NOT NULL,
+        `orderNumber` INTEGER NOT NULL DEFAULT 0
+    )""")
+    db.execSQL("ALTER TABLE `AgentPrompt` ADD COLUMN `categoryId` BLOB DEFAULT NULL")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_AgentPrompt_categoryId` ON `AgentPrompt` (`categoryId`)")
+}
+
+private val addCategoryHidden = makeMigration(17..18) { db ->
+    db.execSQL("ALTER TABLE `PromptCategory` ADD COLUMN `hidden` INTEGER NOT NULL DEFAULT 0")
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `hiddenBuiltInCategories` TEXT NOT NULL DEFAULT ''")
+}
+
+private val addCustomSystemPrompts = makeMigration(18..19) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `customAgentSystemPrompt` TEXT DEFAULT NULL")
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `customTextTransformationSystemPrompt` TEXT DEFAULT NULL")
+}
+
+private val addFavoritePrompts = makeMigration(19..20) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `favoritePrompts` TEXT NOT NULL DEFAULT ''")
+}
+
+private val addRawLogTable = makeMigration(20..21) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `LlmRawLogRecord` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `promptId` BLOB DEFAULT NULL,
+        `promptName` TEXT NOT NULL DEFAULT '',
+        `promptDescription` TEXT DEFAULT NULL,
+        `configuredModelId` BLOB DEFAULT NULL,
+        `modelName` TEXT NOT NULL DEFAULT '',
+        `providerType` TEXT NOT NULL DEFAULT '',
+        `timestamp` INTEGER NOT NULL DEFAULT 0,
+        `totalInputTokens` INTEGER NOT NULL DEFAULT 0,
+        `totalOutputTokens` INTEGER NOT NULL DEFAULT 0,
+        `estimatedCostUsd` REAL NOT NULL DEFAULT 0.0,
+        `logData` BLOB NOT NULL,
+        `iterationCount` INTEGER NOT NULL DEFAULT 0,
+        `wasError` INTEGER NOT NULL DEFAULT 0
+    )""")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_timestamp` ON `LlmRawLogRecord` (`timestamp`)")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_promptId` ON `LlmRawLogRecord` (`promptId`)")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_LlmRawLogRecord_configuredModelId` ON `LlmRawLogRecord` (`configuredModelId`)")
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `rawLogRetentionDays` INTEGER DEFAULT 30")
+}
+
+private val addBuiltinPromptOverride = makeMigration(21..22) { db ->
+    db.execSQL("""CREATE TABLE IF NOT EXISTS `BuiltinPromptOverride` (
+        `id` BLOB NOT NULL PRIMARY KEY,
+        `configuredModelId` BLOB DEFAULT NULL,
+        FOREIGN KEY(`configuredModelId`) REFERENCES `LlmConfiguredModel`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+    )""")
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_BuiltinPromptOverride_configuredModelId` ON `BuiltinPromptOverride` (`configuredModelId`)")
+}
+
+private val addAutoHideAgentLog = makeMigration(22..23) { db ->
+    db.execSQL("ALTER TABLE `GlobalAiSettings` ADD COLUMN `autoHideAgentLogOnCompletion` INTEGER NOT NULL DEFAULT 0")
+}
+
+val aiSettingsMigrations: Array<Migration> = arrayOf(addEditBeforeRun, addNoDocumentCreation, addGlobalAiSettingsAndUsage, setCommentaryTokenDefault, addHiddenBuiltInPrompts, addMaxIterations, addCommentaryDeselected, addConfiguredModels, raiseCommentaryTokenDefault, addAiLanguage, addAutoIncludeFields, addAskModelBeforeRun, addBibleOnly, addIsTextTransformation, addAiDisclaimerAccepted, addPromptCategories, addCategoryHidden, addCustomSystemPrompts, addFavoritePrompts, addRawLogTable, addBuiltinPromptOverride, addAutoHideAgentLog)

--- a/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/ai-settings-authority.json
+++ b/Sources/BibleCore/Tests/Fixtures/AndroidRoomSchemas/ai-settings-authority.json
@@ -1,0 +1,51 @@
+{
+  "androidCommit": "0f3b85823cebbfafeb5a51675827f5314cac3c56",
+  "androidSourceSHA256": {
+    "app/src/main/java/net/bible/android/database/Databases.kt": "c2f5102e1887f55abd94d95bf7c83470e1d7fdcc604b0c7a558adada949fa2dc",
+    "app/src/main/java/net/bible/service/cloudsync/SyncUtilities.kt": "39ad71a66585eb971698351bfe34f026ba4d0124f08f6bf806ec2cd293c5c007",
+    "app/src/main/java/net/bible/service/common/AiSettings.kt": "f5f198cf970a2d8e7dce25e15db1dd36410303584183cb1b7e831079595478a3",
+    "app/src/main/java/net/bible/service/db/DatabaseContainer.kt": "d486a92c74f3cc75886705670a13c155e55795fc283f8836f35a2b97e6c6919f",
+    "app/src/main/java/net/bible/service/llm/AgentPromptEntities.kt": "2385849c7626d7b41dc8008de811eac64b6de53bd6642c41d890e6a6e7a66d45",
+    "app/src/main/java/net/bible/service/llm/LlmCostTracking.kt": "77098da32dea6920efca0bbf0d42c1e83074aabef86219d2f9a4ff9fbbddc44d"
+  },
+  "currentIdentityHash": "c5b1820fd3dfb0390fa3122d2d6e139f",
+  "currentVersion": 23,
+  "derivedSchemaAuthority": {
+    "12": {
+      "baseExportVersion": 11,
+      "canonicalSchemaSHA256": "1fcdbebe0865065824e82c0a995c7c216bce2de8e483f90f6daec3746aa39149",
+      "identityHash": "ce84fdcfd2da69ec7a3dbb0a48598c5b",
+      "introducingAndroidCommit": "b75638905579b061a60485e4559396d5adf755da",
+      "migrationFromVersion": 11,
+      "migrationToVersion": 12,
+      "roomCompilerVersion": "2.7.2"
+    }
+  },
+  "migrationSHA256": "efb0d42f4748a6a3d093d1ba5f824d2bb40ec52e7b4892af4cc6409a2f2255fe",
+  "migrationSQLSHA256": "f578fa0daa2484a115ae8f7fbc682c852c1121e19bee2e1af666a61c4a01c41c",
+  "schemaSHA256": {
+    "1": "4830e45c022f52606a429262d447b8876ce55a01ca4dad60b104a90c3b2e65ed",
+    "2": "675729f112b25639a57d94a46af3b1c6fb00f4c8a0690965d7ae7df347fa09b5",
+    "3": "ebfcc5d4009fe58a9653870659c8e6e519648c7d6012ae22fe17ded3edf7140a",
+    "4": "2032190c61643b424cc7661ad3565005e9643c9f220a070a64fb206e3488da23",
+    "5": "111dd3a9f3fdcd8f459504c254f061b9a5ce831e266d02c43c770f37ca2cd5c0",
+    "6": "de819bed6bbcd2bba7df2946321f7572120254ba132a463d43c3e4157c5aee9d",
+    "7": "2b925287a16f512d145f6f74b8828ab0124d3b2cf62b1ee37805261e2af7b3d8",
+    "8": "0c58783eda96bdbd2d6074855ffc6c6532576597eb7a409c3f59f3375332086c",
+    "9": "8aa3a31355bd5ceb8fc7f1e85d073d1148243b9ee955f725ea8912d8e4d29b3a",
+    "10": "196d0687023d5b891021ed166454e36aa295e2d78bae4d61fb7250f951c7ceb7",
+    "11": "1078c623296925fe5006fa2df921c81bec096ca09a9d479b9ca64bb8ddc1058d",
+    "13": "7f4ae9d7c15b825ecdffb8f5a4bbcd56da16debe500c2b30f55486b2706c5679",
+    "14": "02b94e3020f1b50848b6c12054f55a294dd6d6168f6466d83ec61c2c40423e2f",
+    "15": "95bd373db14d8179f45c1e25917f49e35b505daae161f703853ed4d228141758",
+    "16": "91cc8f7f3769a9e696c448c749bc8a442eab56598e8f85d568833a7292908405",
+    "17": "467c34b5c33c2a8760fecdfebd314c1d2528c048db78b789f982e3c7e92cfa09",
+    "18": "4b5d992a894386597b9469514f573372de2d8580e00bba823657fd04f87c5727",
+    "19": "1b817e89684cb2f4fe90ba29e256750851954ac6b50be7503aee3936992ce9b2",
+    "20": "0ed49e8db55326e84f6a289c77fee9bee3e1809cc01c35157e02f719b09ec85f",
+    "21": "c4fe5713d746e72139120cb4be044c1bbb86a8e8a5b04d2d3dc15ef8a9464952",
+    "22": "8b33721451c80300a1ba9a9a15c44ba97fb2b5a0cc42ee9c7d42bab340a768f7",
+    "23": "20a21c054971dda8911fcbbecb8d5435eefe7534b22c90cb76e0d8e455e8029e"
+  },
+  "utilitySHA256": "9398f2c7b4c02cf3488f48654d33c5d49ad11aff18739ccc8e7706fe40438415"
+}

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentation.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsPresentation.swift
@@ -1,5 +1,6 @@
 // SyncSettingsPresentation.swift - Android-backed sync settings row metadata
 
+import Foundation
 import BibleCore
 
 /**
@@ -49,6 +50,129 @@ public struct RemoteSyncLocalizedString: Equatable, Sendable {
 }
 
 /**
+ Android-aligned user-facing classification for remote synchronization failures.
+
+ Both the settings screen and app lifecycle route errors through this value so initial-backup and
+ incremental schema incompatibilities cannot drift into different messages. The initializer keeps
+ transport and schema types out of view-specific switch statements while preserving an underlying
+ localized message for failures Android does not classify specially.
+
+ - Side effects: none.
+ - Failure modes: Empty underlying messages resolve to Android's generic sync error text.
+ */
+public enum RemoteSyncFailurePresentation: Equatable, Sendable {
+    /// Backend URL or saved WebDAV configuration is invalid.
+    case invalidURL
+
+    /// A required device-local WebDAV password is absent.
+    case signInFailed
+
+    /// Remote initial or incremental data requires a newer app schema.
+    case updateRequired
+
+    /// Transport or domain failure that should retain its supplied localized description.
+    case underlying(String)
+
+    /**
+     Classifies one core synchronization error using Android's visible failure groups.
+
+     - Parameter error: Error emitted by backend construction, bootstrap, staging, or patch replay.
+     - Returns: Stable presentation category shared by manual and lifecycle synchronization.
+     - Side effects: Reads only the error's localized description.
+     - Failure modes: Unknown errors become `.underlying`; an empty description is handled by
+       `localizedMessage`.
+     */
+    public init(error: Error) {
+        switch error {
+        case WebDAVClientError.invalidURL,
+             RemoteSyncSynchronizationServiceFactoryError.invalidWebDAVConfiguration:
+            self = .invalidURL
+        case RemoteSyncSynchronizationServiceFactoryError.missingWebDAVPassword:
+            self = .signInFailed
+        case RemoteSyncArchiveStagingError.incompatibleInitialBackupVersion,
+             RemoteSyncPatchDiscoveryError.incompatiblePatchVersion,
+             RemoteSyncSchemaCompatibilityPolicyError.disabledForCurrentVersion:
+            self = .updateRequired
+        default:
+            self = .underlying(
+                error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+    }
+
+    /**
+     Resolves the classified failure through Android-backed localization keys.
+
+     - Returns: Localized alert text with checked-in English fallbacks.
+     - Side effects: Reads the process localization bundle.
+     - Failure modes: Missing keys use the documented English fallback; empty underlying errors use
+       Android's generic cloud-sync error.
+     */
+    public var localizedMessage: String {
+        switch self {
+        case .invalidURL:
+            return RemoteSyncLocalizedString(
+                key: "invalid_url_message",
+                defaultValue: "The URL you entered is invalid. Please enter a valid URL (e.g., https://nextcloud.example.com)"
+            ).localized
+        case .signInFailed:
+            return RemoteSyncLocalizedString(
+                key: "sign_in_failed",
+                defaultValue: "Signing in to synchronization backend service failed."
+            ).localized
+        case .updateRequired:
+            return [
+                RemoteSyncLocalizedString(
+                    key: "sync_cant_fetch",
+                    defaultValue: "The version of database or patch file stored in Cloud is higher than the one supported by this app."
+                ).localized,
+                RemoteSyncLocalizedString(
+                    key: "sync_update_app",
+                    defaultValue: "Please update the app to continue synchronization."
+                ).localized,
+            ]
+            .joined(separator: " ")
+        case .underlying(let message):
+            guard !message.isEmpty else {
+                return RemoteSyncLocalizedString(
+                    key: "sync_error",
+                    defaultValue: "Error occurred in Cloud synchronization"
+                ).localized
+            }
+            return message
+        }
+    }
+}
+
+/**
+ Determines how the settings screen reconciles its optimistic category-toggle state after failure.
+
+ Configuration failures occur before the persisted toggle is enabled and must turn the visible
+ switch off. Failures after synchronization starts may have changed the persisted value through
+ schema policy, so the UI must reload that authoritative value instead of retaining its optimistic
+ state.
+ */
+enum RemoteSyncFailureEnablementResolution: Equatable, Sendable {
+    /// Persist and display the category as disabled.
+    case disable
+
+    /// Reload the displayed state from the already-authoritative persisted toggle.
+    case reloadPersisted
+
+    /**
+     Maps the caller's failure phase to one deterministic toggle reconciliation action.
+
+     - Parameter revertEnablement: `true` when setup failed before the toggle was persisted.
+     - Returns: Disable for setup failure, otherwise reload persisted state.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    init(revertEnablement: Bool) {
+        self = revertEnablement ? .disable : .reloadPersisted
+    }
+}
+
+/**
  Android-backed title and content strings for one remote sync category.
 
  Android exposes each sync category as a preference title plus summary. iOS uses this descriptor
@@ -84,8 +208,8 @@ public struct RemoteSyncCategoryText: Equatable, Sendable {
 /**
  Android-backed localization catalog for remote sync categories.
 
- The catalog centralizes category title and summary keys so active settings rows, deferred rows,
- and app lifecycle error copy cannot drift independently.
+ The catalog centralizes category title and summary keys so settings rows and app lifecycle error
+ copy cannot drift independently.
 
  - Returns: Android string descriptors for sync category copy.
  - Side effects: none.
@@ -122,6 +246,14 @@ public enum RemoteSyncCategoryLocalization {
                 title: .init(key: "my_documents", defaultValue: "My Documents"),
                 contents: .init(key: "my_documents_contents", defaultValue: "My Documents and their content")
             )
+        case .aiSettings:
+            return RemoteSyncCategoryText(
+                title: .init(key: "ai_settings_sync_title", defaultValue: "AI Settings"),
+                contents: .init(
+                    key: "ai_settings_sync_contents",
+                    defaultValue: "AI prompts and provider configurations"
+                )
+            )
         case .progress:
             return RemoteSyncCategoryText(
                 title: .init(key: "progress_sync_title", defaultValue: "Reading Progress"),
@@ -133,29 +265,6 @@ public enum RemoteSyncCategoryLocalization {
         }
     }
 
-    /**
-     Returns Android title and summary descriptors for a visible deferred sync category.
-
-     Deferred categories use the same Android title/content resources as the future active
-     implementation so the visible parity surface does not change when the engine lands.
-
-     - Parameter category: Android-visible category whose iOS sync engine is not implemented yet.
-     - Returns: Android-backed title/content descriptors.
-     - Side effects: none.
-     - Failure modes: This helper cannot fail because all deferred categories are mapped.
-     */
-    static func deferredText(for category: RemoteSyncDeferredCategory) -> RemoteSyncCategoryText {
-        switch category {
-        case .aiSettings:
-            return RemoteSyncCategoryText(
-                title: .init(key: "ai_settings_sync_title", defaultValue: "AI Settings"),
-                contents: .init(
-                    key: "ai_settings_sync_contents",
-                    defaultValue: "AI prompts and provider configurations"
-                )
-            )
-        }
-    }
 }
 
 /**
@@ -217,15 +326,14 @@ enum SyncSettingsPresentation {
 
     /**
      Android runtime-visible category rows, excluding Reading Plans because `SyncSettings.kt`
-     hides that XML-declared preference and including deferred rows whose iOS sync engines are
-     tracked separately.
+     hides that XML-declared preference.
      */
-    static let visibleCategoryRows: [SyncSettingsCategoryRow] = [
-        .active(.bookmarks),
-        .active(.workspaces),
-        .active(.myDocuments),
-        .deferred(.aiSettings),
-        .active(.progress),
+    static let visibleCategoryRows: [RemoteSyncCategory] = [
+        .bookmarks,
+        .workspaces,
+        .myDocuments,
+        .aiSettings,
+        .progress,
     ]
 
     /**
@@ -246,87 +354,10 @@ enum SyncSettingsPresentation {
             return Row(androidKey: "sync_reading_plans")
         case .myDocuments:
             return Row(androidKey: "sync_documents")
-        case .progress:
-            return Row(androidKey: "sync_reading_progress")
-        }
-    }
-
-    /**
-     Returns the Android presentation row for a deferred remote sync category.
-
-     Deferred rows are visible because Android shows their toggles, but iOS keeps them disabled
-     until the category-specific sync implementation exists. Keeping their Android icon mapping
-     here prevents the UI from drifting while those follow-up issues remain open.
-
-     - Parameter category: Deferred Android-visible category shown in the sync settings list.
-     - Returns: Android-backed row metadata for the deferred category.
-     - Side effects: none.
-     - Failure modes: This helper cannot fail; every deferred category has an Android row mapping.
-     */
-    static func deferredCategory(_ category: RemoteSyncDeferredCategory) -> Row {
-        switch category {
         case .aiSettings:
             return Row(androidKey: "sync_ai")
-        }
-    }
-}
-
-/**
- Android-visible sync categories that iOS intentionally displays as disabled deferred rows.
-
- Android exposes AI Settings in `sync_settings.xml` and wires it through `SyncSettings.kt`. iOS
- does not yet have that category-specific sync engine, so this value preserves the visible parity
- surface without letting users start an unsupported sync stream.
-
- - Returns: Value semantics for visible settings rows and tests.
- - Side effects: none.
- - Failure modes: Deferred categories cannot start synchronization until their follow-up issue
-   provides a real `RemoteSyncCategory` implementation.
- */
-enum RemoteSyncDeferredCategory: String, CaseIterable, Sendable {
-    /// Android `sync_enable_ai_settings`; iOS implementation tracked by issue #74.
-    case aiSettings = "ai_settings"
-
-    /// Stable Android-compatible toggle key reserved for the future category implementation.
-    var androidSyncEnabledKey: String {
-        "sync_enable_\(rawValue)"
-    }
-
-    /// GitHub issue that owns implementing this deferred category's sync engine.
-    var trackingIssueNumber: Int {
-        switch self {
-        case .aiSettings:
-            return 74
-        }
-    }
-}
-
-/**
- One row in the Android-runtime-visible sync category section.
-
- Active rows map to implemented iOS `RemoteSyncCategory` values and can start synchronization.
- Deferred rows map to Android-visible categories whose iOS sync implementation is intentionally
- pending, so the settings screen can disclose the gap without mutating unsupported state.
-
- - Returns: Identifiable row values for `SyncSettingsView` and parity tests.
- - Side effects: none.
- - Failure modes: This enum itself cannot fail; consumers decide how to render active versus
-   deferred rows.
- */
-enum SyncSettingsCategoryRow: Identifiable, Equatable, Sendable {
-    /// Implemented category with an interactive toggle.
-    case active(RemoteSyncCategory)
-
-    /// Android-visible category rendered as disabled until its sync implementation lands.
-    case deferred(RemoteSyncDeferredCategory)
-
-    /// Stable row identity used by SwiftUI lists and tests.
-    var id: String {
-        switch self {
-        case .active(let category):
-            return category.rawValue
-        case .deferred(let category):
-            return category.rawValue
+        case .progress:
+            return Row(androidKey: "sync_reading_progress")
         }
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/SyncSettingsView.swift
@@ -558,13 +558,8 @@ public struct SyncSettingsView: View {
      Shared Android-style remote category toggle list used by supported remote backends.
      */
     private var remoteCategoryList: some View {
-        ForEach(SyncSettingsPresentation.visibleCategoryRows) { row in
-            switch row {
-            case .active(let category):
-                activeRemoteCategoryRow(for: category)
-            case .deferred(let category):
-                deferredRemoteCategoryRow(for: category)
-            }
+        ForEach(SyncSettingsPresentation.visibleCategoryRows, id: \.rawValue) { category in
+            activeRemoteCategoryRow(for: category)
         }
     }
 
@@ -607,36 +602,6 @@ public struct SyncSettingsView: View {
             }
             .disabled(isRemoteSyncInteractionLocked)
         }
-    }
-
-    /**
-     Builds one Android-visible category row whose iOS sync implementation is still deferred.
-
-     - Parameter category: Deferred Android-visible category to disclose.
-     - Returns: Disabled row content that mirrors Android ordering, title, summary, and icon.
-     - Side effects: none; the row never writes `sync_enable_*` or starts synchronization.
-     - Failure modes: The row cannot fail; it remains disabled until the referenced follow-up issue
-       implements the category-specific sync engine.
-     */
-    private func deferredRemoteCategoryRow(for category: RemoteSyncDeferredCategory) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            syncSettingsRowLabel(
-                SyncSettingsPresentation.deferredCategory(category),
-                title: deferredRemoteCategoryTitle(for: category),
-                summary: deferredRemoteCategoryContentDescription(for: category),
-                detail: deferredRemoteCategorySupplementalText(for: category),
-                isEnabled: false
-            )
-            .accessibilityIdentifier("syncCategoryDeferred::\(category.rawValue)")
-            .accessibilityValue("deferred")
-
-            Toggle("", isOn: .constant(false))
-                .labelsHidden()
-                .disabled(true)
-                .accessibilityIdentifier("syncCategoryDeferredSwitch::\(category.rawValue)")
-                .accessibilityValue("deferred")
-        }
-        .disabled(true)
     }
 
     /**
@@ -800,7 +765,6 @@ public struct SyncSettingsView: View {
             "restartRequired=\(syncService.requiresRestart)",
             "icloudState=\(syncStateAccessibilityToken)",
             "visible=\(visibleRemoteCategoryRowsAccessibilityToken)",
-            "deferred=\(deferredRemoteCategoryRowsAccessibilityToken)",
             "remoteStatus=\(remoteStatusAccessibilityValue)",
             "presentation=androidRows",
             "bootstrapPrompt=\(remoteBootstrapPromptAccessibilityToken)",
@@ -846,25 +810,8 @@ public struct SyncSettingsView: View {
      */
     private var visibleRemoteCategoryRowsAccessibilityToken: String {
         SyncSettingsPresentation.visibleCategoryRows
-            .map(\.id)
+            .map(\.rawValue)
             .joined(separator: ",")
-    }
-
-    /**
-     Accessibility-exported token for rows shown as deferred rather than interactive.
-
-     - Returns: Comma-separated deferred row identifiers, or `none` when no rows are deferred.
-     - Side effects: none.
-     - Failure modes: This helper cannot fail.
-     */
-    private var deferredRemoteCategoryRowsAccessibilityToken: String {
-        let deferredRows = SyncSettingsPresentation.visibleCategoryRows.compactMap { row -> String? in
-            if case .deferred(let category) = row {
-                return category.rawValue
-            }
-            return nil
-        }
-        return deferredRows.isEmpty ? "none" : deferredRows.joined(separator: ",")
     }
 
     /**
@@ -1306,8 +1253,9 @@ public struct SyncSettingsView: View {
        - error: Failure emitted by remote settings validation or synchronization services.
        - category: Logical sync category that was being synchronized.
        - revertEnablement: Whether the category toggle should be turned off after the failure.
-     - Side effects: Stores a per-category failure message and presents a global alert. Core schema
-       policy owns category enablement and incremental compatibility gates.
+     - Side effects: Reconciles optimistic toggle state, stores a per-category failure message, and
+       presents a global alert. Core schema policy owns persisted category enablement and incremental
+       compatibility gates after synchronization starts.
      - Failure modes: This helper cannot fail.
      */
     @MainActor
@@ -1316,29 +1264,14 @@ public struct SyncSettingsView: View {
         for category: RemoteSyncCategory,
         revertEnablement: Bool
     ) {
-        let message: String
-
-        switch error {
-        case WebDAVClientError.invalidURL:
-            message = String(localized: "invalid_url_message")
-        case RemoteSyncSynchronizationServiceFactoryError.invalidWebDAVConfiguration:
-            message = String(localized: "invalid_url_message")
-        case RemoteSyncSynchronizationServiceFactoryError.missingWebDAVPassword:
-            message = String(localized: "sign_in_failed")
-        case RemoteSyncPatchDiscoveryError.incompatiblePatchVersion:
-            message = [
-                String(localized: "sync_cant_fetch"),
-                String(localized: "sync_update_app"),
-            ]
-            .joined(separator: " ")
-        default:
-            let localizedMessage = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-            message = localizedMessage.isEmpty ? String(localized: "sync_error") : localizedMessage
-            if revertEnablement {
-                disableRemoteSync(for: category)
-            }
+        switch RemoteSyncFailureEnablementResolution(revertEnablement: revertEnablement) {
+        case .disable:
+            disableRemoteSync(for: category)
+        case .reloadPersisted:
+            remoteCategoryEnabled[category] = remoteSettingsStore.isSyncEnabled(for: category)
         }
 
+        let message = RemoteSyncFailurePresentation(error: error).localizedMessage
         remoteCategoryStatuses[category] = .failed(message)
         remoteSyncErrorMessage = message
     }
@@ -1391,45 +1324,6 @@ public struct SyncSettingsView: View {
      */
     private func remoteCategoryContentDescription(for category: RemoteSyncCategory) -> String {
         RemoteSyncCategoryLocalization.text(for: category).contents.localized
-    }
-
-    /**
-     Returns the Android title string for a deferred category row.
-
-     - Parameter category: Deferred category to label.
-     - Returns: Localized title matching Android's visible sync setting where available.
-     - Side effects: none.
-     - Failure modes: Missing localizations fall back to English defaults.
-     */
-    private func deferredRemoteCategoryTitle(for category: RemoteSyncDeferredCategory) -> String {
-        RemoteSyncCategoryLocalization.deferredText(for: category).title.localized
-    }
-
-    /**
-     Returns the Android summary string for a deferred category row.
-
-     - Parameter category: Deferred category to describe.
-     - Returns: Localized summary matching Android's sync setting where available.
-     - Side effects: none.
-     - Failure modes: Missing localizations fall back to English defaults.
-     */
-    private func deferredRemoteCategoryContentDescription(for category: RemoteSyncDeferredCategory) -> String {
-        RemoteSyncCategoryLocalization.deferredText(for: category).contents.localized
-    }
-
-    /**
-     Returns the explicit deferred-state caption for an Android-visible row without iOS sync support.
-
-     - Parameter category: Deferred category whose follow-up issue should be named.
-     - Returns: Human-readable caption that explains why the row is disabled.
-     - Side effects: none.
-     - Failure modes: This helper cannot fail.
-     */
-    private func deferredRemoteCategorySupplementalText(for category: RemoteSyncDeferredCategory) -> String {
-        String(
-            format: String(localized: "sync_category_deferred_issue", defaultValue: "Sync support is deferred (#%d)."),
-            category.trackingIssueNumber
-        )
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/SettingsIconsTests.swift
@@ -267,11 +267,11 @@ final class SettingsIconsTests: XCTestCase {
         XCTAssertEqual(
             SyncSettingsPresentation.visibleCategoryRows,
             [
-                .active(.bookmarks),
-                .active(.workspaces),
-                .active(.myDocuments),
-                .deferred(.aiSettings),
-                .active(.progress),
+                .bookmarks,
+                .workspaces,
+                .myDocuments,
+                .aiSettings,
+                .progress,
             ]
         )
     }
@@ -298,11 +298,11 @@ final class SettingsIconsTests: XCTestCase {
             "ic_baseline_description_gray_24"
         )
         XCTAssertEqual(
-            SyncSettingsPresentation.deferredCategory(.aiSettings).androidKey,
+            SyncSettingsPresentation.category(.aiSettings).androidKey,
             "sync_ai"
         )
         XCTAssertEqual(
-            SyncSettingsPresentation.deferredCategory(.aiSettings).icon?.androidDrawableName,
+            SyncSettingsPresentation.category(.aiSettings).icon?.androidDrawableName,
             "icon_robot"
         )
         XCTAssertEqual(
@@ -343,9 +343,87 @@ final class SettingsIconsTests: XCTestCase {
         XCTAssertNotEqual(active.title.key, active.contents.key)
     }
 
-    func testDeferredSyncCategoriesReserveAndroidCompatibleKeysAndTrackingIssues() {
-        XCTAssertEqual(RemoteSyncDeferredCategory.aiSettings.androidSyncEnabledKey, "sync_enable_ai_settings")
-        XCTAssertEqual(RemoteSyncDeferredCategory.aiSettings.trackingIssueNumber, 74)
+    func testAISettingsUsesAndroidCategoryIdentityAndLocalization() {
+        XCTAssertEqual(RemoteSyncCategory.aiSettings.rawValue, "ai_settings")
+        XCTAssertEqual(RemoteSyncCategoryLocalization.text(for: .aiSettings).title.key, "ai_settings_sync_title")
+        XCTAssertEqual(RemoteSyncCategoryLocalization.text(for: .aiSettings).contents.key, "ai_settings_sync_contents")
+    }
+
+    /**
+     Verifies manual and lifecycle synchronization classify every schema incompatibility identically.
+
+     Android shows its update-app message for an incompatible initial database, a newer incremental
+     patch, and a category already gated for the current schema. Configuration failures retain their
+     distinct URL and sign-in messages, while unknown transport text passes through. Failure means
+     one synchronization route can regress to a generic enum description.
+     */
+    func testRemoteSyncFailurePresentationMatchesAndroidConfigurationAndSchemaMessages() {
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(error: WebDAVClientError.invalidURL),
+            .invalidURL
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: RemoteSyncSynchronizationServiceFactoryError.invalidWebDAVConfiguration
+            ),
+            .invalidURL
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: RemoteSyncSynchronizationServiceFactoryError.missingWebDAVPassword
+            ),
+            .signInFailed
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: RemoteSyncArchiveStagingError.incompatibleInitialBackupVersion(24)
+            ),
+            .updateRequired
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: RemoteSyncPatchDiscoveryError.incompatiblePatchVersion(24)
+            ),
+            .updateRequired
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: RemoteSyncSchemaCompatibilityPolicyError.disabledForCurrentVersion(
+                    category: .aiSettings,
+                    version: 23
+                )
+            ),
+            .updateRequired
+        )
+        XCTAssertEqual(
+            RemoteSyncFailurePresentation(
+                error: NSError(
+                    domain: "RemoteSyncFailurePresentationTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Transport failed"]
+                )
+            ),
+            .underlying("Transport failed")
+        )
+    }
+
+    /**
+     Pins optimistic switch reconciliation at both synchronization failure boundaries.
+
+     Setup failures occur before persistence and must explicitly disable the category. Failures
+     after synchronization begins must reload the persisted setting because initial-schema policy
+     may have disabled it while ordinary transport failures retain it. Failure recreates a visible
+     switch whose value disagrees with lifecycle routing.
+     */
+    func testRemoteSyncFailureEnablementAlwaysReconcilesOptimisticToggleState() {
+        XCTAssertEqual(
+            RemoteSyncFailureEnablementResolution(revertEnablement: true),
+            .disable
+        )
+        XCTAssertEqual(
+            RemoteSyncFailureEnablementResolution(revertEnablement: false),
+            .reloadPersisted
+        )
     }
 
     func testTextDisplayIconsComeFromAndroidOptionsMenuItems() {

--- a/docs/adr/0003-android-database-backup-restore-parity.md
+++ b/docs/adr/0003-android-database-backup-restore-parity.md
@@ -78,11 +78,14 @@ and supported schema versions:
 - Reading Plans
 - My Documents
 
-Unsupported sections remain visible but disabled with a reason. This includes
-Android categories that are present in the archive but do not yet have safe iOS
-mappers, such as Settings, Repositories, Modules, EPUBs, AI Settings, and
-Progress. Future work may enable a category only after adding a source-backed
-mapper, version validation, focused tests, and any required fidelity state.
+Unsupported manual-backup sections remain visible but disabled with a reason.
+This includes Android archive categories whose manual import/export route does
+not yet have an iOS mapper, such as Settings, Repositories, Modules, EPUBs, AI
+Settings, and Progress. AI Settings now has a native semantic model and a
+source-backed remote-sync mapper; that does not implicitly enable this separate
+manual `.abdb.zip` workflow. Future work may enable a manual category only after
+adding archive routing, version validation, focused tests, and required fidelity
+state for that workflow.
 
 Restore mode replaces the selected local category data with the Android backup
 section mapped through the existing restore engine.
@@ -116,10 +119,10 @@ The top-level workflow may use native iOS plumbing:
 - Android application backup exports an APK. iOS apps cannot export their
   installed bundle as an IPA/APK equivalent at runtime, so iOS omits the
   Application/APK backup row instead of presenting an inert choice.
-- Android AI Settings backup/reset is represented by preserved Android-owned
-  database storage until iOS has a native semantic AI settings model. iOS must
-  not synthesize an empty `ai_settings.sqlite3`; it may export that category
-  only after a real Android database was restored or otherwise preserved.
+- Android AI Settings remote sync maps seven non-secret tables through the
+  native iOS AI model. Manual database backup/reset remains disabled until its
+  archive-level selection and merge contract is implemented; remote-sync support
+  must not be presented as manual `.abdb.zip` support.
 - Android crash-info export and local backup listing are platform-adjacent
   features that require dedicated iOS storage/logging contracts before they can
   be surfaced without inventing iOS-only semantics.

--- a/docs/bridge-guide.md
+++ b/docs/bridge-guide.md
@@ -157,9 +157,9 @@ Notes:
   Text actions retain their explicit document, range, selection, and editor-target identity;
   one AI document marker opens directly while multiple markers use the app-owned chooser; and
   prompt editor requests resolve through the source-aware prompt repository before presentation.
-  Missing or malformed targets fail closed through credential-free native errors. Non-secret AI
-  state is stored in SwiftData while provider credentials remain device-local in Keychain. The
-  related `ai_settings` remote-sync category is a separate parity task tracked in #74.
+  Missing or malformed targets fail closed through credential-free native errors. The seven
+  non-secret Android `ai_settings` tables synchronize through Android-compatible Room artifacts
+  and patch semantics, while provider credentials and raw request logs remain device-local.
 
 ### StudyPad
 

--- a/scripts/check_android_ai_settings_schema_authority.py
+++ b/scripts/check_android_ai_settings_schema_authority.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Verify AI settings Room authority against one exact Android commit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import check_android_workspace_schema_authority as shared
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = (
+    REPOSITORY_ROOT
+    / "Sources"
+    / "BibleCore"
+    / "Tests"
+    / "Fixtures"
+    / "AndroidRoomSchemas"
+)
+MANIFEST_PATH = FIXTURE_ROOT / "ai-settings-authority.json"
+MIGRATION_SQL_PATH = FIXTURE_ROOT / "AiSettingsMigrationSQL.json"
+ANDROID_SCHEMA_RELATIVE_PATH = Path(
+    "app/schemas/net.bible.android.database.AiSettingsDatabase"
+)
+ANDROID_MIGRATION_RELATIVE_PATH = Path(
+    "app/src/main/java/net/bible/android/database/migrations/AiSettingsMigrations.kt"
+)
+ANDROID_UTILITY_RELATIVE_PATH = Path(
+    "app/src/main/java/net/bible/android/database/migrations/Utilities.kt"
+)
+ANDROID_ROOM_VERSION_RELATIVE_PATH = Path("build.gradle.kts")
+REQUIRED_ANDROID_SOURCE_RELATIVE_PATHS = {
+    "app/src/main/java/net/bible/android/database/Databases.kt",
+    "app/src/main/java/net/bible/service/cloudsync/SyncUtilities.kt",
+    "app/src/main/java/net/bible/service/common/AiSettings.kt",
+    "app/src/main/java/net/bible/service/db/DatabaseContainer.kt",
+    "app/src/main/java/net/bible/service/llm/AgentPromptEntities.kt",
+    "app/src/main/java/net/bible/service/llm/LlmCostTracking.kt",
+}
+DERIVED_SCHEMA_AUTHORITY = {
+    "12": {
+        "baseExportVersion": 11,
+        "canonicalSchemaSHA256": "1fcdbebe0865065824e82c0a995c7c216bce2de8e483f90f6daec3746aa39149",
+        "identityHash": "ce84fdcfd2da69ec7a3dbb0a48598c5b",
+        "introducingAndroidCommit": "b75638905579b061a60485e4559396d5adf755da",
+        "migrationFromVersion": 11,
+        "migrationToVersion": 12,
+        "roomCompilerVersion": "2.7.2",
+    }
+}
+VERSION_12_MIGRATION_STATEMENTS = {
+    'ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeDocuments` INTEGER NOT NULL DEFAULT 0',
+    'ALTER TABLE `AgentPrompt` ADD COLUMN `autoIncludeCommentaries` INTEGER NOT NULL DEFAULT 0',
+}
+
+AuthorityDriftError = shared.AuthorityDriftError
+
+
+def normalize_sql(value: str) -> str:
+    """Collapse formatting-only whitespace while preserving SQL token order and spelling."""
+    return " ".join(value.split()).removesuffix(";")
+
+
+def room_272_identity_hash(database: dict[str, Any]) -> str:
+    """Derive Room 2.7.2's database identity from one exported schema object.
+
+    This is an independent Python implementation of Room compiler 2.7.2's
+    ``SchemaIdentityKey`` algorithm. Entity, field, primary-key, index, and foreign-key keys use
+    Room's exact punctuation, boolean spelling, case-insensitive ordering, separator, and MD5
+    composition. AI settings has no views; encountering one fails instead of approximating its
+    compiler query identity.
+    """
+
+    def boolean(value: Any) -> str:
+        return "true" if bool(value) else "false"
+
+    def kotlin_list(values: list[str]) -> str:
+        return f"[{', '.join(values)}]"
+
+    def digest(values: list[str]) -> str:
+        payload = "".join(f"{value}?:?" for value in values)
+        return hashlib.md5(payload.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+    def field_key(field: dict[str, Any]) -> str:
+        key = (
+            f"{field['columnName']}-{field.get('affinity') or 'TEXT'}-"
+            f"{boolean(field.get('notNull', False))}"
+        )
+        if field.get("defaultValue") is not None:
+            key += f"-defaultValue={field['defaultValue']}"
+        return key
+
+    def primary_key(primary_key: dict[str, Any]) -> str:
+        return (
+            f"{boolean(primary_key.get('autoGenerate', False))}-"
+            f"{kotlin_list(primary_key['columnNames'])}"
+        )
+
+    def index_key(index: dict[str, Any]) -> str:
+        key = (
+            f"{boolean(index.get('unique', False))}-{index['name']}-"
+            f"{','.join(index['columnNames'])}"
+        )
+        orders = index.get("orders", [])
+        if orders:
+            key += f"-{','.join(orders)}"
+        return key
+
+    def foreign_key(foreign_key: dict[str, Any]) -> str:
+        return (
+            f"{foreign_key['table']}-{','.join(foreign_key['referencedColumns'])}-"
+            f"{','.join(foreign_key['columns'])}-{foreign_key['onDelete']}-"
+            f"{foreign_key['onUpdate']}-{boolean(foreign_key.get('deferred', False))}"
+        )
+
+    def entity_key(entity: dict[str, Any]) -> str:
+        values = [entity["tableName"], primary_key(entity["primaryKey"])]
+        values.extend(sorted((field_key(value) for value in entity["fields"]), key=str.lower))
+        values.extend(
+            sorted((index_key(value) for value in entity.get("indices", [])), key=str.lower)
+        )
+        values.extend(
+            sorted(
+                (foreign_key(value) for value in entity.get("foreignKeys", [])),
+                key=str.lower,
+            )
+        )
+        return digest(values)
+
+    if database.get("views"):
+        raise AuthorityDriftError("AI settings Room identity derivation does not accept views")
+    entities = database.get("entities")
+    if not isinstance(entities, list):
+        raise AuthorityDriftError("AI settings Room export has no entity list")
+    return digest(sorted((entity_key(entity) for entity in entities), key=str.lower))
+
+
+def derive_version_12_database(
+    version_11_export: dict[str, Any],
+    migration_statements: list[str],
+) -> dict[str, Any]:
+    """Apply Android's 11-to-12 add-column declarations to the v11 Room export model.
+
+    The derivation parses the copied Android SQL instead of embedding the two resulting fields a
+    second time. It returns a detached schema object used only for Room identity calculation and
+    fails when the migration shape cannot be represented exactly as an exported Room field.
+    """
+    database = json.loads(json.dumps(version_11_export.get("database")))
+    if not isinstance(database, dict) or database.get("version") != 11:
+        raise AuthorityDriftError("AI settings v12 derivation requires the v11 Room export")
+    entities = database.get("entities")
+    if not isinstance(entities, list):
+        raise AuthorityDriftError("AI settings v11 Room export has no entity list")
+    entity_by_name = {entity.get("tableName"): entity for entity in entities}
+    add_column_pattern = re.compile(
+        r"ALTER TABLE `([^`]+)` ADD COLUMN `([^`]+)` ([A-Z]+)"
+        r"( NOT NULL)?(?: DEFAULT (.+))?"
+    )
+    for statement in migration_statements:
+        match = add_column_pattern.fullmatch(normalize_sql(statement))
+        if match is None:
+            raise AuthorityDriftError(
+                f"unsupported Android AI v12 identity derivation SQL: {statement}"
+            )
+        table_name, column_name, affinity, not_null, default_value = match.groups()
+        entity = entity_by_name.get(table_name)
+        if not isinstance(entity, dict) or not isinstance(entity.get("fields"), list):
+            raise AuthorityDriftError(f"AI settings v12 derivation table missing: {table_name}")
+        if any(field.get("columnName") == column_name for field in entity["fields"]):
+            raise AuthorityDriftError(
+                f"AI settings v12 derivation column already exists: {table_name}.{column_name}"
+            )
+        field: dict[str, Any] = {
+            "fieldPath": column_name,
+            "columnName": column_name,
+            "affinity": affinity,
+            "notNull": not_null is not None,
+        }
+        if default_value is not None:
+            field["defaultValue"] = default_value
+        entity["fields"].append(field)
+    database["version"] = 12
+    return database
+
+
+def extract_room_compiler_version(source: str) -> str:
+    """Read Android's single root ``roomVersion`` declaration without evaluating Gradle."""
+    matches = re.findall(r'val roomVersion by extra\("([^"]+)"\)', source)
+    if len(matches) != 1:
+        raise AuthorityDriftError("Android Room compiler version declaration drift")
+    return matches[0]
+
+
+def extract_android_migration_sql(source: str) -> dict[str, list[str]]:
+    """Extract every literal `db.execSQL` statement from Android's contiguous migration edges."""
+    block_pattern = re.compile(
+        r"private val \w+ = makeMigration\((\d+)\.\.(\d+)\) \{ db ->\n(.*?)\n\}",
+        re.DOTALL,
+    )
+    statement_pattern = re.compile(
+        r'db\.execSQL\((?:"""(.*?)"""|"((?:\\.|[^"\\])*)")\)',
+        re.DOTALL,
+    )
+    result: dict[str, list[str]] = {}
+    for block in block_pattern.finditer(source):
+        source_version = int(block.group(1))
+        target_version = int(block.group(2))
+        if target_version != source_version + 1:
+            raise AuthorityDriftError(
+                f"non-contiguous Android AI migration {source_version}..{target_version}"
+            )
+        statements: list[str] = []
+        for statement in statement_pattern.finditer(block.group(3)):
+            triple_quoted, quoted = statement.groups()
+            if triple_quoted is not None:
+                value = triple_quoted
+            else:
+                value = json.loads(f'"{quoted}"')
+            statements.append(normalize_sql(value))
+        if not statements:
+            raise AuthorityDriftError(
+                f"Android AI migration {source_version}..{target_version} has no SQL"
+            )
+        result[str(source_version)] = statements
+    expected_edges = {str(version) for version in range(1, 23)}
+    if set(result) != expected_edges:
+        raise AuthorityDriftError(
+            "Android AI migration edge set drift: "
+            f"expected {sorted(expected_edges)}, actual {sorted(result)}"
+        )
+    return result
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    """Load the pinned AI settings schema, migration, and runtime-source manifest."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AuthorityDriftError(f"invalid authority manifest {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise AuthorityDriftError(f"authority manifest must be an object: {path}")
+    return value
+
+
+def validate_local_fixtures(
+    fixture_root: Path = FIXTURE_ROOT,
+    manifest: dict[str, Any] | None = None,
+) -> None:
+    """Require every copied AI Room artifact to retain its pinned Android bytes."""
+    manifest = manifest or load_manifest(fixture_root / "ai-settings-authority.json")
+    if not shared.is_lower_hex(manifest.get("androidCommit"), 40):
+        raise AuthorityDriftError("androidCommit must be a lowercase 40-character commit")
+
+    schema_hashes = manifest.get("schemaSHA256")
+    if not isinstance(schema_hashes, dict) or not schema_hashes:
+        raise AuthorityDriftError("schemaSHA256 must be a nonempty object")
+    expected_versions = {int(version) for version in schema_hashes}
+    schema_root = fixture_root / "AiSettingsDatabase"
+    actual_versions = shared.exported_versions(schema_root)
+    if actual_versions != expected_versions:
+        raise AuthorityDriftError(
+            "local AI settings export set drift: "
+            f"expected {sorted(expected_versions)}, actual {sorted(actual_versions)}"
+        )
+    for version_text, expected_digest in schema_hashes.items():
+        path = schema_root / f"{version_text}.json"
+        if shared.sha256(path) != expected_digest:
+            raise AuthorityDriftError(f"local AI settings schema v{version_text} digest drift")
+        try:
+            exported_schema = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise AuthorityDriftError(
+                f"invalid AI settings schema v{version_text}: {error}"
+            ) from error
+        database = exported_schema.get("database", {})
+        if room_272_identity_hash(database) != database.get("identityHash"):
+            raise AuthorityDriftError(
+                f"AI settings schema v{version_text} Room identity derivation drift"
+            )
+
+    if manifest.get("derivedSchemaAuthority") != DERIVED_SCHEMA_AUTHORITY:
+        raise AuthorityDriftError("derived AI settings schema authority drift")
+
+    migration_path = fixture_root / "AiSettingsMigrations.kt"
+    utility_path = fixture_root / "AiSettingsMigrationUtilities.kt"
+    migration_sql_path = fixture_root / "AiSettingsMigrationSQL.json"
+    if shared.sha256(migration_path) != manifest.get("migrationSHA256"):
+        raise AuthorityDriftError("local AiSettingsMigrations.kt digest drift")
+    if shared.sha256(utility_path) != manifest.get("utilitySHA256"):
+        raise AuthorityDriftError("local AI migration Utilities.kt digest drift")
+    migration_source = migration_path.read_text(encoding="utf-8")
+    for statement in VERSION_12_MIGRATION_STATEMENTS:
+        if migration_source.count(statement) != 1:
+            raise AuthorityDriftError("Android AI v12 derivation migration drift")
+    if shared.sha256(migration_sql_path) != manifest.get("migrationSQLSHA256"):
+        raise AuthorityDriftError("local AI migration SQL fixture digest drift")
+    try:
+        migration_sql = json.loads(migration_sql_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AuthorityDriftError(f"invalid AI migration SQL fixture: {error}") from error
+    if migration_sql != extract_android_migration_sql(migration_source):
+        raise AuthorityDriftError("AI migration SQL fixture differs from Android source")
+    version_11_export = json.loads(
+        (schema_root / "11.json").read_text(encoding="utf-8")
+    )
+    derived_version_12 = derive_version_12_database(
+        version_11_export,
+        migration_sql["11"],
+    )
+    expected_version_12_identity = manifest["derivedSchemaAuthority"]["12"]["identityHash"]
+    if room_272_identity_hash(derived_version_12) != expected_version_12_identity:
+        raise AuthorityDriftError("derived AI settings v12 Room identity drift")
+
+    current_version = manifest.get("currentVersion")
+    current_fixture = fixture_root / f"AiSettingsDatabase-v{current_version}.json"
+    nested_fixture = schema_root / f"{current_version}.json"
+    if current_fixture.read_bytes() != nested_fixture.read_bytes():
+        raise AuthorityDriftError("current AI settings fixture differs from predecessor set")
+    current_export = json.loads(current_fixture.read_text(encoding="utf-8"))
+    database = current_export.get("database", {})
+    if database.get("version") != current_version:
+        raise AuthorityDriftError("current AI settings fixture version drift")
+    if database.get("identityHash") != manifest.get("currentIdentityHash"):
+        raise AuthorityDriftError("current AI settings fixture identity drift")
+
+    source_hashes = manifest.get("androidSourceSHA256")
+    if not isinstance(source_hashes, dict):
+        raise AuthorityDriftError("androidSourceSHA256 must be an object")
+    if set(source_hashes) != REQUIRED_ANDROID_SOURCE_RELATIVE_PATHS:
+        raise AuthorityDriftError(
+            "androidSourceSHA256 paths drift: "
+            f"expected {sorted(REQUIRED_ANDROID_SOURCE_RELATIVE_PATHS)}, "
+            f"actual {sorted(source_hashes)}"
+        )
+    for relative_path, digest in source_hashes.items():
+        if not shared.is_lower_hex(digest, 64):
+            raise AuthorityDriftError(
+                f"androidSourceSHA256 digest must be lowercase SHA-256: {relative_path}"
+            )
+
+
+def validate_android_checkout(
+    android_root: Path,
+    fixture_root: Path = FIXTURE_ROOT,
+    manifest: dict[str, Any] | None = None,
+) -> None:
+    """Require the exact Android commit, AI exports, migrations, and owning source files."""
+    manifest = manifest or load_manifest(fixture_root / "ai-settings-authority.json")
+    validate_local_fixtures(fixture_root, manifest)
+    live_head = shared.android_head(android_root)
+    if live_head != manifest.get("androidCommit"):
+        raise AuthorityDriftError(
+            "Android checkout HEAD drift: "
+            f"expected {manifest.get('androidCommit')}, actual {live_head}"
+        )
+
+    android_schema_root = android_root / ANDROID_SCHEMA_RELATIVE_PATH
+    expected_versions = {int(version) for version in manifest["schemaSHA256"]}
+    actual_versions = shared.exported_versions(android_schema_root)
+    if actual_versions != expected_versions:
+        raise AuthorityDriftError(
+            "Android AI settings export set drift: "
+            f"expected {sorted(expected_versions)}, actual {sorted(actual_versions)}"
+        )
+    local_schema_root = fixture_root / "AiSettingsDatabase"
+    for version in sorted(expected_versions):
+        if (local_schema_root / f"{version}.json").read_bytes() != (
+            android_schema_root / f"{version}.json"
+        ).read_bytes():
+            raise AuthorityDriftError(f"Android AI settings schema v{version} drift")
+
+    source_pairs = [
+        (fixture_root / "AiSettingsMigrations.kt", android_root / ANDROID_MIGRATION_RELATIVE_PATH),
+        (fixture_root / "AiSettingsMigrationUtilities.kt", android_root / ANDROID_UTILITY_RELATIVE_PATH),
+    ]
+    for local_path, android_path in source_pairs:
+        if local_path.read_bytes() != android_path.read_bytes():
+            raise AuthorityDriftError(f"Android AI migration source drift: {android_path}")
+    for relative_path, expected_digest in manifest["androidSourceSHA256"].items():
+        if shared.sha256(android_root / relative_path) != expected_digest:
+            raise AuthorityDriftError(f"Android AI authority source drift: {relative_path}")
+    room_version_source = (
+        android_root / ANDROID_ROOM_VERSION_RELATIVE_PATH
+    ).read_text(encoding="utf-8")
+    expected_room_version = manifest["derivedSchemaAuthority"]["12"]["roomCompilerVersion"]
+    if extract_room_compiler_version(room_version_source) != expected_room_version:
+        raise AuthorityDriftError("Android Room compiler version drift")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the optional Android checkout override."""
+    default_android_root = os.environ.get(
+        "ANDBIBLE_ANDROID_ROOT",
+        str(REPOSITORY_ROOT.parent / "and-bible"),
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--android-root", type=Path, default=Path(default_android_root))
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run local provenance and live Android drift validation."""
+    args = parse_args()
+    try:
+        manifest = load_manifest()
+        validate_android_checkout(args.android_root.resolve(), manifest=manifest)
+    except (AuthorityDriftError, OSError, json.JSONDecodeError) as error:
+        print(f"Android AI Room authority check failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "AI settings Room authority verified: "
+        f"pinned={manifest['androidCommit']} "
+        f"live={shared.android_head(args.android_root.resolve())}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ensure_android_reference_checkout.sh
+++ b/scripts/ensure_android_reference_checkout.sh
@@ -58,10 +58,13 @@ fi
 
 mkdir -p "$(dirname -- "${android_root}")"
 
-clone_args=(--depth 1)
 if [[ -n "${ANDBIBLE_ANDROID_REF:-}" ]]; then
-  clone_args+=(--branch "${ANDBIBLE_ANDROID_REF}")
+  echo "Creating Android reference checkout at ${ANDBIBLE_ANDROID_REF}: ${android_root}"
+  git init --quiet "${android_root}"
+  git -C "${android_root}" remote add origin "${android_repo_url}"
+  git -C "${android_root}" fetch --depth 1 "${android_repo_url}" "${ANDBIBLE_ANDROID_REF}"
+  git -C "${android_root}" checkout --detach --quiet FETCH_HEAD
+else
+  echo "Cloning Android reference checkout into ${android_root}"
+  git clone --depth 1 "${android_repo_url}" "${android_root}"
 fi
-
-echo "Cloning Android reference checkout into ${android_root}"
-git clone "${clone_args[@]}" "${android_repo_url}" "${android_root}"

--- a/scripts/test_check_android_ai_settings_schema_authority.py
+++ b/scripts/test_check_android_ai_settings_schema_authority.py
@@ -1,0 +1,200 @@
+"""Tests for the Android AI settings Room authority drift guard."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_android_ai_settings_schema_authority as guard
+
+
+class AndroidAISettingsSchemaAuthorityTests(unittest.TestCase):
+    """Exercise pinned AI schemas, migrations, runtime sources, and commit provenance."""
+
+    def test_repository_fixtures_match_pinned_commit_digests(self) -> None:
+        """Every copied AI schema and migration source retains its pinned bytes."""
+        guard.validate_local_fixtures()
+
+    def test_derived_version_12_authority_is_pinned_separately_from_exported_schemas(self) -> None:
+        """The Android-derived v12 contract cannot drift or masquerade as a copied Room export."""
+        manifest = json.loads(json.dumps(guard.load_manifest()))
+        manifest["derivedSchemaAuthority"]["12"]["identityHash"] = "0" * 32
+
+        with self.assertRaisesRegex(
+            guard.AuthorityDriftError,
+            "derived AI settings schema authority drift",
+        ):
+            guard.validate_local_fixtures(manifest=manifest)
+
+    def test_version_12_identity_is_independently_derived_from_v11_and_android_sql(self) -> None:
+        """Room 2.7.2 identity calculation catches a coordinated wrong v12 constant."""
+        version_11_export = json.loads(
+            (
+                guard.FIXTURE_ROOT
+                / "AiSettingsDatabase"
+                / "11.json"
+            ).read_text(encoding="utf-8")
+        )
+        migration_sql = json.loads(
+            guard.MIGRATION_SQL_PATH.read_text(encoding="utf-8")
+        )
+        derived_database = guard.derive_version_12_database(
+            version_11_export,
+            migration_sql["11"],
+        )
+
+        self.assertEqual(
+            guard.room_272_identity_hash(derived_database),
+            "ce84fdcfd2da69ec7a3dbb0a48598c5b",
+        )
+        agent_prompt = next(
+            entity
+            for entity in derived_database["entities"]
+            if entity["tableName"] == "AgentPrompt"
+        )
+        auto_include_documents = next(
+            field
+            for field in agent_prompt["fields"]
+            if field["columnName"] == "autoIncludeDocuments"
+        )
+        auto_include_documents["defaultValue"] = "1"
+        self.assertNotEqual(
+            guard.room_272_identity_hash(derived_database),
+            "ce84fdcfd2da69ec7a3dbb0a48598c5b",
+        )
+
+    def test_migration_sql_fixture_must_match_copied_android_source(self) -> None:
+        """A self-consistent fixture rewrite still fails when it differs from Android Kotlin SQL."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture_root = Path(temporary_directory) / "AndroidRoomSchemas"
+            shutil.copytree(guard.FIXTURE_ROOT, fixture_root)
+            manifest = guard.load_manifest(fixture_root / "ai-settings-authority.json")
+            migration_sql_path = fixture_root / "AiSettingsMigrationSQL.json"
+            migration_sql = json.loads(migration_sql_path.read_text(encoding="utf-8"))
+            migration_sql["1"][0] += " INVALID"
+            migration_sql_path.write_text(
+                json.dumps(migration_sql, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            manifest["migrationSQLSHA256"] = guard.shared.sha256(migration_sql_path)
+
+            with self.assertRaisesRegex(
+                guard.AuthorityDriftError,
+                "differs from Android source",
+            ):
+                guard.validate_local_fixtures(fixture_root=fixture_root, manifest=manifest)
+
+    def test_matching_android_checkout_passes_and_schema_drift_fails(self) -> None:
+        """An exact authority checkout passes until one generated schema byte changes."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            android_root = Path(temporary_directory)
+            manifest = self.make_authority_checkout(android_root)
+
+            guard.validate_android_checkout(android_root, manifest=manifest)
+
+            schema_path = android_root / guard.ANDROID_SCHEMA_RELATIVE_PATH / "23.json"
+            schema_path.write_bytes(schema_path.read_bytes() + b"\n")
+            with self.assertRaisesRegex(guard.AuthorityDriftError, "schema v23 drift"):
+                guard.validate_android_checkout(android_root, manifest=manifest)
+
+    def test_migration_runtime_source_and_head_drift_are_independent_gates(self) -> None:
+        """Migration bytes, owning source bytes, and exact repository HEAD each fail closed."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            android_root = Path(temporary_directory)
+            manifest = self.make_authority_checkout(android_root)
+
+            migration_path = android_root / guard.ANDROID_MIGRATION_RELATIVE_PATH
+            migration_path.write_bytes(migration_path.read_bytes() + b"drift")
+            with self.assertRaisesRegex(guard.AuthorityDriftError, "migration source drift"):
+                guard.validate_android_checkout(android_root, manifest=manifest)
+
+            shutil.copyfile(guard.FIXTURE_ROOT / "AiSettingsMigrations.kt", migration_path)
+            source_relative_path = next(iter(manifest["androidSourceSHA256"]))
+            source_path = android_root / source_relative_path
+            source_path.write_bytes(source_path.read_bytes() + b"drift")
+            with self.assertRaisesRegex(guard.AuthorityDriftError, "authority source drift"):
+                guard.validate_android_checkout(android_root, manifest=manifest)
+
+            source_path.write_text(source_relative_path, encoding="utf-8")
+            room_version_path = android_root / guard.ANDROID_ROOM_VERSION_RELATIVE_PATH
+            room_version_path.write_text(
+                'val roomVersion by extra("9.9.9")\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(guard.AuthorityDriftError, "Room compiler version drift"):
+                guard.validate_android_checkout(android_root, manifest=manifest)
+
+            room_version_path.write_text(
+                'val roomVersion by extra("2.7.2")\n',
+                encoding="utf-8",
+            )
+            (android_root / "unrelated.txt").write_text("new commit", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(android_root), "add", "."],
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            subprocess.run(
+                ["git", "-C", str(android_root), "commit", "-q", "-m", "Authority drift"],
+                check=True,
+            )
+            with self.assertRaisesRegex(guard.AuthorityDriftError, "checkout HEAD drift"):
+                guard.validate_android_checkout(android_root, manifest=manifest)
+
+    def make_authority_checkout(
+        self,
+        android_root: Path,
+    ) -> dict[str, Any]:
+        """Create a hermetic Android authority tree and pin its exact synthetic commit."""
+        manifest = json.loads(json.dumps(guard.load_manifest()))
+        schema_root = android_root / guard.ANDROID_SCHEMA_RELATIVE_PATH
+        schema_root.parent.mkdir(parents=True)
+        shutil.copytree(guard.FIXTURE_ROOT / "AiSettingsDatabase", schema_root)
+
+        migration_path = android_root / guard.ANDROID_MIGRATION_RELATIVE_PATH
+        utility_path = android_root / guard.ANDROID_UTILITY_RELATIVE_PATH
+        migration_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(guard.FIXTURE_ROOT / "AiSettingsMigrations.kt", migration_path)
+        shutil.copyfile(guard.FIXTURE_ROOT / "AiSettingsMigrationUtilities.kt", utility_path)
+
+        for relative_path in manifest["androidSourceSHA256"]:
+            source_path = android_root / relative_path
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text(relative_path, encoding="utf-8")
+            manifest["androidSourceSHA256"][relative_path] = guard.shared.sha256(source_path)
+        (android_root / guard.ANDROID_ROOM_VERSION_RELATIVE_PATH).write_text(
+            'val roomVersion by extra("2.7.2")\n',
+            encoding="utf-8",
+        )
+
+        subprocess.run(["git", "init", "-q", str(android_root)], check=True)
+        subprocess.run(
+            ["git", "-C", str(android_root), "config", "user.email", "test@example.invalid"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(android_root), "config", "user.name", "Authority Test"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(android_root), "add", "."],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(android_root), "commit", "-q", "-m", "Pinned authority"],
+            check=True,
+        )
+        manifest["androidCommit"] = guard.shared.android_head(android_root)
+        return manifest
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ensure_android_reference_checkout.py
+++ b/scripts/test_ensure_android_reference_checkout.py
@@ -179,6 +179,62 @@ class EnsureAndroidReferenceCheckoutTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("current\n", updated_marker)
 
+    def test_helper_creates_new_checkout_at_exact_commit(self) -> None:
+        """A raw pinned commit produces a detached checkout without relying on a branch name."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote"
+            android = root / "and-bible"
+            marker = "android-ref.txt"
+            subprocess.run(["git", "init", "-q", str(remote)], check=True)
+            (remote / marker).write_text("pinned\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(remote), "add", marker], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(remote),
+                    "-c",
+                    "user.email=ci@example.invalid",
+                    "-c",
+                    "user.name=CI",
+                    "commit",
+                    "-m",
+                    "pinned",
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            pinned_commit = subprocess.run(
+                ["git", "-C", str(remote), "rev-parse", "HEAD"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+
+            result = subprocess.run(
+                ["bash", str(HELPER), str(android)],
+                cwd=REPO_ROOT,
+                env={
+                    "ANDBIBLE_ANDROID_REF": pinned_commit,
+                    "ANDBIBLE_ANDROID_REPO_URL": str(remote),
+                    "PATH": os.environ["PATH"],
+                },
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            checked_out_commit = subprocess.run(
+                ["git", "-C", str(android), "rev-parse", "HEAD"],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(pinned_commit, checked_out_commit)
+        self.assertIn("Creating Android reference checkout", result.stdout)
+
     def test_helper_updates_existing_checkout_to_remote_head_by_default(self) -> None:
         """Updates an existing checkout to the Android remote default by default.
 


### PR DESCRIPTION
## Summary
Implements Android parity for the AI Settings remote-sync category. iOS now synchronizes the same seven non-secret Room data groups while credentials and raw request logs remain device-local.

## Scope
- Activates the AI Settings category and Android preference key `sync_enable_ai_settings`.
- Synchronizes `LlmProviderConfig`, `LlmConfiguredModel`, `AgentPrompt`, `GlobalAiSettings`, `LlmUsageRecord`, `PromptCategory`, and `BuiltinPromptOverride`.
- Covers initial upload/adoption, restore, incremental patches, conflicts, tombstones, cancellation, reset, and repeated two-device reconciliation.
- Excludes provider credentials, authorization material, and `LlmRawLogRecord`.

## Contract references
- GitHub issue #74.
- Android Room schema version 23 at pinned and-bible commit `0f3b85823cebbfafeb5a51675827f5314cac3c56`.
- Android `AI_SETTINGS` category and `sync_enable_ai_settings` preference contract.
- ADR 0003 and `docs/bridge-guide.md`.

## Change details
- Adds Android-compatible Room projection, migration, restore, patch upload, and transactional patch replay services.
- Journals local AI model mutations and preserves Android foreign-key, ordering, timestamp, conflict, and deletion semantics.
- Rejects credential-bearing provider endpoints, recursively checks encoded values, and fails closed when a security-sensitive Keychain read cannot confirm credential absence.
- Routes incompatible schemas and configuration failures through Android-backed UI messages and reconciles optimistic toggle state.
- Adds schema fixtures for supported Android generations, derives and verifies the unexported version 12 schema, and checks every Room identity hash independently.
- Pins the Android authority checkout in CI and verifies the live source, migrations, Room compiler version, and fixtures.

## Validation evidence
- Clean committed checkout: `swift test`, 1,740 tests passed.
- Focused `SettingsIconsTests`: 36 tests passed.
- Python script suite: 227 tests passed.
- Live Android AI settings schema authority check passed at the pinned commit.
- Bridge parity, source guard, docblock, and localization guardrails passed.
- AndBible app build succeeded for iPhone 17 simulator.
- `git diff --check` passed.
- Adversarial coverage includes all seven tables, byte-level credential exclusion, encoded endpoint attacks, strict credential-read failure, malformed schemas, migration generations, conflict handling, tombstones, transactional rollback, cancellation, and two-device no-echo convergence.

## Risks/follow-ups
- Android database version 17 is intentionally rejected because Android itself cannot migrate that transient exported shape to the current schema.
- Existing local credentials and raw model logs are preserved and never synchronized.
- The change carries checked-in Android Room authority fixtures; CI will fail if upstream schema or migration behavior drifts.

Closes #74
