### PR TITLE
chore: update GitNexus guidance and stabilize archive cancellation

### DIFF
--- a/.gitnexusrc
+++ b/.gitnexusrc
@@ -1,0 +1,3 @@
+{
+  "skipContextFiles": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **and-bible-ios** (22278 symbols, 103751 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **and-bible-ios** (46393 symbols, 332818 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -9,14 +9,38 @@ This project is indexed by GitNexus as **and-bible-ios** (22278 symbols, 103751 
 
 - **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
 - **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
-- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Interpreting Impact Risk
+
+GitNexus impact levels describe dependency reach and potential blast radius. They are inputs to engineering judgment, not permission levels. HIGH or CRITICAL does not mean "do not edit," does not by itself require user approval, and must not be used to justify a parallel implementation. A central shared symbol may be the correct and safest place for a root-cause fix.
+
+When impact is HIGH or CRITICAL:
+
+- Inspect the direct callers, affected execution flows, contracts, and relevant tests before editing.
+- Briefly report the blast radius, why the selected symbol is or is not the correct owner, what behavior must remain unchanged, and how the change will be validated. Continue without waiting for approval unless a genuine escalation condition below applies.
+- Make the smallest coherent change that fixes the root cause at the existing source of truth. "Smallest" means the narrowest architecturally complete solution, not the fewest lines, files, callers, or lowest GitNexus risk score.
+- If the high-impact symbol owns the behavior, edit it carefully rather than bypassing it. Prefer one shared implementation over duplicated logic, shadow state, feature-specific forks, adapters, or parallel implementations that can drift.
+- Preserve unrelated behavior and validate affected contracts proportionally to the blast radius.
+- Cross-check GitNexus output against the actual source and tests. Treat stale, incomplete, or ambiguous graph results as supporting evidence, not authority.
+
+Ask the user before proceeding only when analysis reveals that the change would:
+
+- materially expand product scope beyond the request;
+- require a breaking shared, bridge, sync, persistence, or public API change;
+- require a data migration, irreversible operation, or external/platform coordination;
+- depend on ambiguous intended behavior that cannot be resolved from the code, tests, documentation, or established parity baseline; or
+- affect critical behavior that cannot be validated safely.
+
+A HIGH or CRITICAL score alone is never an escalation condition.
 
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER avoid the correct shared implementation solely because its impact score is HIGH or CRITICAL.
+- NEVER create duplicated logic, parallel features, shadow state, or a drift-prone workaround merely to reduce the reported blast radius.
+- NEVER modify every reported dependent automatically. Impact results identify what must be inspected and validated, not necessarily what must be edited.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,7 @@ Impact:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **and-bible-ios** (22278 symbols, 103751 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **and-bible-ios** (46393 symbols, 332818 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -351,14 +351,38 @@ This project is indexed by GitNexus as **and-bible-ios** (22278 symbols, 103751 
 
 - **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
 - **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
-- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Interpreting Impact Risk
+
+GitNexus impact levels describe dependency reach and potential blast radius. They are inputs to engineering judgment, not permission levels. HIGH or CRITICAL does not mean "do not edit," does not by itself require user approval, and must not be used to justify a parallel implementation. A central shared symbol may be the correct and safest place for a root-cause fix.
+
+When impact is HIGH or CRITICAL:
+
+- Inspect the direct callers, affected execution flows, contracts, and relevant tests before editing.
+- Briefly report the blast radius, why the selected symbol is or is not the correct owner, what behavior must remain unchanged, and how the change will be validated. Continue without waiting for approval unless a genuine escalation condition below applies.
+- Make the smallest coherent change that fixes the root cause at the existing source of truth. "Smallest" means the narrowest architecturally complete solution, not the fewest lines, files, callers, or lowest GitNexus risk score.
+- If the high-impact symbol owns the behavior, edit it carefully rather than bypassing it. Prefer one shared implementation over duplicated logic, shadow state, feature-specific forks, adapters, or parallel implementations that can drift.
+- Preserve unrelated behavior and validate affected contracts proportionally to the blast radius.
+- Cross-check GitNexus output against the actual source and tests. Treat stale, incomplete, or ambiguous graph results as supporting evidence, not authority.
+
+Ask the user before proceeding only when analysis reveals that the change would:
+
+- materially expand product scope beyond the request;
+- require a breaking shared, bridge, sync, persistence, or public API change;
+- require a data migration, irreversible operation, or external/platform coordination;
+- depend on ambiguous intended behavior that cannot be resolved from the code, tests, documentation, or established parity baseline; or
+- affect critical behavior that cannot be validated safely.
+
+A HIGH or CRITICAL score alone is never an escalation condition.
 
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER avoid the correct shared implementation solely because its impact score is HIGH or CRITICAL.
+- NEVER create duplicated logic, parallel features, shadow state, or a drift-prone workaround merely to reduce the reported blast radius.
+- NEVER modify every reported dependent automatically. Impact results identify what must be inspected and validated, not necessarily what must be edited.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 

--- a/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/ImportExportView.swift
@@ -20,10 +20,16 @@ enum AndroidModuleBackupArchiveFileStager {
      - Parameters:
        - sourceURL: Readable provider or local archive URL.
        - destinationURL: Unique app-owned staging destination.
-     - Side effects: Creates or replaces `destinationURL` and writes the source bytes to it.
+       - didWriteChunk: Optional synchronous observer invoked after each completed chunk write.
+     - Side effects: Creates or replaces `destinationURL`, writes the source bytes to it, and invokes
+       `didWriteChunk` on the copy task when supplied.
      - Failure modes: Rethrows cancellation and file-system failures after removing partial output.
      */
-    static func copy(from sourceURL: URL, to destinationURL: URL) throws {
+    static func copy(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        didWriteChunk: (@Sendable (_ byteCount: Int) -> Void)? = nil
+    ) throws {
         try Task.checkCancellation()
         let input = try FileHandle(forReadingFrom: sourceURL)
         defer { try? input.close() }
@@ -37,6 +43,7 @@ enum AndroidModuleBackupArchiveFileStager {
                 if chunk.isEmpty { break }
                 try Task.checkCancellation()
                 try output.write(contentsOf: chunk)
+                didWriteChunk?(chunk.count)
             }
             try Task.checkCancellation()
             try output.synchronize()

--- a/Sources/BibleUI/Tests/BibleUITests/AndroidModuleBackupSettingsWorkflowTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/AndroidModuleBackupSettingsWorkflowTests.swift
@@ -46,11 +46,16 @@ final class AndroidModuleBackupSettingsWorkflowTests: XCTestCase {
     }
 
     /**
-     Verifies cancelling a large provider copy removes its partially written staging archive.
+     Verifies cancelling a provider copy removes its partially written staging archive.
 
-     The sparse source keeps fixture setup bounded while the production 64 KiB loop performs real
-     reads and writes. Failure means closing the picker or leaving Settings can leave a large orphan
-     archive or continue consuming storage after cancellation.
+     A synchronous observer pauses the production copier after its only chunk write. The test
+     cancels at that exact event boundary, then releases the copier so its next cooperative
+     cancellation check must remove the destination before propagating `CancellationError`.
+
+     Side effects: Creates and removes a bounded temporary archive pair.
+
+     Failure modes: A failure means cancellation no longer reaches the production cleanup path, or
+     the staging archive can survive after the Settings operation is cancelled.
      */
     func testProviderArchiveCopyCancellationRemovesPartialOutput() async throws {
         let root = FileManager.default.temporaryDirectory
@@ -59,29 +64,29 @@ final class AndroidModuleBackupSettingsWorkflowTests: XCTestCase {
         let destinationURL = root.appendingPathComponent("staged.abmd.zip")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
-        XCTAssertTrue(FileManager.default.createFile(atPath: sourceURL.path, contents: Data()))
-        let source = try FileHandle(forWritingTo: sourceURL)
-        try source.truncate(atOffset: 1_073_741_824)
-        try source.close()
+        try Data(repeating: 0xA5, count: 64 * 1_024).write(to: sourceURL, options: .atomic)
 
-        let task = Task.detached(priority: .userInitiated) {
+        let reachedWrite = DispatchSemaphore(value: 0)
+        let resumeCopy = DispatchSemaphore(value: 0)
+        let task = Task.detached {
             try AndroidModuleBackupArchiveFileStager.copy(
                 from: sourceURL,
-                to: destinationURL
+                to: destinationURL,
+                didWriteChunk: { byteCount in
+                    guard byteCount > 0 else { return }
+                    reachedWrite.signal()
+                    resumeCopy.wait()
+                }
             )
         }
-        var observedPartialOutput = false
-        for _ in 0..<10_000 {
-            if let size = try? destinationURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-               size > 0 {
-                observedPartialOutput = true
-                break
-            }
-            try await Task.sleep(nanoseconds: 100_000)
-        }
-        XCTAssertTrue(observedPartialOutput, "Production copy never reached its streamed write phase")
 
+        XCTAssertEqual(
+            reachedWrite.wait(timeout: .now() + 5),
+            .success,
+            "Production copy never reached its deterministic write checkpoint"
+        )
         task.cancel()
+        resumeCopy.signal()
         do {
             try await task.value
             XCTFail("Expected cooperative cancellation")


### PR DESCRIPTION
## Summary

Clarifies how agents should interpret GitNexus HIGH and CRITICAL impact results so dependency reach informs engineering judgment without becoming an artificial approval gate or an incentive to build parallel implementations. A repository-local GitNexus configuration also enables `skipContextFiles` for recognized context files.

The full CI run exposed a pre-existing BibleUI cancellation-test race. This PR fixes that root cause rather than exempting `.gitnexusrc` from CI: the real archive stager now offers a defaulted synchronous post-write observer, and the test cancels at that production event boundary instead of polling scheduler and file-system timing around a 1 GiB sparse copy.

## Scope

In scope:

- Update the GitNexus guidance in `AGENTS.md`.
- Mirror the same guidance in the embedded GitNexus block in `CLAUDE.md`.
- Add `.gitnexusrc` with `skipContextFiles` enabled.
- Refresh the documented GitNexus index counts.
- Define genuine escalation conditions and prohibit drift-prone workarounds chosen only to reduce an impact score.
- Make the archive-copy cancellation cleanup test deterministic at the existing production copy boundary.

Out of scope:

- Exempting `.gitnexusrc` or other repository configuration from full CI.
- Changing archive-copy cancellation or cleanup behavior for existing production callers.
- Changes to the separate `app-owned-window-parity` worktree.
- Other GitNexus analysis or index settings.

## Contract References

- The `<!-- gitnexus:start -->` / `<!-- gitnexus:end -->` guidance contract in `AGENTS.md`.
- The mirrored GitNexus guidance contract in `CLAUDE.md`.
- Repository-local GitNexus configuration in `.gitnexusrc`.
- `AndroidModuleBackupArchiveFileStager.copy` cancellation and cleanup contract.
- `.github/PULL_REQUEST_TEMPLATE.md`.
- Repository commit-message and Swift docblock standards.

## Change Details

- Reframes HIGH and CRITICAL as dependency/blast-radius signals rather than permission levels.
- Requires inspection of callers, flows, contracts, and relevant tests for high-impact changes.
- Directs agents toward the smallest architecturally complete root-cause fix at the existing source of truth.
- Defines the conditions that genuinely require user escalation.
- Explicitly forbids duplicated logic, shadow state, parallel features, and automatic edits to every reported dependent merely to lower GitNexus risk.
- Keeps the GitNexus blocks in `AGENTS.md` and `CLAUDE.md` byte-identical.
- Configures GitNexus to skip recognized context files during repository analysis.
- Adds an optional, synchronous `didWriteChunk` observer to the existing archive stager; it defaults to `nil`, preserving every existing caller.
- Replaces the timing-polled 1 GiB sparse cancellation fixture with a bounded 64 KiB copy and an event-driven write barrier. The five-second timeout is deadlock protection only.

## Validation Evidence

- Final implementation: focused cancellation test passed 20 repeated simulator iterations.
- Final implementation: complete `BibleUITests` scheme passed 753/753 tests, with zero failures and zero skips, on an iPhone 17 iOS 26.5 simulator.
- `python3 scripts/check_repo_standards.py docblocks --all-files`: passed for 669 tracked Swift files.
- `python3 scripts/check_repo_standards.py source-guards`: passed.
- `python3 scripts/check_repo_standards.py commits --base-ref origin/main`: passed for 3 commits.
- `python3 -m unittest scripts/test_check_repo_standards.py`: 11 tests passed.
- `python3 -m json.tool .gitnexusrc`: passed.
- GitNexus final staged-scope audit: 2 changed Swift files, LOW risk, 0 affected execution flows.
- Earlier GitNexus audits for the guidance and configuration commits also reported LOW risk and 0 affected execution flows.
- Mirrored GitNexus blocks produced identical SHA-256 hashes.
- `git diff --cached --check`: passed.

## Risks / Follow-ups

- Existing production archive-copy callers retain the same behavior because the observer is internal and defaults to `nil`.
- The cancellation test now synchronizes on a real completed write rather than timing, reducing CI instability without weakening coverage.
- Recognized context files will no longer be included in the GitNexus index; this is the intended repository analysis behavior.
- The recorded index counts will naturally become stale as the repository changes; the existing reanalysis instruction remains the source of truth when GitNexus reports staleness.

## Screenshots

none

## Closes

Closes: none