### PR TITLE
fix(install): match SWORD packaging semantics in the module install validator

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -2759,18 +2759,22 @@ public struct ModuleBrowserView: View {
        - remoteVersion: Repository version string.
        - installedVersion: Local installed version string.
      - Returns: `true` when the remote version sorts after the installed version, or when either
-       value cannot be parsed by Android's JSword version grammar.
+       non-empty value cannot be parsed by Android's JSword version grammar.
 
      Side effects:
      - none
 
      Failure modes:
-     - missing, malformed, or overflowing versions return `true`, matching Android's deliberate
+     - empty versions compare as JSword's read-time `1.0` default, so versionless modules and
+       catalog caches persisted before that default never report a phantom update
+     - malformed or overflowing versions return `true`, matching Android's deliberate
        upgrade-available fallback when `Version(...)` throws
      */
     static func isRemoteVersionNewer(remoteVersion: String, installedVersion: String) -> Bool {
-        guard let remote = parseJSwordVersion(remoteVersion),
-              let installed = parseJSwordVersion(installedVersion) else {
+        let remoteText = remoteVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        let installedText = installedVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let remote = parseJSwordVersion(remoteText.isEmpty ? "1.0" : remoteText),
+              let installed = parseJSwordVersion(installedText.isEmpty ? "1.0" : installedText) else {
             return true
         }
         return compareVersion(remote, installed) == .orderedDescending

--- a/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
@@ -1038,23 +1038,34 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
         XCTAssertEqual(ModuleBrowserView.installSizeText(for: modules[0].installSizeBytes), "1.3 MB")
         XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "1.10", installedVersion: "1.9"))
         XCTAssertFalse(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "1.0", installedVersion: "1.0"))
-        XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "", installedVersion: "1.0"))
+        XCTAssertFalse(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "", installedVersion: "1.0"))
         XCTAssertNil(ModuleBrowserView.installSizeText(for: 0))
         XCTAssertNil(ModuleBrowserView.installSizeText(for: -1))
     }
 
     /**
-     Verifies same-repository invalid version metadata remains updateable like Android.
+     Verifies same-repository malformed versions stay updateable while blank versions compare as 1.0.
 
-     Android constructs both values with JSword `Version`; any constructor failure deliberately
-     returns `UPGRADE_AVAILABLE`. This test covers blank, malformed, excessive-component, and
-     overflowing metadata, JSword's arbitrary single-character separator, rejected line terminators,
-     and `-1` ordering for omitted components. A failure would hide the only reinstall/update
-     affordance for a damaged same-repository catalog or local descriptor.
+     Android constructs both values with JSword `Version`; a constructor failure deliberately
+     returns `UPGRADE_AVAILABLE`, but a *missing* version never reaches the constructor because
+     `SwordBookMetaData` defaults it to `1.0` at read time. This test covers the blank read-time
+     default (including catalog caches persisted before the default existed), malformed,
+     excessive-component, and overflowing metadata, JSword's arbitrary single-character separator,
+     rejected line terminators, and `-1` ordering for omitted components. A failure either hides
+     the reinstall/update affordance for damaged metadata or reports a phantom update forever for
+     versionless modules such as BDBT.
      - Side effects: None.
      */
     func testSameRepositoryInvalidVersionsRemainUpdateableLikeAndroid() {
-        let remote = RemoteModuleInfo(
+        let malformedRemote = RemoteModuleInfo(
+            name: "KJV",
+            description: "King James Version",
+            category: .bible,
+            language: "en",
+            sourceName: "CrossWire",
+            version: "not-a-version"
+        )
+        let versionlessRemote = RemoteModuleInfo(
             name: "KJV",
             description: "King James Version",
             category: .bible,
@@ -1081,11 +1092,19 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
 
         XCTAssertEqual(
             ModuleBrowserView.displayStatus(
-                for: remote,
+                for: malformedRemote,
                 installedModules: [installed],
                 downloadActivities: [:]
             ),
             .updateAvailable
+        )
+        XCTAssertEqual(
+            ModuleBrowserView.displayStatus(
+                for: versionlessRemote,
+                installedModules: [installed],
+                downloadActivities: [:]
+            ),
+            .installed
         )
         XCTAssertEqual(
             ModuleBrowserView.displayStatus(
@@ -1095,6 +1114,9 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
             ),
             .installable
         )
+        XCTAssertFalse(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "", installedVersion: ""))
+        XCTAssertFalse(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "1.0", installedVersion: ""))
+        XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "2.0", installedVersion: ""))
         XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "invalid", installedVersion: "1.0"))
         XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "1.0", installedVersion: "invalid"))
         XCTAssertTrue(ModuleBrowserView.isRemoteVersionNewer(remoteVersion: "1.2.3.4.5", installedVersion: "1.0"))

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -2118,15 +2118,16 @@ public final class ModuleRepository: @unchecked Sendable {
             }
             directRootEntries.append((archiveEntry, relativePath))
         }
-        let expectedConfigPath = layout.configRelativePath
+        // CrossWire packages may name the config differently from the module initials (for
+        // example EpiphanyMaps ships mods.d/epiphany-maps.conf); identity is proven from the
+        // parsed content below and the staged config is written at the canonical path.
         let packageConfigEntries = directRootEntries.filter { item in
             item.1.hasPrefix("mods.d/") && item.1.lowercased().hasSuffix(".conf")
         }
         guard packageConfigEntries.count == 1,
