### PR TITLE
fix(speak): natural continuous TTS narration with Android-style position marker

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/SpeakCommandBuilder.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SpeakCommandBuilder.swift
@@ -104,7 +104,6 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
     private struct PendingText {
         var rawValue: String
         let kind: SpokenTextKind
-        let replacesDivineName: Bool
     }
 
     let playbackSettings: PlaybackSettings
@@ -117,6 +116,9 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
     private var divineNameDepth = 0
     private var footnoteDepth = 0
     private var pendingText: PendingText?
+
+    /// Divine-name content accumulated for replacement before folding into the surrounding run.
+    private var divineNameRun: String?
 
     init(
         playbackSettings: PlaybackSettings,
@@ -135,17 +137,18 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
         qualifiedName qName: String?,
         attributes attributeDict: [String: String] = [:]
     ) {
-        flushPendingText()
         let name = localName(elementName)
         let parentVisible = states.last?.visible ?? true
         switch name {
         case "verse":
+            flushPendingText()
             if let marker = attributeDict["osisID"] ?? attributeDict["sID"],
                let verse = marker.split(separator: ".").last.flatMap({ Int($0) }) {
                 commands.append(.verseNumber(verse))
             }
             states.append(.init(visible: parentVisible, kind: .normal))
         case "note":
+            flushPendingText()
             if attributeDict["type"] == "study", playbackSettings.speakFootnotes {
                 commands.append(.pause(milliseconds: 150))
                 footnoteDepth += 1
@@ -155,9 +158,11 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
                 states.append(.init(visible: false, kind: .hidden))
             }
         case "reference":
+            flushPendingText()
             commands.append(.excluded(.crossReference))
             states.append(.init(visible: false, kind: .hidden))
         case "title":
+            flushPendingText()
             if playbackSettings.speakTitles {
                 commands.append(.pause(milliseconds: 150))
             }
@@ -167,8 +172,10 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
             divineNameDepth += 1
             states.append(.init(visible: parentVisible, kind: .divineName))
         case "p", "l", "lb":
+            flushPendingText()
             states.append(.init(visible: parentVisible, kind: .paragraph))
         case "div":
+            flushPendingText()
             let type = attributeDict["type"] ?? ""
             let isParagraph = ["paragraph", "x-p", "x-end-paragraph"].contains(type)
             if isParagraph, attributeDict["sID"] == nil {
@@ -176,6 +183,10 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
             }
             states.append(.init(visible: parentVisible, kind: isParagraph ? .paragraph : .normal))
         default:
+            // Inline OSIS markup (w, seg, transChange, q, hi, milestones, unknown elements) must
+            // not interrupt the spoken run: Android's OsisToBibleSpeak accumulates straight
+            // through it. Flushing here split Strong's-tagged text into one utterance per word
+            // and left bare punctuation runs that the synthesizer narrated as "comma".
             states.append(.init(visible: parentVisible, kind: .normal))
         }
     }
