### PR TITLE
fix(reader): fullscreen entry hints, Android double-tap timing, My Notes relaunch persistence

### DIFF
--- a/AndBible/af.lproj/Localizable.strings
+++ b/AndBible/af.lproj/Localizable.strings
@@ -1543,3 +1543,6 @@
 "module_installed" = "Geïnstalleer";
 "module_installed_version" = "Geïnstalleer";
 "text_display_margin_size_title_format" = "Kantlyn grootte (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbel tik op die skerm om die volle skerm te verlaat";

--- a/AndBible/ar.lproj/Localizable.strings
+++ b/AndBible/ar.lproj/Localizable.strings
@@ -1548,3 +1548,6 @@
 "module_installed" = "مثبَّت";
 "module_installed_version" = "مثبَّت";
 "text_display_margin_size_title_format" = "حجم الهامش (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "نقراً مزدوجاً على الشاشة للخروج من وضع ملء الشاشة";

--- a/AndBible/bg.lproj/Localizable.strings
+++ b/AndBible/bg.lproj/Localizable.strings
@@ -1546,3 +1546,6 @@
 "module_installed" = "Инсталирани";
 "module_installed_version" = "Инсталирани";
 "text_display_margin_size_title_format" = "Размер на полетата (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двойно докосване на екрана за изход от цял екран";

--- a/AndBible/bn.lproj/Localizable.strings
+++ b/AndBible/bn.lproj/Localizable.strings
@@ -1543,3 +1543,6 @@
 "module_installed" = "ইনস্টল করা";
 "module_installed_version" = "ইনস্টল করা";
 "text_display_margin_size_title_format" = "মার্জিনের আকার (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "ফুলস্ক্রিন থেকে প্রস্থান করতে স্ক্রীনে ডবল-ট্যাপ করুন";

--- a/AndBible/ca.lproj/Localizable.strings
+++ b/AndBible/ca.lproj/Localizable.strings
@@ -1683,3 +1683,6 @@
 
 /* Android shared translations */
 "backup_modules" = "Còpia de seguretat dels documents a…";
+
+/* Android shared translations */
+"exit_fullscreen" = "Fes doble toc a la pantalla per sortir de la pantalla completa";

--- a/AndBible/cs.lproj/Localizable.strings
+++ b/AndBible/cs.lproj/Localizable.strings
@@ -1534,3 +1534,6 @@
 "module_installed" = "Nainstalováno";
 "module_installed_version" = "Nainstalováno";
 "text_display_margin_size_title_format" = "Velikost okrajů (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvojklik ukončí režim celé obrazovky";

--- a/AndBible/da.lproj/Localizable.strings
+++ b/AndBible/da.lproj/Localizable.strings
@@ -1680,3 +1680,6 @@
 
 /* Android shared translations */
 "backup_modules" = "Sikkerhedskopier dokumenter til…";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dobbelttryk på skærmen for at afslutte fuldskærm";

--- a/AndBible/de.lproj/Localizable.strings
+++ b/AndBible/de.lproj/Localizable.strings
@@ -1529,3 +1529,6 @@
 "module_installed" = "Installiert";
 "module_installed_version" = "Installiert";
 "text_display_margin_size_title_format" = "Randgröße (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Doppelt Antippen, um den Vollbildschirm zu verlassen";

--- a/AndBible/el.lproj/Localizable.strings
+++ b/AndBible/el.lproj/Localizable.strings
@@ -1542,3 +1542,6 @@
 "module_installed" = "Εγκατεστημένα";
 "module_installed_version" = "Εγκατεστημένα";
 "text_display_margin_size_title_format" = "Μέγεθος περιθωρίου (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Διπλό πάτημα για έξοδο από πλήρη οθόνη";

--- a/AndBible/en.lproj/Localizable.strings
+++ b/AndBible/en.lproj/Localizable.strings
@@ -1690,3 +1690,6 @@
 
 /* Android shared translations */
 "bug_report_show_in_finder" = "Show in Finder";
+
+/* Android shared translations */
+"exit_fullscreen" = "Double-tap screen to exit fullscreen";

--- a/AndBible/eo.lproj/Localizable.strings
+++ b/AndBible/eo.lproj/Localizable.strings
@@ -1544,3 +1544,6 @@
 "module_installed" = "Instalitaj";
 "module_installed_version" = "Instalitaj";
 "text_display_margin_size_title_format" = "Larĝoj de marĝenoj (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Duoble frapetu por eliri plenekranan reĝimon";

--- a/AndBible/es.lproj/Localizable.strings
+++ b/AndBible/es.lproj/Localizable.strings
@@ -1542,3 +1542,6 @@
 "module_installed" = "Instalados";
 "module_installed_version" = "Instalados";
 "text_display_margin_size_title_format" = "Tamaño de margen (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Toca dos veces la pantalla para salir de la pantalla completa";

--- a/AndBible/et.lproj/Localizable.strings
+++ b/AndBible/et.lproj/Localizable.strings
@@ -1543,3 +1543,6 @@
 "module_installed" = "Paigaldatud";
 "module_installed_version" = "Paigaldatud";
 "text_display_margin_size_title_format" = "Veeriste suurus (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Topeltpuudutus täisekraani sulgemiseks";

--- a/AndBible/fi.lproj/Localizable.strings
+++ b/AndBible/fi.lproj/Localizable.strings
@@ -1545,3 +1545,6 @@
 "module_installed" = "Asennetut";
 "module_installed_version" = "Asennetut";
 "text_display_margin_size_title_format" = "Marginaalin koko (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tupla-napauta ruutua sulkeaksesi kokoruututilan";

--- a/AndBible/fil.lproj/Localizable.strings
+++ b/AndBible/fil.lproj/Localizable.strings
@@ -1659,3 +1659,6 @@
 
 /* Android shared translations */
 "backup_modules" = "I-backup ang Mga Dokumento sa…";
+
+/* Android shared translations */
+"exit_fullscreen" = "I-double-tap ang screen para lumabas sa fullscreen";

--- a/AndBible/fr.lproj/Localizable.strings
+++ b/AndBible/fr.lproj/Localizable.strings
@@ -1520,3 +1520,6 @@
 "module_installed" = "Installés";
 "module_installed_version" = "Installés";
 "text_display_margin_size_title_format" = "Taille de la marge (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Appuyez deux fois sur l’écran pour quitter le mode plein écran";

--- a/AndBible/he.lproj/Localizable.strings
+++ b/AndBible/he.lproj/Localizable.strings
@@ -1545,3 +1545,6 @@
 "module_installed" = "מותקנים";
 "module_installed_version" = "מותקנים";
 "text_display_margin_size_title_format" = "מידת שוליים (%1$d/%2$d/%3$d מ\"מ)";
+
+/* Android shared translations */
+"exit_fullscreen" = "הקשה כפולה כדי לצאת ממסך מלא";

--- a/AndBible/hi.lproj/Localizable.strings
+++ b/AndBible/hi.lproj/Localizable.strings
@@ -1528,3 +1528,6 @@
 "module_installed" = "इंस्टॉल किए गए";
 "module_installed_version" = "इंस्टॉल किए गए";
 "text_display_margin_size_title_format" = "मार्जिन आकार (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "फ़ुलस्क्रीन से बाहर निकलने के लिए स्क्रीन पर दो बार टैप करें";

