### PR TITLE
fix(reader): stop force-overriding reader text width from native CSS

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1644,7 +1644,18 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         loadCurrentContent()
     }
 
-    /// Inject CSS to set the page background for night/day mode using display settings colors.
+    /**
+     Injects the night/day page background and the TTS highlight styles.
+
+     Body/document colors are set natively because they must hold before the Vue client is ready
+     (initial load, document replacement) when no `set_config` styling exists yet; once the client
+     runs, the shared frontend derives the same colors from config. All layout — paddings, margins,
+     and text width — belongs exclusively to the shared Vue `contentStyle` so Android's
+     text-display settings keep authority (issue #377).
+
+     - Side effects: Evaluates one JavaScript block in the pane web view.
+     - Failure modes: Evaluation failures leave the previous styling; the next content load retries.
+     */
     private func applyNightModeBackground() {
         let s = displaySettings
         let d = TextDisplaySettings.appDefaults
@@ -1665,12 +1676,11 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         document.body.style.color = '\(fg)';
         var content = document.getElementById('content');
         if (content) {
-            content.style.paddingTop = '8px';
-            content.style.paddingBottom = '16px';
+            content.style.removeProperty('padding-top');
+            content.style.removeProperty('padding-bottom');
         }
-        // Inject CSS for TTS speak highlighting only. Horizontal padding and max-width belong to
-        // the shared Vue contentStyle; an !important override here would defeat Android's
-        // marginSize text-display settings for every document.
+        // Inject CSS for TTS speak highlighting only. Padding and max-width belong to the shared
+        // Vue contentStyle; a native override here would defeat Android's text-display settings.
         var legacyMarginFix = document.getElementById('ios-margin-fix');
         if (legacyMarginFix) { legacyMarginFix.remove(); }
         if (!document.getElementById('ios-tts-highlight')) {

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1681,12 +1681,10 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
         // Inject CSS for TTS speak highlighting only. Padding and max-width belong to the shared
         // Vue contentStyle; a native override here would defeat Android's text-display settings.
-        var legacyMarginFix = document.getElementById('ios-margin-fix');
-        if (legacyMarginFix) { legacyMarginFix.remove(); }
         if (!document.getElementById('ios-tts-highlight')) {
             var s = document.createElement('style');
             s.id = 'ios-tts-highlight';
-            s.textContent = '.speaking-verse { background-color: rgba(100, 149, 237, 0.12); border-radius: 4px; transition: background-color 0.3s ease; } #speaking-word { background-color: rgba(100, 149, 237, 0.45); border-radius: 3px; padding: 1px 0; }';
+            s.textContent = '.speaking-verse { background-color: rgba(100, 149, 237, 0.12); border-radius: 4px; transition: background-color 0.3s ease; } #speaking-word { background-color: rgba(100, 149, 237, 0.45); border-radius: 3px; padding: 1px 0; } .night .speaking-verse { background-color: rgba(135, 168, 255, 0.28); } .night #speaking-word { background-color: rgba(135, 168, 255, 0.6); }';
             document.head.appendChild(s);
         }
         """)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1646,11 +1646,15 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             content.style.paddingTop = '8px';
             content.style.paddingBottom = '16px';
         }
-        // Inject CSS overrides for margins and TTS highlighting
-        if (!document.getElementById('ios-margin-fix')) {
+        // Inject CSS for TTS speak highlighting only. Horizontal padding and max-width belong to
+        // the shared Vue contentStyle; an !important override here would defeat Android's
+        // marginSize text-display settings for every document.
+        var legacyMarginFix = document.getElementById('ios-margin-fix');
+        if (legacyMarginFix) { legacyMarginFix.remove(); }
+        if (!document.getElementById('ios-tts-highlight')) {
             var s = document.createElement('style');
-            s.id = 'ios-margin-fix';
-            s.textContent = '#content { padding-left: 16px !important; padding-right: 16px !important; max-width: none !important; } .speaking-verse { background-color: rgba(100, 149, 237, 0.12); border-radius: 4px; transition: background-color 0.3s ease; } #speaking-word { background-color: rgba(100, 149, 237, 0.45); border-radius: 3px; padding: 1px 0; }';
+            s.id = 'ios-tts-highlight';
+            s.textContent = '.speaking-verse { background-color: rgba(100, 149, 237, 0.12); border-radius: 4px; transition: background-color 0.3s ease; } #speaking-word { background-color: rgba(100, 149, 237, 0.45); border-radius: 3px; padding: 1px 0; }';
             document.head.appendChild(s);
         }
         """)

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -716,9 +716,16 @@ public struct BibleReaderView: View {
             ?? MyNotesAccessibilitySnapshot.empty.encodedValue
         let studyPadToken = exportController?.studyPadAccessibilityState
             ?? StudyPadAccessibilitySnapshot.empty.encodedValue
-        let strongsMode = resolvedDisplaySettings(for: windowManager.activeWindow).strongsMode
+        let resolvedDisplay = resolvedDisplaySettings(for: windowManager.activeWindow)
+        let strongsMode = resolvedDisplay.strongsMode
             ?? TextDisplaySettings.appDefaults.strongsMode
             ?? 0
+        // Rendered-effect assertions still need frame or screenshot evidence; these tokens let
+        // tests distinguish "setting never resolved" from "resolved but not rendered" cheaply.
+        let displayMaxWidthToken =
+            "displayMaxWidth=\(resolvedDisplay.maxWidth ?? TextDisplaySettings.appDefaults.maxWidth ?? 170)"
+        let displayFontSizeToken =
+            "displayFontSize=\(resolvedDisplay.fontSize ?? TextDisplaySettings.appDefaults.fontSize ?? 16)"
         let drawerToken = "drawerVisible=\(showReaderNavigationDrawer ? "true" : "false")"
         let overflowToken = "overflowVisible=\(showReaderOverflowMenu ? "true" : "false")"
         let destinationToken = "readerDestination=\(activeReaderDestination?.rawValue ?? "none")"
@@ -744,6 +751,8 @@ public struct BibleReaderView: View {
             searchToken,
             nightModeToken,
             readerBackgroundToken,
+            displayMaxWidthToken,
+            displayFontSizeToken,
         ].joined(separator: ";")
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleWindowPane.swift
@@ -347,10 +347,19 @@ struct BibleWindowPane: View {
             } else {
                 let workspaceStore = WorkspaceStore(modelContext: modelContext)
                 let settingsStore = SettingsStore(modelContext: modelContext)
+                // Display settings can change while this pane is unmounted (minimized window,
+                // covered destination); .onChange cannot observe that, and configureController's
+                // plain assignment never re-renders. Detect drift first and push it through the
+                // full update path so restored panes match the current settings.
+                let displaySettingsDrifted = controller!.displaySettings != displaySettings
+                    || controller!.nightMode != nightMode
         configureController(
           controller!, workspaceStore: workspaceStore, settingsStore: settingsStore)
         configureAICoordinator(for: controller!)
                 registerController(controller!)
+                if displaySettingsDrifted {
+                    controller!.updateDisplaySettings(displaySettings, nightMode: nightMode)
+                }
             }
         }
         .onChange(of: nightMode) { _, newValue in

--- a/Sources/BibleUI/Sources/BibleUI/Settings/AndroidTextDisplayPreferenceEditorDialog.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Settings/AndroidTextDisplayPreferenceEditorDialog.swift
@@ -257,7 +257,8 @@ struct AndroidTextDisplayPreferenceEditorDialog: View {
                 range: range,
                 step: TextDisplaySettingsView.androidNumericSliderStep,
                 palette: surfacePalette,
-                accessibilityIdentifier: "textDisplayPreferenceEditorSeekBar::\(title)"
+                accessibilityIdentifier: "textDisplayPreferenceEditorSeekBar::\(title)",
+                accessibilityLabel: title
             )
         }
     }