@@ -186,20 +197,24 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
         namespaceURI: String?,
         qualifiedName qName: String?
     ) {
-        flushPendingText()
         guard states.count > 1 else { return }
         let state = states.removeLast()
         switch state.kind {
         case .title where playbackSettings.speakTitles:
+            flushPendingText()
             commands.append(.pause(milliseconds: 500))
             titleDepth = max(titleDepth - 1, 0)
         case .footnote where playbackSettings.speakFootnotes:
+            flushPendingText()
             commands.append(.pause(milliseconds: 150))
             footnoteDepth = max(footnoteDepth - 1, 0)
         case .divineName:
+            foldDivineNameRun()
             divineNameDepth = max(divineNameDepth - 1, 0)
         case .title:
             titleDepth = max(titleDepth - 1, 0)
+        case .paragraph:
+            flushPendingText()
         default:
             break
         }
@@ -207,6 +222,19 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
 
     func parser(_ parser: XMLParser, foundCharacters string: String) {
         guard let state = states.last, state.visible else { return }
+        if divineNameDepth > 0, advancedSettings.replaceDivineName {
+            divineNameRun = (divineNameRun ?? "") + string
+            return
+        }
+        appendToPendingText(string)
+    }
+
+    func parserDidEndDocument(_ parser: XMLParser) {
+        flushPendingText()
+    }
+
+    /** Accumulates one visible character run into the current same-kind pending text. */
+    private func appendToPendingText(_ string: String) {
         let kind: SpokenTextKind
         if titleDepth > 0 {
             kind = .title
@@ -215,38 +243,76 @@ private final class OSISSpeechParserDelegate: NSObject, XMLParserDelegate {
         } else {
             kind = .normal
         }
-        let replacesDivineName = divineNameDepth > 0 && advancedSettings.replaceDivineName
-        if pendingText?.kind == kind, pendingText?.replacesDivineName == replacesDivineName {
+        if pendingText?.kind == kind {
             pendingText?.rawValue.append(string)
         } else {
             flushPendingText()
-            pendingText = PendingText(
-                rawValue: string,
-                kind: kind,
-                replacesDivineName: replacesDivineName
-            )
+            pendingText = PendingText(rawValue: string, kind: kind)
         }
     }
 
-    /** Flushes one XML character run without crossing an OSIS element boundary. */
+    /** Applies divine-name replacement to the finished run and folds it into the surrounding text. */
+    private func foldDivineNameRun() {
+        guard let run = divineNameRun else { return }
+        divineNameRun = nil
+        var text = run
+        for (source, replacement) in zip(divineNameArrays.original, divineNameArrays.replacement)
+            where !source.isEmpty {
+            text = text.replacingOccurrences(of: source, with: replacement)
+        }
+        appendToPendingText(text)
+    }
+
+    /** Flushes the accumulated spoken run at one structural OSIS boundary. */
     private func flushPendingText() {
         guard let pendingText else { return }
         self.pendingText = nil
-        var text = SpeakCommandBuilder.normalizeText(pendingText.rawValue)
+        let text = SpeakCommandBuilder.normalizeText(pendingText.rawValue)
         guard !text.isEmpty else { return }
-        if pendingText.replacesDivineName {
-            for (source, replacement) in zip(divineNameArrays.original, divineNameArrays.replacement)
-                where !source.isEmpty {
-                text = text.replacingOccurrences(of: source, with: replacement)
-            }
+        // A run without letters or digits is stray markup punctuation; synthesizers narrate it
+        // ("comma", "full stop") when spoken alone, so it merges into the preceding same-kind
+        // command or is dropped.
+        if !text.contains(where: { $0.isLetter || $0.isNumber }) {
+            mergeTrailingPunctuation(text, kind: pendingText.kind)
+            return
         }
-        switch pendingText.kind {
+        commands.append(command(for: text, kind: pendingText.kind))
+    }
+
+    /** Attaches a punctuation-only run to the previous same-kind command when one exists. */
+    private func mergeTrailingPunctuation(_ text: String, kind: SpokenTextKind) {
+        guard let last = commands.last else { return }
+        let merged: SpeakCommand?
+        switch (last, kind) {
+        case (.text(let value), .normal):
+            merged = .text("\(value)\(joiner(for: text))\(text)")
+        case (.heading(let value), .title):
+            merged = .heading("\(value)\(joiner(for: text))\(text)")
+        case (.footnote(let value), .footnote):
+            merged = .footnote("\(value)\(joiner(for: text))\(text)")
+        default:
+            merged = nil
+        }
+        if let merged {
+            commands[commands.count - 1] = merged
+        }
+    }
+
+    /** Sentence punctuation attaches directly; bracketing punctuation keeps one space. */
+    private func joiner(for text: String) -> String {
+        guard let first = text.first else { return "" }
+        return [",", ".", ";", ":", "!", "?"].contains(String(first)) ? "" : " "
+    }
+
+    /** Maps one spoken-text kind onto its command constructor. */
+    private func command(for text: String, kind: SpokenTextKind) -> SpeakCommand {
+        switch kind {
         case .title:
-            commands.append(.heading(text))
+            return .heading(text)
         case .footnote:
-            commands.append(.footnote(text))
+            return .footnote(text)
         case .normal:
-            commands.append(.text(text))
+            return .text(text)
         }
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/SpeechVoiceResolver.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/SpeechVoiceResolver.swift
@@ -17,10 +17,28 @@ struct SpeechVoiceDescriptor: Equatable, Sendable {
     /// BCP-47 language identifier advertised by the installed voice.
     let language: String
 
+    /// Platform quality ranking: 0 compact/default, 1 enhanced, 2 premium.
+    let qualityRank: Int
+
+    /// Whether the platform marks this as a novelty voice unsuitable for long-form reading.
+    let isNoveltyVoice: Bool
+
+    /// Whether this is a Personal Voice requiring authorization the app does not request.
+    let isPersonalVoice: Bool
+
     /** Creates an immutable installed-voice descriptor. */
-    init(identifier: String, language: String) {
+    init(
+        identifier: String,
+        language: String,
+        qualityRank: Int = 0,
+        isNoveltyVoice: Bool = false,
+        isPersonalVoice: Bool = false
+    ) {
         self.identifier = identifier
         self.language = language
+        self.qualityRank = qualityRank
+        self.isNoveltyVoice = isNoveltyVoice
+        self.isPersonalVoice = isPersonalVoice
     }
 }
 
@@ -102,6 +120,10 @@ enum SpeechVoiceResolution {
 
      Exact regional candidates win first. Only the final base-language candidate may accept an
      installed regional variant, mirroring Android's `setLanguage(Locale(language))` behavior.
+     Within one matched candidate, the highest platform quality wins (premium over enhanced over
+     compact) because the platform catalog lists compact voices first and long-form Bible reading
+     with a compact voice is barely usable; novelty and unauthorized Personal voices are never
+     selected. Ties keep catalog order, so selection stays deterministic.
 
      - Parameters:
        - requestedLanguage: Module or document language supplied by the active provider.
@@ -117,7 +139,8 @@ enum SpeechVoiceResolution {
         installedVoices: [SpeechVoiceDescriptor]
     ) -> String? {
         let normalizedVoices = installedVoices.compactMap { voice -> (SpeechVoiceDescriptor, String)? in
-            guard let language = normalizedLanguageIdentifier(voice.language) else { return nil }
+            guard !voice.isNoveltyVoice, !voice.isPersonalVoice,
+                  let language = normalizedLanguageIdentifier(voice.language) else { return nil }
             return (voice, language)
         }
 
@@ -125,19 +148,36 @@ enum SpeechVoiceResolution {
             requestedLanguage: requestedLanguage,
             deviceLocaleIdentifier: deviceLocale.identifier
         ) {
-            if let exact = normalizedVoices.first(where: { $0.1 == candidate.identifier }) {
-                return exact.0.identifier
+            if let exact = bestQualityVoice(
+                in: normalizedVoices,
+                matching: { $0 == candidate.identifier }
+            ) {
+                return exact.identifier
             }
             guard candidate.permitsRegionalVoice,
                   let candidateLanguage = primaryLanguage(in: candidate.identifier),
-                  let regional = normalizedVoices.first(where: {
-                      primaryLanguage(in: $0.1) == candidateLanguage
-                  }) else {
+                  let regional = bestQualityVoice(
+                      in: normalizedVoices,
+                      matching: { primaryLanguage(in: $0) == candidateLanguage }
+                  ) else {
                 continue
             }
-            return regional.0.identifier
+            return regional.identifier
         }
         return nil
+    }
+
+    /** Returns the highest-quality matching voice, keeping catalog order between equal ranks. */
+    private static func bestQualityVoice(
+        in normalizedVoices: [(SpeechVoiceDescriptor, String)],
+        matching languageMatches: (String) -> Bool
+    ) -> SpeechVoiceDescriptor? {
+        var best: SpeechVoiceDescriptor?
+        for (voice, language) in normalizedVoices where languageMatches(language) {
+            if let current = best, current.qualityRank >= voice.qualityRank { continue }
+            best = voice
+        }
+        return best
     }
 
     /** Builds Android's ordered locale candidates and preserves base-language fallback semantics. */
@@ -256,8 +296,26 @@ struct SystemSpeechVoiceResolver: SpeechVoiceResolving {
         deviceLocale: Locale
     ) -> AVSpeechSynthesisVoice? {
         let voices = AVSpeechSynthesisVoice.speechVoices()
-        let descriptors = voices.map {
-            SpeechVoiceDescriptor(identifier: $0.identifier, language: $0.language)
+        let descriptors = voices.map { voice -> SpeechVoiceDescriptor in
+            let qualityRank: Int
+            switch voice.quality {
+            case .premium: qualityRank = 2
+            case .enhanced: qualityRank = 1
+            default: qualityRank = 0
+            }
+            var isNovelty = false
+            var isPersonal = false
+            if #available(iOS 17.0, macOS 14.0, *) {
+                isNovelty = voice.voiceTraits.contains(.isNoveltyVoice)
+                isPersonal = voice.voiceTraits.contains(.isPersonalVoice)
+            }
+            return SpeechVoiceDescriptor(
+                identifier: voice.identifier,
+                language: voice.language,
+                qualityRank: qualityRank,
+                isNoveltyVoice: isNovelty,
+                isPersonalVoice: isPersonal
+            )
         }
         guard let identifier = SpeechVoiceResolution.selectedVoiceIdentifier(
             requestedLanguage: requestedLanguage,

--- a/Sources/BibleCore/Tests/BibleCoreTests/SpeakParityTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/SpeakParityTests.swift
@@ -230,6 +230,71 @@ final class SpeakParityTests: XCTestCase {
     }
 
     /**
+     Verifies Strong's-tagged OSIS speaks as one continuous run with attached punctuation.
+
+     KJV-class modules wrap every word in `<w lemma="strong:...">`, leaving punctuation as bare
+     text nodes between elements. Flushing at inline boundaries produced one utterance per word
+     with prosody gaps, and lone punctuation runs that the synthesizer narrated aloud as "comma"
+     and "full stop". Android's OsisToBibleSpeak accumulates through inline markup, so iOS must
+     produce a single text command per verse body.
+     */
+    func testStrongsTaggedVerseSpeaksAsOneContinuousRun() {
+        let osis = #"<verse osisID="Gen.1.1" sID="Gen.1.1"/>"# +
+            #"<w lemma="strong:H07225">In the beginning</w> "# +
+            #"<w lemma="strong:H0430">God</w> <w lemma="strong:H1254">created</w> "# +
+            #"<transChange type="added">the</transChange> "# +
+            #"<w lemma="strong:H8064">heaven</w> and "# +
+            #"<w lemma="strong:H776">the earth</w>."#
+        let commands = SpeakCommandBuilder.commands(
+            rawOSIS: osis,
+            fallbackPlainText: "",
+            language: "en",
+            playbackSettings: PlaybackSettings(),
+            advancedSettings: AdvancedSpeakSettings()
+        )
+
+        XCTAssertEqual(
+            commands,
+            [
+                .verseNumber(1),
+                .text("In the beginning God created the heaven and the earth."),
+            ],
+            "commands: \(commands)"
+        )
+    }
+
+    /**
+     Verifies punctuation stranded by hidden elements never becomes its own spoken command.
+
+     A run containing no letters or digits must merge into the preceding same-kind command or be
+     dropped; spoken alone, the synthesizer narrates the punctuation name aloud.
+     */
+    func testPunctuationOnlyRunsMergeIntoPrecedingTextInsteadOfBeingSpoken() {
+        let osis = #"<w lemma="strong:G2424">Jesus wept</w>"# +
+            #"<note type="crossReference">hidden</note>."#
+        let commands = SpeakCommandBuilder.commands(
+            rawOSIS: osis,
+            fallbackPlainText: "",
+            language: "en",
+            playbackSettings: PlaybackSettings(),
+            advancedSettings: AdvancedSpeakSettings()
+        )
+
+        XCTAssertEqual(
+            commands,
+            [
+                .text("Jesus wept"),
+                .excluded(.nonStudyNote),
+            ],
+            "Expected the stranded period to be dropped rather than spoken; commands: \(commands)"
+        )
+        XCTAssertFalse(
+            commands.contains(.text(".")),
+            "A lone punctuation run must never become a spoken command."
+        )
+    }
+
+    /**
      Reproduces the aggregate ordering that exposed decoder and localized-command contamination.
 
      The sequence generates localized commands, decodes malformed playback and container settings,

--- a/Sources/BibleCore/Tests/BibleCoreTests/SpeechVoiceAndProductBoundaryTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/SpeechVoiceAndProductBoundaryTests.swift
@@ -117,6 +117,75 @@ final class SpeechVoiceAndProductBoundaryTests: XCTestCase {
         )
     }
 
+    /**
+     Verifies quality-aware voice selection prefers premium and enhanced voices for long reading.
+
+     The platform catalog lists compact voices first, so first-match selection picked the worst
+     installed voice for every language. Failure means Bible reading falls back to a compact voice
+     while a better one is installed, or a novelty/Personal voice is chosen for scripture.
+     */
+    func testVoiceSelectionPrefersHighestQualityAndExcludesNoveltyAndPersonalVoices() {
+        let catalog = [
+            SpeechVoiceDescriptor(identifier: "us-compact", language: "en-US", qualityRank: 0),
+            SpeechVoiceDescriptor(identifier: "us-novelty", language: "en-US", qualityRank: 2, isNoveltyVoice: true),
+            SpeechVoiceDescriptor(identifier: "us-personal", language: "en-US", qualityRank: 2, isPersonalVoice: true),
+            SpeechVoiceDescriptor(identifier: "us-enhanced", language: "en-US", qualityRank: 1),
+            SpeechVoiceDescriptor(identifier: "us-premium", language: "en-US", qualityRank: 2),
+            SpeechVoiceDescriptor(identifier: "gb-compact", language: "en-GB", qualityRank: 0),
+        ]
+
+        XCTAssertEqual(
+            SpeechVoiceResolution.selectedVoiceIdentifier(
+                requestedLanguage: "en-US",
+                deviceLocale: Locale(identifier: "en_US"),
+                installedVoices: catalog
+            ),
+            "us-premium",
+            "Premium must beat enhanced, compact, and excluded high-quality voices."
+        )
+        XCTAssertEqual(
+            SpeechVoiceResolution.selectedVoiceIdentifier(
+                requestedLanguage: "en-US",
+                deviceLocale: Locale(identifier: "en_US"),
+                installedVoices: catalog.filter { $0.identifier != "us-premium" }
+            ),
+            "us-enhanced",
+            "Enhanced must beat compact when premium is absent."
+        )
+        XCTAssertEqual(
+            SpeechVoiceResolution.selectedVoiceIdentifier(
+                requestedLanguage: "en-GB",
+                deviceLocale: Locale(identifier: "en_GB"),
+                installedVoices: catalog
+            ),
+            "gb-compact",
+            "A compact voice remains selectable when it is the only non-excluded match."
+        )
+        XCTAssertNil(
+            SpeechVoiceResolution.selectedVoiceIdentifier(
+                requestedLanguage: "en-US",
+                deviceLocale: Locale(identifier: "en_US"),
+                installedVoices: [
+                    SpeechVoiceDescriptor(identifier: "only-novelty", language: "en-US", qualityRank: 2, isNoveltyVoice: true),
+                    SpeechVoiceDescriptor(identifier: "only-personal", language: "en-US", qualityRank: 2, isPersonalVoice: true),
+                ]
+            ),
+            "Novelty and Personal voices must never be selected even when nothing else matches."
+        )
+        XCTAssertEqual(
+            SpeechVoiceResolution.selectedVoiceIdentifier(
+                requestedLanguage: "en-US",
+                deviceLocale: Locale(identifier: "en_US"),
+                installedVoices: [
+                    SpeechVoiceDescriptor(identifier: "first-enhanced", language: "en-US", qualityRank: 1),
+                    SpeechVoiceDescriptor(identifier: "second-enhanced", language: "en-US", qualityRank: 1),
+                ]
+            ),
+            "first-enhanced",
+            "Equal quality keeps platform catalog order for deterministic selection."
+        )
+    }
+
     /** Unsupported languages stop visibly before the synthesizer receives any spoken content. */
     func testUnsupportedSpeechLanguageStopsWithoutSynthesisAndPublishesFailure() {
         let synthesizer = FakeSpeechSynthesizer()

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1669,13 +1669,13 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
-     Injects the night/day page background and the TTS highlight styles.
+     Injects the night/day page background colors.
 
      Body/document colors are set natively because they must hold before the Vue client is ready
      (initial load, document replacement) when no `set_config` styling exists yet; once the client
-     runs, the shared frontend derives the same colors from config. All layout — paddings, margins,
-     and text width — belongs exclusively to the shared Vue `contentStyle` so Android's
-     text-display settings keep authority (issue #377).
+     runs, the shared frontend derives the same colors from config. All layout and playback
+     styling belongs exclusively to the shared frontend so Android's behavior keeps authority
+     (issues #377 and the speak-highlight parity that followed it).
 
      - Side effects: Evaluates one JavaScript block in the pane web view.
      - Failure modes: Evaluation failures leave the previous styling; the next content load retries.
@@ -1702,14 +1702,6 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
         if (content) {
             content.style.removeProperty('padding-top');
             content.style.removeProperty('padding-bottom');
-        }
-        // Inject CSS for TTS speak highlighting only. Padding and max-width belong to the shared
-        // Vue contentStyle; a native override here would defeat Android's text-display settings.
-        if (!document.getElementById('ios-tts-highlight')) {
-            var s = document.createElement('style');
-            s.id = 'ios-tts-highlight';
-            s.textContent = '.speaking-verse { background-color: rgba(100, 149, 237, 0.12); border-radius: 4px; transition: background-color 0.3s ease; } #speaking-word { background-color: rgba(100, 149, 237, 0.45); border-radius: 3px; padding: 1px 0; } .night .speaking-verse { background-color: rgba(135, 168, 255, 0.28); } .night #speaking-word { background-color: rgba(135, 168, 255, 0.6); }';
-            document.head.appendChild(s);
         }
         """)
     }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -1703,6 +1703,14 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
             content.style.removeProperty('padding-top');
             content.style.removeProperty('padding-bottom');
         }
+        // Live speak-position marker styled as Android's red speak-label bookmark so the
+        // reading position stays visible during playback on both platforms' visual language.
+        if (!document.getElementById('ios-speak-position')) {
+            var s = document.createElement('style');
+            s.id = 'ios-speak-position';
+            s.textContent = '.speak-position { text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: rgb(255, 0, 0); text-underline-offset: 3px; }';
+            document.head.appendChild(s);
+        }
         """)
     }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSQLiteSpeechDispatchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSQLiteSpeechDispatchCoordinator.swift
@@ -95,7 +95,7 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
                 }
             },
             stopped: {
-                // Android leaves no playback styling in the document, so stop needs no DOM cleanup.
+                context.evaluateJavaScript(Self.cleanupScript)
             }
         )
     }
@@ -131,7 +131,7 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
                 }
             },
             stopped: {
-                // Android leaves no playback styling in the document, so stop needs no DOM cleanup.
+                context.evaluateJavaScript(Self.cleanupScript)
             }
         )
     }
@@ -183,18 +183,29 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
      Builds the deterministic spoken-verse DOM highlight and centering script.
 
      - Parameter ordinal: Exact rendered KJVA verse ordinal to select.
-     - Returns: Self-contained JavaScript that centers the matching `data-ordinal` element when
-       present. Android tracks the spoken position by scrolling only, with no playback styling.
+     - Returns: Self-contained JavaScript that marks the matching `data-ordinal` element with the
+       Android-red speak-position class and centers it when present.
      - Side effects: None until the caller evaluates the returned script in the reader WebView.
      - Failure modes: The evaluated script exits without mutation when no matching verse exists.
      */
     private static func highlightScript(ordinal: Int) -> String {
         """
         (function() {
+            var old = document.querySelector('.speak-position');
+            if (old) old.classList.remove('speak-position');
             var verse = document.querySelector('[data-ordinal="\(ordinal)"]');
             if (!verse) return;
+            verse.classList.add('speak-position');
             verse.scrollIntoView({behavior: 'smooth', block: 'center'});
         })();
         """
     }
+
+    /** Removes the speak-position marker when a SQLite speech session stops. */
+    static let cleanupScript = """
+    (function() {
+        var v = document.querySelector('.speak-position');
+        if (v) v.classList.remove('speak-position');
+    })();
+    """
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSQLiteSpeechDispatchCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSQLiteSpeechDispatchCoordinator.swift
@@ -95,7 +95,7 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
                 }
             },
             stopped: {
-                context.evaluateJavaScript(Self.cleanupScript)
+                // Android leaves no playback styling in the document, so stop needs no DOM cleanup.
             }
         )
     }
@@ -131,7 +131,7 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
                 }
             },
             stopped: {
-                context.evaluateJavaScript(Self.cleanupScript)
+                // Android leaves no playback styling in the document, so stop needs no DOM cleanup.
             }
         )
     }