--- a/AndBible/hr.lproj/Localizable.strings
+++ b/AndBible/hr.lproj/Localizable.strings
@@ -1539,3 +1539,6 @@
 "module_installed" = "Instalirano";
 "module_installed_version" = "Instalirano";
 "text_display_margin_size_title_format" = "Veličina margina (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvaput dodirnite zaslon za izlaz iz cijelog zaslona";

--- a/AndBible/hu.lproj/Localizable.strings
+++ b/AndBible/hu.lproj/Localizable.strings
@@ -1541,3 +1541,6 @@
 "module_installed" = "Telepítve";
 "module_installed_version" = "Telepítve";
 "text_display_margin_size_title_format" = "Margó méret (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dupla koppintás a teljes képernyős mód bezárásához";

--- a/AndBible/id.lproj/Localizable.strings
+++ b/AndBible/id.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "module_installed" = "Terpasang";
 "module_installed_version" = "Terpasang";
 "text_display_margin_size_title_format" = "Ukuran margin (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Ketuk dua kali layar untuk keluar dari layar penuh";

--- a/AndBible/it.lproj/Localizable.strings
+++ b/AndBible/it.lproj/Localizable.strings
@@ -1538,3 +1538,6 @@
 "module_installed" = "Installati";
 "module_installed_version" = "Installati";
 "text_display_margin_size_title_format" = "Dimensioni del margine (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tocca due volte per uscire dallo schermo intero";

--- a/AndBible/ja.lproj/Localizable.strings
+++ b/AndBible/ja.lproj/Localizable.strings
@@ -1693,3 +1693,6 @@
 
 /* Android shared translations */
 "backup_modules" = "ドキュメントをバックアップ先…";
+
+/* Android shared translations */
+"exit_fullscreen" = "画面をダブルタップして全画面表示を終了";

--- a/AndBible/kk.lproj/Localizable.strings
+++ b/AndBible/kk.lproj/Localizable.strings
@@ -989,3 +989,6 @@
 "backup_modules" = "Құжаттардың Сақтық көшірмесін жасау";
 "delete_module_index_title" = "Іздеу индексін жою";
 "text_display_margin_size_title_format" = "Маржа өлшемі (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Толық бейне бетінен шығу үшін бейне бетін екі рез түртіңіз";

--- a/AndBible/ko.lproj/Localizable.strings
+++ b/AndBible/ko.lproj/Localizable.strings
@@ -1540,3 +1540,6 @@
 "module_installed" = "설치됨";
 "module_installed_version" = "설치됨";
 "text_display_margin_size_title_format" = "여백 크기 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "두 번 탭하여 전체 화면 종료";

--- a/AndBible/lt.lproj/Localizable.strings
+++ b/AndBible/lt.lproj/Localizable.strings
@@ -1546,3 +1546,6 @@
 "module_installed" = "Įdiegti";
 "module_installed_version" = "Įdiegti";
 "text_display_margin_size_title_format" = "Paraščių plotis (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Bakstelėkite du kartus, kad išeitumėte iš viso ekrano";

--- a/AndBible/ms.lproj/Localizable.strings
+++ b/AndBible/ms.lproj/Localizable.strings
@@ -1682,3 +1682,6 @@
 
 /* Android shared translations */
 "backup_modules" = "Sandaran Dokumen ke…";
+
+/* Android shared translations */
+"exit_fullscreen" = "Ketuk dua kali skrin untuk keluar skrin penuh";

--- a/AndBible/my.lproj/Localizable.strings
+++ b/AndBible/my.lproj/Localizable.strings
@@ -920,3 +920,6 @@
 
 /* Android shared translations */
 "delete_module_index_title" = "အညွှန်း ရှာဖွေမှုကို ဖျက်ပါ";
+
+/* Android shared translations */
+"exit_fullscreen" = "မျက်နှာပြင်အပြည့်မှထွက်ရန် မျက်နှာပြင်ကို နှစ်ချက်နှိပ်ပါ";

--- a/AndBible/nb.lproj/Localizable.strings
+++ b/AndBible/nb.lproj/Localizable.strings
@@ -1538,3 +1538,6 @@
 "module_installed" = "Installert";
 "module_installed_version" = "Installert";
 "text_display_margin_size_title_format" = "Margstørrelse (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dobbel-tap for å gå ut av fullskjermmodus";

--- a/AndBible/ne.lproj/Localizable.strings
+++ b/AndBible/ne.lproj/Localizable.strings
@@ -1690,3 +1690,6 @@
 
 /* Android shared translations */
 "backup_modules" = "कागजातहरू ब्याकअप गर्नुहोस्…";
+
+/* Android shared translations */
+"exit_fullscreen" = "पूर्णस्क्रिन बाहिर निस्कन स्क्रिन दोहोरो ट्याप गर्नुहोस्";

--- a/AndBible/nl.lproj/Localizable.strings
+++ b/AndBible/nl.lproj/Localizable.strings
@@ -1521,3 +1521,6 @@
 "module_installed" = "Geïnstalleerd";
 "module_installed_version" = "Geïnstalleerd";
 "text_display_margin_size_title_format" = "Margegrootte (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbeltikken om volledig scherm te verlaten";

--- a/AndBible/pl.lproj/Localizable.strings
+++ b/AndBible/pl.lproj/Localizable.strings
@@ -1538,3 +1538,6 @@
 "module_installed" = "Zainstalowane";
 "module_installed_version" = "Zainstalowane";
 "text_display_margin_size_title_format" = "Szerokość marginesów (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Stuknij podwójnie, aby wyjść z trybu pełnoekranowego";

--- a/AndBible/pt-BR.lproj/Localizable.strings
+++ b/AndBible/pt-BR.lproj/Localizable.strings
@@ -1540,3 +1540,6 @@
 "module_installed" = "Instalados";
 "module_installed_version" = "Instalados";
 "text_display_margin_size_title_format" = "Tamanho da margem (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Duplo toque para sair da tela cheia";

--- a/AndBible/pt.lproj/Localizable.strings
+++ b/AndBible/pt.lproj/Localizable.strings
@@ -1541,3 +1541,6 @@
 "module_installed" = "Instalados";
 "module_installed_version" = "Instalados";
 "text_display_margin_size_title_format" = "Tamanho das margens (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Toque duas vezes para sair de ecran inteiro";

--- a/AndBible/ro.lproj/Localizable.strings
+++ b/AndBible/ro.lproj/Localizable.strings
@@ -1535,3 +1535,6 @@
 "module_installed" = "Instalate";
 "module_installed_version" = "Instalate";
 "text_display_margin_size_title_format" = "Dimensiunile marginilor (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Apasă de două ori pentru a reduce";

--- a/AndBible/ru.lproj/Localizable.strings
+++ b/AndBible/ru.lproj/Localizable.strings
@@ -1545,3 +1545,6 @@
 "module_installed" = "Установленные";
 "module_installed_version" = "Установленные";
 "text_display_margin_size_title_format" = "Размер поля (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Дважды коснитесь экрана, чтобы выйти из полноэкранного режима";