-              let packageConfigEntry = packageConfigEntries.first,
-              packageConfigEntry.1.caseInsensitiveCompare(expectedConfigPath) == .orderedSame else {
+              let packageConfigEntry = packageConfigEntries.first else {
             throw ModuleRepositoryError.invalidZip(
-                "\(downloadedPackageURL.lastPathComponent) must contain only \(expectedConfigPath) as its module config"
+                "\(downloadedPackageURL.lastPathComponent) must contain exactly one mods.d module config"
             )
         }
         let packageConfigurationContent = try configurationContent(
@@ -2144,7 +2145,7 @@ public final class ModuleRepository: @unchecked Sendable {
             packageLayout.ownsPayload(atRelativePath: item.1)
         }
         let unexpectedEntries = directRootEntries.filter { item in
-            item.1.caseInsensitiveCompare(expectedConfigPath) != .orderedSame
+            item.1.caseInsensitiveCompare(packageConfigEntry.1) != .orderedSame
                 && !packageLayout.ownsPayload(atRelativePath: item.1)
         }
         guard unexpectedEntries.isEmpty else {

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
@@ -117,7 +117,7 @@ public struct ModuleStoreStagedInstallPlan: Sendable, Equatable {
  requires every target to remain a strict descendant of canonical `modules`.
  */
 public struct ModuleStoreInstalledLayoutResolver: @unchecked Sendable {
-    /// Drivers whose `DataPath` ends in a filename stem rather than a directory.
+    /** Drivers whose slash-less `DataPath` ends in a filename stem; a trailing slash still denotes a directory. */
     public static let filenamePrefixDrivers: Set<String> = [
         "rawld", "rawld4", "zld", "rawgenbook", "rawfiles",
     ]
@@ -204,9 +204,15 @@ public struct ModuleStoreInstalledLayoutResolver: @unchecked Sendable {
         let normalizedDataPath = try validatedDataPath(dataPath, moduleName: normalizedName)
         let components = normalizedDataPath.split(separator: "/").map(String.init)
         let normalizedDriver = driver.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        // SWORD distinguishes stem and directory DataPaths by the trailing slash, not the driver
+        // alone: font add-ons such as FontPack declare RawGenBook with a trailing-slash DataPath
+        // and ship payload in nested subdirectories of that directory.
+        let denotesDirectory = dataPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .hasSuffix("/")
         let shape: ModuleStorePayloadShape
         let directoryComponents: [String]
-        if Self.filenamePrefixDrivers.contains(normalizedDriver) {
+        if Self.filenamePrefixDrivers.contains(normalizedDriver), !denotesDirectory {
             guard components.count >= 3, let prefix = components.last, !prefix.isEmpty else {
                 throw ModuleStoreMutationError.unsafeDataPath(
                     moduleName: normalizedName,

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
@@ -9,7 +9,13 @@ public enum ModuleStorePayloadShape: Sendable, Equatable {
     /// Every staged file below the exact data directory belongs to the module.
     case directory
 
-    /// Direct children whose filename starts with the associated stem belong to the module.
+    /**
+     The stem's parent directory belongs to the module; the associated stem names its data files.
+
+     Ownership matches `.directory` because Android/JSword treat the stem's parent directory as the
+     module's directory for extraction and deletion, and real packages ship non-stem files such as
+     `BuildModule` scripts and `images/` directories beside the stem.
+     */
     case filenamePrefix(String)
 }
 
@@ -48,24 +54,14 @@ public struct ModuleStoreInstalledLayout: Sendable, Equatable {
      Tests whether one validated archive-relative file is owned by this config.
 
      - Parameter relativePath: Exact `modules/...` file path.
-     - Returns: `true` only for files bound by this layout's directory or filename-prefix rule.
-       Stem layouts additionally own nested subdirectories (for example ThML `images/`) because
-     SWORD stem modules routinely ship auxiliary directories beside their stem files, while sibling
-     stem files sharing the same directory remain protected by the prefix rule.
+     - Returns: `true` for every file below this layout's data directory. Stem layouts own their
+       parent directory exactly like directory layouts because Android/JSword extract and delete
+       the whole module directory, and real CrossWire packages ship non-stem files such as
+       `BuildModule` scripts and `images/` directories beside the stem files.
      - Side effects: none.
      */
     public func ownsPayload(atRelativePath relativePath: String) -> Bool {
-        switch payloadShape {
-        case .directory:
-            return relativePath.hasPrefix(dataDirectoryRelativePath + "/")
-        case .filenamePrefix(let prefix):
-            let nsPath = relativePath as NSString
-            let parent = nsPath.deletingLastPathComponent
-            if parent == dataDirectoryRelativePath {
-                return nsPath.lastPathComponent.hasPrefix(prefix)
-            }
-            return parent.hasPrefix(dataDirectoryRelativePath + "/")
-        }
+        relativePath.hasPrefix(dataDirectoryRelativePath + "/")
     }
 }
 

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift
@@ -49,6 +49,9 @@ public struct ModuleStoreInstalledLayout: Sendable, Equatable {
 
      - Parameter relativePath: Exact `modules/...` file path.
      - Returns: `true` only for files bound by this layout's directory or filename-prefix rule.
+       Stem layouts additionally own nested subdirectories (for example ThML `images/`) because
+     SWORD stem modules routinely ship auxiliary directories beside their stem files, while sibling
+     stem files sharing the same directory remain protected by the prefix rule.
      - Side effects: none.
      */
     public func ownsPayload(atRelativePath relativePath: String) -> Bool {
@@ -57,8 +60,11 @@ public struct ModuleStoreInstalledLayout: Sendable, Equatable {
             return relativePath.hasPrefix(dataDirectoryRelativePath + "/")
         case .filenamePrefix(let prefix):
             let nsPath = relativePath as NSString
-            return nsPath.deletingLastPathComponent == dataDirectoryRelativePath
-                && nsPath.lastPathComponent.hasPrefix(prefix)
+            let parent = nsPath.deletingLastPathComponent
+            if parent == dataDirectoryRelativePath {
+                return nsPath.lastPathComponent.hasPrefix(prefix)
+            }
+            return parent.hasPrefix(dataDirectoryRelativePath + "/")
         }
     }
 }

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift
@@ -83,9 +83,12 @@ extension ModuleStoreTransactionPublisher {
      Resolves current live payload targets for a driver-aware layout.
 
      - Parameter layout: Revalidated installed layout.
-     - Returns: Existing directory target or exact prefix-driver files.
-     - Side effects: Reads live directory entries and canonical path metadata.
-     - Throws: Filesystem or canonical-containment errors.
+     - Returns: The module's whole data directory when it exists. Stem layouts delete their parent
+       directory exactly like directory layouts because Android's JSword `SwordBookDriver.delete`
+       removes the book's location directory, and stem packages ship non-stem files such as
+       `BuildModule` scripts and `images/` directories that would otherwise be orphaned.
+     - Side effects: Reads canonical path metadata.
+     - Throws: Filesystem errors or a data path that is not a directory.
      */
     func payloadTargets(for layout: ModuleStoreInstalledLayout) throws -> [URL] {
         guard fileManager.fileExists(atPath: layout.dataDirectoryURL.path) else { return [] }
@@ -93,30 +96,7 @@ extension ModuleStoreTransactionPublisher {
         guard directoryValues.isDirectory == true else {
             throw ModuleStoreMutationError.invalidConfiguration(layout.configRelativePath)
         }
-
-        switch layout.payloadShape {
-        case .directory:
-            return [layout.dataDirectoryURL]
-        case .filenamePrefix(let prefix):
-            let prefixKey = resolver.filesystemCollisionKey(prefix)
-            let children = try fileManager.contentsOfDirectory(
-                at: layout.dataDirectoryURL,
-                includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
-                options: [.skipsHiddenFiles]
-            )
-            var targets: [URL] = []
-            for child in children where resolver.filesystemCollisionKey(child.lastPathComponent)
-                .hasPrefix(prefixKey) {
-                let values = try child.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
-                guard values.isRegularFile == true, values.isSymbolicLink != true else { continue }
-                try resolver.validateCanonicalContainment(
-                    of: child,
-                    beneath: try resolver.canonicalModulesRootURL()
-                )
-                targets.append(child)
-            }
-            return targets
-        }
+        return [layout.dataDirectoryURL]
     }
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModule.swift
@@ -389,7 +389,10 @@ public final class SwordModule: @unchecked Sendable {
             let directionPtr = SWModule_getConfigEntry(handle, "Direction")
             let direction = directionPtr != nil ? String(cString: directionPtr!) : "LtoR"
             let versionPtr = SWModule_getConfigEntry(handle, "Version")
-            let versionStr = versionPtr != nil ? String(cString: versionPtr!) : ""
+            // JSword defaults a missing Version to 1.0; matching it keeps installed metadata equal
+            // to catalog metadata for versionless modules so no phantom update is reported.
+            let rawVersion = versionPtr.map { String(cString: $0) } ?? ""
+            let versionStr = rawVersion.isEmpty ? "1.0" : rawVersion
             func configValue(_ key: String) -> String {
                 guard let value = SWModule_getConfigEntry(handle, key) else { return "" }
                 return String(cString: value)

--- a/Sources/SwordKit/Sources/SwordKit/SwordModuleConfig.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordModuleConfig.swift
@@ -163,7 +163,9 @@ struct SwordModuleConfig: Sendable {
             language: firstValue("lang", in: values) ?? "en",
             modDrv: modDrv,
             dataPath: normalizedDataPath(firstValue("datapath", in: values) ?? "", modDrv: modDrv),
-            version: firstValue("version", in: values) ?? "",
+            // JSword's SwordBookMetaData defaults a missing Version to 1.0; Android compares that
+            // default on both sides, so versionless modules never report a phantom update.
+            version: firstValue("version", in: values).flatMap { $0.isEmpty ? nil : $0 } ?? "1.0",
             installSize: firstValue("installsize", in: values) ?? "",
             direction: firstValue("direction", in: values) ?? "LtoR",
             features: ModuleFeatures.fromConfigValues(

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
@@ -2493,6 +2493,115 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
     }
 
     /**
+     Verifies a stem package with a differently named config and nested images payload installs.
+
+     Real CrossWire packages ship both traits: EpiphanyMaps names its config
+     `mods.d/epiphany-maps.conf` while its initials are `EpiphanyMaps`, and stem modules such as
+     EpiphanyMaps and OpenHymnal carry ThML `images/` subdirectories beside their stem files.
+     Failure means the package validator rejects modules Android installs without complaint.
+     */
+    func testModuleRepositoryInstallsStemPackageWithRenamedConfigAndNestedImages() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let source = SourceConfig(
+            name: "Package Repo",
+            type: "HTTP",
+            host: "example.test",
+            catalogPath: "/raw",
+            packageDirectory: "/packages"
+        )
+        let dataPath = "./modules/lexdict/rawld4/epiphany-maps/maps"
+        let catalogData = try makeModuleRepositoryCatalogArchive(
+            moduleName: "EpiphanyMaps",
+            category: "Maps",
+            modDrv: "RawLD4",
+            dataPath: dataPath
+        )
+        let zipData = makeModuleRepositoryZip([
+            ("mods.d/", Data()),
+            ("mods.d/epiphany-maps.conf", Data(moduleRepositoryConfiguration(
+                moduleName: "EpiphanyMaps",
+                category: "Maps",
+                modDrv: "RawLD4",
+                dataPath: dataPath,
+                description: "Maps by Epiphany Software"
+            ).utf8)),
+            ("modules/", Data()),
+            ("modules/lexdict/", Data()),
+            ("modules/lexdict/rawld4/", Data()),
+            ("modules/lexdict/rawld4/epiphany-maps/", Data()),
+            ("modules/lexdict/rawld4/epiphany-maps/maps.dat", Data("maps-data".utf8)),
+            ("modules/lexdict/rawld4/epiphany-maps/maps.idx", Data("maps-index".utf8)),
+            ("modules/lexdict/rawld4/epiphany-maps/images/", Data()),
+            ("modules/lexdict/rawld4/epiphany-maps/images/israjesu.jpg", Data("map-image".utf8))
+        ])
+
+        ModuleRepositoryDownloadMockURLProtocol.requestHandler = { request in
+            let response: HTTPURLResponse
+            let data: Data
+            switch request.url?.path {
+            case "/raw/mods.d.tar.gz":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = catalogData
+            case "/packages/EpiphanyMaps.zip":
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = zipData
+            default:
+                XCTFail("Unexpected request: \(request.url?.absoluteString ?? "<nil>")")
+                response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                data = Data()
+            }
+            return (response, data)
+        }
+        defer { ModuleRepositoryDownloadMockURLProtocol.requestHandler = nil }
+
+        let repository = ModuleRepository(
+            basePath: tempDir.path,
+            swordPath: swordDir.path,
+            session: makeModuleRepositoryDownloadMockSession()
+        )
+
+        _ = try await repository.refreshCatalog(for: source)
+        try await repository.installModule(named: "EpiphanyMaps", from: source)
+
+        let dataDir = swordDir
+            .appendingPathComponent("modules/lexdict/rawld4/epiphany-maps", isDirectory: true)
+        XCTAssertEqual(
+            try Data(contentsOf: dataDir.appendingPathComponent("maps.dat")),
+            Data("maps-data".utf8)
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: dataDir.appendingPathComponent("images/israjesu.jpg")),
+            Data("map-image".utf8)
+        )
+        let installedConfiguration = try String(
+            contentsOf: swordDir.appendingPathComponent("mods.d/epiphanymaps.conf"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(installedConfiguration.contains("[EpiphanyMaps]"))
+        XCTAssertTrue(installedConfiguration.contains("Repository=Package Repo"))
+    }
+
+    /**
      Verifies direct SWORD catalog custom repositories install from `catalogPath/packages`.
 
      Android's custom repository editor accepts a direct SWORD catalog only when both

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
@@ -2534,6 +2534,7 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
             ("modules/lexdict/", Data()),
             ("modules/lexdict/rawld4/", Data()),
             ("modules/lexdict/rawld4/epiphany-maps/", Data()),
+            ("modules/lexdict/rawld4/epiphany-maps/BuildModule", Data("#!/bin/sh".utf8)),
             ("modules/lexdict/rawld4/epiphany-maps/maps.dat", Data("maps-data".utf8)),
             ("modules/lexdict/rawld4/epiphany-maps/maps.idx", Data("maps-index".utf8)),
             ("modules/lexdict/rawld4/epiphany-maps/images/", Data()),

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
@@ -38,7 +38,47 @@ final class ModuleStoreLayoutTests: XCTestCase {
         XCTAssertEqual(prefix.payloadShape, .filenamePrefix("strongs"))
         XCTAssertTrue(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/strongs.dat"))
         XCTAssertFalse(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/other.dat"))
-        XCTAssertFalse(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/nested/strongs.dat"))
+        XCTAssertFalse(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/other/strongs.dat"))
+    }
+
+    /**
+     Verifies stem layouts own nested auxiliary subdirectories while direct stem siblings stay
+     protected.
+
+     Failure means real CrossWire stem modules that ship ThML `images/` directories beside their
+     stem files (for example EpiphanyMaps and OpenHymnal) are rejected at install, or a stem module
+     can claim a sibling module's stem files in a shared directory.
+     */
+    func testResolverBindsStemDriverNestedSubdirectoryPayload() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let resolver = ModuleStoreInstalledLayoutResolver(moduleRootURL: root)
+
+        let maps = try resolver.resolve(configuration(
+            name: "EpiphanyMaps",
+            driver: "RawLD4",
+            dataPath: "./modules/lexdict/rawld4/epiphany-maps/maps"
+        ))
+        XCTAssertEqual(maps.payloadShape, .filenamePrefix("maps"))
+        XCTAssertTrue(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/epiphany-maps/maps.dat"))
+        XCTAssertTrue(maps.ownsPayload(
+            atRelativePath: "modules/lexdict/rawld4/epiphany-maps/images/israjesu.jpg"
+        ))
+        XCTAssertFalse(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/epiphany-maps/other.dat"))
+        XCTAssertFalse(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/other/images/israjesu.jpg"))
+
+        let hymnal = try resolver.resolve(configuration(
+            name: "OpenHymnal",
+            driver: "RawGenBook",
+            dataPath: "./modules/genbook/rawgenbook/openhymnal/openhymnal"
+        ))
+        XCTAssertEqual(hymnal.payloadShape, .filenamePrefix("openhymnal"))
+        XCTAssertTrue(hymnal.ownsPayload(
+            atRelativePath: "modules/genbook/rawgenbook/openhymnal/openhymnal.bdt"
+        ))
+        XCTAssertTrue(hymnal.ownsPayload(
+            atRelativePath: "modules/genbook/rawgenbook/openhymnal/images/Abide_With_Me-Eventide.gif"
+        ))
     }
 
     /**

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
@@ -42,6 +42,33 @@ final class ModuleStoreLayoutTests: XCTestCase {
     }
 
     /**
+     Verifies a trailing-slash `DataPath` binds directory ownership even for stem-capable drivers.
+
+     Failure means font add-ons such as FontPack (RawGenBook with a directory `DataPath` whose
+     payload lives in nested subdirectories) are rejected at install for owning payload "outside"
+     their own declared data directory.
+     */
+    func testResolverBindsTrailingSlashStemDriverDataPathAsDirectory() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let resolver = ModuleStoreInstalledLayoutResolver(moduleRootURL: root)
+
+        let fontPack = try resolver.resolve(configuration(
+            name: "FontPack",
+            driver: "RawGenBook",
+            dataPath: "./modules/texts/ztext/FontPack/"
+        ))
+        XCTAssertEqual(fontPack.payloadShape, .directory)
+        XCTAssertEqual(fontPack.dataDirectoryRelativePath, "modules/texts/ztext/FontPack")
+        XCTAssertTrue(fontPack.ownsPayload(
+            atRelativePath: "modules/texts/ztext/FontPack/and-bible/AntiochText.ttf"
+        ))
+        XCTAssertTrue(fontPack.ownsPayload(atRelativePath: "modules/texts/ztext/FontPack/readme.txt"))
+        XCTAssertFalse(fontPack.ownsPayload(atRelativePath: "modules/texts/ztext/FontPack2/font.ttf"))
+        XCTAssertFalse(fontPack.ownsPayload(atRelativePath: "modules/texts/ztext/other/font.ttf"))
+    }
+
+    /**
      Verifies every forbidden lexical `DataPath` form is rejected from raw config text.
 
      Failure means an absolute, empty, dot-component, backslash, encoded traversal, repeated

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreLayoutTests.swift
@@ -11,10 +11,10 @@ import XCTest
  */
 final class ModuleStoreLayoutTests: XCTestCase {
     /**
-     Verifies directory and filename-prefix drivers bind only their actual staged payload files.
+     Verifies directory and filename-prefix drivers bind their whole data directory like Android.
 
-     Failure means RawLD-family modules can be treated as directories, or directory drivers can
-     accidentally claim sibling module data.
+     Failure means stem modules cannot ship auxiliary files (`BuildModule`, `images/`) beside their
+     stem data as real CrossWire packages do, or any driver can claim a sibling module's directory.
      */
     func testResolverBindsDirectoryAndFilenamePrefixDriverLayouts() throws {
         let root = try makeRoot()
@@ -37,19 +37,18 @@ final class ModuleStoreLayoutTests: XCTestCase {
         ))
         XCTAssertEqual(prefix.payloadShape, .filenamePrefix("strongs"))
         XCTAssertTrue(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/strongs.dat"))
-        XCTAssertFalse(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/other.dat"))
+        XCTAssertTrue(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/strongs/BuildModule"))
         XCTAssertFalse(prefix.ownsPayload(atRelativePath: "modules/lexdict/rawld4/other/strongs.dat"))
     }
 
     /**
-     Verifies stem layouts own nested auxiliary subdirectories while direct stem siblings stay
-     protected.
+     Verifies stem layouts own auxiliary files and nested subdirectories like Android extraction.
 
-     Failure means real CrossWire stem modules that ship ThML `images/` directories beside their
-     stem files (for example EpiphanyMaps and OpenHymnal) are rejected at install, or a stem module
-     can claim a sibling module's stem files in a shared directory.
+     Failure means real CrossWire stem modules that ship `BuildModule` scripts or ThML `images/`
+     directories beside their stem files (EpiphanyMaps, OpenHymnal, WebstersLinked,
+     StrongsRealGreek) are rejected at install even though Android installs them verbatim.
      */
-    func testResolverBindsStemDriverNestedSubdirectoryPayload() throws {
+    func testResolverBindsStemDriverAuxiliaryAndNestedPayload() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
         let resolver = ModuleStoreInstalledLayoutResolver(moduleRootURL: root)
@@ -64,7 +63,7 @@ final class ModuleStoreLayoutTests: XCTestCase {
         XCTAssertTrue(maps.ownsPayload(
             atRelativePath: "modules/lexdict/rawld4/epiphany-maps/images/israjesu.jpg"
         ))
-        XCTAssertFalse(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/epiphany-maps/other.dat"))
+        XCTAssertTrue(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/epiphany-maps/BuildModule"))
         XCTAssertFalse(maps.ownsPayload(atRelativePath: "modules/lexdict/rawld4/other/images/israjesu.jpg"))
 
         let hymnal = try resolver.resolve(configuration(

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreTransactionTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreTransactionTests.swift
@@ -647,60 +647,54 @@ final class ModuleStoreTransactionTests: XCTestCase {
     }
 
     /**
-     Verifies prefix-driver uninstall deletes only matching files and preserves sibling ownership.
+     Verifies stem-driver uninstall removes the module's whole data directory like Android.
 
-     Failure means RawLD/RawLD4 uninstall can remove a shared containing directory.
+     JSword's `SwordBookDriver.delete` removes the book's location directory, so stem uninstall
+     must also delete auxiliary files (`BuildModule`, `images/`) beside the stem files while other
+     modules' directories stay untouched.
      */
-    func testPrefixDriverUninstallPreservesSiblingModuleFiles() throws {
+    func testPrefixDriverUninstallRemovesWholeModuleDirectoryLikeAndroid() throws {
         let context = try makeContext()
         defer { try? FileManager.default.removeItem(at: context.parent) }
         try writeInstalledModule(
             root: context.root,
             name: "STRONGS",
             driver: "RawLD4",
-            dataPath: "./modules/lexdict/rawld4/shared/strongs",
-            payloadPath: "modules/lexdict/rawld4/shared/strongs.dat",
+            dataPath: "./modules/lexdict/rawld4/strongs/strongs",
+            payloadPath: "modules/lexdict/rawld4/strongs/strongs.dat",
             marker: "strongs"
         )
         try writeInstalledModule(
             root: context.root,
             name: "OTHER",
             driver: "RawLD4",
-            dataPath: "./modules/lexdict/rawld4/shared/other",
-            payloadPath: "modules/lexdict/rawld4/shared/other.dat",
+            dataPath: "./modules/lexdict/rawld4/other/other",
+            payloadPath: "modules/lexdict/rawld4/other/other.dat",
             marker: "other"
         )
         try Data("index".utf8).write(
-            to: context.root.appendingPathComponent("modules/lexdict/rawld4/shared/strongs.idx")
+            to: context.root.appendingPathComponent("modules/lexdict/rawld4/strongs/strongs.idx")
         )
-        let matchingDirectory = context.root
-            .appendingPathComponent("modules/lexdict/rawld4/shared/strongs-cache", isDirectory: true)
-        try FileManager.default.createDirectory(at: matchingDirectory, withIntermediateDirectories: true)
-        let matchingSymlink = context.root
-            .appendingPathComponent("modules/lexdict/rawld4/shared/strongs-alias")
-        try FileManager.default.createSymbolicLink(
-            at: matchingSymlink,
-            withDestinationURL: context.root
-                .appendingPathComponent("modules/lexdict/rawld4/shared/other.dat")
+        try Data("#!/bin/sh".utf8).write(
+            to: context.root.appendingPathComponent("modules/lexdict/rawld4/strongs/BuildModule")
         )
+        let imagesDirectory = context.root
+            .appendingPathComponent("modules/lexdict/rawld4/strongs/images", isDirectory: true)
+        try FileManager.default.createDirectory(at: imagesDirectory, withIntermediateDirectories: true)
+        try Data("map".utf8).write(to: imagesDirectory.appendingPathComponent("map.gif"))
 
         try context.firstPublisher.uninstall(moduleName: "STRONGS")
 
         XCTAssertFalse(FileManager.default.fileExists(
-            atPath: context.root.appendingPathComponent("modules/lexdict/rawld4/shared/strongs.dat").path
-        ))
-        XCTAssertFalse(FileManager.default.fileExists(
-            atPath: context.root.appendingPathComponent("modules/lexdict/rawld4/shared/strongs.idx").path
+            atPath: context.root.appendingPathComponent("modules/lexdict/rawld4/strongs").path
         ))
         XCTAssertEqual(
-            try payloadString(context.root, "modules/lexdict/rawld4/shared/other.dat"),
+            try payloadString(context.root, "modules/lexdict/rawld4/other/other.dat"),
             "other"
         )
         XCTAssertTrue(FileManager.default.fileExists(
             atPath: context.root.appendingPathComponent("mods.d/other.conf").path
         ))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: matchingDirectory.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: matchingSymlink.path))
         try assertNoTransactionBackups(in: context.root)
     }
 
@@ -1071,8 +1065,8 @@ final class ModuleStoreTransactionTests: XCTestCase {
     /**
      Verifies no-overwrite publication rejects every existing path owned by the incoming layout.
 
-     Exact staged filenames are insufficient: directory drivers own the complete target subtree,
-     while prefix drivers own matching sibling files even when those names are absent from the ZIP.
+     Exact staged filenames are insufficient: directory and stem drivers both own their complete
+     target directory, so any existing file below it must block a no-overwrite install.
      */
     func testNoOverwriteRejectsExistingDirectoryAndPrefixOwnedPayload() throws {
         let context = try makeContext()
@@ -1132,7 +1126,7 @@ final class ModuleStoreTransactionTests: XCTestCase {
             guard case let ModuleStoreMutationError.destinationFilesExist(paths) = error else {
                 return XCTFail("Expected prefix conflict, received \(error)")
             }
-            XCTAssertTrue(paths.contains("modules/lexdict/rawld/prefixconflict/dict.idx"))
+            XCTAssertTrue(paths.contains("modules/lexdict/rawld/prefixconflict"))
         }
         XCTAssertEqual(try String(contentsOf: existingPrefixFile, encoding: .utf8), "existing-prefix")
         XCTAssertFalse(FileManager.default.fileExists(

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -265,6 +265,31 @@ final class SwordManagerTests: XCTestCase {
         XCTAssertEqual(info.aboutMetadata.swordVersionDate, "2024-01-02")
     }
 
+    /**
+     Verifies a versionless config defaults to JSword's `1.0` on parse.
+
+     Android reads `Version` through `SwordBookMetaData`, which defaults a missing value to `1.0`
+     on both the catalog and installed sides. Failure means modules without a `Version` line (for
+     example BDBT) permanently report an update because an empty installed version can never equal
+     the catalog value.
+     */
+    func testConfigWithoutVersionDefaultsToJSwordOneDotZero() throws {
+        let config = try XCTUnwrap(SwordModuleConfig.parse("""
+        [BDBT]
+        DataPath=./modules/texts/MyBible/BDBT/
+        ModDrv=MyBibleDictionary
+        """))
+        XCTAssertEqual(config.version, "1.0")
+
+        let versioned = try XCTUnwrap(SwordModuleConfig.parse("""
+        [KJV]
+        DataPath=./modules/texts/ztext/kjv/
+        ModDrv=zText
+        Version=2.3
+        """))
+        XCTAssertEqual(versioned.version, "2.3")
+    }
+
     func testRemoteModuleInfoDefaultsToInstallable() {
         let info = RemoteModuleInfo(
             name: "KJV",

--- a/docs/adr/0011-transactional-module-store-mechanism.md
+++ b/docs/adr/0011-transactional-module-store-mechanism.md
@@ -1,0 +1,124 @@
+---
+adr: ADR-0011
+title: "Transactional Module Store Mechanism"
+description: >-
+  Keep Android's observable document-management contract while replacing its
+  in-place mutation mechanics with a transactional, journaled, serialized
+  module store on iOS.
+date: 2026-08-08
+status: accepted
+supersedes: []
+superseded-by: null
+decision-owner: "iOS parity maintainers"
+deciders: ["iOS parity maintainers"]
+consulted:
+  - "jsword AbstractSwordInstaller / IOUtil.unpackZip"
+  - "jsword SwordBookDriver / Books registry"
+  - "AndBible DownloadControl / DownloadQueue / BackupControl"
+  - "SwordKit ModuleStoreTransactionPublisher / ModuleStoreMutationCoordinator"
+informed: ["AndBible iOS contributors"]
+tags: [parity, module-store, install, transactions, android]
+related-adrs: [ADR-0010, ADR-0012]
+related-work-items: ["PR #380"]
+---
+
+# 0011: Transactional Module Store Mechanism
+
+Status: Accepted
+
+Date: 2026-08-08
+
+## Context
+
+Android's document management mutates the live SWORD tree in place. JSword's
+installer unpacks a downloaded ZIP directly into `mods.d/` and `modules/`,
+upgrades overwrite files without pruning stale ones, uninstall deletes the
+config and then the data non-atomically, and installs run on unbounded
+concurrent coroutines. Recovery from interruption is "idempotent rescan":
+partially written modules can register and fail at read time, failed uninstalls
+can orphan payload, and a corrupt config silently disappears from enumeration.
+
+iOS rebuilt the same workflows around a single transactional publisher. That
+mechanism intentionally does not match Android's mechanics, and without a
+durable record the divergence invites two kinds of future error: weakening the
+transactional core in the name of parity, or extending its strictness into
+behavior users can observe (which ADR-0012 governs).
+
+## Decision
+
+1. Observable behavior follows Android; mutation mechanics do not have to. The
+   parity contract for document management is what users and shared data
+   formats can observe: which modules install, the repository list, install
+   statuses, on-disk layout, identity rules, and Android-compatible backup
+   archives. The machinery that produces those observations is iOS-owned.
+
+2. Every mutation of the installed module tree goes through
+   `ModuleStoreTransactionPublisher` under the process-wide
+   `ModuleStoreMutationCoordinator` lease: staged extraction into an isolated
+   root, payload published before configs, displaced files moved to a backup
+   tree, rollback on failure, an fsync-backed recovery journal for overlay
+   publishes, and cache invalidation plus a payload-free change notification
+   after commit. Startup recovery failure is fatal rather than running on a
+   half-published store. Ad-hoc `FileManager` writes into the live tree are
+   not an accepted implementation pattern.
+
+3. Remote SWORD installs are package-ZIP-only. Android's raw file-by-file
+   fallback can publish a partial module after one transient missing file, so
+   iOS does not implement it. If a repository that serves only raw files ever
+   matters in practice, the fallback must download into staging and publish
+   through the same transaction, not write into the live tree.
+
+4. Commits are serialized; downloads are not. Concurrent catalog refreshes and
+   downloads remain allowed, and the coordinator lease is the single choke
+   point where the live tree changes.
+
+5. Enumeration re-projects installed state from disk instead of trusting
+   process-global caches. `SwordManager.installedModules()` reads `mods.d`
+   directly, bypassing the flat bridge's global module list, keeping locked
+   encrypted modules visible for the unlock affordance, and re-deriving
+   non-SWORD custom modules from their on-disk state on every scan. Rejected
+   files surface as diagnostics rather than disappearing silently.
+
+## Consequences
+
+- Interrupted installs, upgrades, uninstalls, and restores leave either the
+  old state or the new state, never a mixture — a deliberate improvement over
+  Android that must not be traded away for mechanical parity.
+- A repository without package ZIPs reports the module unavailable where
+  Android's raw fallback might install it. This is an accepted coverage gap
+  until a real repository demonstrates the need (none of the shipped
+  repositories do).
+- Replacing a non-SWORD module file on disk is reflected at the next scan,
+  unlike Android's register-once model that requires an app restart.
+- The transactional mechanism carries real complexity (leases, journals,
+  staged plans, byte-identical revalidation). That cost is accepted; changes
+  to it need concurrency and recovery test coverage, not simplification for
+  its own sake.
+- Mechanism-level divergence is never a justification for observable
+  divergence. When observable behavior differs from Android, ADR-0012's rule
+  applies.
+
+## Alternatives Considered
+
+- **Port Android's in-place mutation for maximum fidelity.** Rejected: its
+  failure modes (partial installs, orphaned payload, silent corruption) are
+  defects users experience, not contracts to preserve.
+- **Transactional writes without serialization.** Rejected: concurrent
+  transactions over one live tree reintroduce the races serialization exists
+  to prevent, and commit time is negligible next to download time.
+- **Implement Android's raw file-by-file install fallback now.** Rejected:
+  no shipped repository requires it, and done naively it defeats the
+  transactional guarantee.
+- **Keep libsword's global module-list cache for enumeration.** Rejected:
+  process-global staleness hides just-installed modules and locked modules,
+  and cache bypass has negligible cost at realistic library sizes.
+
+## Related
+
+- SwordKit `ModuleStoreTransactionPublisher` (+ Uninstall/ExactOverlay
+  extensions), `ModuleStoreMutationCoordinator`, `ModuleStoreRecoveryJournal`,
+  `ModuleStoreInstalledLayout`, `ModuleRepository.installModulePackage`,
+  `SwordManager.installedModules()`.
+- JSword `AbstractSwordInstaller.install`, `IOUtil.unpackZip`,
+  `SwordBookDriver.delete`, `Books`.
+- ADR-0012 for the validation semantics applied inside this mechanism.

--- a/docs/adr/0012-install-validation-follows-observed-sword-packaging.md
+++ b/docs/adr/0012-install-validation-follows-observed-sword-packaging.md
@@ -1,0 +1,132 @@
+---
+adr: ADR-0012
+title: "Install Validation Follows Observed SWORD Packaging"
+description: >-
+  Module install validation accepts what Android/JSword demonstrably accepts,
+  adding only path-safety and transactional-integrity guards; packaging
+  assumptions JSword does not enforce are not valid rejection grounds.
+date: 2026-08-08
+status: accepted
+supersedes: []
+superseded-by: null
+decision-owner: "iOS parity maintainers"
+deciders: ["iOS parity maintainers"]
+consulted:
+  - "jsword IOUtil.unpackZip / AbstractSwordInstaller"
+  - "jsword SwordBookDriver.delete"
+  - "jsword SwordBookMetaData Version default"
+  - "AndBible DownloadControl.getDocumentStatus"
+  - "Real packages: FontPack, EpiphanyMaps, OpenHymnal, WebstersLinked, StrongsRealGreek, BDBT"
+informed: ["AndBible iOS contributors"]
+tags: [parity, install, validation, sword, android]
+related-adrs: [ADR-0011]
+related-work-items: ["PR #380", "Issue #373 follow-on reports"]
+---
+
+# 0012: Install Validation Follows Observed SWORD Packaging
+
+Status: Accepted
+
+Date: 2026-08-08
+
+## Context
+
+Android performs almost no structural validation at install: JSword extracts
+every ZIP entry under `mods.d/` and `modules/` verbatim, deletes a module's
+whole location directory on uninstall, and defaults a missing `Version` to
+`1.0` at read time. iOS's validator initially encoded stricter assumptions
+about how SWORD packages "should" look: stem-driver DataPaths always denote
+filename prefixes, a module owns only direct stem-prefixed children of its
+directory, the package config filename equals the lowercased initials, and
+configs declare a version.
+
+Real CrossWire and AndBible packages violate every one of those assumptions.
+FontPack declares RawGenBook with a trailing-slash directory DataPath and
+nested font payload; EpiphanyMaps ships `mods.d/epiphany-maps.conf` for
+initials `EpiphanyMaps`; stem modules (EpiphanyMaps, OpenHymnal,
+WebstersLinked, Webster1828, StrongsRealGreek/Hebrew, NaveLinked,
+InvStrongsRealGreek, Easton, Berean modules, ACDCRef) ship `BuildModule`
+scripts and `images/` directories beside their stem files; BDBT declares no
+`Version` at all. Each assumption produced a user-facing install failure or a
+phantom permanent update that Android does not have. The rejections protected
+nothing real: Android has installed these exact packages for years.
+
+## Decision
+
+1. The parity baseline for install validation is what JSword demonstrably
+   does, verified against its source and real packages — not inferred
+   packaging conventions. A package Android installs must install on iOS
+   unless rejecting it defends one of the guards in point 4.
+
+2. Ownership and deletion are directory-scoped for every driver. A module
+   owns every file below its data directory. Stem-style DataPaths (RawLD,
+   RawLD4, zLD, RawGenBook, RawFiles) still name the data files, and a
+   trailing slash — not the driver — marks a directory DataPath, but
+   ownership and uninstall both cover the whole parent directory, matching
+   JSword extraction and `SwordBookDriver.delete`.
+
+3. Metadata semantics use JSword's read-time defaults. A missing or empty
+   `Version` reads as `1.0` on both comparison sides, so versionless modules
+   never report a phantom update; genuinely malformed versions keep Android's
+   deliberate update-available fallback. A remote package's single config may
+   use any direct `mods.d/*.conf` filename; identity is proven from parsed
+   content against the catalog, and the staged config is written at the
+   canonical path.
+
+4. iOS-added guards are limited to what Android's absence of them makes
+   exploitable or what ADR-0011's transaction requires: path traversal,
+   symlink and canonical-containment escapes, percent-encoded and absolute
+   paths, duplicate initials, multi-config packages, catalog identity
+   mismatches, staged-plan revalidation, and archive-digest-bound overwrite
+   consent. These reject malicious or self-inconsistent archives, never
+   merely unconventional ones.
+
+5. New rejection rules carry a burden of proof. Before adding a validation
+   rule stricter than JSword's behavior, cite the JSword source path it
+   mirrors or the concrete attack it blocks, and test it against real
+   packages from the shipped repositories. "The packaging looks wrong" is not
+   a rejection ground.
+
+## Consequences
+
+- The module population installable on iOS tracks Android's, so parity bugs
+  in this area are regressions against a stated rule rather than judgment
+  calls.
+- Uninstalling a stem module removes its whole data directory, exactly as
+  Android does. In the theoretical case of two modules sharing one directory,
+  uninstalling one removes the other's files — Android-identical, and no real
+  CrossWire package shares directories.
+- Security review of the install path concentrates on the point-4 guard list;
+  loosening any of those needs its own decision, not an appeal to this ADR.
+- Known accepted gap: the local ZIP import path still requires the config
+  filename to match the module initials, which Android does not. Closing it
+  should follow this ADR's rule (canonicalize, don't reject).
+- When a new package fails to install, the diagnostic procedure is: download
+  the actual package, read the actual JSword code path, and align — the
+  procedure that produced this ADR.
+
+## Alternatives Considered
+
+- **Keep strict conventional validation and fix packages upstream.** Rejected:
+  iOS does not control CrossWire packaging, decades of published modules
+  already violate the conventions, and users experience the mismatch as
+  broken installs.
+- **Drop validation entirely to match Android byte-for-byte.** Rejected:
+  Android's absence of zip-slip and containment checks is a latent defect,
+  and ADR-0011's transactional publish requires staged-plan validation to
+  exist.
+- **Treat malformed versions as equal instead of updateable.** Rejected:
+  Android deliberately reports update-available when `Version(...)` throws,
+  keeping a reinstall affordance for damaged metadata; iOS preserves that.
+
+## Related
+
+- SwordKit `ModuleStoreInstalledLayout` (payload shape, `ownsPayload`),
+  `ModuleStoreTransactionPublisher+Uninstall.payloadTargets`,
+  `ModuleRepository.installModulePackage` /
+  `validatedRemotePackageLayout`, `SwordModuleConfig.parse`,
+  `ModuleBrowserView.isRemoteVersionNewer`.
+- JSword `IOUtil.unpackZip`, `SwordBookDriver.delete`,
+  `SwordBookMetaData` defaults, `Version`; AndBible
+  `DownloadControl.getDocumentStatus`.
+- PR #380 carries the implementing changes and validation evidence.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,5 @@ sections or their front-matter equivalents:
 - [0008: Parity Documentation Ownership](0008-parity-documentation-ownership.md)
 - [0009: Android Localization Source Of Truth](0009-android-localization-source-of-truth.md)
 - [0010: Unrecognized Module Versification Handling](0010-unrecognized-module-versification-handling.md)
+- [0011: Transactional Module Store Mechanism](0011-transactional-module-store-mechanism.md)
+- [0012: Install Validation Follows Observed SWORD Packaging](0012-install-validation-follows-observed-sword-packaging.md)


### PR DESCRIPTION
## Summary

A family of real-world modules that install fine on Android failed on iOS because the install validator encoded assumptions about SWORD packaging that actual packages violate. Three commits align the validator with Android/JSword behavior:

1. **Trailing-slash DataPath = directory** (FontPack): stem-capable drivers (`rawld`, `rawld4`, `zld`, `rawgenbook`, `rawfiles`) were always classified as filename-stem layouts, but SWORD distinguishes stem from directory DataPaths by the trailing slash. FontPack (`RawGenBook`, `DataPath=./modules/texts/ztext/FontPack/`, fonts in a nested `and-bible/` dir) was rejected as owning payload "outside" its own directory.
2. **Renamed configs + nested payload** (EpiphanyMaps, OpenHymnal): packages may name their config differently from the module initials (`mods.d/epiphany-maps.conf` for `EpiphanyMaps`), and stem modules ship `images/` subdirectories beside their stem files.
3. **Full Android ownership/version parity** (WebstersLinked, Webster1828, StrongsRealGreek/Hebrew, NaveLinked, InvStrongsRealGreek, Easton, Berean modules, ACDCRef, BDBT): stem packages also ship `BuildModule` scripts as direct non-stem children, so stem layouts now own their whole data directory exactly like directory layouts (matching JSword extraction), uninstall removes the whole module directory (matching `SwordBookDriver.delete`), and a missing `Version` defaults to JSword's `1.0` on both comparison sides so versionless modules (BDBT) stop reporting a phantom update forever.

## Scope

- `Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledLayout.swift` — DataPath shape classification + directory-subtree ownership
- `Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift` — whole-directory uninstall targets
- `Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift` — package config-name guard
- `Sources/SwordKit/Sources/SwordKit/SwordModuleConfig.swift`, `SwordModule.swift` — JSword `Version` default
- SwordKit test suites — parity regressions

## Contract references

- Commits follow the locked commit-message standard.
- Android parity verified against JSword source (`IOUtil.unpackZip`, `SwordBookDriver.delete`, `SwordBookMetaData` `Version` default) and the actual failing packages downloaded from the AndBible repositories.

## Change details

- `ownsPayload` owns every file below the module's data directory for both directory and stem layouts; the stem still names the data files and derives the directory.
- Uninstall/overwrite `payloadTargets` return the whole data directory for stem modules, so auxiliary files (`BuildModule`, `images/`) are not orphaned — identical to Android's delete.
- A remote package's single config may live at any direct `mods.d/*.conf` path; identity is proven from parsed content against the catalog and the staged config is written at the canonical path.
- `Version` missing or empty defaults to `"1.0"` at both parse sites (config parser and libsword reader), mirroring JSword's `SwordBookMetaData` defaults. Explicitly invalid version strings still compare as updateable, which is Android's exception behavior.
- Path-safety validation is untouched: traversal/symlink/canonical-containment rejections, duplicate-initials, multi-config packages, and identity mismatches all still fail closed.

## Validation evidence

- `swift build` passes.
- Full `SwordKitTests` suite: 195 tests, 0 failures (ownership, uninstall, no-overwrite, layout, download, TTF suites).
- `BibleUITests`: `ModuleBrowserDownloadsTests` + `BibleReaderModulePickerTests`, 51 tests, 0 failures.
- `git diff --check`, commit-message, and docblock guardrails pass.
- Manual on simulator: FontPack, EpiphanyMaps, and OpenHymnal install after their respective fixes; remaining modules pending manual retest with this build.

## Risks / follow-ups

- Uninstalling a stem module now removes its whole data directory, exactly as Android does. In the theoretical case of two modules sharing one directory, uninstalling one removes the other's files — identical to Android's behavior, and no real CrossWire package uses shared directories.
- Follow-up (not in this PR): local ZIP *import* still requires the config filename to match the module initials.
- Manual confirmation: retry WebstersLinked, Webster1828, StrongsRealGreek/Hebrew, NaveLinked, InvStrongsRealGreek, Easton, Berean modules, ACDCRef; confirm BDBT shows "installed" without a perpetual update badge.

## Issue closure

Closes: none — no GitHub issue exists for these failures; they were found while manually testing the merged #379 in the simulator.