### PR TITLE
fix(ui): host document-selection dropdowns at the activity level

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -664,7 +664,7 @@ struct BibleReaderModulePicker: View {
      - Side effects: Menus and the text field mutate the active picker filters.
      - Failure modes: Large Dynamic Type splits controls into two rows to avoid overlap.
      */
-    private func androidFilterBar(visibleDocumentCount: Int) -> some View {
+    private func androidFilterBar(visibleDocumentCount: Int) -> AndroidDocumentSelectionFilterBar {
         AndroidDocumentSelectionFilterBar(
             surfacePalette: surfacePalette,
             languageTitle: languageFilterTitle(for: selectedLanguage),

--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -1052,7 +1052,7 @@ public struct ModuleBrowserView: View {
        mutates `searchText`.
      - Failure modes: Empty language catalogs show the all-language label and keep the menu usable.
      */
-    private func androidFilterBar(visibleModuleCount: Int) -> some View {
+    private func androidFilterBar(visibleModuleCount: Int) -> AndroidDocumentSelectionFilterBar {
         let categoryOptions = [nil] + visibleCategoryFilters.map(Optional.some)
         return AndroidDocumentSelectionFilterBar(
             surfacePalette: surfacePalette,

--- a/Sources/BibleUI/Sources/BibleUI/Shared/AndroidDocumentSelectionControls.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/AndroidDocumentSelectionControls.swift
@@ -23,6 +23,12 @@ struct AndroidDocumentSelectionOption: Identifiable, Equatable {
     let title: String
 }
 
+/// Popup anchors shared by the filter-strip triggers and the activity-screen dropdown host.
+private enum AndroidDocumentSelectionPopupAnchor {
+    static let language = "androidDocumentSelectionLanguageAnchor"
+    static let documentType = "androidDocumentSelectionTypeAnchor"
+}
+
 /**
  Shared full-screen activity host for Android screens derived from `DocumentSelectionBase`.
 
@@ -50,7 +56,9 @@ struct AndroidDocumentSelectionOption: Identifiable, Equatable {
  - accessibility-sized content may scroll only when the caller's row content provides scrolling,
    matching the ownership boundary of Android's `DocumentSelectionBase`
  */
-struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Rows: View>: View {
+struct AndroidDocumentSelectionActivityScreen<TopBar: View, Rows: View>: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     /// Reader/workspace colors shared by Choose Document and Download Documents.
     let surfacePalette: ReaderThemeSurfacePalette
 
@@ -58,10 +66,16 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
     private let topBar: TopBar
 
     /// Configured shared language/search/type filter strip.
-    private let filterBar: FilterBar
+    private let filterBar: AndroidDocumentSelectionFilterBar
 
     /// Activity-specific document rows and empty/loading states.
     private let rows: Rows
+
+    /// Whether the app-owned language dropdown overlays the activity.
+    @State private var showsLanguageOptions = false
+
+    /// Whether the app-owned document-type dropdown overlays the activity.
+    @State private var showsDocumentTypeOptions = false
 
     /**
      Creates the shared Android document-selection activity host.
@@ -69,7 +83,8 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
      - Parameters:
        - surfacePalette: Palette inherited from the launching reader window or workspace.
        - topBar: Normal or contextual app bar for the active activity state.
-       - filterBar: Shared `document_selection.xml` filter projection.
+       - filterBar: Shared `document_selection.xml` filter projection. The host owns the dropdown
+         popups so they can overlay the whole activity like Android spinner popup windows.
        - rows: Activity-owned document rows and state content.
      - Returns: A configured viewport-filling activity host.
      - Side effects: Evaluates the view-builder closures once during initialization.
@@ -78,7 +93,7 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
     init(
         surfacePalette: ReaderThemeSurfacePalette,
         @ViewBuilder topBar: () -> TopBar,
-        @ViewBuilder filterBar: () -> FilterBar,
+        filterBar: () -> AndroidDocumentSelectionFilterBar,
         @ViewBuilder rows: () -> Rows
     ) {
         self.surfacePalette = surfacePalette
@@ -92,11 +107,79 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
             topBar
         } content: {
             VStack(spacing: 0) {
-                filterBar
+                filterBar.dropdownVisibility(
+                    language: $showsLanguageOptions,
+                    documentType: $showsDocumentTypeOptions
+                )
                 rows
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
+        .androidAnchoredPopupMenu(
+            anchorID: AndroidDocumentSelectionPopupAnchor.language,
+            isPresented: $showsLanguageOptions,
+            menuWidth: 260,
+            estimatedMenuHeight: Self.popupHeight(optionCount: filterBar.languageOptions.count),
+            accessibilityIdentifier: "\(filterBar.accessibilityPrefix)LanguageMenu"
+        ) {
+            optionsPopup(
+                filterBar.languageOptions,
+                accessibilityIdentifier: "\(filterBar.accessibilityPrefix)LanguageMenuSurface"
+            ) { optionID in
+                showsLanguageOptions = false
+                filterBar.onSelectLanguage(optionID)
+            }
+        }
+        .androidAnchoredPopupMenu(
+            anchorID: AndroidDocumentSelectionPopupAnchor.documentType,
+            isPresented: $showsDocumentTypeOptions,
+            menuWidth: 240,
+            estimatedMenuHeight: Self.popupHeight(optionCount: filterBar.documentTypeOptions.count),
+            accessibilityIdentifier: "\(filterBar.accessibilityPrefix)DocumentTypeMenu"
+        ) {
+            optionsPopup(
+                filterBar.documentTypeOptions,
+                accessibilityIdentifier: "\(filterBar.accessibilityPrefix)DocumentTypeMenuSurface"
+            ) { optionID in
+                showsDocumentTypeOptions = false
+                filterBar.onSelectDocumentType(optionID)
+            }
+        }
+    }
+
+    /** Builds a bounded shared popup so long language catalogs remain usable on compact screens. */
+    private func optionsPopup(
+        _ options: [AndroidDocumentSelectionOption],
+        accessibilityIdentifier: String,
+        onSelect: @escaping (String) -> Void
+    ) -> some View {
+        AndroidPopupMenuSurface(
+            colorScheme: colorScheme,
+            accessibilityIdentifier: accessibilityIdentifier,
+            backgroundColor: surfacePalette.backgroundColor,
+            primaryTextColor: surfacePalette.foregroundColor,
+            secondaryTextColor: surfacePalette.secondaryForegroundColor,
+            accentColor: AndroidDialogSurfacePalette.accent(for: colorScheme)
+        ) {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(options) { option in
+                        AndroidPopupMenuRow(
+                            title: option.title,
+                            accessibilityIdentifier: "\(accessibilityIdentifier)::\(option.id)"
+                        ) {
+                            onSelect(option.id)
+                        }
+                    }
+                }
+            }
+            .frame(height: Self.popupHeight(optionCount: options.count))
+        }
+    }
+
+    /** Resolves the measured popup height while keeping at least one row tappable. */
+    private static func popupHeight(optionCount: Int) -> CGFloat {
+        min(max(CGFloat(optionCount) * 48, 48), 336)
     }
 }
 
@@ -106,7 +189,9 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
  Android's Choose Document and Download Documents activities inflate the same
  `document_selection.xml`: a 55dp strip containing language autocomplete, free-text search,
  document-type spinner, and result count. This component preserves that shared ownership boundary
- on iOS and presents both dropdowns through the app-owned popup system rather than native `Menu`.
+ on iOS. Its dropdowns use the app-owned popup system rather than native `Menu`, and
+ `AndroidDocumentSelectionActivityScreen` hosts those popups at the activity level because an
+ overlay attached to the 55-point strip would paint underneath the sibling document list.
 
  Inputs:
  - owner palette for the active reader/workspace
@@ -129,12 +214,6 @@ struct AndroidDocumentSelectionActivityScreen<TopBar: View, FilterBar: View, Row
    accessibility Dynamic Type sizes
  */
 struct AndroidDocumentSelectionFilterBar: View {
-    /// Popup anchors shared by the trigger buttons and app-owned overlay modifiers.
-    private enum PopupAnchor {
-        static let language = "androidDocumentSelectionLanguageAnchor"
-        static let documentType = "androidDocumentSelectionTypeAnchor"
-    }
-
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -177,11 +256,87 @@ struct AndroidDocumentSelectionFilterBar: View {
     /// Document-type selection callback receiving the option identity.
     let onSelectDocumentType: (String) -> Void
 
-    /// Whether the app-owned language dropdown is visible.
-    @State private var showsLanguageOptions = false
+    /// Language-dropdown visibility owned by the presenting activity screen.
+    @Binding private var showsLanguageOptions: Bool
 
-    /// Whether the app-owned document-type dropdown is visible.
-    @State private var showsDocumentTypeOptions = false
+    /// Document-type-dropdown visibility owned by the presenting activity screen.
+    @Binding private var showsDocumentTypeOptions: Bool
+
+    /**
+     Creates the shared filter strip with inert dropdown visibility.
+
+     The activity screen replaces the inert visibility through `dropdownVisibility(language:documentType:)`
+     so the dropdowns can overlay the whole activity instead of the 55-point strip.
+
+     - Parameters:
+       - surfacePalette: Reader/workspace colors resolved by the launching activity.
+       - languageTitle: Current localized language field title.
+       - languageOptions: Ordered language dropdown values.
+       - documentTypeTitle: Current localized document-type field title.
+       - documentTypeOptions: Ordered document-type dropdown values.
+       - resultCountTitle: Localized visible-result count.
+       - searchPlaceholder: Localized Android search hint.
+       - searchText: Caller-owned free-text filter.
+       - accessibilityPrefix: Prefix used for stable accessibility identifiers.
+       - onOpenLanguageOptions: Android autocomplete-open callback.
+       - onSelectLanguage: Language selection callback receiving the option identity.
+       - onSearchFocused: Android search-focus callback.
+       - onSelectDocumentType: Document-type selection callback receiving the option identity.
+     - Returns: A configured strip whose triggers mutate inert visibility until adopted by a host.
+     - Side effects: none.
+     - Failure modes: none; an unadopted strip renders but its dropdown triggers show no popup.
+     */
+    init(
+        surfacePalette: ReaderThemeSurfacePalette,
+        languageTitle: String,
+        languageOptions: [AndroidDocumentSelectionOption],
+        documentTypeTitle: String,
+        documentTypeOptions: [AndroidDocumentSelectionOption],
+        resultCountTitle: String,
+        searchPlaceholder: String,
+        searchText: Binding<String>,
+        accessibilityPrefix: String,
+        onOpenLanguageOptions: @escaping () -> Void,
+        onSelectLanguage: @escaping (String) -> Void,
+        onSearchFocused: @escaping () -> Void,
+        onSelectDocumentType: @escaping (String) -> Void
+    ) {
+        self.surfacePalette = surfacePalette
+        self.languageTitle = languageTitle
+        self.languageOptions = languageOptions
+        self.documentTypeTitle = documentTypeTitle
+        self.documentTypeOptions = documentTypeOptions
+        self.resultCountTitle = resultCountTitle
+        self.searchPlaceholder = searchPlaceholder
+        _searchText = searchText
+        self.accessibilityPrefix = accessibilityPrefix
+        self.onOpenLanguageOptions = onOpenLanguageOptions
+        self.onSelectLanguage = onSelectLanguage
+        self.onSearchFocused = onSearchFocused
+        self.onSelectDocumentType = onSelectDocumentType
+        _showsLanguageOptions = .constant(false)
+        _showsDocumentTypeOptions = .constant(false)
+    }
+
+    /**
+     Returns a copy whose dropdown visibility is owned by the presenting activity screen.
+
+     - Parameters:
+       - language: Host-owned language dropdown visibility.
+       - documentType: Host-owned document-type dropdown visibility.
+     - Returns: The strip with its triggers wired to the host's popup state.
+     - Side effects: none.
+     - Failure modes: none.
+     */
+    func dropdownVisibility(
+        language: Binding<Bool>,
+        documentType: Binding<Bool>
+    ) -> AndroidDocumentSelectionFilterBar {
+        var copy = self
+        copy._showsLanguageOptions = language
+        copy._showsDocumentTypeOptions = documentType
+        return copy
+    }
 
     /**
      Formats Android's shared visible-document count with the exact resource key and placeholder.
@@ -211,36 +366,6 @@ struct AndroidDocumentSelectionFilterBar: View {
                 Rectangle()
                     .fill(surfacePalette.inactiveBorderColor)
                     .frame(height: 1)
-            }
-            .androidAnchoredPopupMenu(
-                anchorID: PopupAnchor.language,
-                isPresented: $showsLanguageOptions,
-                menuWidth: 260,
-                estimatedMenuHeight: popupHeight(optionCount: languageOptions.count),
-                accessibilityIdentifier: "\(accessibilityPrefix)LanguageMenu"
-            ) {
-                optionsPopup(
-                    languageOptions,
-                    accessibilityIdentifier: "\(accessibilityPrefix)LanguageMenuSurface"
-                ) { optionID in
-                    showsLanguageOptions = false
-                    onSelectLanguage(optionID)
-                }
-            }
-            .androidAnchoredPopupMenu(
-                anchorID: PopupAnchor.documentType,
-                isPresented: $showsDocumentTypeOptions,
-                menuWidth: 240,
-                estimatedMenuHeight: popupHeight(optionCount: documentTypeOptions.count),
-                accessibilityIdentifier: "\(accessibilityPrefix)DocumentTypeMenu"
-            ) {
-                optionsPopup(
-                    documentTypeOptions,
-                    accessibilityIdentifier: "\(accessibilityPrefix)DocumentTypeMenuSurface"
-                ) { optionID in
-                    showsDocumentTypeOptions = false
-                    onSelectDocumentType(optionID)
-                }
             }
     }
 
@@ -283,7 +408,7 @@ struct AndroidDocumentSelectionFilterBar: View {
             underlinedLabel(languageTitle, alignment: .leading, includesDropdownIndicator: false)
         }
         .buttonStyle(.plain)
-        .androidPopupMenuAnchor(id: PopupAnchor.language)
+        .androidPopupMenuAnchor(id: AndroidDocumentSelectionPopupAnchor.language)
         .accessibilityIdentifier("\(accessibilityPrefix)LanguageFilter")
     }
 
@@ -333,7 +458,7 @@ struct AndroidDocumentSelectionFilterBar: View {
                 )
             }
             .buttonStyle(.plain)
-            .androidPopupMenuAnchor(id: PopupAnchor.documentType)
+            .androidPopupMenuAnchor(id: AndroidDocumentSelectionPopupAnchor.documentType)
         }
         .accessibilityIdentifier("\(accessibilityPrefix)CategoryFilter")
     }
@@ -363,41 +488,6 @@ struct AndroidDocumentSelectionFilterBar: View {
                 .frame(height: 1)
         }
         .contentShape(Rectangle())
-    }
-
-    /** Builds a bounded shared popup so long language catalogs remain usable on compact screens. */
-    private func optionsPopup(
-        _ options: [AndroidDocumentSelectionOption],
-        accessibilityIdentifier: String,
-        onSelect: @escaping (String) -> Void
-    ) -> some View {
-        AndroidPopupMenuSurface(
-            colorScheme: colorScheme,
-            accessibilityIdentifier: accessibilityIdentifier,
-            backgroundColor: surfacePalette.backgroundColor,
-            primaryTextColor: surfacePalette.foregroundColor,
-            secondaryTextColor: surfacePalette.secondaryForegroundColor,
-            accentColor: AndroidDialogSurfacePalette.accent(for: colorScheme)
-        ) {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(options) { option in
-                        AndroidPopupMenuRow(
-                            title: option.title,
-                            accessibilityIdentifier: "\(accessibilityIdentifier)::\(option.id)"
-                        ) {
-                            onSelect(option.id)
-                        }
-                    }
-                }
-            }
-            .frame(height: popupHeight(optionCount: options.count))
-        }
-    }
-
-    /** Resolves the measured popup height while keeping at least one row tappable. */
-    private func popupHeight(optionCount: Int) -> CGFloat {
-        min(max(CGFloat(optionCount) * 48, 48), 336)
     }
 }
 


### PR DESCRIPTION
## Summary

In the Download Documents screen, tapping "All types" (or the language filter) opened a dropdown that rendered underneath the document list (#375). The dropdowns were presented as a SwiftUI overlay of the 55-point filter strip; since later `VStack` siblings paint above earlier ones, the menu was drawn under the rows, its placement math ran against the strip's 55-point geometry, and its "full-screen" tap-to-dismiss layer covered only the strip. The same defect existed in the Choose Document screen, which shares the filter strip.

## Scope

- `Sources/BibleUI/Sources/BibleUI/Shared/AndroidDocumentSelectionControls.swift` — filter strip and activity host (substantive change)
- `Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift` — filter-bar builder return type only
- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift` — filter-bar builder return type only

No data contracts, sync formats, bridge payloads, or localization keys change.

## Contract references

- Commit follows the locked commit-message standard (typed subject, Why/What Changed/Validation/Impact, Refs).
- Android parity: dropdowns now behave like Android spinner popup windows — floating above the activity — matching how this repo's overflow menus already attach at screen level.
- All accessibility identifiers (triggers, menus, menu surfaces, rows) are unchanged, so existing XCUITest contracts still hold.

## Change details

- `AndroidDocumentSelectionActivityScreen` now owns the dropdown visibility state and applies both `androidAnchoredPopupMenu` presentations to the full activity surface, so menus draw above the list, drop below their trigger, and dismiss from anywhere on screen.
- `AndroidDocumentSelectionFilterBar` keeps its triggers and anchor registrations but no longer presents popups itself; the host adopts its visibility via a new `dropdownVisibility(language:documentType:)` wiring method.
- The two feature screens now return the concrete filter-bar type so the shared host can wire the popups; their configuration call sites are otherwise untouched.

## Validation evidence

- `swift build` passes in the worktree.
- Targeted simulator suites green (61 tests, 0 failures): `BibleReaderModulePickerTests`, `ModuleBrowserDownloadsTests`, `GenericSwordChooserContractsTests`.
- `git diff --check`, commit-message, docblock, and static source guardrails all pass.
- GitNexus impact analysis on the edited symbols reported 2 direct callers (the two feature screens, both updated here); the CRITICAL transitive rating reflects how widely these screens are rendered, not unreviewed call sites. `detect_changes` could not run because the fix was built in an unindexed worktree — the diff above is the complete change scope.

## Risks / follow-ups

- Draft until manually verified on a device/simulator: open Downloads → tap "All types" → menu must overlay the list, drop below the trigger, and dismiss on outside tap; same for the language filter and both filters in Choose Document.
- The dropdowns of an `AndroidDocumentSelectionFilterBar` rendered outside `AndroidDocumentSelectionActivityScreen` would be inert; both current consumers use the screen host.

## Issue closure

Closes #375