--- a/AndBible/sk.lproj/Localizable.strings
+++ b/AndBible/sk.lproj/Localizable.strings
@@ -1535,3 +1535,6 @@
 "module_installed" = "Nainštalované";
 "module_installed_version" = "Nainštalované";
 "text_display_margin_size_title_format" = "Veľkosť okraja (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvojitým klepnutím opustiť režim celej obrazovky";

--- a/AndBible/sl.lproj/Localizable.strings
+++ b/AndBible/sl.lproj/Localizable.strings
@@ -1538,3 +1538,6 @@
 "module_installed" = "Nameščeno";
 "module_installed_version" = "Nameščeno";
 "text_display_margin_size_title_format" = "Robovi (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvakrat tapnite za izhod iz celozaslonskega načina";

--- a/AndBible/sr-Latn.lproj/Localizable.strings
+++ b/AndBible/sr-Latn.lproj/Localizable.strings
@@ -1542,3 +1542,6 @@
 "module_installed" = "Instalirano";
 "module_installed_version" = "Instalirano";
 "text_display_margin_size_title_format" = "Veličina margina (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvaput dodirnite ekran za izlaz iz Celog Ekrana";

--- a/AndBible/sr.lproj/Localizable.strings
+++ b/AndBible/sr.lproj/Localizable.strings
@@ -1546,3 +1546,6 @@
 "module_installed" = "Инсталирано";
 "module_installed_version" = "Инсталирано";
 "text_display_margin_size_title_format" = "Величина маргина (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двапут додирните екран за излаз из Целог Екрана";

--- a/AndBible/sv.lproj/Localizable.strings
+++ b/AndBible/sv.lproj/Localizable.strings
@@ -1532,3 +1532,6 @@
 "module_installed" = "Installerade";
 "module_installed_version" = "Installerade";
 "text_display_margin_size_title_format" = "Marginalstorlek (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbeltryck på skärmen för att avbryta helskärmsläge";

--- a/AndBible/sw.lproj/Localizable.strings
+++ b/AndBible/sw.lproj/Localizable.strings
@@ -1694,3 +1694,6 @@
 
 /* Android shared translations */
 "backup_modules" = "Hifadhi Hati hadi…";
+
+/* Android shared translations */
+"exit_fullscreen" = "Gonga mara mbili skrini kutoka hali ya skrini nzima";

--- a/AndBible/ta.lproj/Localizable.strings
+++ b/AndBible/ta.lproj/Localizable.strings
@@ -1543,3 +1543,6 @@
 "module_installed" = "நிறுவப்பட்டது";
 "module_installed_version" = "நிறுவப்பட்டது";
 "text_display_margin_size_title_format" = "விளிம்பு அளவு (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "இரு முறை தட்டினால் முழு திரை பயன்முறையிலிருந்து வெளியேறலாம்";

--- a/AndBible/te.lproj/Localizable.strings
+++ b/AndBible/te.lproj/Localizable.strings
@@ -1545,3 +1545,6 @@
 "module_installed" = "ఇన్‌స్టాల్ చేయబడింది";
 "module_installed_version" = "ఇన్‌స్టాల్ చేయబడింది";
 "text_display_margin_size_title_format" = "మార్జిన్ పరిమాణం (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి స్క్రీన్‌పై రెండుసార్లు నొక్కండి";

--- a/AndBible/th.lproj/Localizable.strings
+++ b/AndBible/th.lproj/Localizable.strings
@@ -1693,3 +1693,6 @@
 
 /* Android shared translations */
 "backup_modules" = "สำรองเอกสารไปยัง…";
+
+/* Android shared translations */
+"exit_fullscreen" = "แตะหน้าจอสองครั้งเพื่อออกจากโหมดเต็มหน้าจอ";

--- a/AndBible/tr.lproj/Localizable.strings
+++ b/AndBible/tr.lproj/Localizable.strings
@@ -1540,3 +1540,6 @@
 "module_installed" = "Yüklü";
 "module_installed_version" = "Yüklü";
 "text_display_margin_size_title_format" = "Kenar boşlukları (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tam ekrandan çıkmak için ekrana iki kez dokunun";

--- a/AndBible/uk.lproj/Localizable.strings
+++ b/AndBible/uk.lproj/Localizable.strings
@@ -1547,3 +1547,6 @@
 "module_installed" = "Встановлені";
 "module_installed_version" = "Встановлені";
 "text_display_margin_size_title_format" = "Розмір поля (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двічі торкніться екрана, щоб вийти з повноекранного режиму";

--- a/AndBible/ur.lproj/Localizable.strings
+++ b/AndBible/ur.lproj/Localizable.strings
@@ -1692,3 +1692,6 @@
 
 /* Android shared translations */
 "backup_modules" = "دستاویزات کا بیک اپ کریں…";
+
+/* Android shared translations */
+"exit_fullscreen" = "فل اسکرین سے باہر نکلنے کے لیے اسکرین ڈبل ٹیپ کریں";

--- a/AndBible/vi.lproj/Localizable.strings
+++ b/AndBible/vi.lproj/Localizable.strings
@@ -1690,3 +1690,6 @@
 
 /* Android shared translations */
 "backup_modules" = "Sao lưu tài liệu vào…";
+
+/* Android shared translations */
+"exit_fullscreen" = "Nhấn đúp màn hình để thoát toàn màn hình";

--- a/AndBible/yue.lproj/Localizable.strings
+++ b/AndBible/yue.lproj/Localizable.strings
@@ -986,3 +986,6 @@
 "backup_modules" = "備份文件至...";
 "delete_module_index_title" = "刪除索引";
 "text_display_margin_size_title_format" = "邊界大小 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "雙點以離開全螢幕模式";

--- a/AndBible/zh-Hans.lproj/Localizable.strings
+++ b/AndBible/zh-Hans.lproj/Localizable.strings
@@ -1544,3 +1544,6 @@
 "module_installed" = "已安装";
 "module_installed_version" = "已安装";
 "text_display_margin_size_title_format" = "边距大小（%1$d/%2$d/%3$d mm）";
+
+/* Android shared translations */
+"exit_fullscreen" = "双击以退出全屏幕模式";

--- a/AndBible/zh-Hant.lproj/Localizable.strings
+++ b/AndBible/zh-Hant.lproj/Localizable.strings
@@ -1545,3 +1545,6 @@
 "module_installed" = "已安裝";
 "module_installed_version" = "已安裝";
 "text_display_margin_size_title_format" = "邊界大小 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "雙點以離開全螢幕模式";

--- a/Localizations/af.lproj/Localizable.strings
+++ b/Localizations/af.lproj/Localizable.strings
@@ -1529,3 +1529,6 @@ Wanneer Google Drive gebruik word, kry %@ slegs toegang tot toepassinglêers, ni
 "move_down" = "Skuif af";
 "move_up" = "Skuif op";
 "text_display_margin_size_title_format" = "Kantlyn grootte (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbel tik op die skerm om die volle skerm te verlaat";