@@ -183,38 +183,18 @@ struct BibleReaderSQLiteSpeechDispatchCoordinator {
      Builds the deterministic spoken-verse DOM highlight and centering script.
 
      - Parameter ordinal: Exact rendered KJVA verse ordinal to select.
-     - Returns: Self-contained JavaScript that replaces the prior verse highlight and centers the
-       matching `data-ordinal` element when present.
+     - Returns: Self-contained JavaScript that centers the matching `data-ordinal` element when
+       present. Android tracks the spoken position by scrolling only, with no playback styling.
      - Side effects: None until the caller evaluates the returned script in the reader WebView.
      - Failure modes: The evaluated script exits without mutation when no matching verse exists.
      */
     private static func highlightScript(ordinal: Int) -> String {
         """
         (function() {
-            var oldVerse = document.querySelector('.speaking-verse');
-            if (oldVerse) oldVerse.classList.remove('speaking-verse');
             var verse = document.querySelector('[data-ordinal="\(ordinal)"]');
             if (!verse) return;
-            verse.classList.add('speaking-verse');
             verse.scrollIntoView({behavior: 'smooth', block: 'center'});
         })();
         """
     }
-
-    /**
-     Deterministic DOM cleanup for word and verse speech highlights.
-
-     Evaluation removes the current verse class and unwraps a transient spoken-word marker while
-     preserving its text. Missing nodes are accepted, making repeated cleanup idempotent.
-     */
-    private static let cleanupScript = """
-    (function() {
-        var word = document.getElementById('speaking-word');
-        if (word && word.parentNode) {
-            word.parentNode.replaceChild(document.createTextNode(word.textContent || ''), word);
-        }
-        var verse = document.querySelector('.speaking-verse');
-        if (verse) verse.classList.remove('speaking-verse');
-    })();
-    """
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpeechCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpeechCoordinator.swift
@@ -665,10 +665,10 @@ final class BibleReaderSpeechCoordinator {
     }
 
     /**
-     Scrolls the reader to one provider-owned Bible verse after session-generation validation.
+     Marks and centers one provider-owned Bible verse after session-generation validation.
 
-     Android tracks the spoken position by scrolling only; it applies no per-verse highlight
-     styling during playback, so iOS must not either.
+     The marker uses Android's red speak-label visual so the live reading position matches the
+     speak identity users know from Android's paused speak bookmark.
      */
     private func highlightVerseNow(
         _ ordinal: Int,
@@ -677,8 +677,11 @@ final class BibleReaderSpeechCoordinator {
         currentHighlightedOrdinal = ordinal
         let js = """
         (function() {
+            var old = document.querySelector('.speak-position');
+            if (old) old.classList.remove('speak-position');
             var verse = document.querySelector('[data-ordinal="\(ordinal)"]');
             if (!verse) return;
+            verse.classList.add('speak-position');
             verse.scrollIntoView({behavior: 'smooth', block: 'center'});
         })();
         """
@@ -686,14 +689,18 @@ final class BibleReaderSpeechCoordinator {
     }
 
     /**
-     Clears spoken-position tracking when playback stops.
+     Clears the spoken-position marker when playback stops.
 
-     - Parameter evaluateJavaScript: Retained for call-site symmetry; Android leaves no playback
-       styling in the document, so there is no DOM state to clean.
-     - Side effects: Resets the current tracked ordinal.
+     - Parameter evaluateJavaScript: Closure used to remove the marker class in the reader client.
+     - Side effects: Resets the current tracked ordinal and removes the marker class.
      */
     private func clearSpeakHighlightNow(evaluateJavaScript: @escaping (String) -> Void) {
         currentHighlightedOrdinal = nil
-        _ = evaluateJavaScript
+        evaluateJavaScript("""
+        (function() {
+            var v = document.querySelector('.speak-position');
+            if (v) v.classList.remove('speak-position');
+        })();
+        """)
     }
 }

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpeechCoordinator.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderSpeechCoordinator.swift
@@ -664,7 +664,12 @@ final class BibleReaderSpeechCoordinator {
         })
     }
 
