### PR TITLE
fix(windowing): toggle and restore window tabs like Android

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
@@ -239,6 +239,41 @@ public final class WindowManager {
         }
     }
 
+    /**
+     Applies Android's restore-strip tap behavior to one managed window.
+
+     Android routes both visible and hidden restore buttons through `WindowControl.restoreWindow`.
+     A minimized window is restored and focused; a visible window is minimized unless it is a
+     terminal non-primary links window, which Android closes instead. The terminal check resolves
+     the target identifier against current manager state so stale target metadata behaves like
+     Android's nullable `ownTargetLinksWindow`.
+
+     - Parameter window: Active-workspace window represented by the tapped restore-strip button.
+     - Side Effects: Delegates to `restoreWindow`, `minimizeWindow`, or `removeWindow`, including
+       their persistence, focus repair, controller cleanup, and published-window refresh behavior.
+     - Failure Modes: Foreign windows are ignored. Existing lifecycle guards keep the final visible
+       pane from being minimized and the final workspace window from being removed.
+     - Note: Visibility is read at execution time rather than accepted from SwiftUI so a stale render
+       snapshot cannot invert the requested transition.
+     */
+    public func toggleWindowVisibility(_ window: Window) {
+        guard allWindows.contains(where: { $0.id == window.id }) else { return }
+
+        if window.layoutState == "minimized" {
+            restoreWindow(window)
+            return
+        }
+
+        let isPrimaryLinksWindow = activeWorkspace?.primaryTargetLinksWindowId == window.id
+        let isTerminalLinksWindow = window.isLinksWindow
+            && explicitLinksWindowTarget(for: window) == nil
+        if isTerminalLinksWindow && !isPrimaryLinksWindow {
+            removeWindow(window)
+        } else {
+            minimizeWindow(window)
+        }
+    }
+
     // MARK: - Window Lifecycle
 
     /**

--- a/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
@@ -243,10 +243,11 @@ public final class WindowManager {
      Applies Android's restore-strip tap behavior to one managed window.
 
      Android routes both visible and hidden restore buttons through `WindowControl.restoreWindow`.
-     A minimized window is restored and focused; a visible window is minimized unless it is a
-     terminal non-primary links window, which Android closes instead. The terminal check resolves
-     the target identifier against current manager state so stale target metadata behaves like
-     Android's nullable `ownTargetLinksWindow`.
+     A window Android considers hidden is restored and focused; a visible window is minimized unless
+     it is a terminal non-primary links window, which Android closes instead. Visibility includes
+     Android's maximized-window rule rather than assuming every non-minimized window is on screen.
+     The terminal check resolves the target identifier against current manager state so stale target
+     metadata behaves like Android's nullable `ownTargetLinksWindow`.
 
      - Parameter window: Active-workspace window represented by the tapped restore-strip button.
      - Side Effects: Delegates to `restoreWindow`, `minimizeWindow`, or `removeWindow`, including
@@ -259,7 +260,7 @@ public final class WindowManager {
     public func toggleWindowVisibility(_ window: Window) {
         guard allWindows.contains(where: { $0.id == window.id }) else { return }
 
-        if window.layoutState == "minimized" {
+        if !isVisibleForAndroidRestoreAction(window) {
             restoreWindow(window)
             return
         }
@@ -272,6 +273,30 @@ public final class WindowManager {
         } else {
             minimizeWindow(window)
         }
+    }
+
+    /**
+     Resolves Android's `Window.isVisible` branch for restore-strip actions.
+
+     When a workspace is maximized, Android treats only the maximized pane as visible except for
+     that pane's explicit chained links target. Outside that special case, any pane that is neither
+     minimized nor closed is visible. Keeping this projection separate from `visibleWindows`
+     preserves the chained-links exception and prevents a split-but-hidden peer from being
+     misclassified as visible.
+
+     - Parameter window: Managed window whose restore-strip action is being classified.
+     - Returns: `true` when Android would take the visible minimize/close branch.
+     - Side Effects: None.
+     - Failure Modes: A stale maximized identifier falls back to ordinary layout-state visibility,
+       matching `refreshWindows` repairing an unresolved maximized pane.
+     */
+    private func isVisibleForAndroidRestoreAction(_ window: Window) -> Bool {
+        if let maximizedWindowId = activeWorkspace?.maximizedWindowId,
+           let maximizedWindow = allWindows.first(where: { $0.id == maximizedWindowId }),
+           maximizedWindow.targetLinksWindowId != window.id {
+            return maximizedWindowId == window.id
+        }
+        return window.layoutState != "minimized" && window.layoutState != "closed"
     }
 
     // MARK: - Window Lifecycle