--- a/Localizations/ar.lproj/Localizable.strings
+++ b/Localizations/ar.lproj/Localizable.strings
@@ -1533,3 +1533,6 @@
 "move_down" = "تحريك للأسفل";
 "move_up" = "تحريك للأعلى";
 "text_display_margin_size_title_format" = "حجم الهامش (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "نقراً مزدوجاً على الشاشة للخروج من وضع ملء الشاشة";

--- a/Localizations/bg.lproj/Localizable.strings
+++ b/Localizations/bg.lproj/Localizable.strings
@@ -1531,3 +1531,6 @@
 "move_down" = "Премести надолу";
 "move_up" = "Премести нагоре";
 "text_display_margin_size_title_format" = "Размер на полетата (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двойно докосване на екрана за изход от цял екран";

--- a/Localizations/bn.lproj/Localizable.strings
+++ b/Localizations/bn.lproj/Localizable.strings
@@ -1529,3 +1529,6 @@ Google ড্রাইভ ব্যবহার করার সময়, %@শ
 "move_down" = "নিচে সরান";
 "move_up" = "উপরে সরান";
 "text_display_margin_size_title_format" = "মার্জিনের আকার (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "ফুলস্ক্রিন থেকে প্রস্থান করতে স্ক্রীনে ডবল-ট্যাপ করুন";

--- a/Localizations/ca.lproj/Localizable.strings
+++ b/Localizations/ca.lproj/Localizable.strings
@@ -1655,3 +1655,6 @@
 "move_up" = "Mou amunt";
 "tilt_to_scroll" = "Inclina per desplaçar";
 "window_pinning" = "Fixació de finestres";
+
+/* Android shared translations */
+"exit_fullscreen" = "Fes doble toc a la pantalla per sortir de la pantalla completa";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -1519,3 +1519,6 @@
 "move_down" = "Přesunout dolů";
 "move_up" = "Přesunout nahoru";
 "text_display_margin_size_title_format" = "Velikost okrajů (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvojklik ukončí režim celé obrazovky";

--- a/Localizations/da.lproj/Localizable.strings
+++ b/Localizations/da.lproj/Localizable.strings
@@ -1652,3 +1652,6 @@
 "move_up" = "Flyt op";
 "tilt_to_scroll" = "Vip for at rulle";
 "window_pinning" = "Fastgøring af vindue";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dobbelttryk på skærmen for at afslutte fuldskærm";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -1515,3 +1515,6 @@ Wenn Google Drive verwendet wird, hat %@ nur Zugriff auf Dateien der Anwendung, 
 "move_down" = "Nach unten verschieben";
 "move_up" = "Nach oben verschieben";
 "text_display_margin_size_title_format" = "Randgröße (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Doppelt Antippen, um den Vollbildschirm zu verlassen";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -1527,3 +1527,6 @@
 "move_down" = "Μετακίνηση κάτω";
 "move_up" = "Μετακίνηση πάνω";
 "text_display_margin_size_title_format" = "Μέγεθος περιθωρίου (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Διπλό πάτημα για έξοδο από πλήρη οθόνη";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -1666,3 +1666,6 @@
 "move_up" = "Move up";
 "tilt_to_scroll" = "Tilt to scroll";
 "window_pinning" = "Window pinning";
+
+/* Android shared translations */
+"exit_fullscreen" = "Double-tap screen to exit fullscreen";

--- a/Localizations/eo.lproj/Localizable.strings
+++ b/Localizations/eo.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@ Dum uzi Google Drive, %@ akiros aliron nur al aplikaĵaj datumoj, al neniu priva
 "move_down" = "Movi malsupren";
 "move_up" = "Movi supren";
 "text_display_margin_size_title_format" = "Larĝoj de marĝenoj (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Duoble frapetu por eliri plenekranan reĝimon";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -1527,3 +1527,6 @@
 "move_down" = "Mover abajo";
 "move_up" = "Mover arriba";
 "text_display_margin_size_title_format" = "Tamaño de margen (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Toca dos veces la pantalla para salir de la pantalla completa";

--- a/Localizations/et.lproj/Localizable.strings
+++ b/Localizations/et.lproj/Localizable.strings
@@ -1528,3 +1528,6 @@
 "move_down" = "Liiguta alla";
 "move_up" = "Liiguta üles";
 "text_display_margin_size_title_format" = "Veeriste suurus (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Topeltpuudutus täisekraani sulgemiseks";

--- a/Localizations/fi.lproj/Localizable.strings
+++ b/Localizations/fi.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "move_down" = "Siirrä alas";
 "move_up" = "Siirrä ylös";
 "text_display_margin_size_title_format" = "Marginaalin koko (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tupla-napauta ruutua sulkeaksesi kokoruututilan";

--- a/Localizations/fil.lproj/Localizable.strings
+++ b/Localizations/fil.lproj/Localizable.strings
@@ -1631,3 +1631,6 @@
 "move_up" = "Ilipat pataas";
 "tilt_to_scroll" = "Itilt para mag-scroll";
 "window_pinning" = "Pag-pin ng window";
+
+/* Android shared translations */
+"exit_fullscreen" = "I-double-tap ang screen para lumabas sa fullscreen";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -1505,3 +1505,6 @@
 "move_down" = "Déplacer vers le bas";
 "move_up" = "Déplacer vers le haut";
 "text_display_margin_size_title_format" = "Taille de la marge (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Appuyez deux fois sur l’écran pour quitter le mode plein écran";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "move_down" = "הזז למטה";
 "move_up" = "הזז למעלה";
 "text_display_margin_size_title_format" = "מידת שוליים (%1$d/%2$d/%3$d מ\"מ)";
+
+/* Android shared translations */
+"exit_fullscreen" = "הקשה כפולה כדי לצאת ממסך מלא";

--- a/Localizations/hi.lproj/Localizable.strings
+++ b/Localizations/hi.lproj/Localizable.strings
@@ -1513,3 +1513,6 @@
 "move_down" = "नीचे ले जाएं";
 "move_up" = "ऊपर ले जाएं";
 "text_display_margin_size_title_format" = "मार्जिन आकार (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "फ़ुलस्क्रीन से बाहर निकलने के लिए स्क्रीन पर दो बार टैप करें";

--- a/Localizations/hr.lproj/Localizable.strings
+++ b/Localizations/hr.lproj/Localizable.strings
@@ -1525,3 +1525,6 @@ Kada koristite Google Drive, %@ dozvoljen je pristup samo datotekama aplikacije,
 "move_down" = "Pomakni dolje";
 "move_up" = "Pomakni gore";
 "text_display_margin_size_title_format" = "Veličina margina (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvaput dodirnite zaslon za izlaz iz cijelog zaslona";

--- a/Localizations/hu.lproj/Localizable.strings
+++ b/Localizations/hu.lproj/Localizable.strings
@@ -1526,3 +1526,6 @@
 "move_down" = "Mozgatás lefelé";
 "move_up" = "Mozgatás felfelé";
 "text_display_margin_size_title_format" = "Margó méret (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dupla koppintás a teljes képernyős mód bezárásához";

--- a/Localizations/id.lproj/Localizable.strings
+++ b/Localizations/id.lproj/Localizable.strings
@@ -1515,3 +1515,6 @@
 "move_down" = "Pindah ke bawah";
 "move_up" = "Pindah ke atas";
 "text_display_margin_size_title_format" = "Ukuran margin (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Ketuk dua kali layar untuk keluar dari layar penuh";