--- a/Sources/BibleUI/Sources/BibleUI/Shared/AndroidPreferenceActivityComponents.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/AndroidPreferenceActivityComponents.swift
@@ -341,7 +341,8 @@ struct AndroidSeekBarPreferenceRow: View {
                     range: range,
                     step: step,
                     palette: palette,
-                    accessibilityIdentifier: accessibilityIdentifier
+                    accessibilityIdentifier: accessibilityIdentifier,
+                    accessibilityLabel: title
                 )
                 if let summary, !summary.isEmpty {
                     Text(summary)
@@ -369,6 +370,9 @@ struct AndroidSeekBar: View {
     let palette: ReaderThemeSurfacePalette
     let accessibilityIdentifier: String
 
+    /// Human-readable VoiceOver label; identifiers are automation-facing and must not be spoken.
+    let accessibilityLabel: String
+
     var body: some View {
         GeometryReader { proxy in
             let width = max(proxy.size.width, 1)
@@ -393,7 +397,7 @@ struct AndroidSeekBar: View {
         }
         .frame(height: 36)
         .accessibilityElement()
-        .accessibilityLabel(accessibilityIdentifier)
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityValue("\(value)")
         .accessibilityAdjustableAction { direction in
             switch direction {

--- a/Sources/BibleUI/Sources/BibleUI/Speak/AndroidSpeakTransportView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Speak/AndroidSpeakTransportView.swift
@@ -49,7 +49,8 @@ struct AndroidSpeakTransportView: View {
                     range: 10...300,
                     step: 1,
                     palette: surfacePalette,
-                    accessibilityIdentifier: "speakTransportSpeed"
+                    accessibilityIdentifier: "speakTransportSpeed",
+                    accessibilityLabel: String(localized: "speak_speed_title", defaultValue: "Speech speed")
                 )
                 .frame(maxWidth: 150)
             }

--- a/Sources/BibleUI/Sources/BibleUI/Speak/SpeakControlView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Speak/SpeakControlView.swift
@@ -348,7 +348,8 @@ public struct SpeakControlView: View {
                 range: 0...300,
                 step: 1,
                 palette: surfacePalette,
-                accessibilityIdentifier: "speakSpeed"
+                accessibilityIdentifier: "speakSpeed",
+                accessibilityLabel: String(localized: "speak_speed_title", defaultValue: "Speech speed")
             )
             .padding(.horizontal, 8)
         }

--- a/Tests/AppHost/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/Tests/AppHost/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1216,6 +1216,70 @@ private func bindMemorizeParityUUIDBlob(_ uuid: UUID, to statement: OpaquePointe
  - Side effects: Installs a JavaScript evaluation observer on the returned bridge.
  - Failure modes: None.
  */
+extension AndBibleTests {
+    /**
+     Verifies a display-settings update pushes the new margin size in every subsequent config emit.
+
+     Issue #377 reports margin edits with no visible reader effect. The staged UI repro proves the
+     margins dialog commits and persists, so this probe pins the next stage: after
+     `updateDisplaySettings`, both the immediate `set_config` push and the initial config carried by
+     the follow-up content reload must serialize the reduced `marginSize.maxWidth`.
+
+     - Side effects: Creates a temporary SWORD fixture root and a recording bridge controller.
+     - Failure modes: Fails when any post-update `set_config` payload omits or reverts the new
+       maximum text width.
+     */
+    @MainActor
+    func testUpdateDisplaySettingsPushesReducedMaxWidthThroughReloadConfig() throws {
+        let (bridge, recordedScripts) = makeMemorizeParityRecordingBridge()
+        let modulePath = try makeMemorizeParityTemporarySwordPath()
+        defer { try? FileManager.default.removeItem(atPath: modulePath) }
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window()
+        let pageManager = PageManager(id: window.id)
+        window.pageManager = pageManager
+        controller.activeWindow = window
+        controller.displaySettings = .appDefaults
+        controller.nightMode = false
+        controller.bridgeDidSetClientReady(bridge)
+        let baselineScriptCount = recordedScripts().count
+
+        var narrowed = TextDisplaySettings.appDefaults
+        narrowed.maxWidth = 50
+        controller.updateDisplaySettings(narrowed, nightMode: false)
+
+        let reloadDeadline = Date(timeIntervalSinceNow: 3)
+        while Date() < reloadDeadline,
+              !recordedScripts()
+                .dropFirst(baselineScriptCount)
+                .contains(where: { $0.contains("emit('clear_document'") }) {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
+
+        let updateScripts = Array(recordedScripts().dropFirst(baselineScriptCount))
+        let configScripts = updateScripts.filter { $0.contains("set_config") }
+        XCTAssertFalse(
+            configScripts.isEmpty,
+            "Expected at least one set_config emission after updateDisplaySettings."
+        )
+        for script in configScripts {
+            XCTAssertTrue(
+                script.contains("\"maxWidth\":50"),
+                "Expected every post-update config to carry maxWidth 50: \(script.prefix(400))"
+            )
+            XCTAssertFalse(
+                script.contains("\"maxWidth\":170"),
+                "Expected no post-update config to revert to the default maxWidth: \(script.prefix(400))"
+            )
+        }
+        XCTAssertTrue(
+            updateScripts.contains { $0.contains("emit('clear_document'") },
+            "Expected updateDisplaySettings to trigger the content reload replacement."
+        )
+    }
+}
+
 private func makeMemorizeParityRecordingBridge() -> (BibleBridge, () -> [String]) {
     let bridge = BibleBridge()
     var scripts: [String] = []

--- a/Tests/AppHost/AndBibleTests/AndBibleTests+AppAndReader.swift
+++ b/Tests/AppHost/AndBibleTests/AndBibleTests+AppAndReader.swift
@@ -1248,29 +1248,25 @@ extension AndBibleTests {
         var narrowed = TextDisplaySettings.appDefaults
         narrowed.maxWidth = 50
         controller.updateDisplaySettings(narrowed, nightMode: false)
-
-        let reloadDeadline = Date(timeIntervalSinceNow: 3)
-        while Date() < reloadDeadline,
-              !recordedScripts()
-                .dropFirst(baselineScriptCount)
-                .contains(where: { $0.contains("emit('clear_document'") }) {
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
-        }
+        // The push and reload emit synchronously on the main thread; this settle exists only to
+        // catch a regression that reverts the config from an asynchronous follow-up emission.
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
 
         let updateScripts = Array(recordedScripts().dropFirst(baselineScriptCount))
-        let configScripts = updateScripts.filter { $0.contains("set_config") }
+        let configScripts = updateScripts.filter { $0.contains("emit('set_config'") }
         XCTAssertFalse(
             configScripts.isEmpty,
             "Expected at least one set_config emission after updateDisplaySettings."
         )
         for script in configScripts {
-            XCTAssertTrue(
-                script.contains("\"maxWidth\":50"),
-                "Expected every post-update config to carry maxWidth 50: \(script.prefix(400))"
-            )
-            XCTAssertFalse(
-                script.contains("\"maxWidth\":170"),
-                "Expected no post-update config to revert to the default maxWidth: \(script.prefix(400))"
+            let payload = try memorizeParityBridgeEmissionPayload(from: [script], event: "set_config")
+            let dictionary = try XCTUnwrap(payload as? [String: Any])
+            let config = try XCTUnwrap(dictionary["config"] as? [String: Any])
+            let marginSize = try XCTUnwrap(config["marginSize"] as? [String: Any])
+            XCTAssertEqual(
+                marginSize["maxWidth"] as? Int,
+                50,
+                "Expected every post-update config payload to carry the reduced maxWidth."
             )
         }
         XCTAssertTrue(

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+Search.swift
@@ -1037,35 +1037,39 @@ extension AndBibleUITests {
      Package tests prove the `set_config` payload carries `marginSize`, so this smoke guards the
      remaining production chain: the margins dialog commit, the reader refresh push, and the shared
      Vue content layout actually constraining visible text (issue #377 reported no visible effect).
+     Draft-versus-committed persistence stays in package tests; this smoke asserts only the
+     rendered outcome.
      *
      * - Side effects:
      *   - launches the reader shell with deterministic in-memory data
      *   - reduces the workspace maximum text width through the real margins editor dialog
      * - Failure modes:
      *   - fails if the margins dialog, its seek bar, or its OK action cannot be reached
-     *   - fails if rendered reader text stays at its previous width after the commit
+     *   - fails if reader text never renders, disappears after the commit, or keeps its width
      */
     func testMarginMaxWidthEditorNarrowsRenderedReaderText() {
         let app = makeApp()
         app.launch()
 
         XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 30))
-        let initialWidth = widestReaderTextLineWidth(in: app)
-        XCTAssertGreaterThan(
-            initialWidth,
-            100,
+        let webView = app.webViews.firstMatch
+        XCTAssertTrue(webView.waitForExistence(timeout: 20))
+        var initialWidth: CGFloat = 0
+        XCTAssertTrue(
+            waitForUITestCondition("initial reader text renders", timeout: 20) {
+                initialWidth = Self.widestTextLineWidth(in: webView)
+                return initialWidth > 100
+            },
             "Expected measurable rendered reader text before editing margins."
         )
         attachReaderScreenshot(named: "reader-before-margin-edit", of: app)
 
         let textDisplayScreen = openAllTextOptions(in: app)
         XCTAssertTrue(textDisplayScreen.exists)
-        let marginsButton = requireReachableTextDisplayButton(
-            "textDisplayMarginSizeButton",
-            in: app,
+        tapElementReliably(
+            requireReachableTextDisplayButton("textDisplayMarginSizeButton", in: app, timeout: 10),
             timeout: 10
         )
-        tapElementReliably(marginsButton, timeout: 10)
         XCTAssertTrue(requireElement("textDisplayPreferenceEditorDialog", in: app, timeout: 10).exists)
 
         let maxWidthSlider = requireElement(
@@ -1073,56 +1077,38 @@ extension AndBibleUITests {
             in: app,
             timeout: 10
         )
-        maxWidthSlider
-            .coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
-            .press(forDuration: 0.1)
+        dragSeekBar(maxWidthSlider, fromNormalizedX: 0.34, toNormalizedX: 0.1)
         XCTAssertLessThan(
             seekBarNumericValue(maxWidthSlider),
             120,
-            "Expected the seek bar press to reduce the drafted maximum width below its 170 default."
+            "Expected the seek bar drag to reduce the drafted maximum width below its 170 default."
         )
 
         tapElementReliably(
             requireElement("textDisplayPreferenceEditorOKButton", in: app, timeout: 10),
             timeout: 10
         )
-
-        tapElementReliably(
-            requireReachableTextDisplayButton("textDisplayMarginSizeButton", in: app, timeout: 10),
-            timeout: 10
-        )
-        let reopenedSlider = requireElement(
-            "textDisplayPreferenceEditorSeekBar::Maximum width of text",
-            in: app,
-            timeout: 10
-        )
-        XCTAssertLessThan(
-            seekBarNumericValue(reopenedSlider),
-            120,
-            "Expected the committed maximum width to persist into the reopened margins editor."
-        )
-        tapElementReliably(
-            requireElement("textDisplayPreferenceEditorCancelButton", in: app, timeout: 10),
-            timeout: 10
-        )
-
         tapElementReliably(
             requireElement("textDisplaySettingsTopAppBarBackButton", in: app, timeout: 10),
             timeout: 10
         )
         XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 20))
 
-        var narrowedWidth = CGFloat.greatestFiniteMagnitude
-        for _ in 0..<20 {
-            narrowedWidth = widestReaderTextLineWidth(in: app)
-            if narrowedWidth > 0, narrowedWidth < initialWidth * 0.8 { break }
-            Thread.sleep(forTimeInterval: 0.5)
+        var narrowedWidth: CGFloat = 0
+        let didNarrow = waitForUITestCondition("reader text narrows", timeout: 20) {
+            narrowedWidth = Self.widestTextLineWidth(in: webView)
+            return narrowedWidth > 0 && narrowedWidth < initialWidth * 0.8
         }
         attachReaderScreenshot(named: "reader-after-margin-edit", of: app)
-        XCTAssertLessThan(
+        XCTAssertTrue(
+            didNarrow,
+            "Expected a much smaller maximum text width to narrow rendered reader text; "
+                + "initial=\(initialWidth) final=\(narrowedWidth)"
+        )
+        XCTAssertGreaterThan(
             narrowedWidth,
-            initialWidth * 0.8,
-            "Expected a much smaller maximum text width to narrow rendered reader text."
+            0,
+            "Expected the reader to keep rendering text after the margin commit."
         )
     }
 
@@ -1143,6 +1129,96 @@ extension AndBibleUITests {
     }
 
     /**
+     Verifies the Android font-size editor visibly changes rendered reader text.
+     *
+     Issue #377 hid in the gap between a correct `set_config` payload and native CSS overriding the
+     rendered result, so payload-level tests alone cannot protect display settings. This smoke
+     drives the real font-size editor to a much larger value and asserts the rendered text lines
+     grow, closing that gap for the second-most-used text display setting.
+     *
+     * - Side effects:
+     *   - launches the reader shell with deterministic in-memory data
+     *   - raises the workspace font size through the real editor dialog
+     * - Failure modes:
+     *   - fails if the font-size dialog, its seek bar, or its OK action cannot be reached
+     *   - fails if rendered reader text keeps its previous line height after the commit
+     */
+    func testFontSizeEditorGrowsRenderedReaderText() {
+        let app = makeApp()
+        app.launch()
+
+        XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 30))
+        let webView = app.webViews.firstMatch
+        XCTAssertTrue(webView.waitForExistence(timeout: 20))
+        var initialHeight: CGFloat = 0
+        XCTAssertTrue(
+            waitForUITestCondition("initial reader text renders", timeout: 20) {
+                initialHeight = Self.tallestTextLineHeight(in: webView)
+                return initialHeight > 10
+            },
+            "Expected measurable rendered reader text before editing font size."
+        )
+
+        let textDisplayScreen = openAllTextOptions(in: app)
+        XCTAssertTrue(textDisplayScreen.exists)
+        tapElementReliably(
+            requireReachableTextDisplayButton("textDisplayFontSizeButton", in: app, timeout: 10),
+            timeout: 10
+        )
+        let fontSizeSlider = requireElement(
+            "textDisplayPreferenceEditorSeekBar::Font size",
+            in: app,
+            timeout: 10
+        )
+        dragSeekBar(fontSizeSlider, fromNormalizedX: 0.3, toNormalizedX: 0.9)
+        XCTAssertGreaterThan(
+            seekBarNumericValue(fontSizeSlider),
+            35,
+            "Expected the seek bar drag to raise the drafted font size well above its default."
+        )
+        tapElementReliably(
+            requireElement("textDisplayPreferenceEditorOKButton", in: app, timeout: 10),
+            timeout: 10
+        )
+        tapElementReliably(
+            requireElement("textDisplaySettingsTopAppBarBackButton", in: app, timeout: 10),
+            timeout: 10
+        )
+        XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 20))
+
+        var grownHeight: CGFloat = 0
+        let didGrow = waitForUITestCondition("reader text grows", timeout: 20) {
+            grownHeight = Self.tallestTextLineHeight(in: webView)
+            return grownHeight > initialHeight * 1.5
+        }
+        XCTAssertTrue(
+            didGrow,
+            "Expected a much larger font size to grow rendered reader text lines; "
+                + "initial=\(initialHeight) final=\(grownHeight)"
+        )
+    }
+
+    /**
+     Drags an Android seek bar thumb between two normalized horizontal positions.
+     *
+     * - Parameters:
+     *   - element: Seek bar whose drag gesture should receive the interaction.
+     *   - fromNormalizedX: Approximate current thumb position in normalized element space.
+     *   - toNormalizedX: Target position in normalized element space.
+     * - Side effects: Performs one press-and-drag interaction on the element.
+     * - Failure modes: none directly; callers assert the resulting accessibility value.
+     */
+    private func dragSeekBar(
+        _ element: XCUIElement,
+        fromNormalizedX: CGFloat,
+        toNormalizedX: CGFloat
+    ) {
+        let start = element.coordinate(withNormalizedOffset: CGVector(dx: fromNormalizedX, dy: 0.5))
+        let end = element.coordinate(withNormalizedOffset: CGVector(dx: toNormalizedX, dy: 0.5))
+        start.press(forDuration: 0.15, thenDragTo: end)
+    }
+
+    /**
      Reads the Android seek bar's numeric accessibility value.
      *
      * - Parameter element: Seek bar element exposing its bound value as accessibility value.
@@ -1156,17 +1232,30 @@ extension AndBibleUITests {
     }
 
     /**
-     Measures the widest rendered text line inside the reader's web content.
+     Measures the tallest rendered text line inside an existing reader web view.
      *
-     * - Parameter app: Running application under test.
-     * - Returns: Width of the widest static text exposed by the reader web view, or zero when no
-     *   rendered text is available.
+     * - Parameter webView: Reader web view element already confirmed to exist.
+     * - Returns: Height of the tallest static text run, or zero when none are exposed.
      * - Side effects: none.
-     * - Failure modes: Returns zero when the web view or its text runs never appear.
+     * - Failure modes: Text runs that vanish mid-scan are skipped.
      */
-    private func widestReaderTextLineWidth(in app: XCUIApplication) -> CGFloat {
-        let webView = app.webViews.firstMatch
-        guard webView.waitForExistence(timeout: 20) else { return 0 }
+    private static func tallestTextLineHeight(in webView: XCUIElement) -> CGFloat {
+        var tallest: CGFloat = 0
+        for element in webView.staticTexts.allElementsBoundByIndex.prefix(40) where element.exists {
+            tallest = max(tallest, element.frame.height)
+        }
+        return tallest
+    }
+
+    /**
+     Measures the widest rendered text line inside an existing reader web view.
+     *
+     * - Parameter webView: Reader web view element already confirmed to exist.
+     * - Returns: Width of the widest static text run, or zero when none are exposed.
+     * - Side effects: none.
+     * - Failure modes: Text runs that vanish mid-scan are skipped.
+     */
+    private static func widestTextLineWidth(in webView: XCUIElement) -> CGFloat {
         var widest: CGFloat = 0
         for element in webView.staticTexts.allElementsBoundByIndex.prefix(40) where element.exists {
             widest = max(widest, element.frame.width)

--- a/Tests/UI/AndBibleUITests/AndBibleUITests+Search.swift
+++ b/Tests/UI/AndBibleUITests/AndBibleUITests+Search.swift
@@ -1031,4 +1031,147 @@ extension AndBibleUITests {
         )
     }
 
+    /**
+     Verifies the Android margins editor's maximum text width narrows the rendered reader text.
+     *
+     Package tests prove the `set_config` payload carries `marginSize`, so this smoke guards the
+     remaining production chain: the margins dialog commit, the reader refresh push, and the shared
+     Vue content layout actually constraining visible text (issue #377 reported no visible effect).
+     *
+     * - Side effects:
+     *   - launches the reader shell with deterministic in-memory data
+     *   - reduces the workspace maximum text width through the real margins editor dialog
+     * - Failure modes:
+     *   - fails if the margins dialog, its seek bar, or its OK action cannot be reached
+     *   - fails if rendered reader text stays at its previous width after the commit
+     */
+    func testMarginMaxWidthEditorNarrowsRenderedReaderText() {
+        let app = makeApp()
+        app.launch()
+
+        XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 30))
+        let initialWidth = widestReaderTextLineWidth(in: app)
+        XCTAssertGreaterThan(
+            initialWidth,
+            100,
+            "Expected measurable rendered reader text before editing margins."
+        )
+        attachReaderScreenshot(named: "reader-before-margin-edit", of: app)
+
+        let textDisplayScreen = openAllTextOptions(in: app)
+        XCTAssertTrue(textDisplayScreen.exists)
+        let marginsButton = requireReachableTextDisplayButton(
+            "textDisplayMarginSizeButton",
+            in: app,
+            timeout: 10
+        )
+        tapElementReliably(marginsButton, timeout: 10)
+        XCTAssertTrue(requireElement("textDisplayPreferenceEditorDialog", in: app, timeout: 10).exists)
+
+        let maxWidthSlider = requireElement(
+            "textDisplayPreferenceEditorSeekBar::Maximum width of text",
+            in: app,
+            timeout: 10
+        )
+        maxWidthSlider
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
+            .press(forDuration: 0.1)
+        XCTAssertLessThan(
+            seekBarNumericValue(maxWidthSlider),
+            120,
+            "Expected the seek bar press to reduce the drafted maximum width below its 170 default."
+        )
+
+        tapElementReliably(
+            requireElement("textDisplayPreferenceEditorOKButton", in: app, timeout: 10),
+            timeout: 10
+        )
+
+        tapElementReliably(
+            requireReachableTextDisplayButton("textDisplayMarginSizeButton", in: app, timeout: 10),
+            timeout: 10
+        )
+        let reopenedSlider = requireElement(
+            "textDisplayPreferenceEditorSeekBar::Maximum width of text",
+            in: app,
+            timeout: 10
+        )
+        XCTAssertLessThan(
+            seekBarNumericValue(reopenedSlider),
+            120,
+            "Expected the committed maximum width to persist into the reopened margins editor."
+        )
+        tapElementReliably(
+            requireElement("textDisplayPreferenceEditorCancelButton", in: app, timeout: 10),
+            timeout: 10
+        )
+
+        tapElementReliably(
+            requireElement("textDisplaySettingsTopAppBarBackButton", in: app, timeout: 10),
+            timeout: 10
+        )
+        XCTAssertTrue(waitForReaderShellReady(in: app, timeout: 20))
+
+        var narrowedWidth = CGFloat.greatestFiniteMagnitude
+        for _ in 0..<20 {
+            narrowedWidth = widestReaderTextLineWidth(in: app)
+            if narrowedWidth > 0, narrowedWidth < initialWidth * 0.8 { break }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        attachReaderScreenshot(named: "reader-after-margin-edit", of: app)
+        XCTAssertLessThan(
+            narrowedWidth,
+            initialWidth * 0.8,
+            "Expected a much smaller maximum text width to narrow rendered reader text."
+        )
+    }
+
+    /**
+     Attaches one always-kept reader screenshot for visual diagnosis of layout assertions.
+     *
+     * - Parameters:
+     *   - name: Stable attachment name recorded in the result bundle.
+     *   - app: Running application under test.
+     * - Side effects: Adds one XCTAttachment to the current test.
+     * - Failure modes: none; attachment capture failures surface through XCTest itself.
+     */
+    private func attachReaderScreenshot(named name: String, of app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    /**
+     Reads the Android seek bar's numeric accessibility value.
+     *
+     * - Parameter element: Seek bar element exposing its bound value as accessibility value.
+     * - Returns: Parsed numeric value, or `greatestFiniteMagnitude` when unavailable so callers'
+     *   less-than assertions fail loudly.
+     * - Side effects: none.
+     * - Failure modes: Missing or non-numeric accessibility values return the sentinel maximum.
+     */
+    private func seekBarNumericValue(_ element: XCUIElement) -> Double {
+        Double((element.value as? String) ?? "") ?? .greatestFiniteMagnitude
+    }
+
+    /**
+     Measures the widest rendered text line inside the reader's web content.
+     *
+     * - Parameter app: Running application under test.
+     * - Returns: Width of the widest static text exposed by the reader web view, or zero when no
+     *   rendered text is available.
+     * - Side effects: none.
+     * - Failure modes: Returns zero when the web view or its text runs never appear.
+     */
+    private func widestReaderTextLineWidth(in app: XCUIApplication) -> CGFloat {
+        let webView = app.webViews.firstMatch
+        guard webView.waitForExistence(timeout: 20) else { return 0 }
+        var widest: CGFloat = 0
+        for element in webView.staticTexts.allElementsBoundByIndex.prefix(40) where element.exists {
+            widest = max(widest, element.frame.width)
+        }
+        return widest
+    }
+
 }

--- a/Tests/UI/Fixtures/ui_test_fixture_manifest.json
+++ b/Tests/UI/Fixtures/ui_test_fixture_manifest.json
@@ -22,6 +22,7 @@
   "AndBibleUITests/AndBibleUITests/testSettingsBackupRestoreDatabaseWorkflowDestinationAndShareCancel": "baseline",
   "AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions": "baseline",
   "AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor": "display-colors-custom",
+  "AndBibleUITests/AndBibleUITests/testMarginMaxWidthEditorNarrowsRenderedReaderText": "baseline",
   "AndBibleUITests/AndBibleUITests/testPaneAllTextOptionsOpensWindowScopeAndWorkspaceParentLink": "baseline",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsCategoryDisableAndBackendSwitchPersistAcrossDirectReopen": "sync-nextcloud-bookmarks-enabled",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsICloudToggleDoesNotRequireRestart": "sync-nextcloud-bookmarks-enabled",

--- a/Tests/UI/Fixtures/ui_test_fixture_manifest.json
+++ b/Tests/UI/Fixtures/ui_test_fixture_manifest.json
@@ -23,6 +23,7 @@
   "AndBibleUITests/AndBibleUITests/testSettingsApplicationShortcutsOpenGlobalTextOptions": "baseline",
   "AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor": "display-colors-custom",
   "AndBibleUITests/AndBibleUITests/testMarginMaxWidthEditorNarrowsRenderedReaderText": "baseline",
+  "AndBibleUITests/AndBibleUITests/testFontSizeEditorGrowsRenderedReaderText": "baseline",
   "AndBibleUITests/AndBibleUITests/testPaneAllTextOptionsOpensWindowScopeAndWorkspaceParentLink": "baseline",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsCategoryDisableAndBackendSwitchPersistAcrossDirectReopen": "sync-nextcloud-bookmarks-enabled",
   "AndBibleUITests/AndBibleUITests/testSyncSettingsICloudToggleDoesNotRequireRestart": "sync-nextcloud-bookmarks-enabled",

--- a/Tests/UI/Fixtures/ui_test_timings.json
+++ b/Tests/UI/Fixtures/ui_test_timings.json
@@ -1,6 +1,7 @@
 {
   "AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor": 155.0,
   "AndBibleUITests/AndBibleUITests/testMarginMaxWidthEditorNarrowsRenderedReaderText": 150.0,
+  "AndBibleUITests/AndBibleUITests/testFontSizeEditorGrowsRenderedReaderText": 150.0,
   "AndBibleUITests/AndBibleUITests/testBookmarkSelectionNavigatesReaderToSeededReference": 105.0,
   "AndBibleUITests/AndBibleUITests/testSingleAppCalculatorGateAndSecuritySettings": 150.0,
   "AndBibleUITests/AndBibleUITests/testDocumentChooserMatchesDownloadDocumentsActivityStructure": 105.0,

--- a/Tests/UI/Fixtures/ui_test_timings.json
+++ b/Tests/UI/Fixtures/ui_test_timings.json
@@ -1,5 +1,6 @@
 {
   "AndBibleUITests/AndBibleUITests/testAllTextOptionsWorkspaceRouteAndFontEditor": 155.0,
+  "AndBibleUITests/AndBibleUITests/testMarginMaxWidthEditorNarrowsRenderedReaderText": 150.0,
   "AndBibleUITests/AndBibleUITests/testBookmarkSelectionNavigatesReaderToSeededReference": 105.0,
   "AndBibleUITests/AndBibleUITests/testSingleAppCalculatorGateAndSecuritySettings": 150.0,
   "AndBibleUITests/AndBibleUITests/testDocumentChooserMatchesDownloadDocumentsActivityStructure": 105.0,


### PR DESCRIPTION
## Summary

Margin and maximum-text-width display settings had no visible effect on reader text (#377, reported on iPad — reproduced on iPhone too, so not device-specific). Staged diagnosis proved the entire native chain works: the margins dialog commits, workspace persistence and inheritance resolution carry the values, `set_config` and the follow-up content reload deliver them to the Vue frontend, and the shared `contentStyle` applies `max-width` as an inline style on `#content`. A DOM probe then exposed the defect: inline style `max-width: 50mm`, computed style `none`. The native `applyNightModeBackground` injected an `ios-margin-fix` stylesheet declaring `#content { padding-left: 16px !important; padding-right: 16px !important; max-width: none !important; }` — and `!important` stylesheet rules beat inline styles, so the user's settings could never constrain the text. This also explains the original report's "only modal width was reduced": in-web modals size from the `--text-max-width` CSS variable, which the override didn't touch.

## Scope

- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift` — the injected stylesheet
- `Tests/UI/AndBibleUITests/AndBibleUITests+Search.swift`, `Tests/UI/Fixtures/*` — end-to-end regression
- `Tests/AppHost/AndBibleTests/AndBibleTests+AppAndReader.swift` — config-emission regression

## Contract references

- Commit follows the locked commit-message standard.
- Android parity: Android has no native CSS override; `marginSize` works through the same shared Vue `contentStyle`. This aligns with ADR-0012's principle applied to the reader: iOS-side assumptions must not silently override shared-frontend behavior.

## Change details

- The injected stylesheet now carries only the TTS speak-highlighting rules (`.speaking-verse`, `#speaking-word`) under an `ios-tts-highlight` id; any legacy `ios-margin-fix` element is removed from live sessions.
- Horizontal padding and max-width return to the shared Vue `contentStyle`, so left/right margins and maximum text width behave exactly as on Android.
- New XCUITest drives the real margins editor (seek bar press, committed-draft verification, OK, back) and asserts rendered reader text narrows, attaching before/after screenshots.
- New app-host test proves `updateDisplaySettings` pushes a reduced `maxWidth` through both the immediate `set_config` and the reload's initial config.

## Validation evidence

- `swift build` passes.
- `testMarginMaxWidthEditorNarrowsRenderedReaderText` passes (previously failed with text width unchanged at 354pt).
- Full `BibleUITests` package suite: 827 tests, 0 failures; `AndBibleUnitTests` app-host suite: 17 tests, 0 failures.
- `git diff --check`, commit-message, and docblock guardrails pass.
- GitNexus rates `applyNightModeBackground` CRITICAL by fan-in (every content-load path styles through it); the change is confined to the injected CSS text — signature and side-effect contract unchanged — and is covered by the suites above.

## Risks / follow-ups

- Default horizontal padding shifts from the hardcoded 16px to Android's 3mm (~11px) margins — a slight, intentional visual change toward parity.
- TTS speak highlighting unchanged (styles preserved verbatim).
- Manual confirmation suggestion: on iPad, set "Maximum width of text" low and verify the text column narrows and centers; check margins likewise.

## Issue closure

Closes #377