--- a/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
@@ -683,6 +683,55 @@ final class WorkspaceWindowStoreTests: XCTestCase {
     }
 
     /**
+     Protects Android's final-visible-window minimization guard through the restore-button entry.
+
+     The workspace contains exactly one visible pane and sends its footer action through
+     `toggleWindowVisibility`. Android's `isWindowMinimizable` rejects that transition, so the pane,
+     focus, and split layout must remain unchanged. A failure means a future lifecycle edit can
+     leave the reader with no visible window despite the toggle's documented safety guarantee.
+     */
+    func testWindowManagerRestoreButtonCannotMinimizeOnlyVisibleWindow() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Final Visible Restore Button")
+        let onlyWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        manager.setActiveWorkspace(workspace)
+
+        manager.toggleWindowVisibility(onlyWindow)
+
+        XCTAssertEqual(manager.allWindows.map(\.id), [onlyWindow.id])
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [onlyWindow.id])
+        XCTAssertEqual(manager.activeWindow?.id, onlyWindow.id)
+        XCTAssertEqual(onlyWindow.layoutState, "split")
+    }
+
+    /**
+     Verifies Android's closed layout state takes the hidden restore branch.
+
+     Synced or legacy workspace data can retain Android's `CLOSED` state even though ordinary iOS
+     removal deletes a window. Android's `Window.isVisible` returns false for that state, so a
+     restore-button action must reveal and focus the durable window rather than treating it as a
+     visible terminal pane to close. A failure means imported Android state can invert the toggle.
+     */
+    func testWindowManagerRestoreButtonRestoresClosedWindow() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Closed Restore Button")
+        let closedWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        closedWindow.layoutState = "closed"
+        store.persistChanges()
+        manager.setActiveWorkspace(workspace)
+
+        manager.toggleWindowVisibility(closedWindow)
+
+        XCTAssertTrue(manager.allWindows.contains(where: { $0.id == closedWindow.id }))
+        XCTAssertEqual(closedWindow.layoutState, "split")
+        XCTAssertEqual(manager.activeWindow?.id, closedWindow.id)
+    }
+
+    /**
      Protects Android's distinct primary and terminal nested links restore-button behavior.
 
      The setup creates the workspace primary links window and one nested terminal links window.
@@ -717,6 +766,78 @@ final class WorkspaceWindowStoreTests: XCTestCase {
         XCTAssertEqual(primaryLinksWindow.layoutState, "split")
         XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id, primaryLinksWindow.id])
         XCTAssertEqual(manager.activeWindow?.id, primaryLinksWindow.id)
+    }
+
+    /**
+     Verifies dangling nested-links metadata degrades to Android's terminal-window behavior.
+
+     The setup creates primary links → nested links → terminal links, removes the terminal target,
+     and leaves the middle pane's stored target identifier dangling. Android's
+     `ownTargetLinksWindow` then resolves to null, making that middle non-primary pane terminal; its
+     next visible restore-button tap must close it. A failure means stale relationship metadata can
+     turn transient links panes into durable hidden tabs.
+     */
+    func testWindowManagerRestoreButtonClosesNestedLinksWindowAfterTargetBecomesStale() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Stale Nested Links Restore Button")
+        let firstWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        manager.setActiveWorkspace(workspace)
+        let primaryLinksWindow = try XCTUnwrap(manager.linksWindow(for: firstWindow))
+        let nestedLinksWindow = try XCTUnwrap(manager.linksWindow(for: primaryLinksWindow))
+        let terminalLinksWindow = try XCTUnwrap(manager.linksWindow(for: nestedLinksWindow))
+        let terminalLinksWindowId = terminalLinksWindow.id
+
+        manager.removeWindow(terminalLinksWindow)
+
+        XCTAssertEqual(nestedLinksWindow.targetLinksWindowId, terminalLinksWindowId)
+        XCTAssertTrue(manager.allWindows.contains(where: { $0.id == nestedLinksWindow.id }))
+
+        manager.toggleWindowVisibility(nestedLinksWindow)
+
+        XCTAssertFalse(manager.allWindows.contains(where: { $0.id == nestedLinksWindow.id }))
+        XCTAssertTrue(manager.allWindows.contains(where: { $0.id == primaryLinksWindow.id }))
+        XCTAssertEqual(
+            manager.visibleWindows.map(\.id),
+            [firstWindow.id, primaryLinksWindow.id]
+        )
+    }
+
+    /**
+     Protects Android's maximization-aware `Window.isVisible` restore-button branch.
+
+     A terminal nested links pane remains in split state while another pane is maximized, making it
+     hidden even though it is not minimized. Android routes that hidden pane through restore/focus,
+     not the visible terminal-links close branch. The maximized layout remains authoritative and the
+     nested pane must survive for a later unmaximize. A failure means a future non-footer caller can
+     delete a hidden pane merely because its persisted layout state says split.
+     */
+    func testWindowManagerRestoreButtonDoesNotCloseSplitWindowHiddenByMaximization() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Maximized Restore Button")
+        let firstWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        manager.setActiveWorkspace(workspace)
+        let primaryLinksWindow = try XCTUnwrap(manager.linksWindow(for: firstWindow))
+        let hiddenTerminalLinksWindow = try XCTUnwrap(
+            manager.linksWindow(for: primaryLinksWindow)
+        )
+        manager.maximizeWindow(firstWindow)
+
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id])
+        XCTAssertEqual(hiddenTerminalLinksWindow.layoutState, "split")
+
+        manager.toggleWindowVisibility(hiddenTerminalLinksWindow)
+
+        XCTAssertTrue(
+            manager.allWindows.contains(where: { $0.id == hiddenTerminalLinksWindow.id })
+        )
+        XCTAssertEqual(hiddenTerminalLinksWindow.layoutState, "split")
+        XCTAssertEqual(workspace.maximizedWindowId, firstWindow.id)
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id])
+        XCTAssertEqual(manager.activeWindow?.id, firstWindow.id)
     }
 
     /**

--- a/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceWindowStoreTests.swift
@@ -653,6 +653,73 @@ final class WorkspaceWindowStoreTests: XCTestCase {
     }
 
     /**
+     Verifies a normal restore-strip button toggles its pane through Android's manager-owned path.
+
+     The setup creates two auto-pinned visible panes, then taps the second pane's restore button
+     twice through `toggleWindowVisibility`. Android's `WindowControl.restoreWindow` first minimizes
+     the visible pane and then restores and focuses it. A failure means iOS or macOS has reverted to
+     treating the bottom control as a focus-only tab or cannot restore the hidden pane.
+     */
+    func testWindowManagerRestoreButtonTogglesNormalWindowVisibilityLikeAndroid() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Restore Button")
+        let firstWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        manager.setActiveWorkspace(workspace)
+        let secondWindow = try XCTUnwrap(manager.addWindow(from: firstWindow))
+
+        manager.toggleWindowVisibility(secondWindow)
+
+        XCTAssertEqual(secondWindow.layoutState, "minimized")
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id])
+        XCTAssertEqual(manager.activeWindow?.id, firstWindow.id)
+
+        manager.toggleWindowVisibility(secondWindow)
+
+        XCTAssertEqual(secondWindow.layoutState, "split")
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id, secondWindow.id])
+        XCTAssertEqual(manager.activeWindow?.id, secondWindow.id)
+    }
+
+    /**
+     Protects Android's distinct primary and terminal nested links restore-button behavior.
+
+     The setup creates the workspace primary links window and one nested terminal links window.
+     Android closes a visible non-primary links window with no live chained target, while its primary
+     links window remains durable and follows ordinary minimize/restore toggling. A failure means
+     transient links panes leak as hidden tabs or the reusable primary links pane is deleted.
+     */
+    func testWindowManagerRestoreButtonClosesTerminalNestedLinksButTogglesPrimaryLinks() throws {
+        let container = try makeWorkspaceModelContainer()
+        let store = WorkspaceStore(modelContext: ModelContext(container))
+        let manager = WindowManager(workspaceStore: store)
+        let workspace = store.createWorkspace(name: "Links Restore Button")
+        let firstWindow = try XCTUnwrap(store.windows(workspaceId: workspace.id).first)
+        manager.setActiveWorkspace(workspace)
+        let primaryLinksWindow = try XCTUnwrap(manager.linksWindow(for: firstWindow))
+        let nestedLinksWindow = try XCTUnwrap(manager.linksWindow(for: primaryLinksWindow))
+
+        manager.toggleWindowVisibility(nestedLinksWindow)
+
+        XCTAssertFalse(manager.allWindows.contains(where: { $0.id == nestedLinksWindow.id }))
+        XCTAssertTrue(manager.allWindows.contains(where: { $0.id == primaryLinksWindow.id }))
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id, primaryLinksWindow.id])
+
+        manager.toggleWindowVisibility(primaryLinksWindow)
+
+        XCTAssertTrue(manager.allWindows.contains(where: { $0.id == primaryLinksWindow.id }))
+        XCTAssertEqual(primaryLinksWindow.layoutState, "minimized")
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id])
+
+        manager.toggleWindowVisibility(primaryLinksWindow)
+
+        XCTAssertEqual(primaryLinksWindow.layoutState, "split")
+        XCTAssertEqual(manager.visibleWindows.map(\.id), [firstWindow.id, primaryLinksWindow.id])
+        XCTAssertEqual(manager.activeWindow?.id, primaryLinksWindow.id)
+    }
+
+    /**
      Verifies visible-window ordering keeps pinned panes before unpinned panes.
 
      The setup flips pin state so a later pane is pinned while the first pane is not. The expected

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -79,7 +79,19 @@ struct BibleReaderSpeechSelection: Equatable {
  */
 @Observable
 public final class BibleReaderController: NSObject, BibleBridgeDelegate {
+    /// Native/Vue bridge dedicated to this controller's reader window.
     let bridge: BibleBridge
+
+    /**
+     Per-window owner of the live WebView host and its weak WebKit delegates.
+
+     The window manager retains this controller while a pane is minimized, so retaining the render
+     session here gives iOS and macOS Android's `BibleViewFactory` lifetime: SwiftUI can detach the
+     pane without destroying the loaded Vue client. Closing the window unregisters this controller
+     and releases the cached host.
+     */
+    let webViewSession: BibleWebViewSession
+
   /// Cancellable app-owned subscription that keeps this pane's Vue marker state current.
   @ObservationIgnored
   private var aiDocMarkerEventObservation: MyDocumentAIDocMarkerEventObservation?
@@ -986,6 +998,8 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
      - Parameters:
        - bridge: Bridge used to emit events to the Vue.js reader and receive callbacks.
+       - webViewSession: Optional pre-created render session already used by the pane's first
+         SwiftUI pass. When omitted, the controller creates a session around `bridge`.
        - bookmarkService: Optional bookmark/studypad service used for annotation features.
        - initializesSword: Whether to initialize SWORD immediately. Pane controllers that will
          copy an existing controller's shared module state pass `false` to avoid creating a
@@ -994,19 +1008,29 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
 
      Side effects:
      - assigns itself as the bridge delegate
+     - retains the render session until the controller leaves the window registry
      - initializes SWORD state and installed-module caches when `initializesSword` is `true`
 
      Failure modes:
+     - a supplied render session paired with another bridge fails fast because mixing the two would
+       route Vue callbacks and native emissions to different windows
      - if SWORD initialization is requested and `SwordManager` creation fails, the controller
        remains usable for placeholder/fallback rendering with empty installed-module caches.
      */
     public init(
         bridge: BibleBridge,
+        webViewSession: BibleWebViewSession? = nil,
         bookmarkService: BookmarkService? = nil,
     initializesSword: Bool = true,
     aiDocMarkerEventCenter: MyDocumentAIDocMarkerEventCenter = .shared
     ) {
+        let resolvedWebViewSession = webViewSession ?? BibleWebViewSession(bridge: bridge)
+        precondition(
+            resolvedWebViewSession.bridge === bridge,
+            "BibleReaderController and BibleWebViewSession must share one bridge"
+        )
         self.bridge = bridge
+        self.webViewSession = resolvedWebViewSession
         self.bookmarkService = bookmarkService
         self.compareDocumentBuildOperation = BibleReaderCompareDocumentBuilder.buildDocumentJSON
         super.init()
@@ -1017,8 +1041,24 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     }
 
+    /**
+     Creates a controller with an injected SWORD manager for deterministic integration tests.
+
+     - Parameters:
+       - bridge: Window-scoped native/Vue bridge.
+       - webViewSession: Optional matching render session; omitted tests receive a lazy empty
+         session that never creates a WebView unless explicitly attached.
+       - bookmarkService: Optional bookmark service used by annotation paths.
+       - swordManagerOverride: Preconfigured SWORD manager replacing production discovery.
+       - compareDocumentBuildOperation: Injectable Compare payload builder.
+       - aiDocMarkerEventCenter: Typed marker event source observed by this pane.
+     - Side Effects: Assigns the bridge delegate, retains the render session, subscribes to marker
+       events, and projects the supplied SWORD manager into controller state.
+     - Failure Modes: A render session paired with another bridge fails fast.
+     */
     init(
         bridge: BibleBridge,
+        webViewSession: BibleWebViewSession? = nil,
         bookmarkService: BookmarkService? = nil,
         swordManagerOverride: SwordManager,
     compareDocumentBuildOperation:
@@ -1026,7 +1066,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
       BibleReaderCompareDocumentBuilder.buildDocumentJSON,
     aiDocMarkerEventCenter: MyDocumentAIDocMarkerEventCenter = .shared
     ) {
+        let resolvedWebViewSession = webViewSession ?? BibleWebViewSession(bridge: bridge)
+        precondition(
+            resolvedWebViewSession.bridge === bridge,
+            "BibleReaderController and BibleWebViewSession must share one bridge"
+        )
         self.bridge = bridge
+        self.webViewSession = resolvedWebViewSession
         self.bookmarkService = bookmarkService
         self.compareDocumentBuildOperation = compareDocumentBuildOperation
         super.init()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -42,11 +42,11 @@ enum BibleWindowPaneReferenceRouter {
 /**
  Hosts one fully independent reading pane inside the multi-window reader.
 
- Each pane uses the `BibleBridge` and `BibleReaderController` registered for its `Window`, while
- delegating sheet/alert/toast presentation back to `BibleReaderView` through callback closures.
- Keeping that controller/bridge pair scoped to the window, not transient SwiftUI appearances, lets
- multiple panes render different modules and references simultaneously while still sharing
- workspace-level state from `WindowManager`.
+ Each pane uses the `BibleBridge`, `BibleWebViewSession`, and `BibleReaderController` registered for
+ its `Window`, while delegating sheet/alert/toast presentation back to `BibleReaderView` through
+ callback closures. Keeping the controller, bridge, and actual WebView host scoped to the window—not
+ transient SwiftUI appearances—lets minimized panes reattach instantly and lets multiple panes
+ render different modules and references simultaneously.
 
  Data dependencies:
  - `window`, `displaySettings`, `nightMode`, `monochromeMode`, `disableTwoStepBookmarking`, and
@@ -57,7 +57,8 @@ enum BibleWindowPaneReferenceRouter {
    bookmark, history, and settings mutations initiated by the controller
 
  Side effects:
- - `onAppear` lazily creates or reuses the pane controller and registers it with `WindowManager`
+ - `onAppear` lazily creates or reuses the pane controller and its retained WebView session, then
+   registers the controller with `WindowManager`
  - window removal or workspace switching unregisters controllers from `WindowManager`
  - `onChange` for `nightMode` and `displaySettings` pushes updated display state into the
    embedded web view via `BibleReaderController.updateDisplaySettings`
@@ -87,8 +88,8 @@ struct BibleWindowPane: View {
     /// Reader-session owner for Android's typed Copy/Open reference contract.
     let windowMenuReferenceStore: BibleWindowMenuReferenceStore
 
-    /// Native/web bridge for this pane's WKWebView instance.
-    @State private var bridge = BibleBridge()
+    /// First-appearance bridge/session pair adopted by a newly created pane controller.
+    @State private var renderSeed = BibleWindowRenderSeed()
 
     /// Controller that owns module state, navigation, and bridge callbacks for this pane.
     @State private var controller: BibleReaderController?
@@ -117,15 +118,22 @@ struct BibleWindowPane: View {
   /// Shared search index used by Android-compatible AI search tools.
   @Environment(SearchIndexService.self) private var searchIndexService
 
-    /// Bridge that should back the current `BibleWebView` render pass.
-    private var webBridge: BibleBridge {
+    /**
+     Render session that should back the current SwiftUI representable pass.
+
+     - Returns: The local controller session, the manager-registered controller session during
+       restoration, or the initial seed before any controller exists.
+     - Side Effects: None.
+     - Failure Modes: None; the seed guarantees a session for the first render.
+     */
+    private var webViewSession: BibleWebViewSession {
         if let controller {
-            return controller.bridge
+            return controller.webViewSession
         }
         if let registeredController = windowManager.controllers[window.id] as? BibleReaderController {
-            return registeredController.bridge
+            return registeredController.webViewSession
         }
-        return bridge
+        return renderSeed.webViewSession
     }
 
     /// Requests the parent reader to present the book chooser.
@@ -237,9 +245,21 @@ struct BibleWindowPane: View {
         )
     }
 
+    /**
+     Renders the cached WebView host with pane-owned overlays and lifecycle wiring.
+
+     The `BibleWebView` receives the stable session resolved from the registered controller, so
+     removing this pane from the split hierarchy detaches rather than destroys its Vue client.
+
+     - Returns: One pane surface with selection, window-menu, help, and AI overlays.
+     - Side Effects: Appearance creates/configures/registers the pane controller; display-setting
+       changes emit updated configuration through that controller.
+     - Failure Modes: Before controller registration, the render seed supplies the first host and
+       is adopted by the controller during `onAppear`.
+     */
     var body: some View {
         ZStack(alignment: .bottom) {
-            BibleWebView(bridge: webBridge, backgroundColorInt: activeBackgroundColorInt)
+            BibleWebView(session: webViewSession, backgroundColorInt: activeBackgroundColorInt)
                 .ignoresSafeArea(edges: .bottom)
 
             // Selection action bar — shows when text is long-press selected
@@ -583,7 +603,6 @@ struct BibleWindowPane: View {
         let store = SettingsStore(modelContext: modelContext)
 
         if let existingController = windowManager.controllers[window.id] as? BibleReaderController {
-            bridge = existingController.bridge
             controller = existingController
             configureController(existingController, workspaceStore: workspaceStore, settingsStore: store)
       configureAICoordinator(for: existingController)
@@ -596,7 +615,8 @@ struct BibleWindowPane: View {
         let sharedControllers = windowManager.controllers.values
             .compactMap { $0 as? BibleReaderController }
         let ctrl = BibleReaderController(
-            bridge: bridge,
+            bridge: renderSeed.bridge,
+            webViewSession: renderSeed.webViewSession,
             bookmarkService: bookmarkService,
             initializesSword: sharedControllers.isEmpty
         )

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowRenderSeed.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowRenderSeed.swift
@@ -1,0 +1,37 @@
+// BibleWindowRenderSeed.swift — First-render bridge and WebView-session ownership
+
+import BibleView
+
+/**
+ Creates the bridge/render-session pair needed before a pane controller exists.
+
+ SwiftUI constructs the WebView host before `BibleWindowPane.onAppear` initializes the reader
+ controller. Keeping the pair in one state-owned reference lets that first host be adopted by the
+ controller instead of creating a second `WKWebView`. On later pane appearances the registered
+ controller's retained session wins and this seed remains unused.
+
+ Side effects:
+ - creates one bridge and one lazy `BibleWebViewSession`
+
+ Failure modes:
+ - none; the session does not instantiate WebKit until the representable requests its WebView
+ */
+final class BibleWindowRenderSeed {
+    /// Bridge adopted by a newly created reader controller.
+    let bridge: BibleBridge
+
+    /// Lazy render session paired with `bridge`.
+    let webViewSession: BibleWebViewSession
+
+    /**
+     Creates a mutually paired bridge and render session.
+
+     - Side Effects: Allocates native coordination objects but does not create or load a WebView.
+     - Failure Modes: None.
+     */
+    init() {
+        let bridge = BibleBridge()
+        self.bridge = bridge
+        self.webViewSession = BibleWebViewSession(bridge: bridge)
+    }
+}

--- a/Sources/BibleUI/Sources/BibleUI/Bible/WindowActionRouting.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/WindowActionRouting.swift
@@ -13,6 +13,9 @@ protocol WindowTabActionTarget: AnyObject {
     /// Activates a visible window and applies the manager's focus normalization.
     func activateWindow(_ window: BibleCore.Window)
 
+    /// Applies Android's restore-strip visibility toggle, including transient links-window closure.
+    func toggleWindowVisibility(_ window: BibleCore.Window)
+
     /// Restores a minimized window through the manager lifecycle.
     func restoreWindow(_ window: BibleCore.Window)
 
@@ -48,8 +51,8 @@ protocol WindowTabActionTarget: AnyObject {
  validation, normalization, and persistence behavior to its `WindowTabActionTarget`.
  */
 enum WindowTabAction: Equatable {
-    /// Selects a tab, restoring it when it is currently minimized and activating it otherwise.
-    case select(isMinimized: Bool)
+    /// Delegates an Android restore-strip tap using the manager's current visibility and links state.
+    case select
 
     /// Activates the tab before a secondary action such as typed-reference navigation.
     case activate
@@ -85,9 +88,9 @@ enum WindowTabAction: Equatable {
 /**
  Routes typed window-tab commands into the production window lifecycle boundary.
 
- The dispatcher contains no window behavior of its own beyond choosing restore versus activate for
- tab selection. Every mutation is delegated to `WindowManager` in production, preserving its
- validation, normalization, synchronization, and persistence contracts.
+ The dispatcher contains no window behavior of its own. Restore-strip selection and every explicit
+ mutation are delegated to `WindowManager` in production, preserving its validation, normalization,
+ synchronization, and persistence contracts.
  */
 struct WindowTabActionDispatcher {
     /// Production manager or recording test target that receives routed commands.
@@ -116,12 +119,8 @@ struct WindowTabActionDispatcher {
      */
     func perform(_ action: WindowTabAction, for window: BibleCore.Window) {
         switch action {
-        case .select(let isMinimized):
-            if isMinimized {
-                target.restoreWindow(window)
-            } else {
-                target.activateWindow(window)
-            }
+        case .select:
+            target.toggleWindowVisibility(window)
         case .activate:
             target.activateWindow(window)
         case .restore:

--- a/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/WindowTabBar.swift
@@ -329,7 +329,7 @@ struct WindowTabBar: View {
         )
 
         return Button {
-            actionDispatcher.perform(.select(isMinimized: isMinimized), for: window)
+            actionDispatcher.perform(.select, for: window)
         } label: {
             ZStack(alignment: .topLeading) {
                 tabShape

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderRenderSessionTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderRenderSessionTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import BibleView
+@testable import BibleUI
+
+/**
+ Protects the controller ownership boundary that keeps a window's rendered Vue client alive.
+
+ `WindowManager` retains each `BibleReaderController` while its window is minimized. These tests
+ avoid constructing WebKit and instead verify that the controller retains the exact supplied
+ render session, then releases it when the controller lifetime ends.
+ */
+@MainActor
+final class BibleReaderRenderSessionTests: XCTestCase {
+    /**
+     Verifies the pre-controller render seed cannot split bridge and WebView ownership.
+
+     `BibleWindowPane` must render with the same bridge/session pair that it later gives the
+     controller. A failure would let the first Vue client send callbacks to one bridge while the
+     registered controller emits document events through another.
+     */
+    func testWindowRenderSeedPairsOneBridgeWithItsSession() {
+        let seed = BibleWindowRenderSeed()
+
+        XCTAssertTrue(seed.webViewSession.bridge === seed.bridge)
+    }
+
+    /**
+     Verifies a pane controller adopts and owns the session used by its first SwiftUI render pass.
+
+     The local strong session reference leaves scope after controller creation. The session must
+     remain alive and preserve identity until the controller is released, after which it must
+     deallocate. A failure means minimizing can either lose the cached WebView or leak it after the
+     window closes.
+     */
+    func testControllerRetainsSuppliedRenderSessionOnlyForItsOwnLifetime() {
+        let bridge = BibleBridge()
+        weak var retainedSession: BibleWebViewSession?
+        var controller: BibleReaderController?
+
+        do {
+            let session = BibleWebViewSession(bridge: bridge)
+            retainedSession = session
+            controller = BibleReaderController(
+                bridge: bridge,
+                webViewSession: session,
+                initializesSword: false
+            )
+
+            XCTAssertTrue(controller?.webViewSession === session)
+        }
+
+        XCTAssertNotNil(retainedSession)
+        controller = nil
+        XCTAssertNil(retainedSession)
+    }
+}

--- a/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/WindowTabBarLayoutTests.swift
@@ -111,20 +111,42 @@ final class WindowTabBarLayoutTests: XCTestCase {
     }
 
     /**
+     Protects Android restore-button visibility toggling on the shared iOS and macOS footer.
+
+     Android's `SplitBibleArea.createRestoreButton` sends every button tap to
+     `WindowControl.restoreWindow`: a visible pane minimizes, while a minimized pane restores.
+     The recording target proves SwiftUI delegates one visibility-toggle command instead of deciding
+     the lifecycle branch from rendered state. Manager tests cover the resulting minimize, restore,
+     and transient-links closure branches. A failure means the footer has resumed treating a visible
+     window button like a conventional focus-only tab.
+     */
+    func testWindowTabSelectionDelegatesAndroidRestoreButtonBehaviorToManager() {
+        let window = BibleCore.Window()
+        let target = RecordingWindowTabActionTarget()
+        let dispatcher = WindowTabActionDispatcher(target: target)
+
+        dispatcher.perform(.select, for: window)
+
+        XCTAssertEqual(target.calls, [
+            .toggleVisibility(window.id),
+        ])
+    }
+
+    /**
      Executes every state-changing tab command through the dispatcher used by `WindowTabBar`.
 
      The recording target stands in for `WindowManager` and proves selection, focus, movement,
      synchronization, pinning, grouping, layout, and close actions delegate exactly once without
-     directly mutating the window fixture. A failure means the UI command seam no longer preserves
-     the manager-owned lifecycle contract.
+     directly mutating the window fixture. Selection delegates Android's restore-strip behavior to
+     the manager rather than branching from the view's snapshot. A failure means the UI command seam
+     no longer preserves the manager-owned lifecycle contract.
     */
     func testWindowTabDispatcherRoutesEveryMutationToManagerBoundary() {
         let window = BibleCore.Window(isSynchronized: true, isPinMode: false, syncGroup: 0)
         let target = RecordingWindowTabActionTarget()
         let dispatcher = WindowTabActionDispatcher(target: target)
 
-        dispatcher.perform(.select(isMinimized: false), for: window)
-        dispatcher.perform(.select(isMinimized: true), for: window)
+        dispatcher.perform(.select, for: window)
         dispatcher.perform(.activate, for: window)
         dispatcher.perform(.restore, for: window)
         dispatcher.perform(.move(toPosition: 3), for: window)
@@ -137,8 +159,7 @@ final class WindowTabBarLayoutTests: XCTestCase {
         dispatcher.perform(.close, for: window)
 
         let expectedCalls: [RecordingWindowTabActionTarget.Call] = [
-            .activate(window.id),
-            .restore(window.id),
+            .toggleVisibility(window.id),
             .activate(window.id),
             .restore(window.id),
             .move(window.id, position: 3),
@@ -296,6 +317,8 @@ private final class RecordingWindowTabActionTarget: WindowTabActionTarget {
     enum Call: Equatable {
         /// Window activation request.
         case activate(UUID)
+        /// Android restore-strip visibility-toggle request.
+        case toggleVisibility(UUID)
         /// Window restoration request.
         case restore(UUID)
         /// Window movement request and zero-based destination.
@@ -321,6 +344,11 @@ private final class RecordingWindowTabActionTarget: WindowTabActionTarget {
 
     /// Records activation without mutating the window.
     func activateWindow(_ window: BibleCore.Window) { calls.append(.activate(window.id)) }
+
+    /// Records Android restore-strip selection without mutating the window.
+    func toggleWindowVisibility(_ window: BibleCore.Window) {
+        calls.append(.toggleVisibility(window.id))
+    }
 
     /// Records restoration without mutating the window.
     func restoreWindow(_ window: BibleCore.Window) { calls.append(.restore(window.id)) }

--- a/Sources/BibleView/Sources/BibleView/BibleWebView.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleWebView.swift
@@ -12,7 +12,7 @@ import AppKit
 
  Usage:
  ```swift
- BibleWebView(bridge: bridge)
+ BibleWebView(session: BibleWebViewSession(bridge: bridge))
      .onAppear { bridge.emit(event: "loadDocument", data: documentJson) }
  ```
  */
@@ -79,29 +79,59 @@ public class BibleWebViewController: UIViewController {
 /**
  SwiftUI wrapper that hosts the Vue.js Bible client inside `WKWebView`.
 
- The native bridge/controller layer owns this view and uses `BibleBridge.emit(event:data:)`
- to push documents, config, and bookmark updates into the already loaded client bundle.
+ A window-scoped `BibleWebViewSession` owns the rendered `WKWebView` and coordinator. SwiftUI may
+ dismantle this representable while a pane is minimized, but recreating it with the same session
+ wraps and reattaches the already-loaded Vue client instead of constructing and replaying another
+ `WKWebView`.
  */
 public struct BibleWebView: UIViewControllerRepresentable {
     public typealias UIViewControllerType = BibleWebViewController
 
-    let bridge: BibleBridge
+    /// Window-scoped owner of the bridge, coordinator, and cached WebView.
+    let session: BibleWebViewSession
+
+    /// Optional serialized bootstrap state retained for compatibility with existing callers.
     let initialState: String?
+
+    /// Android-style signed ARGB color applied to every native host surface.
     var backgroundColorInt: Int
 
-    /// Creates a new bridge-backed web view wrapper.
-    public init(bridge: BibleBridge, initialState: String? = nil, backgroundColorInt: Int = -1) {
-        self.bridge = bridge
+    /**
+     Creates a transient SwiftUI wrapper around one persistent window render session.
+
+     - Parameters:
+       - session: Per-window session whose cached WebView should be attached by this representable.
+       - initialState: Reserved serialized bootstrap state retained for API compatibility.
+       - backgroundColorInt: Signed Android ARGB color for the WebView and native backing surfaces.
+     - Side Effects: None; WebView creation remains lazy until SwiftUI calls `makeUIViewController`.
+     - Failure Modes: Reusing one session in simultaneous visible hierarchies violates the session
+       ownership contract.
+     */
+    public init(
+        session: BibleWebViewSession,
+        initialState: String? = nil,
+        backgroundColorInt: Int = -1
+    ) {
+        self.session = session
         self.initialState = initialState
         self.backgroundColorInt = backgroundColorInt
     }
 
-    /// Builds the UIKit controller wrapper and initial web view.
+    /**
+     Wraps and attaches the session's cached WebView, creating and loading it only on first use.
+
+     - Parameter context: SwiftUI representable context whose coordinator is session-owned.
+     - Returns: A transient UIKit controller containing the persistent per-window `WKWebView`.
+     - Side Effects: First use creates a WebView and starts the packaged Vue bundle navigation.
+     - Failure Modes: Bundle lookup retains the existing placeholder fallback behavior.
+     */
     public func makeUIViewController(context: Context) -> BibleWebViewController {
-        let webView = createWebView(coordinator: context.coordinator)
-        let vc = BibleWebViewController(webView: webView, bridge: bridge)
-        vc.backgroundColorInt = backgroundColorInt
-        return vc
+        let webView = session.webView {
+            createWebView(coordinator: context.coordinator)
+        }
+        let viewController = BibleWebViewController(webView: webView, bridge: session.bridge)
+        viewController.backgroundColorInt = backgroundColorInt
+        return viewController
     }
 
     /// Reapplies visual state that can change after creation.
@@ -120,9 +150,15 @@ public struct BibleWebView: UIViewControllerRepresentable {
         return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 
-    /// Creates the coordinator that owns navigation, logging, and gesture callbacks.
+    /**
+     Returns the coordinator retained by the per-window session.
+
+     - Returns: Stable coordinator identity for the cached host's complete lifetime.
+     - Side Effects: None.
+     - Failure Modes: None.
+     */
     public func makeCoordinator() -> WebViewCoordinator {
-        WebViewCoordinator(bridge: bridge)
+        session.coordinator
     }
 }
 #elseif os(macOS)
@@ -173,30 +209,64 @@ final class InteractionReportingWKWebView: WKWebView {
 public struct BibleWebView: NSViewRepresentable {
     public typealias NSViewType = WKWebView
 
-    let bridge: BibleBridge
+    /// Window-scoped owner of the bridge, coordinator, and cached AppKit WebView.
+    let session: BibleWebViewSession
+
+    /// Optional serialized bootstrap state retained for compatibility with existing callers.
     let initialState: String?
+
+    /// Android-style signed ARGB color retained for cross-platform API symmetry.
     var backgroundColorInt: Int
 
-    /// Creates a new bridge-backed macOS web view wrapper.
-    public init(bridge: BibleBridge, initialState: String? = nil, backgroundColorInt: Int = -1) {
-        self.bridge = bridge
+    /**
+     Creates a transient SwiftUI wrapper around one persistent window render session.
+
+     - Parameters:
+       - session: Per-window session whose cached WebView should be attached.
+       - initialState: Reserved serialized bootstrap state retained for API compatibility.
+       - backgroundColorInt: Signed Android ARGB color retained for cross-platform API symmetry.
+     - Side Effects: None; host creation remains lazy until SwiftUI calls `makeNSView`.
+     - Failure Modes: Reusing one session in simultaneous visible hierarchies violates the session
+       ownership contract.
+     */
+    public init(
+        session: BibleWebViewSession,
+        initialState: String? = nil,
+        backgroundColorInt: Int = -1
+    ) {
+        self.session = session
         self.initialState = initialState
         self.backgroundColorInt = backgroundColorInt
     }
 
-    /// Builds the `WKWebView` and attaches the coordinator.
+    /**
+     Attaches the session's cached AppKit WebView, creating and loading it only on first use.
+
+     - Parameter context: SwiftUI representable context whose coordinator is session-owned.
+     - Returns: The same `WKWebView` across pane detach/reattach cycles.
+     - Side Effects: First use creates a WebView and starts the packaged Vue bundle navigation.
+     - Failure Modes: Bundle lookup retains the existing placeholder fallback behavior.
+     */
     public func makeNSView(context: Context) -> WKWebView {
-        let webView = createWebView(coordinator: context.coordinator)
-        webView.setValue(false, forKey: "drawsBackground")
-        return webView
+        session.webView {
+            let webView = createWebView(coordinator: context.coordinator)
+            webView.setValue(false, forKey: "drawsBackground")
+            return webView
+        }
     }
 
     /// macOS currently has no incremental update work beyond the bridge itself.
     public func updateNSView(_ webView: WKWebView, context: Context) {}
 
-    /// Creates the coordinator that owns navigation and logging callbacks.
+    /**
+     Returns the coordinator retained by the per-window session.
+
+     - Returns: Stable coordinator identity for the cached host's complete lifetime.
+     - Side Effects: None.
+     - Failure Modes: None.
+     */
     public func makeCoordinator() -> WebViewCoordinator {
-        WebViewCoordinator(bridge: bridge)
+        session.coordinator
     }
 }
 #endif
@@ -331,7 +401,7 @@ extension BibleWebView {
 
         // Register bridge message handler
         let contentController = WKUserContentController()
-        contentController.add(bridge, name: BibleBridge.handlerName)
+        contentController.add(session.bridge, name: BibleBridge.handlerName)
 
         // Inject platform detection and Android API shim before page loads.
         // The Vue.js code calls window.android.xxx() directly (from android.ts).
@@ -383,7 +453,7 @@ extension BibleWebView {
 
         #if os(macOS)
         let webView = InteractionReportingWKWebView(frame: .zero, configuration: config)
-        webView.onNativeUserInteraction = { [weak bridge] in
+        webView.onNativeUserInteraction = { [weak bridge = session.bridge] in
             bridge?.onNativeUserInteraction?()
         }
         #else
@@ -401,7 +471,7 @@ extension BibleWebView {
         coordinator.installSwipeRecognizersIfNeeded(on: webView)
         #endif
 
-        bridge.webView = webView
+        session.bridge.webView = webView
         coordinator.webView = webView
         webView.navigationDelegate = coordinator
 

--- a/Sources/BibleView/Sources/BibleView/BibleWebViewSession.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleWebViewSession.swift
@@ -1,0 +1,74 @@
+// BibleWebViewSession.swift — Per-window native WebView lifetime owner
+
+import WebKit
+
+/**
+ Retains one bridge-backed WebView host for the lifetime of a reader window.
+
+ Android's `BibleViewFactory.windowBibleViewMap` keeps the actual `BibleView` alive while its
+ `BibleFrame` is detached for minimization. This session provides the same ownership boundary for
+ iOS and macOS: SwiftUI may remove and later recreate a representable, but the pane controller keeps
+ this session alive and the representable reattaches the already-bootstrapped `WKWebView`.
+
+ The session owns the original `WebViewCoordinator` because WebKit delegate properties are weak.
+ Keeping the coordinator beside the cached host preserves navigation, native interaction, and
+ scroll callbacks across detach/reattach cycles.
+
+ Side effects:
+ - lazily retains the first `WKWebView` returned by a resolver factory
+ - retains one coordinator bound to `bridge`
+
+ Failure modes:
+ - callers must use the session only with the bridge supplied at initialization
+ - WebView creation still propagates any failure behavior of the supplied factory
+
+ Concurrency:
+ - WebKit and representable lifecycle access must remain on the main thread
+ - one session must not be attached to two visible view hierarchies concurrently
+ */
+public final class BibleWebViewSession {
+    /// Bridge shared by the cached WebView host and its owning reader controller.
+    public let bridge: BibleBridge
+
+    /**
+     Coordinator retained independently of transient SwiftUI representable instances.
+
+     WebKit stores navigation and scroll delegates weakly, so retaining this coordinator is required
+     for a cached WebView to keep routing callbacks after the original representable is dismantled.
+     */
+    let coordinator: WebViewCoordinator
+
+    /// Rendered Vue surface retained while its reader window is minimized or hidden by layout.
+    private var cachedWebView: WKWebView?
+
+    /**
+     Creates an empty per-window render session.
+
+     - Parameter bridge: Window-scoped native/Vue bridge that must remain paired with the cached
+       host for the session's complete lifetime.
+     - Side Effects: Creates and retains a coordinator; no `WKWebView` or bundle navigation starts
+       until the platform representable first requests a WebView.
+     - Failure Modes: None.
+     */
+    public init(bridge: BibleBridge) {
+        self.bridge = bridge
+        self.coordinator = WebViewCoordinator(bridge: bridge)
+    }
+
+    /**
+     Returns the existing rendered WebView or creates it exactly once.
+
+     - Parameter create: Main-thread factory that builds the bridge-backed WebView on first use.
+     - Returns: The identical `WKWebView` instance for every call during this session's lifetime.
+     - Side Effects: Retains the first WebView produced by `create`.
+     - Failure Modes: The factory is not called after a WebView has been cached.
+     */
+    func webView(create: () -> WKWebView) -> WKWebView {
+        if let cachedWebView {
+            return cachedWebView
+        }
+        let webView = create()
+        cachedWebView = webView
+        return webView
+    }
+}

--- a/Sources/BibleView/Tests/BibleViewTests/BibleWebViewSessionTests.swift
+++ b/Sources/BibleView/Tests/BibleViewTests/BibleWebViewSessionTests.swift
@@ -1,0 +1,41 @@
+import WebKit
+import XCTest
+@testable import BibleView
+
+/**
+ Verifies Android-style per-window native WebView retention in the BibleView layer.
+
+ The tests exercise the platform host resolver without loading the packaged Vue bundle. Stable
+ host and coordinator identity is the deterministic contract needed for SwiftUI pane
+ detach/reattach; document replay behavior remains covered by reader-controller bridge tests.
+ */
+@MainActor
+final class BibleWebViewSessionTests: XCTestCase {
+    /**
+     Proves a render session creates one WebView and reuses it after a simulated reattach.
+
+     Two resolver calls represent SwiftUI constructing the same window pane before and after
+     minimization. The second factory must not execute, and the representable must return the
+     coordinator retained by the session. A failure means restore can rebuild the `WKWebView`,
+     restart Vue, and replay the document instead of reattaching rendered state.
+     */
+    func testSessionReusesWebViewAndCoordinatorAcrossRepresentableLifetimes() {
+        let bridge = BibleBridge()
+        let session = BibleWebViewSession(bridge: bridge)
+        var hostCreationCount = 0
+
+        let first = session.webView {
+            hostCreationCount += 1
+            return WKWebView()
+        }
+        let second = session.webView {
+            hostCreationCount += 1
+            return WKWebView()
+        }
+        let representableCoordinator = BibleWebView(session: session).makeCoordinator()
+
+        XCTAssertTrue(first === second)
+        XCTAssertEqual(hostCreationCount, 1)
+        XCTAssertTrue(representableCoordinator === session.coordinator)
+    }
+}


### PR DESCRIPTION
## Summary

Aligns bottom window-button behavior and pane restoration with Android on iOS and macOS. A visible durable window minimizes when its button is tapped; tapping its hidden button restores it; terminal non-primary links windows close on a visible tap. Restored panes now reattach their existing rendered WebView instead of rebuilding Vue and replaying the document.

## Scope

- Centralizes restore-strip tap behavior at the window lifecycle boundary.
- Caches the actual rendered WebView per active-workspace window, matching Android's BibleViewFactory ownership model.
- Keeps each bridge, WebView coordinator, and reader controller paired for the complete minimized-pane lifetime.
- Covers normal, primary-links, terminal nested-links, stale-target, maximized-hidden, closed-state, and final-visible-pane behavior.
- Does not migrate persisted autoPin=false; that remains an explicit, valid workspace preference.

## Contract references

- Android SplitBibleArea.createRestoreButton always delegates a footer-button tap to WindowControl.restoreWindow(window).
- Android WindowControl.restoreWindow restores hidden windows, minimizes visible durable windows, and closes visible terminal non-primary links windows.
- Android Window.isVisible is maximization-aware and treats MINIMISED and CLOSED as hidden.
- Android BibleViewFactory.windowBibleViewMap and getOrCreateBibleView retain the actual BibleView while BibleFrame detaches and reattaches it.
- Existing WindowManager guards preserve at least one visible window and at least one workspace window.
- Related historical window-tab alignment: #229.
- Built on the reader/theme fixes merged in #368.

## Change details

- Added WindowManager.toggleWindowVisibility, which reads current manager state at execution time and delegates to existing restore, minimize, or removal lifecycle operations.
- Matched Android's maximization-aware visibility branch instead of equating every non-minimized pane with an on-screen pane.
- Removed view-snapshot branching from the typed tab dispatcher.
- Added BibleWebViewSession as the per-window owner of the rendered WKWebView and its weak WebKit delegates.
- Added a first-render bridge/session seed so the WebView created before SwiftUI onAppear is the exact session adopted by BibleReaderController.
- Kept minimized-pane controllers registered, allowing SwiftUI to detach and later reattach the same live Vue surface.
- Added deterministic regressions for WebView identity, coordinator identity, controller/session lifetime, bridge pairing, final-pane safety, stale links targets, closed state, and maximized hidden panes.

## Validation evidence

- Focused BibleView, BibleUI, WindowTabBar, and WorkspaceWindowStore suites: 61 passed, 0 failed.
- BibleUI production target build: passed.
- Exact committed Debug iPhone simulator app build: passed.
- Installed and launched on AndBible Local BibleUI iPhone 17 without resetting app data.
- Full Swift docblock guardrail: passed across 768 tracked Swift files.
- Static source guardrails: passed.
- Commit-message guardrail: passed.
- GitNexus staged detection: 9 files, 55 mapped symbols, 8 affected controller-initialization flows, high aggregate risk as expected for pane ownership and WindowManager lifecycle changes.
- Latest origin/main fetched before push; branch was 0 commits behind and 2 commits ahead.

## Risks / follow-ups

- This is intentionally a high-risk lifecycle change: the live WebView now has window-controller lifetime instead of transient SwiftUI-representable lifetime. Ownership and release behavior have direct regression coverage.
- Minimized windows retain their rendered WebView and associated memory until the window closes or the active workspace changes, matching Android's factory cache and clear-on-workspace-switch behavior.
- Android's lastSyncWindowId bookkeeping for synchronization fallback has no direct iOS equivalent. That is a pre-existing synchronization parity gap, not implemented or claimed as part of this restore-button patch.
- Physical iPad workspaces that persisted the one-day bad autoPin=false default still need the pinning preference enabled manually. A blanket migration would overwrite legitimate explicit unpinned choices.
- Physical iPad and macOS interaction confirmation remains useful before merge, especially for terminal links-window behavior and reload-free restoration.

## Issue closure

Closes: none

No matching open GitHub issue was found for the window-tab minimize/restore regression.

Related: #229, #368