--- a/Localizations/it.lproj/Localizable.strings
+++ b/Localizations/it.lproj/Localizable.strings
@@ -1523,3 +1523,6 @@
 "move_down" = "Sposta giù";
 "move_up" = "Sposta su";
 "text_display_margin_size_title_format" = "Dimensioni del margine (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tocca due volte per uscire dallo schermo intero";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -1665,3 +1665,6 @@
 "move_up" = "上に移動";
 "tilt_to_scroll" = "傾けてスクロール";
 "window_pinning" = "ウィンドウのピン留め";
+
+/* Android shared translations */
+"exit_fullscreen" = "画面をダブルタップして全画面表示を終了";

--- a/Localizations/kk.lproj/Localizable.strings
+++ b/Localizations/kk.lproj/Localizable.strings
@@ -973,3 +973,6 @@ Google Drive пайдаланған кезде, %@ кез келген жеке 
 "backup_modules" = "Құжаттардың Сақтық көшірмесін жасау";
 "delete_module_index_title" = "Іздеу индексін жою";
 "text_display_margin_size_title_format" = "Маржа өлшемі (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Толық бейне бетінен шығу үшін бейне бетін екі рез түртіңіз";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -1525,3 +1525,6 @@
 "move_down" = "아래로 이동";
 "move_up" = "위로 이동";
 "text_display_margin_size_title_format" = "여백 크기 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "두 번 탭하여 전체 화면 종료";

--- a/Localizations/lt.lproj/Localizable.strings
+++ b/Localizations/lt.lproj/Localizable.strings
@@ -1531,3 +1531,6 @@
 "move_down" = "Perkelti žemyn";
 "move_up" = "Perkelti aukštyn";
 "text_display_margin_size_title_format" = "Paraščių plotis (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Bakstelėkite du kartus, kad išeitumėte iš viso ekrano";

--- a/Localizations/ms.lproj/Localizable.strings
+++ b/Localizations/ms.lproj/Localizable.strings
@@ -1654,3 +1654,6 @@
 "move_up" = "Pindah ke atas";
 "tilt_to_scroll" = "Tilt untuk menatal";
 "window_pinning" = "Penepatan tetingkap";
+
+/* Android shared translations */
+"exit_fullscreen" = "Ketuk dua kali skrin untuk keluar skrin penuh";

--- a/Localizations/my.lproj/Localizable.strings
+++ b/Localizations/my.lproj/Localizable.strings
@@ -902,3 +902,6 @@
 
 /* Android shared translations */
 "delete_module_index_title" = "အညွှန်း ရှာဖွေမှုကို ဖျက်ပါ";
+
+/* Android shared translations */
+"exit_fullscreen" = "မျက်နှာပြင်အပြည့်မှထွက်ရန် မျက်နှာပြင်ကို နှစ်ချက်နှိပ်ပါ";

--- a/Localizations/nb.lproj/Localizable.strings
+++ b/Localizations/nb.lproj/Localizable.strings
@@ -1523,3 +1523,6 @@
 "move_down" = "Flytt ned";
 "move_up" = "Flytt opp";
 "text_display_margin_size_title_format" = "Margstørrelse (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dobbel-tap for å gå ut av fullskjermmodus";

--- a/Localizations/ne.lproj/Localizable.strings
+++ b/Localizations/ne.lproj/Localizable.strings
@@ -1663,3 +1663,6 @@
 "move_up" = "माथि सार्नुहोस्";
 "tilt_to_scroll" = "झुकाएर स्क्रोल गर्नुहोस्";
 "window_pinning" = "विन्डो पिनिङ";
+
+/* Android shared translations */
+"exit_fullscreen" = "पूर्णस्क्रिन बाहिर निस्कन स्क्रिन दोहोरो ट्याप गर्नुहोस्";

--- a/Localizations/nl.lproj/Localizable.strings
+++ b/Localizations/nl.lproj/Localizable.strings
@@ -1507,3 +1507,6 @@
 "move_down" = "Omlaag verplaatsen";
 "move_up" = "Omhoog verplaatsen";
 "text_display_margin_size_title_format" = "Margegrootte (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbeltikken om volledig scherm te verlaten";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -1524,3 +1524,6 @@ Podczas korzystania z Dysku Google, aplikacja %@ otrzymuje uprawnienie na dostę
 "move_down" = "Przesuń w dół";
 "move_up" = "Przesuń w górę";
 "text_display_margin_size_title_format" = "Szerokość marginesów (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Stuknij podwójnie, aby wyjść z trybu pełnoekranowego";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -1525,3 +1525,6 @@
 "move_down" = "Mover para baixo";
 "move_up" = "Mover para cima";
 "text_display_margin_size_title_format" = "Tamanho da margem (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Duplo toque para sair da tela cheia";

--- a/Localizations/pt.lproj/Localizable.strings
+++ b/Localizations/pt.lproj/Localizable.strings
@@ -1526,3 +1526,6 @@
 "move_down" = "Mover para baixo";
 "move_up" = "Mover para cima";
 "text_display_margin_size_title_format" = "Tamanho das margens (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Toque duas vezes para sair de ecran inteiro";

--- a/Localizations/ro.lproj/Localizable.strings
+++ b/Localizations/ro.lproj/Localizable.strings
@@ -1520,3 +1520,6 @@
 "move_down" = "Mută în jos";
 "move_up" = "Mută în sus";
 "text_display_margin_size_title_format" = "Dimensiunile marginilor (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Apasă de două ori pentru a reduce";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "move_down" = "Переместить вниз";
 "move_up" = "Переместить вверх";
 "text_display_margin_size_title_format" = "Размер поля (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Дважды коснитесь экрана, чтобы выйти из полноэкранного режима";

--- a/Localizations/sk.lproj/Localizable.strings
+++ b/Localizations/sk.lproj/Localizable.strings
@@ -1520,3 +1520,6 @@
 "move_down" = "Presunúť nadol";
 "move_up" = "Presunúť nahor";
 "text_display_margin_size_title_format" = "Veľkosť okraja (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvojitým klepnutím opustiť režim celej obrazovky";

--- a/Localizations/sl.lproj/Localizable.strings
+++ b/Localizations/sl.lproj/Localizable.strings
@@ -1524,3 +1524,6 @@
 "move_down" = "Premakni navzdol";
 "move_up" = "Premakni navzgor";
 "text_display_margin_size_title_format" = "Robovi (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvakrat tapnite za izhod iz celozaslonskega načina";

--- a/Localizations/sr-Latn.lproj/Localizable.strings
+++ b/Localizations/sr-Latn.lproj/Localizable.strings
@@ -1528,3 +1528,6 @@ Kada koristite Google Drive, %@ dat je pristup samo fajlovima aplikacije, ne liÄ
 "move_down" = "Pomeri dole";
 "move_up" = "Pomeri gore";
 "text_display_margin_size_title_format" = "VeliÄina margina (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dvaput dodirnite ekran za izlaz iz Celog Ekrana";

