### PR TITLE
fix(reader): open StudyPad and My Notes modal links in the links window

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1236,6 +1236,28 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
    */
   var onOpenAIDocumentPageInLinksWindow: ((AIDocumentPageRequest) -> Void)?
 
+    /**
+     Callback for routing a StudyPad journal document through the pane-owned links-window policy.
+
+     Android's `LinkControl.openStudyPad` wraps the label in a `StudyPadKey` and hands it to
+     `showLink`, so modal StudyPad buttons open the journal document in the dedicated links window
+     by default. The owning pane applies the same preference, window-creation, and registration
+     retry path as other link results. Without an owner, the bridge keeps its current-pane
+     fallback for standalone controller use.
+     */
+    var onOpenStudyPadInLinksWindow: ((UUID, UUID?) -> Void)?
+
+    /**
+     Callback for routing the My Notes document through the pane-owned links-window policy.
+
+     Android's `LinkControl.openMyNotes` resolves the source-versification verse and routes it
+     through `showLink` like any other link result. The parameters are the raw source
+     versification name and source ordinal from the bridge, so the destination controller performs
+     its own KJVA projection. Without an owner, the bridge keeps its current-pane fallback for
+     standalone controller use.
+     */
+    var onOpenMyNotesInLinksWindow: ((String, Int) -> Void)?
+
     /// Callback for presenting native AI regeneration for a validated My Documents page.
     var onRegenerateMyDocumentPage: ((MyDocumentAIPageActionContext) -> Void)?
 
@@ -6999,34 +7021,80 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
-     Opens a label-backed StudyPad journal document in the current pane.
+     Opens a label-backed StudyPad journal document through the links-window policy.
+
+     Android routes `openStudyPad` through `LinkControl.showLink`, so the journal document opens in
+     the dedicated links window unless the links preference or window mode selects the current
+     window. The pane owner installs that policy through `onOpenStudyPadInLinksWindow`; without an
+     owner the document loads in the current pane as the standalone-controller fallback.
+
+     - Parameters:
+       - bridge: BibleView bridge instance that delivered the action; unused because routing is
+         owned by the controller and its pane owner.
+       - labelId: Persisted StudyPad label identifier string from the shared frontend.
+       - bookmarkId: Bookmark row to scroll to after the journal document renders.
+     - Side effects: Delegates to pane-owned links routing when configured, otherwise loads the
+       StudyPad document in this controller.
+     - Failure modes: A malformed label identifier fails closed without touching reader state.
      */
     public func bridge(_ bridge: BibleBridge, openStudyPad labelId: String, bookmarkId: String) {
         logger.info("Open StudyPad for label: \(labelId)")
         guard let uuid = UUID(uuidString: labelId) else { return }
         let bmUuid = UUID(uuidString: bookmarkId)
+        if let route = onOpenStudyPadInLinksWindow {
+            route(uuid, bmUuid)
+            return
+        }
         loadStudyPadDocument(labelId: uuid, bookmarkId: bmUuid)
     }
 
     /**
-     Opens the chapter-level My Notes document in the current pane.
+     Opens the chapter-level My Notes document through the links-window policy.
 
-     Android passes My Notes modal links as the source versification plus the bookmark's original
-     source ordinal, while the fake My Notes document itself renders rows in KJVA order. This bridge
-     converts the source ordinal before loading the document so the optional scroll target stays in
-     the document's ordinal domain.
+     Android routes `openMyNotes` through `LinkControl.showLink`, so the My Notes document opens in
+     the dedicated links window unless the links preference selects the current window. The pane
+     owner installs that policy through `onOpenMyNotesInLinksWindow`; without an owner the document
+     loads in the current pane as the standalone-controller fallback.
 
      - Parameters:
-       - bridge: BibleView bridge instance that delivered the action; unused because the controller
-         owns document loading state.
+       - bridge: BibleView bridge instance that delivered the action; unused because routing is
+         owned by the controller and its pane owner.
        - v11n: Source versification name associated with `ordinal`.
        - ordinal: Source-versification ordinal from the bookmark modal link.
+     - Side effects: Delegates to pane-owned links routing when configured, otherwise loads the
+       My Notes document through `loadMyNotesDocument(v11nName:sourceOrdinal:)`.
+     - Failure modes: If the source ordinal cannot be projected to KJVA, the destination load fails
+       closed rather than opening an unrelated active chapter or sending an ordinal from the wrong
+       domain.
+     */
+    public func bridge(_ bridge: BibleBridge, openMyNotes v11n: String, ordinal: Int) {
+        if let route = onOpenMyNotesInLinksWindow {
+            route(v11n, ordinal)
+            return
+        }
+        loadMyNotesDocument(v11nName: v11n, sourceOrdinal: ordinal)
+    }
+
+    /**
+     Loads the My Notes document for an Android source-domain verse coordinate.
+
+     Android passes My Notes modal links as the source versification plus the bookmark's original
+     source ordinal, while the fake My Notes document itself renders rows in KJVA order. This entry
+     point converts the source ordinal before loading the document so the optional scroll target
+     stays in the document's ordinal domain, and is public so pane-owned links routing can run the
+     same conversion on the destination controller.
+
+     - Parameters:
+       - v11nName: Source versification name associated with `sourceOrdinal`.
+       - sourceOrdinal: Source-versification ordinal from the bookmark modal link.
      - Side effects: Loads or queues the My Notes document through `loadMyNotesDocument`.
      - Failure modes: If the source ordinal cannot be projected to KJVA, the route fails closed
        rather than opening an unrelated active chapter or sending an ordinal from the wrong domain.
      */