-    /** Highlights one provider-owned Bible verse after the caller validates session generation. */
+    /**
+     Scrolls the reader to one provider-owned Bible verse after session-generation validation.
+
+     Android tracks the spoken position by scrolling only; it applies no per-verse highlight
+     styling during playback, so iOS must not either.
+     */
     private func highlightVerseNow(
         _ ordinal: Int,
         evaluateJavaScript: @escaping (String) -> Void
@@ -672,11 +677,8 @@ final class BibleReaderSpeechCoordinator {
         currentHighlightedOrdinal = ordinal
         let js = """
         (function() {
-            var oldVerse = document.querySelector('.speaking-verse');
-            if (oldVerse) oldVerse.classList.remove('speaking-verse');
             var verse = document.querySelector('[data-ordinal="\(ordinal)"]');
             if (!verse) return;
-            verse.classList.add('speaking-verse');
             verse.scrollIntoView({behavior: 'smooth', block: 'center'});
         })();
         """
@@ -684,28 +686,14 @@ final class BibleReaderSpeechCoordinator {
     }
 
     /**
-     Clears speech highlights from the reader web view.
+     Clears spoken-position tracking when playback stops.
 
-     - Parameter evaluateJavaScript: Closure used to run DOM cleanup in the reader web view.
-     - Side effects: Resets the current highlighted ordinal and removes the active word/verse
-       highlight DOM state. The caller owns main-actor and session-generation validation.
+     - Parameter evaluateJavaScript: Retained for call-site symmetry; Android leaves no playback
+       styling in the document, so there is no DOM state to clean.
+     - Side effects: Resets the current tracked ordinal.
      */
     private func clearSpeakHighlightNow(evaluateJavaScript: @escaping (String) -> Void) {
         currentHighlightedOrdinal = nil
-        let js = """
-        (function() {
-            var prev = document.getElementById('speaking-word');
-            if (prev) {
-                var p = prev.parentNode;
-                if (p) {
-                    p.replaceChild(document.createTextNode(prev.textContent || ''), prev);
-                    p.normalize();
-                }
-            }
-            var v = document.querySelector('.speaking-verse');
-            if (v) v.classList.remove('speaking-verse');
-        })();
-        """
-        evaluateJavaScript(js)
+        _ = evaluateJavaScript
     }
 }


### PR DESCRIPTION
## Summary

A quality pass on TTS playback, driven by maintainer feedback that narration was unusable. Four commits:

1. **Continuous narration (the core fix):** the OSIS speech parser flushed its text run at every element boundary. Strong's-tagged modules (KJV) wrap every word in `<w>` tags, so each word became its own utterance with a prosody gap, and punctuation stranded between elements was spoken by name ("comma", "full stop"). Inline markup is now transparent to accumulation — matching Android's `OsisToBibleSpeak` — producing one continuous utterance per verse with punctuation as prosody. Divine-name replacement folds into the run instead of splitting it; letter-less runs can never be spoken alone.
2. **Quality-aware voice selection:** selection previously took the first catalog voice for the language — the compact robot, since Apple lists compact voices first. It now prefers premium > enhanced > compact within Android's unchanged locale precedence, excludes novelty and unauthorized Personal voices, and tie-breaks by catalog order. Premium voices downloaded in system settings are picked up automatically. (Identifier-based selection also sidesteps the known iOS 26 language-lookup regression.)
3. **Playback presentation:** removed the iOS-invented blue verse wash and vestigial word-highlight machinery.
4. **Live speak-position marker:** restored a visible reading position per maintainer request, styled as Android's red speak-label bookmark (underline) so the speak visual identity matches across platforms; marks and centers the spoken verse on both SWORD and SQLite paths and clears on stop.

## Scope

- `Sources/BibleCore/Sources/BibleCore/Services/SpeakCommandBuilder.swift` — inline-transparent accumulation
- `Sources/BibleCore/Sources/BibleCore/Services/SpeechVoiceResolver.swift` — quality-aware selection
- `Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift`, `BibleReaderSpeechCoordinator.swift`, `BibleReaderSQLiteSpeechDispatchCoordinator.swift` — presentation and marker
- BibleCore speak/voice test suites — regressions

## Contract references

- Commits follow the locked commit-message standard.
- Android parity verified against `OsisToBibleSpeak` (inline accumulation), `BibleSpeakTextProvider.kt` (speak bookmark lifecycle), and `BookmarkEntities` (speak-label red). The live marker is an intentional, Android-styled presentation choice recorded here.

## Validation evidence

- All 15 CI checks green on the branch tip (including all four UI test shards).
- New regressions: a Strong's-tagged verse yields exactly one continuous text command; stranded punctuation is never spoken; premium beats enhanced beats compact with exclusions and deterministic ties. All 48 pre-existing speak-parity expectations pass unchanged.
- Manual: word-by-word pausing and punctuation narration confirmed fixed by the maintainer in simulator; premium-voice timbre verified in system settings on device (in-app device verification pending a TestFlight build, since local device signing is unavailable on this machine).

## Risks / follow-ups

- Voice timbre depends on the user downloading premium voices (Settings → Accessibility → Spoken Content → Voices); Apple offers no in-app download API.
- Follow-up candidates: per-language voice picker with active-voice readout and premium-download guidance; one-utterance lookahead enqueue to remove the small inter-verse delegate gap.
- Migrating TTS marker CSS into the bundled frontend stylesheet remains open from #383's follow-up notes.

## Issue closure

Closes: none