--- a/Localizations/sr.lproj/Localizable.strings
+++ b/Localizations/sr.lproj/Localizable.strings
@@ -1532,3 +1532,6 @@
 "move_down" = "Помери доле";
 "move_up" = "Помери горе";
 "text_display_margin_size_title_format" = "Величина маргина (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двапут додирните екран за излаз из Целог Екрана";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -1517,3 +1517,6 @@
 "move_down" = "Flytta ned";
 "move_up" = "Flytta upp";
 "text_display_margin_size_title_format" = "Marginalstorlek (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Dubbeltryck på skärmen för att avbryta helskärmsläge";

--- a/Localizations/sw.lproj/Localizable.strings
+++ b/Localizations/sw.lproj/Localizable.strings
@@ -1666,3 +1666,6 @@
 "move_up" = "Hamia juu";
 "tilt_to_scroll" = "Inamisha kusogeza";
 "window_pinning" = "Upinzani wa dirisha";
+
+/* Android shared translations */
+"exit_fullscreen" = "Gonga mara mbili skrini kutoka hali ya skrini nzima";

--- a/Localizations/ta.lproj/Localizable.strings
+++ b/Localizations/ta.lproj/Localizable.strings
@@ -1528,3 +1528,6 @@
 "move_down" = "கீழே நகர்த்து";
 "move_up" = "மேலே நகர்த்து";
 "text_display_margin_size_title_format" = "விளிம்பு அளவு (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "இரு முறை தட்டினால் முழு திரை பயன்முறையிலிருந்து வெளியேறலாம்";

--- a/Localizations/te.lproj/Localizable.strings
+++ b/Localizations/te.lproj/Localizable.strings
@@ -1532,3 +1532,6 @@ Google డ్రైవ్ ని ఉపయోగిస్తున్నప�
 "move_down" = "కిందికి తరలించు";
 "move_up" = "పైకి తరలించు";
 "text_display_margin_size_title_format" = "మార్జిన్ పరిమాణం (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి స్క్రీన్‌పై రెండుసార్లు నొక్కండి";

--- a/Localizations/th.lproj/Localizable.strings
+++ b/Localizations/th.lproj/Localizable.strings
@@ -1665,3 +1665,6 @@
 "move_up" = "เลื่อนขึ้น";
 "tilt_to_scroll" = "เอียงเพื่อเลื่อน";
 "window_pinning" = "การปักหมุดหน้าต่าง";
+
+/* Android shared translations */
+"exit_fullscreen" = "แตะหน้าจอสองครั้งเพื่อออกจากโหมดเต็มหน้าจอ";

--- a/Localizations/tr.lproj/Localizable.strings
+++ b/Localizations/tr.lproj/Localizable.strings
@@ -1525,3 +1525,6 @@
 "move_down" = "Aşağı taşı";
 "move_up" = "Yukarı taşı";
 "text_display_margin_size_title_format" = "Kenar boşlukları (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Tam ekrandan çıkmak için ekrana iki kez dokunun";

--- a/Localizations/uk.lproj/Localizable.strings
+++ b/Localizations/uk.lproj/Localizable.strings
@@ -1532,3 +1532,6 @@
 "move_down" = "Перемістити вниз";
 "move_up" = "Перемістити вгору";
 "text_display_margin_size_title_format" = "Розмір поля (%1$d/%2$d/%3$d мм)";
+
+/* Android shared translations */
+"exit_fullscreen" = "Двічі торкніться екрана, щоб вийти з повноекранного режиму";

--- a/Localizations/ur.lproj/Localizable.strings
+++ b/Localizations/ur.lproj/Localizable.strings
@@ -1664,3 +1664,6 @@
 "move_up" = "اوپر منتقل کریں";
 "tilt_to_scroll" = "جھکا کر اسکرول کریں";
 "window_pinning" = "ونڈو پننگ";
+
+/* Android shared translations */
+"exit_fullscreen" = "فل اسکرین سے باہر نکلنے کے لیے اسکرین ڈبل ٹیپ کریں";

--- a/Localizations/vi.lproj/Localizable.strings
+++ b/Localizations/vi.lproj/Localizable.strings
@@ -1662,3 +1662,6 @@
 "move_up" = "Di chuyển lên";
 "tilt_to_scroll" = "Nghiêng để cuộn";
 "window_pinning" = "Ghim cửa sổ";
+
+/* Android shared translations */
+"exit_fullscreen" = "Nhấn đúp màn hình để thoát toàn màn hình";

--- a/Localizations/yue.lproj/Localizable.strings
+++ b/Localizations/yue.lproj/Localizable.strings
@@ -969,3 +969,6 @@
 "backup_modules" = "備份文件至...";
 "delete_module_index_title" = "刪除索引";
 "text_display_margin_size_title_format" = "邊界大小 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "雙點以離開全螢幕模式";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "move_down" = "下移";
 "move_up" = "上移";
 "text_display_margin_size_title_format" = "边距大小（%1$d/%2$d/%3$d mm）";
+
+/* Android shared translations */
+"exit_fullscreen" = "双击以退出全屏幕模式";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -1530,3 +1530,6 @@
 "move_down" = "向下移動";
 "move_up" = "向上移動";
 "text_display_margin_size_title_format" = "邊界大小 (%1$d/%2$d/%3$d mm)";
+
+/* Android shared translations */
+"exit_fullscreen" = "雙點以離開全螢幕模式";

--- a/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncWorkspaceRestoreService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncWorkspaceRestoreService.swift
@@ -2760,6 +2760,11 @@ public final class RemoteSyncWorkspaceRestoreService {
             return "general_book"
         case "MAP", "MAPS":
             return "map"
+        case "MYNOTE":
+            // Android persists the My Notes fake document as its own page category; iOS restores
+            // it through the reader's `mynote` page-manager key so relaunch and cross-device
+            // sync reopen the My Notes page instead of collapsing to the Bible text.
+            return "mynote"
         default:
             return "bible"
         }

--- a/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceSyncRestoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/WorkspaceSyncRestoreTests.swift
@@ -666,7 +666,9 @@ final class WorkspaceSyncRestoreTests: XCTestCase {
         let pageManagers = try modelContext.fetch(FetchDescriptor<PageManager>()).sorted { $0.id.uuidString < $1.id.uuidString }
         XCTAssertEqual(pageManagers.count, 2)
         XCTAssertEqual(pageManagers.first(where: { $0.id == firstWindowID })?.currentCategoryName, "general_book")
-        XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.currentCategoryName, "bible")
+        // Android MYNOTE windows restore into iOS's `mynote` page-manager key so the reader
+        // reopens the My Notes page instead of collapsing the window to the Bible text.
+        XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.currentCategoryName, "mynote")
         XCTAssertEqual(pageManagers.first(where: { $0.id == firstWindowID })?.generalBookDocument, "Josephus")
         XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.commentaryDocument, "TSK")
 