-    public func bridge(_ bridge: BibleBridge, openMyNotes v11n: String, ordinal: Int) {
-        guard let target = myNotesTarget(v11nName: v11n, sourceOrdinal: ordinal) else { return }
+    public func loadMyNotesDocument(v11nName: String, sourceOrdinal: Int) {
+        guard let target = myNotesTarget(v11nName: v11nName, sourceOrdinal: sourceOrdinal) else {
+            return
+        }
         loadMyNotesDocument(target: target)
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -1120,6 +1120,57 @@ struct BibleWindowPane: View {
                 )
             }
         }
+
+        // StudyPad modal buttons follow Android's LinkControl.openStudyPad -> showLink routing:
+        // the journal document opens in the dedicated links window unless the preference is off.
+        ctrl.onOpenStudyPadInLinksWindow = { [weak ctrl, weak windowManager] labelId, bookmarkId in
+            guard let ctrl else { return }
+            let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
+            guard useLinksWindow else {
+                ctrl.loadStudyPadDocument(labelId: labelId, bookmarkId: bookmarkId)
+                return
+            }
+
+            guard let wm = windowManager,
+                let linksWindow = prepareLinksWindow(using: wm)
+            else { return }
+
+            withLinksController(
+                for: linksWindow,
+                using: wm,
+                fallback: {
+                    ctrl.loadStudyPadDocument(labelId: labelId, bookmarkId: bookmarkId)
+                }
+            ) { targetController in
+                targetController.loadStudyPadDocument(labelId: labelId, bookmarkId: bookmarkId)
+            }
+        }
+
+        // My Notes modal links follow Android's LinkControl.openMyNotes -> showLink routing. The
+        // raw source coordinate is forwarded so the destination controller runs the KJVA
+        // projection itself.
+        ctrl.onOpenMyNotesInLinksWindow = { [weak ctrl, weak windowManager] v11nName, ordinal in
+            guard let ctrl else { return }
+            let useLinksWindow = store.getBool(.openLinksInSpecialWindowPref)
+            guard useLinksWindow else {
+                ctrl.loadMyNotesDocument(v11nName: v11nName, sourceOrdinal: ordinal)
+                return
+            }
+
+            guard let wm = windowManager,
+                let linksWindow = prepareLinksWindow(using: wm)
+            else { return }
+
+            withLinksController(
+                for: linksWindow,
+                using: wm,
+                fallback: {
+                    ctrl.loadMyNotesDocument(v11nName: v11nName, sourceOrdinal: ordinal)
+                }
+            ) { targetController in
+                targetController.loadMyNotesDocument(v11nName: v11nName, sourceOrdinal: ordinal)
+            }
+        }
     }
 
   /** Whether Android's AI action rows should be visible for this installation. */

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -756,6 +756,177 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies the StudyPad bridge action hands the parsed identifiers to pane-owned link routing.
+
+     Android's `LinkControl.openStudyPad` routes the journal document through `showLink`, so the
+     dedicated links window — not the initiating window — hosts the StudyPad by default. The iOS
+     bridge must therefore delegate to the installed links-window policy without mutating the
+     initiating pane's reader state.
+
+     - Setup: Installs a routing callback on a controller with no StudyPad state loaded.
+     - Expected result: The callback receives the exact label/bookmark UUID pair, no StudyPad
+       document loads in the initiating controller, and no bridge emission occurs.
+     - Failure meaning: Modal StudyPad buttons replace the initiating pane before the links-window
+       policy chooses its destination, diverging from Android issue #376 behavior.
+     - Side effects: Invokes one in-memory bridge delegate callback only.
+     */
+    @MainActor
+    func testOpenStudyPadBridgeDelegatesToPaneRoutingPolicy() {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let controller = BibleReaderController(bridge: bridge, initializesSword: false)
+        let labelId = UUID()
+        let bookmarkId = UUID()
+        var routedLabelId: UUID?
+        var routedBookmarkId: UUID??
+        controller.onOpenStudyPadInLinksWindow = { label, bookmark in
+            routedLabelId = label
+            routedBookmarkId = bookmark
+        }
+
+        controller.bridge(
+            bridge,
+            openStudyPad: labelId.uuidString,
+            bookmarkId: bookmarkId.uuidString
+        )
+
+        XCTAssertEqual(routedLabelId, labelId)
+        XCTAssertEqual(routedBookmarkId, bookmarkId)
+        XCTAssertFalse(controller.showingStudyPad)
+        XCTAssertFalse(recordedScripts().contains { $0.contains("emit('add_documents'") })
+    }
+
+    /**
+     Verifies a malformed StudyPad label identifier fails closed before links routing runs.
+
+     Android resolves the label before building the `StudyPadKey`, so an unresolvable identifier
+     never reaches window routing. The iOS bridge must keep that ordering: parse failures may not
+     open or create a links window.
+
+     - Setup: Installs a routing callback, then delivers a non-UUID label identifier.
+     - Expected result: The routing callback never fires and reader state is untouched.
+     - Failure meaning: Malformed frontend payloads could create or focus a links window with no
+       document to show.
+     - Side effects: None.
+     */
+    @MainActor
+    func testOpenStudyPadBridgeRejectsMalformedLabelIdBeforeRouting() {
+        let bridge = BibleBridge()
+        let controller = BibleReaderController(bridge: bridge, initializesSword: false)
+        var routed = false
+        controller.onOpenStudyPadInLinksWindow = { _, _ in routed = true }
+
+        controller.bridge(bridge, openStudyPad: "not-a-uuid", bookmarkId: UUID().uuidString)
+
+        XCTAssertFalse(routed)
+        XCTAssertFalse(controller.showingStudyPad)
+    }
+
+    /**
+     Verifies the StudyPad bridge action keeps its current-pane fallback without a routing owner.
+
+     Standalone controllers (and panes whose owner installs no policy) must retain the existing
+     in-pane StudyPad load so the bridge action never becomes a no-op.
+
+     - Setup: Creates a bookmark service with one label and delivers the bridge action with no
+       routing callback installed.
+     - Expected result: The controller loads the StudyPad document itself and exposes native
+       StudyPad visible state.
+     - Failure meaning: The links-window delegation removed the standalone fallback and orphaned
+       the bridge action.
+     - Side effects: Persists one label in an in-memory bookmark store.
+     */
+    @MainActor
+    func testOpenStudyPadBridgeFallsBackToCurrentPaneWithoutRoutingOwner() throws {
+        let bridge = BibleBridge()
+        let container = try makeBookmarkRestoreModelContainer()
+        let modelContext = ModelContext(container)
+        let bookmarkService = BookmarkService(store: BookmarkStore(modelContext: modelContext))
+        let controller = BibleReaderController(bridge: bridge)
+        controller.bookmarkService = bookmarkService
+        let label = bookmarkService.createLabel(name: "Fallback Pad", color: Label.defaultColor)
+
+        controller.bridge(bridge, openStudyPad: label.id.uuidString, bookmarkId: "")
+
+        XCTAssertTrue(controller.showingStudyPad)
+        XCTAssertTrue(controller.studyPadAccessibilityState.contains("studyPadLabel=Fallback Pad"))
+    }
+
+    /**
+     Verifies the My Notes bridge action hands the raw source coordinate to pane-owned routing.
+
+     Android's `LinkControl.openMyNotes` routes the notes document through `showLink`, so the
+     dedicated links window hosts My Notes by default. The routed payload must stay in the source
+     versification domain because the destination controller performs its own KJVA projection.
+
+     - Setup: Installs a routing callback on a controller with no My Notes state loaded.
+     - Expected result: The callback receives the unconverted versification/ordinal pair and the
+       initiating controller shows no My Notes state.
+     - Failure meaning: My Notes modal links replace the initiating pane, or the coordinate is
+       projected twice and scrolls to the wrong row.
+     - Side effects: Invokes one in-memory bridge delegate callback only.
+     */
+    @MainActor
+    func testOpenMyNotesBridgeDelegatesToPaneRoutingPolicy() {
+        let bridge = BibleBridge()
+        let controller = BibleReaderController(bridge: bridge, initializesSword: false)
+        var routedV11n: String?
+        var routedOrdinal: Int?
+        controller.onOpenMyNotesInLinksWindow = { v11nName, ordinal in
+            routedV11n = v11nName
+            routedOrdinal = ordinal
+        }
+
+        controller.bridge(bridge, openMyNotes: "Vulg", ordinal: 4242)
+
+        XCTAssertEqual(routedV11n, "Vulg")
+        XCTAssertEqual(routedOrdinal, 4242)
+        XCTAssertFalse(controller.showingMyNotes)
+    }
+
+    /**
+     Guards the production `BibleWindowPane` StudyPad and My Notes links-window callbacks.
+
+     The source slice covers both new callback assignments. Each must honor the Android links
+     preference and pass the identical payload to all three destination branches (preference-off
+     current pane, exhausted-retry fallback, and registered links controller). Dropping a branch
+     would silently strand one route in the wrong window and diverge from Android's
+     `LinkControl.showLink` behavior.
+     */
+    func testBibleWindowPaneProductionCallbacksRouteStudyPadAndMyNotesThroughLinksPolicy() throws {
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift"
+        )
+
+        let studyPadStart = try XCTUnwrap(
+            source.range(of: "ctrl.onOpenStudyPadInLinksWindow = {")
+        )
+        let myNotesStart = try XCTUnwrap(
+            source.range(
+                of: "ctrl.onOpenMyNotesInLinksWindow = {",
+                range: studyPadStart.upperBound..<source.endIndex
+            )
+        )
+        let studyPadSlice = source[studyPadStart.lowerBound..<myNotesStart.lowerBound]
+        let myNotesSlice = source[myNotesStart.lowerBound...]
+
+        XCTAssertTrue(studyPadSlice.contains(".openLinksInSpecialWindowPref"))
+        XCTAssertEqual(
+            studyPadSlice
+                .components(separatedBy: ".loadStudyPadDocument(labelId: labelId, bookmarkId: bookmarkId)")
+                .count - 1,
+            3
+        )
+
+        XCTAssertTrue(myNotesSlice.contains(".openLinksInSpecialWindowPref"))
+        XCTAssertEqual(
+            myNotesSlice
+                .components(separatedBy: ".loadMyNotesDocument(v11nName: v11nName, sourceOrdinal: ordinal)")
+                .count - 1,
+            3
+        )
+    }
+
+    /**
      Verifies StudyPad requests made before the Vue client is ready replay after client-ready.
 
      Android treats StudyPad as a reader document, so selecting a StudyPad label while the shared


### PR DESCRIPTION
## Summary

The StudyPad button in the AmbiguousSelection modal opened the journal document by replacing the tapped pane with the in-pane StudyPad mode. Android routes `openStudyPad` through `LinkControl.showLink`, so the journal opens in the dedicated links window by default and the tapped window stays on the Bible text. The My Notes modal link had the same gap. This PR routes both bridge actions through the same pane-owned links-window policy the other link types already use.

## Scope

- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift` — bridge handlers and routing hooks
- `Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift` — pane wiring of the two new hooks
- `Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift` — new coverage

No changes to bridge payloads, the shared `bibleview-js` frontend, persisted formats, or sync contracts.

## Contract references

- Android parity baseline: `LinkControl.openStudyPad` / `LinkControl.openMyNotes` both route through `showLink`, which honors `open_links_in_special_window_pref` (default true) and targets the dedicated links window. iOS now mirrors that policy through the existing `openLinksInSpecialWindowPref` registry key (same Android reference, same default).
- Commit follows the locked commit-message standard (typed subject, Why/What Changed/Validation/Impact sections).

## Change details

- `BibleReaderController` gains `onOpenStudyPadInLinksWindow` and `onOpenMyNotesInLinksWindow` hooks alongside the five existing links-window callbacks. The `openStudyPad` and `openMyNotes` bridge handlers delegate to them and keep the current-pane load as the standalone-controller fallback, with the malformed-label guard still running before routing.
- New public `loadMyNotesDocument(v11nName:sourceOrdinal:)` lets the destination controller run the KJVA projection itself, so the routed payload stays in the source versification domain and is never converted twice.
- `BibleWindowPane.configureController` wires both hooks with the identical pattern used by the existing routes: `openLinksInSpecialWindowPref` check, `prepareLinksWindow` find-or-create, and the `withLinksController` registration-retry with current-pane fallback.

## Validation evidence

- `BibleUITests/BookmarkReaderBridgeTests`: 49 tests, 0 failures on the iPhone 17 simulator, including five new tests: routing delegation for StudyPad and My Notes, malformed-label fail-closed ordering, the no-owner standalone fallback, and a source-slice guard asserting the production `BibleWindowPane` wiring honors the preference and reaches all three destination branches.
- `git diff --check`, `scripts/check_repo_standards.py commits --base-ref main`, and `scripts/check_repo_standards.py docblocks --all-files` pass locally.

## Risks / follow-ups

- Impact analysis rated `loadStudyPadDocument` upstream blast radius CRITICAL, but this change does not alter that method's signature or behavior — it only adds a routing layer in front of the two bridge call sites, and every pane installs the hooks, so in-app behavior changes only in the intended direction (destination window selection).
- The links-window controller registration retry is the same shared `withLinksController` path used by existing routes; no new timing behavior was introduced.
- Follow-up candidate: a manual device pass over the AmbiguousSelection modal with the links preference toggled both ways.

## Issue closure

Closes #376
