### PR TITLE
fix(search): keep full-Bible search index builds memory-bounded

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/BibleSearchIndexSource.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/BibleSearchIndexSource.swift
@@ -342,40 +342,44 @@ extension SQLiteDocumentModule: BibleSearchIndexSource {
         _ consume: (BibleSearchIndexEntry) throws -> Bool
     ) throws {
         guard info.category == .bible else { return }
+        // Drained per chapter: whole-Bible streaming otherwise accumulates every XML-projection
+        // temporary until the indexing dispatch block finishes.
         try reader.forEachBibleChapter { sourceBook, chapter in
-            guard let osisBookId = osisId(forSourceBookNumber: sourceBook) else {
+            try autoreleasepool {
+                guard let osisBookId = osisId(forSourceBookNumber: sourceBook) else {
+                    return true
+                }
+                for row in try reader.chapterContent(book: sourceBook, chapter: chapter) {
+                    guard let ordinal = JSwordKJVAVersification.verseOrdinal(
+                        osisId: osisBookId,
+                        chapter: chapter,
+                        verse: row.verse
+                    ) else {
+                        continue
+                    }
+                    let visibleText = try SQLiteSearchTextProjection.visibleText(
+                        row.text,
+                        metadata: reader.metadata,
+                        moduleInitials: info.name
+                    )
+                    let key = "\(osisBookId) \(chapter):\(row.verse)"
+                    let shouldContinue = try consume(BibleSearchIndexEntry(
+                        displayKey: key,
+                        visibleText: visibleText,
+                        sourceMarkup: row.text,
+                        taggedText: row.text,
+                        entryOrder: ordinal,
+                        sourcePosition: ordinal,
+                        osisBookId: osisBookId,
+                        displayBook: osisBookId,
+                        chapter: chapter,
+                        verse: row.verse,
+                        bookNamePresentation: .localizedCanonical
+                    ))
+                    guard shouldContinue else { return false }
+                }
                 return true
             }
-            for row in try reader.chapterContent(book: sourceBook, chapter: chapter) {
-                guard let ordinal = JSwordKJVAVersification.verseOrdinal(
-                    osisId: osisBookId,
-                    chapter: chapter,
-                    verse: row.verse
-                ) else {
-                    continue
-                }
-                let visibleText = try SQLiteSearchTextProjection.visibleText(
-                    row.text,
-                    metadata: reader.metadata,
-                    moduleInitials: info.name
-                )
-                let key = "\(osisBookId) \(chapter):\(row.verse)"
-                let shouldContinue = try consume(BibleSearchIndexEntry(
-                    displayKey: key,
-                    visibleText: visibleText,
-                    sourceMarkup: row.text,
-                    taggedText: row.text,
-                    entryOrder: ordinal,
-                    sourcePosition: ordinal,
-                    osisBookId: osisBookId,
-                    displayBook: osisBookId,
-                    chapter: chapter,
-                    verse: row.verse,
-                    bookNamePresentation: .localizedCanonical
-                ))
-                guard shouldContinue else { return false }
-            }
-            return true
         }
     }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift
@@ -713,68 +713,73 @@ public final class SearchIndexService: @unchecked Sendable {
         )
 
         var insertedVerseCount = 0
+        // Drained per entry: one Bible streams tens of thousands of verses through regex and
+        // analyzer calls inside a single dispatch block, and undrained autoreleased temporaries
+        // grow until iOS terminates the app mid-build.
         try source.forEachSearchIndexEntry { entry in
-            try cancellationProbe.checkCancellation()
-            let cleaned = entry.visibleText.trimmingCharacters(in: .whitespacesAndNewlines)
-            let analyzed = cleaned.isEmpty
-                ? ""
-                : try SearchTextAnalyzer.analyzedText(cleaned, profile: analyzer)
-            guard source.searchIndexIncludesEmptyVisibleText
-                    || (!cleaned.isEmpty && !analyzed.isEmpty) else {
+            try autoreleasepool {
+                try cancellationProbe.checkCancellation()
+                let cleaned = entry.visibleText.trimmingCharacters(in: .whitespacesAndNewlines)
+                let analyzed = cleaned.isEmpty
+                    ? ""
+                    : try SearchTextAnalyzer.analyzedText(cleaned, profile: analyzer)
+                guard source.searchIndexIncludesEmptyVisibleText
+                        || (!cleaned.isEmpty && !analyzed.isEmpty) else {
+                    return true
+                }
+                guard let verseStatement, let strongsStatement else {
+                    throw SearchIndexError.databaseUnavailable(operation: "indexing \(moduleName)")
+                }
+
+                sqlite3_reset(verseStatement)
+                sqlite3_clear_bindings(verseStatement)
+                bind(analyzed, to: verseStatement, at: 1)
+                bind(entry.displayKey, to: verseStatement, at: 2)
+                bind(cleaned, to: verseStatement, at: 3)
+                bind(moduleName, to: verseStatement, at: 4)
+                sqlite3_bind_int64(verseStatement, 5, sqlite3_int64(entry.entryOrder))
+                bind(entry.osisBookId, to: verseStatement, at: 6)
+                bind(entry.displayBook, to: verseStatement, at: 7)
+                bind(entry.bookNamePresentation.rawValue, to: verseStatement, at: 8)
+                sqlite3_bind_int(verseStatement, 9, Int32(entry.chapter))
+                sqlite3_bind_int(verseStatement, 10, Int32(entry.verse))
+                sqlite3_bind_int64(
+                    verseStatement,
+                    11,
+                    sqlite3_int64(SearchCanonicalBookCatalog.order(of: entry.osisBookId))
+                )
+                let canonSection = SearchCanonicalBookCatalog.section(of: entry.osisBookId)
+                bind(canonSection.rawValue, to: verseStatement, at: 12)
+                try stepDone(db: db, statement: verseStatement, operation: "inserting \(entry.displayKey)")
+
+                let rawTokens = StrongsTokenNormalizer.canonicalTokens(
+                    rawEntry: entry.sourceMarkup,
+                    renderedTextProvider: { entry.taggedText },
+                    isNewTestamentBook: canonSection == .newTestament
+                )
+                let taggedTokens = StrongsTokenNormalizer.canonicalTokens(taggedText: entry.taggedText)
+                for token in Self.orderedUnique(rawTokens + taggedTokens) {
+                    sqlite3_reset(strongsStatement)
+                    sqlite3_clear_bindings(strongsStatement)
+                    bind(moduleName, to: strongsStatement, at: 1)
+                    bind(token, to: strongsStatement, at: 2)
+                    bind(entry.displayKey, to: strongsStatement, at: 3)
+                    sqlite3_bind_int64(strongsStatement, 4, sqlite3_int64(entry.entryOrder))
+                    try stepDone(db: db, statement: strongsStatement, operation: "inserting Strong's token")
+                }
+
+                insertedVerseCount += 1
+                if insertedVerseCount.isMultiple(of: 200) {
+                    let total = max(source.searchIndexProgressTotal, 1)
+                    let progress = min(Double(entry.sourcePosition) / Double(total), 0.99)
+                    DispatchQueue.main.async {
+                        guard self.indexingGeneration == generation else { return }
+                        self.indexProgress = progress
+                        self.indexingKey = entry.displayKey
+                    }
+                }
                 return true
             }
-            guard let verseStatement, let strongsStatement else {
-                throw SearchIndexError.databaseUnavailable(operation: "indexing \(moduleName)")
-            }
-
-            sqlite3_reset(verseStatement)
-            sqlite3_clear_bindings(verseStatement)
-            bind(analyzed, to: verseStatement, at: 1)
-            bind(entry.displayKey, to: verseStatement, at: 2)
-            bind(cleaned, to: verseStatement, at: 3)
-            bind(moduleName, to: verseStatement, at: 4)
-            sqlite3_bind_int64(verseStatement, 5, sqlite3_int64(entry.entryOrder))
-            bind(entry.osisBookId, to: verseStatement, at: 6)
-            bind(entry.displayBook, to: verseStatement, at: 7)
-            bind(entry.bookNamePresentation.rawValue, to: verseStatement, at: 8)
-            sqlite3_bind_int(verseStatement, 9, Int32(entry.chapter))
-            sqlite3_bind_int(verseStatement, 10, Int32(entry.verse))
-            sqlite3_bind_int64(
-                verseStatement,
-                11,
-                sqlite3_int64(SearchCanonicalBookCatalog.order(of: entry.osisBookId))
-            )
-            let canonSection = SearchCanonicalBookCatalog.section(of: entry.osisBookId)
-            bind(canonSection.rawValue, to: verseStatement, at: 12)
-            try stepDone(db: db, statement: verseStatement, operation: "inserting \(entry.displayKey)")
-
-            let rawTokens = StrongsTokenNormalizer.canonicalTokens(
-                rawEntry: entry.sourceMarkup,
-                renderedTextProvider: { entry.taggedText },
-                isNewTestamentBook: canonSection == .newTestament
-            )
-            let taggedTokens = StrongsTokenNormalizer.canonicalTokens(taggedText: entry.taggedText)
-            for token in Self.orderedUnique(rawTokens + taggedTokens) {
-                sqlite3_reset(strongsStatement)
-                sqlite3_clear_bindings(strongsStatement)
-                bind(moduleName, to: strongsStatement, at: 1)
-                bind(token, to: strongsStatement, at: 2)
-                bind(entry.displayKey, to: strongsStatement, at: 3)
-                sqlite3_bind_int64(strongsStatement, 4, sqlite3_int64(entry.entryOrder))
-                try stepDone(db: db, statement: strongsStatement, operation: "inserting Strong's token")
-            }
-
-            insertedVerseCount += 1
-            if insertedVerseCount.isMultiple(of: 200) {
-                let total = max(source.searchIndexProgressTotal, 1)
-                let progress = min(Double(entry.sourcePosition) / Double(total), 0.99)
-                DispatchQueue.main.async {
-                    guard self.indexingGeneration == generation else { return }
-                    self.indexProgress = progress
-                    self.indexingKey = entry.displayKey
-                }
-            }
-            return true
         }
 
         try cancellationProbe.checkCancellation()
@@ -1360,18 +1365,24 @@ public final class SearchIndexService: @unchecked Sendable {
 
     // MARK: - Text Cleaning
 
+    /// Compiled once because text cleanup runs for every verse of a full-Bible index build.
+    private static let inlineStrongsTagRegex = try? NSRegularExpression(pattern: "<[HGhgW]\\d+>")
+
+    /// Compiled once because text cleanup runs for every verse of a full-Bible index build.
+    private static let repeatedSpaceRegex = try? NSRegularExpression(pattern: "  +")
+
     /** Removes inline Strong's tags from user-visible indexed text. */
     public static func cleanText(_ text: String) -> String {
         guard text.contains("<") else { return text }
         var result = text
-        if let regex = try? NSRegularExpression(pattern: "<[HGhgW]\\d+>") {
+        if let regex = inlineStrongsTagRegex {
             result = regex.stringByReplacingMatches(
                 in: result,
                 range: NSRange(result.startIndex..., in: result),
                 withTemplate: ""
             )
         }
-        if let regex = try? NSRegularExpression(pattern: "  +") {
+        if let regex = repeatedSpaceRegex {
             result = regex.stringByReplacingMatches(
                 in: result,
                 range: NSRange(result.startIndex..., in: result),

--- a/Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift
@@ -39,6 +39,26 @@ public struct NormalizedStrongsQueryOptions: Equatable, Sendable {
  same token rules for iOS FTS indexing, Search UI routing, and SWORD fallback validation.
  */
 public enum StrongsTokenNormalizer {
+    /// Compiled once because token extraction runs for every verse of a full-Bible index build.
+    private static let taggedTextTokenRegex = try? NSRegularExpression(
+        pattern: #"<\s*([GgHh][0-9]+!?[A-Za-z]*)\s*>"#
+    )
+
+    /// Compiled once because token extraction runs for every verse of a full-Bible index build.
+    private static let rawOSISTokenRegex = try? NSRegularExpression(
+        pattern: #"strong:([GgHh][0-9]+!?[A-Za-z]*)"#
+    )
+
+    /// Compiled once because token extraction runs for every verse of a full-Bible index build.
+    private static let renderedTextTokenRegex = try? NSRegularExpression(
+        pattern: #"showStrong=([0-9]+!?[A-Za-z]*)#cv"#
+    )
+
+    /// Compiled once because number parsing runs for every extracted token of every verse.
+    private static let strongNumberRegex = try? NSRegularExpression(
+        pattern: #"^([GgHh])([0-9]+)!?([A-Za-z]+)?"#
+    )
+
     /**
      Normalizes a user-entered Strong's query into JSword canonical tokens and SWORD fallback
      entry-attribute queries.
@@ -131,8 +151,7 @@ public enum StrongsTokenNormalizer {
      - Failure modes: Malformed or out-of-range Strong's values are ignored.
      */
     public static func canonicalTokens(taggedText: String) -> [String] {
-        let pattern = #"<\s*([GgHh][0-9]+!?[A-Za-z]*)\s*>"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        guard let regex = taggedTextTokenRegex else { return [] }
 
         let matches = regex.matches(in: taggedText, range: NSRange(taggedText.startIndex..., in: taggedText))
         return orderedUnique(matches.flatMap { match -> [String] in
@@ -176,8 +195,7 @@ public enum StrongsTokenNormalizer {
     }
 
     private static func canonicalTokensFromRawOSIS(_ rawEntry: String) -> [String] {
-        let pattern = #"strong:([GgHh][0-9]+!?[A-Za-z]*)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        guard let regex = rawOSISTokenRegex else { return [] }
 
         let matches = regex.matches(in: rawEntry, range: NSRange(rawEntry.startIndex..., in: rawEntry))
         return matches.flatMap { match -> [String] in
@@ -193,8 +211,7 @@ public enum StrongsTokenNormalizer {
         _ renderedText: String,
         isNewTestamentBook: Bool
     ) -> [String] {
-        let pattern = #"showStrong=([0-9]+!?[A-Za-z]*)#cv"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        guard let regex = renderedTextTokenRegex else { return [] }
         let prefix = isNewTestamentBook ? "G" : "H"
 
         let matches = regex.matches(in: renderedText, range: NSRange(renderedText.startIndex..., in: renderedText))
@@ -208,8 +225,7 @@ public enum StrongsTokenNormalizer {
     }
 
     private static func parseStrongNumber(_ text: String) -> ParsedStrongNumber? {
-        let pattern = #"^([GgHh])([0-9]+)!?([A-Za-z]+)?"#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
+        guard let regex = strongNumberRegex,
               let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
               let languageRange = Range(match.range(at: 1), in: text),
               let digitsRange = Range(match.range(at: 2), in: text) else {

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -1424,7 +1424,9 @@ public final class SwordModule: @unchecked Sendable {
        entry. Native rendering failures surface as empty strings from SWORD and are left for the
        caller to filter.
      - Important: Callback work runs while holding `SwordRuntime`; keep it bounded and do not wait
-       on work that also needs SWORD access from another thread.
+       on work that also needs SWORD access from another thread. Each entry runs inside its own
+       autorelease pool because a full-Bible traversal otherwise accumulates every temporary
+       Foundation object until the surrounding dispatch block ends.
      */
     public func iterateAllEntriesWithRaw(_ callback: (String, String, String, Int) -> Bool) {
         SwordRuntime.sync {
@@ -1435,13 +1437,19 @@ public final class SwordModule: @unchecked Sendable {
             guard SWModule_popError(handle) == 0 else { return }
 
             var index = 0
-            while true {
-                let key = String(cString: SWModule_getKeyText(handle))
-                let text = String(cString: SWModule_getStripText(handle))
-                let rawEntry = String(cString: SWModule_getRawEntry(handle))
-                if !callback(key, text, rawEntry, index) { break }
-                index += 1
-                if SWModule_next(handle) != 0 { break }
+            var shouldContinue = true
+            while shouldContinue {
+                autoreleasepool {
+                    let key = String(cString: SWModule_getKeyText(handle))
+                    let text = String(cString: SWModule_getStripText(handle))
+                    let rawEntry = String(cString: SWModule_getRawEntry(handle))
+                    guard callback(key, text, rawEntry, index) else {
+                        shouldContinue = false
+                        return
+                    }
+                    index += 1
+                    if SWModule_next(handle) != 0 { shouldContinue = false }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Search-index creation crashed partway through building an index (reported "around Ezekiel" with multiple Bibles including ASV 1901 on iPhone 17 Pro / iOS 26.6). The build streams all 31,102 verses through one dispatch block whose autorelease pool never drains, and every verse compiled fresh regexes and produced autoreleased match temporaries — on Strong's-heavy modules that grows memory without bound until iOS jetsam-kills the app. This PR makes the build memory-bounded per verse/chapter.

## Scope

- `Sources/SwordKit/Sources/SwordKit/SwordModule.swift` — SWORD verse iteration
- `Sources/BibleCore/Sources/BibleCore/Services/SearchIndexService.swift` — index build loop and `cleanText`
- `Sources/BibleCore/Sources/BibleCore/Services/BibleSearchIndexSource.swift` — Android-compatible SQLite source adapter
- `Sources/BibleCore/Sources/BibleCore/Services/StrongsTokenNormalizer.swift` — Strong's token extraction

No changes to the index schema, query semantics, bridge payloads, or sync formats.

## Contract references

- Commit follows the locked commit-message standard (typed subject, Why/What Changed/Validation/Impact sections).
- Android parity contracts are unaffected: JSword-compatible Strong's token rules, KJVA projection, and FTS row identity are behavior-identical; only allocation lifetime and regex caching changed.

## Change details

- `SwordModule.iterateAllEntriesWithRaw` runs each verse iteration inside its own `autoreleasepool`.
- `SearchIndexService.buildIndex` wraps the per-entry consume work (analyzer, Strong's extraction, SQLite binds) in an `autoreleasepool` so any current or future source stays memory-bounded.
- `SQLiteDocumentModule.forEachSearchIndexEntry` drains per chapter, covering XML-projection temporaries for MyBible/MySword/e-Sword formats.
- `StrongsTokenNormalizer` and `SearchIndexService.cleanText` compile their six regexes once as cached statics instead of per verse / per token (previously 20+ compilations per verse on ASV 1901), which also speeds up index builds.

## Validation evidence

- `swift build` passes.
- Targeted simulator suites green (19 tests, 0 failures): `SearchIndexServiceMutationTests`, `SearchIndexServiceQueryTests`, `SearchIndexEndToEndParityTests`, `SQLiteBibleSearchIndexTests`, `SearchIndexReplacementTests`.
- `git diff --check`, `scripts/check_repo_standards.py commits --base-ref main`, and `scripts/check_repo_standards.py all --base-ref main --all-files` all pass locally.

## Risks / follow-ups

- The jetsam behavior itself is not reproducible in unit tests; the existing suites prove the refactor is semantics-preserving. Follow-up: confirm the fix by building the ASV 1901 index on a physical device.
- Risk is low: changes are allocation-lifetime only, on the index-creation path, validated LOW blast radius per impact analysis.

## Issue closure

Closes #373