@@ -1652,7 +1654,9 @@ final class WorkspaceSyncRestoreTests: XCTestCase {
         let pageManagers = try modelContext.fetch(FetchDescriptor<PageManager>())
         XCTAssertEqual(pageManagers.count, 2)
         XCTAssertEqual(pageManagers.first(where: { $0.id == firstWindowID })?.currentCategoryName, "general_book")
-        XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.currentCategoryName, "bible")
+        // Android MYNOTE windows restore into iOS's `mynote` page-manager key so the reader
+        // reopens the My Notes page instead of collapsing the window to the Bible text.
+        XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.currentCategoryName, "mynote")
         XCTAssertEqual(pageManagers.first(where: { $0.id == secondWindowID })?.dictionaryDocument, "Easton")
 
         let historyItems = try modelContext.fetch(FetchDescriptor<HistoryItem>())

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -4973,6 +4973,18 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         }
     logger.info(
       "Restored position: \(self.currentBook) \(self.currentChapter):\(self.currentVerse)")
+
+        // Android's page manager persists the MYNOTE category so a relaunch restores the My
+        // Notes page; the window's persisted Bible position supplies the chapter. An
+        // unresolvable target falls back to the Bible document instead of a blank pane.
+        if pm.currentCategoryName == Self.myNotesPageManagerCategoryName {
+            if let target = currentMyNotesTarget(jumpToOrdinal: nil) {
+                loadMyNotesDocument(target: target)
+            } else {
+                pm.currentCategoryName = DocumentCategory.bible.pageManagerKey
+                onPersistState?()
+            }
+        }
     }
 
     /// Apply SWORD global options based on current display settings.
@@ -7196,8 +7208,41 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      - Failure modes: An unresolved target chapter fails in the annotation loader without falling
        back to the active pane's chapter.
      */
