### PR TITLE
fix(reader): render bookmark OSIS fragments and harden links-window state

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift
@@ -213,7 +213,12 @@ public final class WindowManager {
            let maxWindow = allWindows.first(where: { $0.id == maxId }) {
             visibleWindows = [maxWindow]
         } else {
-            visibleWindows = allWindows.filter { $0.layoutState != "minimized" }
+            // Android renders only VISIBLE windows; `closed` rows exist solely through synced
+            // or imported Android state (local close deletes the row) and must stay hidden
+            // like Android hides them instead of rendering as extra panes.
+            visibleWindows = allWindows.filter {
+                $0.layoutState != "minimized" && $0.layoutState != "closed"
+            }
         }
 
         if activeWindow == nil || !visibleWindows.contains(where: { $0.id == activeWindow?.id }) {
@@ -480,6 +485,17 @@ public final class WindowManager {
         } else {
             window = workspaceStore.addWindow(to: workspace, document: document, category: category)
             window.isLinksWindow = asLinksWindow
+        }
+
+        // Android also clones the source page manager into a chained links window, but its
+        // showLink overwrites the target's document synchronously before anything can observe
+        // the clone. iOS panes boot asynchronously, so a cloned `mynote` category could restore
+        // the My Notes page in the new links window before the link navigation lands. Reset it
+        // to the Bible category Android guarantees as the post-link state.
+        if asLinksWindow,
+           let pageManager = window.pageManager,
+           pageManager.currentCategoryName == "mynote" {
+            pageManager.currentCategoryName = "bible"
         }
 
         // Intentional divergence from Android: Android's window creation never touches

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift
@@ -915,7 +915,7 @@ struct BibleReaderAnnotationPayloadFactory {
             verseRangeOnlyNumber: displayProjection.verseRangeOnlyNumber,
             verseRangeAbbreviated: displayProjection.verseRangeAbbreviated,
             v11n: hasSourceModule ? bookmark.v11n : JSwordKJVAVersification.name,
-            osisFragment: nil
+            osisFragment: bibleBookmarkOsisFragment(for: bookmark)
         )
     }
 
@@ -994,6 +994,58 @@ struct BibleReaderAnnotationPayloadFactory {
      - Failure modes: Malformed KJVA ordinals retain best-effort display coordinates with ordinal
        `0`; source ordinals are never reinterpreted as KJVA or active-module ordinals.
      */
+    /**
+     Builds Android's per-bookmark OSIS fragment for the expanded `BookmarkText` view.
+
+     Android's `BookmarkControl.addText` renders every serialized Bible bookmark's verse range
+     from the bookmark's own module (falling back to the default Bible) via `readOsisFragment`.
+     The shared `BookmarkText` component renders that fragment when a row expands, so a null
+     fragment makes expansion collapse the visible quote into empty content — the "text
+     disappears" defect in My Notes rows.
+
+     - Parameter bookmark: Persisted Bible bookmark being serialized.
+     - Returns: Bridge fragment for the bookmark's range, or `nil` when no Bible module resolves,
+       the stored canon cannot resolve the ordinals, or content is incomplete — Android's
+       `OsisError` null path, which keeps the collapsed one-liner.
+     - Side effects: Reads SWORD content on the shared serialization queue.
+     - Failure modes: Returns `nil`; the web client keeps the collapsed quote.
+     */
+    private func bibleBookmarkOsisFragment(for bookmark: BibleBookmark) -> OsisFragment? {
+        let initials = bookmark.bookInitials.trimmingCharacters(in: .whitespacesAndNewlines)
+        let module = (initials.isEmpty ? nil : sourceModuleResolver(initials)) ?? activeModule
+        guard let module, module.info.category == .bible else { return nil }
+        let source = BibleReaderInstalledScriptureSource.sword(module)
+        let sourceV11n = bookmark.v11n
+        guard !sourceV11n.isEmpty, bookmark.ordinalStart > 0 else { return nil }
+        let endOrdinal = max(bookmark.ordinalEnd, bookmark.ordinalStart)
+        var references: [VerseKeyReference] = []
+        for ordinal in bookmark.ordinalStart...endOrdinal {
+            guard let reference = SwordVersification.reference(
+                forIndex: ordinal,
+                versification: sourceV11n
+            ) else { return nil }
+            // Chapter-introduction slots are outside Android's VerseRange membership.
+            guard reference.verse > 0 else { continue }
+            guard let mapped = source.mappedReference(
+                osisBookId: reference.osisBookId,
+                chapter: reference.chapter,
+                verse: reference.verse,
+                from: sourceV11n
+            ) else { return nil }
+            if let previous = references.last {
+                if previous == mapped { continue }
+                guard source.isCanonicallyAdjacent(mapped, after: previous) else { return nil }
+            }
+            references.append(mapped)
+        }
+        guard !references.isEmpty else { return nil }
+        return BibleReaderInstalledScriptureFragmentBuilder.build(
+            source: source,
+            references: references,
+            requiresCompleteContent: true
+        )
+    }
+
     /**
      Builds the bookmark's own-versification display projection for annotation documents.
 

--- a/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift
@@ -970,6 +970,18 @@ final class BookmarkReaderBridgeTests: BibleUISwordFixtureTestCase {
         XCTAssertEqual(hasNoteById.count, 2)
         XCTAssertEqual(hasNoteById[noteless.id.uuidString.lowercased()], false)
         XCTAssertEqual(hasNoteById[noted.id.uuidString.lowercased()], true)
+
+        // Android's addText serializes each row's rendered OSIS fragment; the shared
+        // BookmarkText component renders it when the row expands, so a null fragment makes
+        // expansion blank the visible quote.
+        let notedRow = try XCTUnwrap(
+            (documentPayload["bookmarks"] as? [[String: Any]])?.first {
+                ($0["id"] as? String)?.lowercased() == noted.id.uuidString.lowercased()
+            }
+        )
+        let fragment = try XCTUnwrap(notedRow["osisFragment"] as? [String: Any])
+        XCTAssertEqual(fragment["bookInitials"] as? String, "KJV")
+        XCTAssertFalse(((fragment["xml"] as? String) ?? "").isEmpty)
     }
 
     /**


### PR DESCRIPTION
## Summary

Root-cause fix for the "My Notes text disappears on tap" defect, plus two window-management defects confirmed by an adversarial Codex review. The headline defect was diagnosed by running the Android app empirically (emulator build from the parity checkout) side-by-side with iOS: tapping a My Notes row's collapsed verse quote *expands* into the styled passage on Android but blanked the row on iOS, because iOS hardcoded `osisFragment: null` in every Bible bookmark payload while the shared `BookmarkText` component renders exactly that fragment in its expanded state.

## Scope

- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderAnnotationPayloadFactory.swift` — per-bookmark OSIS fragment serialization
- `Sources/BibleCore/Sources/BibleCore/Services/WindowManager.swift` — links-window clone category reset; closed-row visibility
- `Sources/BibleUI/Tests/BibleUITests/BookmarkReaderBridgeTests.swift` — fragment contract test

No shared-frontend changes; `BookmarkText.vue` is byte-identical to Android's and simply starts receiving the data it always expected.

## Contract references

- Android baselines: `BookmarkControl.addText` renders each serialized bookmark's verse range from the bookmark's own module (default-Bible fallback) via `readOsisFragment` with null-on-`OsisError`; `bookmarksForVerseRange(withText = true)` applies it to chapter, My Notes, and StudyPad documents alike. Window parity: Android's `showLink` overwrites a chained links window's cloned page synchronously, and `WindowRepository.visibleWindows` renders only `VISIBLE` windows.
- Commits follow the locked commit-message standard.

## Change details

1. **`bibleBookmarkJSON` now emits the real fragment**: stored source ordinals resolve in the bookmark's own versification, map into the resolved module's domain (bookmark module first, active-module fallback), and render through the existing `BibleReaderInstalledScriptureFragmentBuilder` with Android's null-on-failure semantics. Applies to chapter, My Notes, and StudyPad payloads — the same universality as Android.
2. **Chained links windows can no longer boot into My Notes**: `createManagedWindow` resets a cloned `mynote` page category to `bible` for links windows. Android clones the same state but overwrites it synchronously before it can be observed; iOS's asynchronous pane boot could restore the clone first (Codex-confirmed, explains phantom My Notes panes deepening the links chain).
3. **Synced `closed` windows stay hidden**: `refreshWindows` excludes `closed` rows from `visibleWindows` like Android's VISIBLE-only rendering. Local close deletes rows; `closed` arrives only via synced/imported Android workspaces.

## Validation evidence

- `BibleUITests` (BookmarkReaderBridgeTests 54, ReaderBridgeParityTests 21, ReaderNavigationTests 86): 161 tests, 0 failures; `BibleCoreTests` (WorkspaceSyncRestoreTests, WorkspaceWindowStoreTests, WindowCloneFidelityTests): 76 tests, 0 failures (iPhone 17 simulator).
- Empirical Android baseline: and-bible standardGithub debug build (v5.1.1112) on a Pixel 7 API-34 emulator, exercising the exact My Notes tap flow.
- `git diff --check`, docblock and commit-message guardrails pass for both commits.

## Risks / follow-ups

- Fragment rendering adds per-bookmark SWORD reads to bookmark-bearing document emissions — the same cost Android pays on every `addText`; ranges are verse-scale.
- SQLite-backed bookmark modules fall back to the active module's fragment (Android falls back to the default Bible); a dedicated SQLite fragment path can follow if divergent-module fidelity matters there.

## Issue closure

Closes: none — follow-up fixes from empirical parity testing and the Codex window-management review; no open issue maps to them (verified against the GitHub issue list).