+    /**
+     Android's persisted page-manager category value for the My Notes fake document; the Android
+     backup boundary upper-cases it to the `MYNOTE` enum name.
+     */
+    static let myNotesPageManagerCategoryName = "mynote"
+
+    /**
+     Persists Android's MYNOTE page-manager category for this window.
+
+     Android's `CurrentPageManager` stores the MYNOTE category so relaunch and workspace sync
+     restore the My Notes page. iOS mirrors that by writing the lower-case page-manager key the
+     backup and sync boundaries translate to Android's enum name.
+
+     - Parameter visible: `true` while the My Notes document owns the pane; `false` restores the
+       Bible category, but only when My Notes still owns the stored value so other categories
+       keep their own key.
+     - Side effects: Mutates the active window's page manager and persists workspace state when
+       the stored value changes.
+     - Failure modes: Missing page managers are ignored.
+     */
+    private func persistMyNotesPageCategory(visible: Bool) {
+        guard let pm = activeWindow?.pageManager else { return }
+        if visible {
+            guard pm.currentCategoryName != Self.myNotesPageManagerCategoryName else { return }
+            pm.currentCategoryName = Self.myNotesPageManagerCategoryName
+        } else {
+            guard pm.currentCategoryName == Self.myNotesPageManagerCategoryName else { return }
+            pm.currentCategoryName = DocumentCategory.bible.pageManagerKey
+        }
+        onPersistState?()
+    }
+
     private func loadMyNotesDocument(target: MyNotesTarget) {
         beginReplacingContentIntent()
+        persistMyNotesPageCategory(visible: true)
         guard clientReady else {
             pendingClientReadyMyNotesTarget = target
             activeMyNotesTarget = target
@@ -7493,6 +7538,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     public func loadStudyPadDocument(labelId: UUID, bookmarkId: UUID? = nil) {
         beginReplacingContentIntent()
+        persistMyNotesPageCategory(visible: false)
         guard clientReady else {
             guard let label = bookmarkService?.label(id: labelId) else { return }
             let labelName = AndroidLabelPresentation.displayName(for: label)
@@ -9465,6 +9511,7 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
      */
     private func loadCurrentChapter() {
         beginReplacingContentIntent()
+        persistMyNotesPageCategory(visible: false)
         showingMyNotes = false
         showingStudyPad = false
         activeStudyPadLabelId = nil

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift
@@ -1626,7 +1626,36 @@ public struct BibleReaderView: View {
     private func handleFullScreenChange(_ fullScreen: Bool) {
         if !fullScreen {
             lastFullScreenByDoubleTap = false
+        } else {
+            // Android's MainBibleActivity.toggleFullScreen posts the exit_fullscreen toast on
+            // every entry into fullscreen so hidden chrome never becomes a trap. All iOS entry
+            // paths (double-tap, overflow menu, auto fullscreen) funnel through this change
+            // handler, matching Android's single toggle path.
+            showReaderToast(
+                String(
+                    localized: "exit_fullscreen",
+                    defaultValue: "Double-tap screen to exit fullscreen"
+                )
+            )
         }
+    }
+
+    /**
+     Shows the transient reader toast and schedules its dismissal.
+
+     - Parameter text: Localized message to display above the reader's bottom edge.
+     - Side effects: Cancels any pending toast dismissal, animates the overlay in, and schedules
+       one dismissal after 2.5 seconds.
+     - Failure modes: None.
+     */
+    private func showReaderToast(_ text: String) {
+        toastWorkItem?.cancel()
+        withAnimation { toastMessage = text }
+        let work = DispatchWorkItem {
+            withAnimation { toastMessage = nil }
+        }
+        toastWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: work)
     }
 
     /// Builds reader-stack destinations opened from the drawer, overflow, or keyboard shortcuts.
@@ -4154,13 +4183,7 @@ public struct BibleReaderView: View {
                 presentModulePicker(category, from: window.id)
             },
             onShowToast: { text in
-                toastWorkItem?.cancel()
-                withAnimation { toastMessage = text }
-                let work = DispatchWorkItem {
-                    withAnimation { toastMessage = nil }
-                }
-                toastWorkItem = work
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: work)
+                showReaderToast(text)
             },
             onShowWorkspaces: { presentReaderDestination(.workspaces, from: window.id) },
             onToggleFullScreen: {

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -1021,6 +1021,56 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies a persisted MYNOTE page category restores the My Notes document after relaunch.
+
+     Android's `CurrentPageManager` persists the MYNOTE category, so a window showing My Notes
+     reopens on My Notes after restart; iOS previously collapsed it to the Bible text. The
+     persisted Bible position supplies the restored chapter, and exiting My Notes must hand the
+     stored category back to the Bible page.
+
+     - Setup: Restores a controller whose page manager persisted the `mynote` category, then
+       marks the client ready so the pre-ready restore replays.
+     - Expected result: The controller restores into visible My Notes state, replays a `notes`
+       document on client-ready, and `returnFromMyNotes` restores the persisted `bible` category.
+     - Failure meaning: Relaunch or workspace sync silently turns a My Notes window into a Bible
+       window, diverging from Android's page restore.
+     - Side effects: Emits bridge documents against an in-memory recording bridge only.
+     */
+    @MainActor
+    func testRestoreSavedPositionReopensPersistedMyNotesPage() throws {
+        let (bridge, recordedScripts) = makeRecordingBridge()
+        let modulePath = try makeTemporarySwordFixturePath()
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let controller = BibleReaderController(bridge: bridge, swordManagerOverride: manager)
+        let window = Window(isSynchronized: false, isLinksWindow: true)
+        let pageManager = PageManager(
+            id: window.id,
+            currentCategoryName: BibleReaderController.myNotesPageManagerCategoryName
+        )
+        window.pageManager = pageManager
+        controller.activeWindow = window
+
+        controller.restoreSavedPosition()
+
+        XCTAssertTrue(controller.showingMyNotes)
+        XCTAssertEqual(
+            pageManager.currentCategoryName,
+            BibleReaderController.myNotesPageManagerCategoryName
+        )
+
+        controller.bridgeDidSetClientReady(bridge)
+        let payload = try XCTUnwrap(
+            bridgeEmissionPayload(from: recordedScripts(), event: "add_documents") as? [String: Any]
+        )
+        XCTAssertEqual(payload["type"] as? String, "notes")
+
+        controller.returnFromMyNotes()
+
+        XCTAssertFalse(controller.showingMyNotes)
+        XCTAssertEqual(pageManager.currentCategoryName, DocumentCategory.bible.pageManagerKey)
+    }
+
+    /**
      Verifies chapter stepping keeps the My Notes document current like Android.
 
      Android's `CurrentMyNotePage.next()/previous()` step the underlying Bible key one chapter

--- a/Sources/BibleView/Sources/BibleView/BibleWebView.swift
+++ b/Sources/BibleView/Sources/BibleView/BibleWebView.swift
@@ -375,15 +375,34 @@ extension BibleWebView {
                 } catch(e) {}
             };
         })();
-        // Double-click/tap toggles fullscreen mode (matching Android behavior)
-        document.addEventListener('dblclick', function(e) {
-            // Don't toggle fullscreen if clicking on interactive elements
-            if (e.target.closest('a, button, input, textarea, [contenteditable]')) return;
-            window.webkit.messageHandlers.bibleView.postMessage({
-                method: 'toggleFullScreen',
-                args: []
+        // Double-tap toggles fullscreen mode (matching Android behavior). Android's
+        // GestureDetector pairs taps within 300 ms and ~100 px of slop; the DOM dblclick
+        // event instead follows the host pointer's double-click interval (the macOS system
+        // setting under Mac Catalyst and the simulator), which pairs unrelated taps into
+        // accidental fullscreen toggles. Detect the double tap manually with Android's
+        // timing so single taps never toggle.
+        (function() {
+            var lastTap = null;
+            document.addEventListener('click', function(e) {
+                // Don't toggle fullscreen if clicking on interactive elements
+                if (e.target.closest('a, button, input, textarea, [contenteditable]')) {
+                    lastTap = null;
+                    return;
+                }
+                var now = Date.now();
+                if (lastTap && (now - lastTap.time) <= 300
+                        && Math.abs(e.clientX - lastTap.x) <= 50
+                        && Math.abs(e.clientY - lastTap.y) <= 50) {
+                    lastTap = null;
+                    window.webkit.messageHandlers.bibleView.postMessage({
+                        method: 'toggleFullScreen',
+                        args: []
+                    });
+                    return;
+                }
+                lastTap = { time: now, x: e.clientX, y: e.clientY };
             });
-        });
+        })();
         """
     }
 

--- a/docs/adr/0011-reader-annotation-parity-divergences.md
+++ b/docs/adr/0011-reader-annotation-parity-divergences.md
@@ -67,6 +67,17 @@ time.
   matters under slow SwiftUI pane creation and degrades to Android's
   "open here" behavior.
 
+## Confirmed-parity behaviors that read as bugs
+
+- **Chained links windows.** A link tapped inside the dedicated links window
+  (for example a My Notes row's verse-number link while My Notes occupies the
+  links window) opens a *new* chained links window, exactly like Android's
+  `Window.targetLinksWindow`. On a phone this shrinks every pane and moves
+  focus to the new pane, which can scroll the My Notes heading out of view.
+  Verified against a live trace and explicitly decided (2026-08-09) to keep
+  Android's behavior rather than reuse the tapped pane or route to the main
+  window.
+
 ## Follow-ups that need their own scoped changes
 
 - **History semantics.** Android records the pre-navigation location before


### PR DESCRIPTION
## Summary

Three fixes from hands-on testing of the merged parity work (#382), each diagnosed against live simulator traces and the Android reference: fullscreen could be entered by loosely spaced single clicks with no visible way back; and a window showing My Notes silently restored as a Bible window after relaunch or Android workspace sync. Also records the verified chained-links-window UX decision in ADR-0011.

## Scope

- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderView.swift` — fullscreen-entry toast, shared toast helper
- `Sources/BibleView/Sources/BibleView/BibleWebView.swift` — Android-timing double-tap detector (injected script)
- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift` — My Notes page-category persistence and restore
- `Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncWorkspaceRestoreService.swift` — Android `MYNOTE` import mapping
- Tests: `BookmarkReaderBridgeTests` (restore test), `WorkspaceSyncRestoreTests` (mapping assertions)
- `docs/adr/0011` — chained links-window UX decision

## Contract references

- Android baselines: `MainBibleActivity.toggleFullScreen` posts the `exit_fullscreen` toast on every entry; `GestureDetector` pairs double taps within 300 ms; `CurrentPageManager` persists the `MYNOTE` category and restores the My Notes page. The persisted iOS `mynote` key round-trips through the existing uppercase/lowercase category translation, so Android sees its own enum name unchanged.
- Commits follow the locked commit-message standard.

## Change details

1. **Fullscreen entry announces itself and requires a real double-tap.** iOS never showed Android's "Double-tap screen to exit fullscreen" toast, and the toggle listened to the DOM `dblclick` event, which follows the host pointer's double-click interval (macOS system setting under the simulator/Catalyst) — loosely spaced clicks toggled fullscreen and users lost the header and tab bar with no hint. The toast now fires on every entry path, and the injected script detects double taps manually with Android's timing (300 ms, 50 px slop).
2. **My Notes windows survive relaunch and sync.** The reader persists the `MYNOTE` page category while My Notes owns a pane, hands it back to Bible on every exit path, and `restoreSavedPosition` reopens My Notes at the saved chapter. The Android workspace importer now maps `MYNOTE` to the reader key instead of collapsing it to Bible (two sync tests locked the collapse and now assert the mapping).
3. **ADR-0011** records the live-trace-verified decision to keep Android's chained links-window behavior (a link tapped inside the links window opens a new chained pane).

## Validation evidence

- `BibleUITests` (BookmarkReaderBridgeTests 54, ReaderNavigationTests 86): 140 tests, 0 failures; `BibleCoreTests/WorkspaceSyncRestoreTests`: 25 tests, 0 failures (iPhone 17 simulator).
- Manual verification on the simulator: single taps no longer toggle fullscreen, the entry toast appears, and a My Notes pane restores as My Notes after killing and relaunching the app.
- `git diff --check`, docblock and commit-message guardrails pass for all 3 commits.

## Risks / follow-ups

- The double-tap detector runs on `click` events in the injected script; interactive elements reset it, so links/buttons cannot compose into a toggle. Risk is low and behavior now matches Android timing.
- The persisted `mynote` category is new on iOS; every exit path hands it back to Bible, and restore falls back to Bible when no KJVA target resolves, so a stale value cannot blank a pane.

## Issue closure

Closes: none — follow-up fixes to #382 from manual validation; no open issue maps to them (verified against the GitHub issue list).
