### PR TITLE
refactor(documents): remove unsafe publication bypasses

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/AI/AIGeneratedPageStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/AI/AIGeneratedPageStore.swift
@@ -126,7 +126,7 @@ public final class AIGeneratedPageStore {
       fileURLWithPath: SwordManager.defaultModulePath(),
       isDirectory: true
     ),
-    isDocumentInitialsUnavailable: @escaping (String) throws -> Bool = { _ in false }
+    isDocumentInitialsUnavailable: @escaping (String) throws -> Bool
   ) {
     modelContainer = modelContext.container
     self.markerEventCenter = markerEventCenter

--- a/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentLibraryStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentLibraryStore.swift
@@ -75,36 +75,6 @@ public final class MyDocumentLibraryStore {
     }
 
     /**
-     Applies the session delta atomically and marks it clean only after SwiftData saves.
-
-     - Parameters:
-       - session: Editable session to persist and advance to a clean baseline.
-       - reservedInitials: Legacy installed identities compared with Java-exact UTF-16 semantics.
-       - isInitialsUnavailable: Optional live JSword registry predicate rechecked for newly inserted
-         documents immediately before persistence.
-     - Side effects: Inserts, updates, and deletes only rows/fields changed from the session baseline,
-       saves once, then refreshes the session to include concurrent rows. The coordinator lease is
-       held from the fresh persisted-state fetch through validation, save, and rollback.
-     - Failure modes: Validation failures leave the context untouched; persistence failures roll the
-       context back and preserve the session's dirty baseline.
-     - Important: The global module-store coordinator is acquired before any registry callback may
-       take the recursive EPUB library lock, preserving the process-wide lock order.
-     */
-    public func save(
-        _ session: inout MyDocumentManagementSession,
-        reservedInitials: Set<String> = [],
-        isInitialsUnavailable: ((String) -> Bool)? = nil
-    ) throws {
-        try saveWithExclusiveRegistryAdmission(
-            &session,
-            reservedInitials: reservedInitials,
-            isInitialsUnavailable: { initials in
-                isInitialsUnavailable?(initials) ?? false
-            }
-        )
-    }
-
-    /**
      Applies a session delta after one throwing live-registry check under the global lease.
 
      Production identity publishers use this overload so corrupt or unreadable native/local
@@ -112,10 +82,10 @@ public final class MyDocumentLibraryStore {
 
      - Parameters:
        - session: Editable session to persist and advance only after successful publication.
-       - reservedInitials: Legacy installed identities compared with Java-exact semantics.
+       - reservedInitials: Caller-supplied installed identities compared with Java-exact semantics.
        - registryInitialsUnavailable: Fresh complete-registry lookup invoked for every new document
          while the canonical module-store lease is held.
-     - Side effects: Performs the same isolated SwiftData delta save as the compatibility overload.
+     - Side effects: Applies the isolated SwiftData delta, journals it, and advances the baseline.
      - Throws: Registry snapshot, validation, journaling, or persistence failures without committing
        any part of the candidate graph.
      */
@@ -155,8 +125,8 @@ public final class MyDocumentLibraryStore {
 
      - Parameters:
        - session: Editable management graph whose baseline-to-draft delta is published.
-       - reservedInitials: Legacy native/local identities compared with Java-exact semantics.
-       - isInitialsUnavailable: Optional complete-registry lookup evaluated for each inserted row.
+       - reservedInitials: Additional native/local identities compared with Java-exact semantics.
+       - isInitialsUnavailable: Required complete-registry lookup evaluated for each inserted row.
      - Side effects: Fetches a fresh isolated context, applies only the session delta, writes the
        remote-sync mutation journal and SwiftData graph once, then advances the saved baseline.
      - Throws: Validation and persistence failures after rolling back the isolated context; the

--- a/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentStore.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Database/MyDocumentStore.swift
@@ -131,8 +131,8 @@ public final class MyDocumentStore {
     /// SwiftData context supplied by the owning UI/app actor.
     private let modelContext: ModelContext
 
-    /// Synchronous save operation used by editable page writes.
-    private let savePageContentChanges: () throws -> Void
+    /// Synchronous journaled-save operation used by operation-isolated page writes.
+    private let savePageContentChanges: (ModelContext) throws -> Void
 
     /// App-owned channel that propagates committed AI marker changes to every open reader pane.
     private let aiDocMarkerEventCenter: MyDocumentAIDocMarkerEventCenter
@@ -152,10 +152,10 @@ public final class MyDocumentStore {
     ) {
         self.modelContext = modelContext
         self.aiDocMarkerEventCenter = aiDocMarkerEventCenter
-        self.savePageContentChanges = {
+        self.savePageContentChanges = { operationContext in
             try RemoteSyncMutationJournalService.savePendingGraphChanges(
                 for: .myDocuments,
-                modelContext: modelContext
+                modelContext: operationContext
             )
         }
     }
@@ -165,17 +165,18 @@ public final class MyDocumentStore {
 
      - Parameters:
        - modelContext: SwiftData context containing the My Documents graph.
-       - savePageContentChanges: Synchronous operation that persists pending page-content changes;
-         production callers use `ModelContext.save()` through the public initializer.
+       - savePageContentChanges: Synchronous operation that persists pending page-content changes
+         in the supplied operation-isolated context; the public initializer supplies the My
+         Documents remote-sync journal boundary.
        - aiDocMarkerEventCenter: Typed app event channel shared by open reader controllers.
      - Side effects: Stores references only; no fetch or save occurs during initialization.
      - Failure modes: Errors thrown by `savePageContentChanges` are handled by
        `savePageContent(bookInitials:pageId:content:title:)`.
-     - Important: The closure must obey the supplied context's actor/thread confinement.
+     - Important: The closure must obey the operation context's actor/thread confinement.
      */
     init(
         modelContext: ModelContext,
-        savePageContentChanges: @escaping () throws -> Void,
+        savePageContentChanges: @escaping (ModelContext) throws -> Void,
         aiDocMarkerEventCenter: MyDocumentAIDocMarkerEventCenter = .shared
     ) {
         self.modelContext = modelContext
@@ -184,9 +185,15 @@ public final class MyDocumentStore {
     }
 
     /**
-     Fetches one document by its stable bridge initials.
+     Fetches one persisted document by its stable bridge initials.
+
+     - Parameter initials: Exact Android My Documents identity.
+     - Returns: The first deterministic persisted match, or `nil` when none can be read.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
+     - Failure modes: Fetch failures fail closed as `nil`.
      */
     public func document(initials: String) -> MyDocument? {
+        let context = makeIsolatedContext()
         var descriptor = FetchDescriptor<MyDocument>(
             predicate: #Predicate { $0.initials == initials },
             sortBy: [
@@ -196,20 +203,21 @@ public final class MyDocumentStore {
             ]
         )
         descriptor.fetchLimit = 1
-        return try? modelContext.fetch(descriptor).first
+        return try? context.fetch(descriptor).first
     }
 
     /**
      Lists My Documents in Android registration order for global book identity resolution.
 
      - Returns: Persisted documents ordered by `orderNumber` with deterministic metadata tie-breakers.
-     - Side effects: Reads document rows from the supplied SwiftData context without saving.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
      - Throws: Re-throws SwiftData metadata fetch failures so callers fail the combined local
        registry closed instead of substituting an EPUB or another document.
      - Important: This method does not access page content. Registration consumers must resolve an
        owner before calling `page(bookInitials:pageKey:)` or another content API.
      */
     public func documentsInRegistrationOrder() throws -> [MyDocument] {
+        let context = makeIsolatedContext()
         let descriptor = FetchDescriptor<MyDocument>(
             sortBy: [
                 SortDescriptor(\.orderNumber),
@@ -218,7 +226,7 @@ public final class MyDocumentStore {
                 SortDescriptor(\.initials),
             ]
         )
-        return try modelContext.fetch(descriptor)
+        return try context.fetch(descriptor)
     }
 
     /**
@@ -230,12 +238,29 @@ public final class MyDocumentStore {
 
      - Parameter initials: Non-empty document initials; matching is case-sensitive and untrimmed.
      - Returns: The only document with the supplied initials.
-     - Side effects: Reads the supplied SwiftData context without saving or mutating models.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
      - Throws: `MyDocumentExactLookupError` for invalid input, no match, duplicate matches, or a
        SwiftData read failure.
-     - Important: The call inherits the supplied context's actor/thread confinement.
+     - Important: The call inherits the store's actor/thread confinement.
      */
     public func exactDocument(initials: String) throws -> MyDocument {
+        try exactDocument(initials: initials, in: makeIsolatedContext())
+    }
+
+    /**
+     Resolves one exact persisted document inside a caller-owned operation context.
+
+     - Parameters:
+       - initials: Non-empty byte-exact Android document identity.
+       - context: Clean isolated context shared with a subsequent exact page lookup.
+     - Returns: The only matching persisted document.
+     - Side effects: Reads SwiftData without saving or mutating rows.
+     - Throws: `MyDocumentExactLookupError` for invalid, missing, duplicate, or unreadable identity.
+     */
+    private func exactDocument(
+        initials: String,
+        in context: ModelContext
+    ) throws -> MyDocument {
         guard !initials.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MyDocumentExactLookupError.invalidDocumentInitials
         }
@@ -246,7 +271,7 @@ public final class MyDocumentStore {
 
         let matches: [MyDocument]
         do {
-            matches = try modelContext.fetch(descriptor)
+            matches = try context.fetch(descriptor)
         } catch {
             throw MyDocumentExactLookupError.documentReadFailed(initials: initials)
         }
@@ -260,9 +285,17 @@ public final class MyDocumentStore {
     }
 
     /**
-     Resolves one page by the Android-compatible document initials and page key.
+     Resolves one persisted page by Android-compatible document initials and page key.
+
+     - Parameters:
+       - bookInitials: Exact persisted parent identity.
+       - pageKey: Parent-scoped Android page key.
+     - Returns: The first display-ordered persisted match, or `nil` when none can be read.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
+     - Failure modes: Fetch failures fail closed as `nil`.
      */
     public func page(bookInitials: String, pageKey: String) -> MyDocumentPage? {
+        let context = makeIsolatedContext()
         var descriptor = FetchDescriptor<MyDocumentPage>(
             predicate: #Predicate {
                 $0.pageKey == pageKey && $0.document?.initials == bookInitials
@@ -275,7 +308,7 @@ public final class MyDocumentStore {
             ]
         )
         descriptor.fetchLimit = 1
-        return try? modelContext.fetch(descriptor).first
+        return try? context.fetch(descriptor).first
     }
 
     /**
@@ -289,13 +322,14 @@ public final class MyDocumentStore {
        - bookInitials: Non-empty exact parent document initials.
        - pageKey: Exact parent-scoped persisted page key; empty keys are looked up literally.
      - Returns: The only matching page.
-     - Side effects: Reads the supplied SwiftData context without saving or mutating models.
+     - Side effects: Opens one isolated read context; caller-staged graph changes are ignored.
      - Throws: `MyDocumentExactLookupError` for invalid/missing/duplicate document identity,
        missing/duplicate page identity, or a SwiftData read failure.
-     - Important: The call inherits the supplied context's actor/thread confinement.
+     - Important: Document and page uniqueness are evaluated in the same persisted snapshot.
      */
     public func exactPage(bookInitials: String, pageKey: String) throws -> MyDocumentPage {
-        let document = try exactDocument(initials: bookInitials)
+        let context = makeIsolatedContext()
+        let document = try exactDocument(initials: bookInitials, in: context)
         let documentID = document.id
         var descriptor = FetchDescriptor<MyDocumentPage>(
             predicate: #Predicate {
@@ -306,7 +340,7 @@ public final class MyDocumentStore {
 
         let matches: [MyDocumentPage]
         do {
-            matches = try modelContext.fetch(descriptor)
+            matches = try context.fetch(descriptor)
         } catch {
             throw MyDocumentExactLookupError.pageReadFailed(
                 bookInitials: bookInitials,
@@ -329,28 +363,41 @@ public final class MyDocumentStore {
     }
 
     /**
-     Resolves one page by its stable page identifier and parent document initials.
+     Resolves one persisted page by stable page identifier and parent document initials.
+
+     - Parameters:
+       - bookInitials: Exact persisted parent identity.
+       - pageId: Stable page UUID.
+     - Returns: The persisted matching page, or `nil` when none can be read.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
+     - Failure modes: Fetch failures fail closed as `nil`.
      */
     public func page(bookInitials: String, pageId: UUID) -> MyDocumentPage? {
+        let context = makeIsolatedContext()
         var descriptor = FetchDescriptor<MyDocumentPage>(
             predicate: #Predicate {
                 $0.id == pageId && $0.document?.initials == bookInitials
             }
         )
         descriptor.fetchLimit = 1
-        return try? modelContext.fetch(descriptor).first
+        return try? context.fetch(descriptor).first
     }
 
     /**
-     Resolves one page by its stable page identifier without requiring the
-     parent document initials.
+     Resolves one persisted page by stable identifier without requiring parent initials.
+
+     - Parameter pageId: Stable page UUID.
+     - Returns: The persisted matching page, or `nil` when none can be read.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
+     - Failure modes: Fetch failures fail closed as `nil`.
      */
     public func page(pageId: UUID) -> MyDocumentPage? {
+        let context = makeIsolatedContext()
         var descriptor = FetchDescriptor<MyDocumentPage>(
             predicate: #Predicate { $0.id == pageId }
         )
         descriptor.fetchLimit = 1
-        return try? modelContext.fetch(descriptor).first
+        return try? context.fetch(descriptor).first
     }
 
     /**
@@ -389,7 +436,8 @@ public final class MyDocumentStore {
          therefore uses Android's localized unknown-prompt fallback.
      - Returns: Deterministically ordered metadata matching `CurrentPageBase` and
        `AiDocMarkerInfo`.
-     - Side effects: Reads SwiftData only.
+     - Side effects: Reads metadata from the supplied page and opens an isolated context only for
+       marker inventory, so caller-staged marker rows are ignored.
      - Failure modes: Marker fetch failures degrade to an empty marker list; page metadata remains.
      */
     public func readerMetadata(
@@ -424,11 +472,12 @@ public final class MyDocumentStore {
        - bookInitials: Source document initials stored by `AiPageCacheEntry`.
        - pageKey: Exact source key stored by `AiPageCacheEntry`.
      - Returns: Deterministically ordered markers whose generated page and document still exist.
-     - Side effects: Reads SwiftData only.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
      - Failure modes: Fetch failures and dangling generated-page relationships return an empty or
        filtered marker list; no nearest-key or module-only fallback is attempted.
      */
     public func aiDocMarkers(bookInitials: String, pageKey: String) -> [MyDocumentAIDocMarker] {
+        let context = makeIsolatedContext()
         let sourceInitials = bookInitials
         let sourceKey = pageKey
         let descriptor = FetchDescriptor<AiPageCacheEntry>(
@@ -436,7 +485,7 @@ public final class MyDocumentStore {
                 $0.sourceBookInitials == sourceInitials && $0.sourceBookKey == sourceKey
             }
         )
-        let entries: [AiPageCacheEntry] = (try? modelContext.fetch(descriptor)) ?? []
+        let entries: [AiPageCacheEntry] = (try? context.fetch(descriptor)) ?? []
         return projectedAIDocMarkers(entries)
     }
 
@@ -445,13 +494,14 @@ public final class MyDocumentStore {
 
      - Parameter range: Inclusive KJVA range for the rendered Bible document.
      - Returns: Deterministically ordered generated-page markers with overlapping stored ranges.
-     - Side effects: Reads SwiftData only.
+     - Side effects: Opens an isolated read context; caller-staged graph changes are ignored.
      - Failure modes: Fetch failures, nil source ranges, and dangling page/document relationships are
        omitted; source initials and keys do not constrain Bible marker visibility.
      */
     public func aiDocMarkers(kjvaRange range: ClosedRange<Int>) -> [MyDocumentAIDocMarker] {
+        let context = makeIsolatedContext()
         let descriptor = FetchDescriptor<AiPageCacheEntry>()
-        let entries: [AiPageCacheEntry] = (try? modelContext.fetch(descriptor)) ?? []
+        let entries: [AiPageCacheEntry] = (try? context.fetch(descriptor)) ?? []
         return projectedAIDocMarkers(entries.filter { entry in
             guard let start = entry.kjvOrdinalStart,
                   let end = entry.kjvOrdinalEnd else {
@@ -541,14 +591,20 @@ public final class MyDocumentStore {
     }
 
     /**
-     Deletes one AI-generated My Documents page and its cascaded content/cache.
+     Deletes one persisted AI-generated My Documents page and its cascaded content/cache.
 
-     User-authored pages are refused so the Android action-menu gate stays
-     sourcePromptId-driven on iOS too.
+     - Parameter pageId: Stable page UUID from the Android-compatible reader action payload.
+     - Returns: The deleted page context or the exact fail-closed refusal reason.
+     - Side effects: Opens an operation-owned context, updates the parent timestamp, deletes the
+       page, commits the My Documents remote-sync journal, and posts one marker deletion event.
+       Pending changes in the caller-owned context are neither read nor saved.
+     - Failure modes: Missing and user-authored pages are refused; fetch or journaled-save failures
+       return `.pageNotFound` or `.saveFailed` without committing the operation context.
      */
     @discardableResult
     public func deleteAIPage(pageId: UUID) -> MyDocumentAIPageDeletionResult {
-        guard let page = page(pageId: pageId) else {
+        let operationContext = makeIsolatedContext()
+        guard let page = page(pageId: pageId, in: operationContext) else {
             return .pageNotFound
         }
 
@@ -561,19 +617,19 @@ public final class MyDocumentStore {
             document.updatedAt = now
         }
 
-        modelContext.delete(page)
+        operationContext.delete(page)
 
         do {
             try RemoteSyncMutationJournalService.savePendingGraphChanges(
                 for: .myDocuments,
-                modelContext: modelContext
+                modelContext: operationContext
             )
             aiDocMarkerEventCenter.post(
                 MyDocumentAIDocMarkersChangedEvent(deletedPageIDs: [context.pageId])
             )
             return .deleted(context)
         } catch {
-            modelContext.rollback()
+            operationContext.rollback()
             return .saveFailed
         }
     }
@@ -587,12 +643,12 @@ public final class MyDocumentStore {
        - content: Replacement raw page body.
        - title: Optional replacement page title; `nil` preserves the current title.
      - Returns: `true` when a matching page was found and saved.
-     - Side effects: Mutates the matching page, its parent document timestamp, and its content row,
-       then saves the supplied `ModelContext` synchronously.
-     - Failure modes: Returns `false` when the page cannot be resolved or persistence fails. A save
-       failure restores only the page graph fields changed by this call and removes any content row
-       this call inserted, leaving unrelated pending context changes intact.
-     - Important: The operation inherits the supplied context's actor/thread confinement.
+     - Side effects: Opens an operation-owned context, mutates the matching page, its parent document
+       timestamp, and its content row, commits the My Documents journal, and posts marker upserts.
+       Pending changes in the caller-owned context are neither read nor saved.
+     - Failure modes: Returns `false` when the persisted page cannot be resolved or the journaled
+       operation save fails; the operation context is rolled back without publishing marker changes.
+     - Important: The synchronous operation inherits the store's actor/thread confinement.
      */
     @discardableResult
     public func savePageContent(
@@ -601,17 +657,15 @@ public final class MyDocumentStore {
         content: String,
         title: String?
     ) -> Bool {
-        guard let page = page(bookInitials: bookInitials, pageId: pageId) else {
+        let operationContext = makeIsolatedContext()
+        guard let page = page(
+            bookInitials: bookInitials,
+            pageId: pageId,
+            in: operationContext
+        ) else {
             return false
         }
-
-        let originalTitle = page.title
-        let originalPageUpdatedAt = page.updatedAt
         let document = page.document
-        let originalDocumentUpdatedAt = document?.updatedAt
-        let originalPageContent = page.pageContent
-        let originalContent = originalPageContent?.content
-        var insertedPageContent: MyDocumentPageContent?
 
         let now = Date()
         if let title {
@@ -626,84 +680,73 @@ public final class MyDocumentStore {
             let pageContent = MyDocumentPageContent(pageId: page.id, content: content)
             pageContent.page = page
             page.pageContent = pageContent
-            modelContext.insert(pageContent)
-            insertedPageContent = pageContent
+            operationContext.insert(pageContent)
         }
 
         do {
-            try savePageContentChanges()
+            try savePageContentChanges(operationContext)
             postAIDocMarkerUpserts(for: [page])
             return true
         } catch {
-            page.title = originalTitle
-            page.updatedAt = originalPageUpdatedAt
-            if let document, let originalDocumentUpdatedAt {
-                document.updatedAt = originalDocumentUpdatedAt
-            }
-
-            if let originalPageContent, let originalContent {
-                originalPageContent.content = originalContent
-            } else if let insertedPageContent {
-                page.pageContent = nil
-                insertedPageContent.page = nil
-                modelContext.delete(insertedPageContent)
-            }
+            operationContext.rollback()
             return false
         }
     }
 
     /**
-     Inserts a My Documents graph and saves immediately.
+     Creates a clean context for one persisted read or mutation boundary.
 
-     - Parameter document: Detached graph whose exact initials must be absent from My Documents.
-     - Returns: `true` after the graph and sync journal save, otherwise `false` after rollback.
-     - Side effects: Inserts the graph, records pending remote-sync mutations, updates AI markers,
-       and saves through the journal service.
-     - Failure modes: Duplicate My Documents initials or any persistence error returns `false`.
-     - Important: This compatibility API has no production caller and does not participate in the
-       complete native/SQLite/EPUB/MyDocument admission lease. New application publishers must use
-       `MyDocumentLibraryStore` or another globally coordinated strict publication boundary.
+     - Returns: A non-autosaving context backed by the same persistent container as the read store.
+     - Side effects: Allocates one SwiftData context without fetching or saving rows.
+     - Failure modes: None; context construction is synchronous and nonthrowing.
      */
-    @discardableResult
-    public func insert(_ document: MyDocument) -> Bool {
-        guard !hasDocument(initials: document.initials, excluding: document.id) else {
-            return false
-        }
-        modelContext.insert(document)
-        do {
-            try RemoteSyncMutationJournalService.savePendingGraphChanges(
-                for: .myDocuments,
-                modelContext: modelContext
-            )
-            postAIDocMarkerUpserts(for: document.pages ?? [])
-            return true
-        } catch {
-            modelContext.rollback()
-            return false
-        }
+    private func makeIsolatedContext() -> ModelContext {
+        let context = ModelContext(modelContext.container)
+        context.autosaveEnabled = false
+        return context
     }
 
     /**
-     Saves pending My Documents changes with their remote-sync mutation journal.
+     Fetches one persisted page by stable identifier in an explicit operation context.
 
-     - Side Effects: Commits the graph and Android-compatible `LogEntry` rows atomically, then
-       publishes the complete current AI marker set so open readers replace changed marker values.
-     - Failure: Journal or persistence errors are swallowed and publish no event, preserving this
-       store's eager-save API without exposing uncommitted marker state.
+     - Parameters:
+       - pageId: Stable page UUID supplied by the reader action.
+       - context: Clean operation context that owns any subsequent delete.
+     - Returns: The first persisted matching page, or `nil` when no row can be read.
+     - Side effects: Reads SwiftData without saving or mutating rows.
+     - Failure modes: Fetch failures fail closed as `nil`.
      */
-    public func save() {
-        do {
-            try RemoteSyncMutationJournalService.savePendingGraphChanges(
-                for: .myDocuments,
-                modelContext: modelContext
-            )
-            let entries = (try? modelContext.fetch(FetchDescriptor<AiPageCacheEntry>())) ?? []
-            aiDocMarkerEventCenter.post(
-                MyDocumentAIDocMarkersChangedEvent(markers: projectedAIDocMarkers(entries))
-            )
-        } catch {
-            return
-        }
+    private func page(pageId: UUID, in context: ModelContext) -> MyDocumentPage? {
+        var descriptor = FetchDescriptor<MyDocumentPage>(
+            predicate: #Predicate { $0.id == pageId }
+        )
+        descriptor.fetchLimit = 1
+        return try? context.fetch(descriptor).first
+    }
+
+    /**
+     Fetches one persisted page by exact parent initials and stable identifier.
+
+     - Parameters:
+       - bookInitials: Byte-exact Android My Documents identity.
+       - pageId: Stable page UUID supplied by the editor payload.
+       - context: Clean operation context that owns any subsequent edit.
+     - Returns: The first persisted matching page, or `nil` when no row can be read.
+     - Side effects: Reads SwiftData without saving or mutating rows.
+     - Failure modes: Fetch failures fail closed as `nil`.
+     */
+    private func page(
+        bookInitials: String,
+        pageId: UUID,
+        in context: ModelContext
+    ) -> MyDocumentPage? {
+        var descriptor = FetchDescriptor<MyDocumentPage>(
+            predicate: #Predicate {
+                $0.id == pageId && $0.document?.initials == bookInitials
+            }
+        )
+        descriptor.fetchLimit = 1
+        return try? context.fetch(descriptor).first
     }
 
     /**
@@ -721,21 +764,4 @@ public final class MyDocumentStore {
         )
     }
 
-    /**
-     Checks whether another persisted My Documents row already owns the supplied bridge initials.
-
-     `MyDocument.initials` must stay unique for Android-compatible bridge resolution and remote
-     backup export, but CloudKit-backed SwiftData stores cannot use a store-level unique
-     constraint. This helper preserves the uniqueness contract at the app layer before new local
-     rows are inserted.
-     */
-    private func hasDocument(initials: String, excluding documentID: UUID) -> Bool {
-        var descriptor = FetchDescriptor<MyDocument>(
-            predicate: #Predicate {
-                $0.initials == initials && $0.id != documentID
-            }
-        )
-        descriptor.fetchLimit = 1
-        return ((try? modelContext.fetch(descriptor)) ?? []).isEmpty == false
-    }
 }

--- a/Sources/BibleCore/Sources/BibleCore/Formats/EpubAndroidModuleBackup.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Formats/EpubAndroidModuleBackup.swift
@@ -41,30 +41,6 @@ extension EpubReader {
     }
 
     /**
-     Installs one extracted Android `MODULE_BACKUP` EPUB directory into the default EPUB library.
-
-     The supplied URL must identify the exact `epub/<displayName>/` directory from Android's module
-     tree. Its final path component, rather than a temporary backup filename, owns the portable
-     `Epub-<sanitized displayName>` identity used by Android bookmarks and workspace state.
-
-     - Parameter epubDirectoryURL: Root containing `META-INF/container.xml`, the OPF/resources, and
-       optional Android optimization artifacts.
-     - Returns: Stable iOS library identifier used to reopen the published book.
-     - Side effects: Reads a security-scoped directory, stages a package and native index, and
-       atomically publishes one immutable generation in the app's Documents EPUB library.
-     - Throws: `EpubError` or file-system errors for unsafe, incomplete, corrupt, or mismatched trees.
-       A failure leaves any previously published generation selected and readable.
-     */
-    public static func installAndroidModuleBackup(epubDirectoryURL: URL) throws -> String {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let libraryRootURL = documents.appendingPathComponent("epub", isDirectory: true)
-        return try installAndroidModuleBackup(
-            epubDirectoryURL: epubDirectoryURL,
-            libraryRootURL: libraryRootURL
-        )
-    }
-
-    /**
      Installs one Android EPUB tree into an explicit isolated library root.
 
      Raw trees use the ordinary OPF/XHTML indexer. Optimized trees whose original spine documents

--- a/Sources/BibleCore/Sources/BibleCore/Formats/EpubReader.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Formats/EpubReader.swift
@@ -328,27 +328,6 @@ public final class EpubReader: @unchecked Sendable {
     }
 
     /**
-     Installs an EPUB into the default app library.
-
-     - Parameter epubURL: User-selected local or security-scoped EPUB URL.
-     - Returns: Stable local identifier used to reopen the package.
-     - Side effects: Reads the archive, writes a staged extraction/index, and atomically replaces a
-       prior current-generation pointer only after complete validation succeeds.
-     - Throws: `EpubError`, `ZipArchiveReaderError`, or file-system errors. A failure leaves any
-       previously installed package intact.
-     - Important: This compatibility entry point cannot inspect the app's SwiftData registry. App
-       import flows must use `install(epubURL:moduleStoreRootURL:admittingCandidateWith:)` so native,
-       SQLite, EPUB, and My Documents ownership is revalidated under the global publication lease.
-     */
-    public static func install(epubURL: URL) throws -> String {
-        try install(
-            epubURL: epubURL,
-            moduleStoreRootURL: defaultModuleStoreRootURL,
-            admittingCandidateWith: { _ in }
-        )
-    }
-
-    /**
      Installs an EPUB only after a lock-owned live-registry admission check succeeds.
 
      This overload is the production boundary for Android-compatible global book registration.
@@ -361,8 +340,8 @@ public final class EpubReader: @unchecked Sendable {
        - moduleStoreRootURL: SWORD root whose canonical mutation coordinator owns global ordering.
        - admission: Live complete-registry validator invoked with the typed EPUB identity.
      - Returns: Stable local identifier used to reopen the package.
-     - Side effects: On admission, performs the same staged extraction, indexing, and atomic
-       publication as `install(epubURL:)`; rejection leaves the candidate unpublished and unstaged.
+     - Side effects: On admission, performs staged extraction, indexing, and atomic publication;
+       rejection leaves the candidate unpublished and unstaged.
      - Throws: Propagates admission, EPUB validation, ZIP, indexing, and filesystem errors.
      - Important: Admission and all candidate file mutation execute under one library lock hold.
      */
@@ -410,7 +389,7 @@ public final class EpubReader: @unchecked Sendable {
     /**
      Deletes one installed EPUB's stable pointer from the default app library.
 
-     - Parameter identifier: Stable identifier returned by `install(epubURL:)`.
+     - Parameter identifier: Stable identifier returned by a successful EPUB installation.
      - Side effects: Prevents new opens immediately; immutable generations are removed after all
        readers holding them close.
      - Throws: File-system errors raised before the published EPUB identity can be removed. A failed

--- a/Sources/BibleCore/Tests/BibleCoreTests/AIGeneratedPageStoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AIGeneratedPageStoreTests.swift
@@ -27,7 +27,8 @@ final class AIGeneratedPageStoreTests: XCTestCase {
     let store = AIGeneratedPageStore(
       modelContext: context,
       markerEventCenter: center,
-      languageCodeProvider: { "en" }
+      languageCodeProvider: { "en" },
+      isDocumentInitialsUnavailable: { _ in false }
     )
     let promptID = UUID()
     let cacheContext = CacheableContext(
@@ -88,7 +89,10 @@ final class AIGeneratedPageStoreTests: XCTestCase {
    */
   func testCacheLookupMatchesAndroidStrictAndLooseQueries() throws {
     let container = try makeContainer()
-    let store = AIGeneratedPageStore(modelContext: ModelContext(container))
+    let store = AIGeneratedPageStore(
+      modelContext: ModelContext(container),
+      isDocumentInitialsUnavailable: { _ in false }
+    )
     let promptID = UUID()
     let strictPrompt = prompt(id: promptID, strict: true)
     let loosePrompt = prompt(id: promptID, strict: false)
@@ -162,7 +166,10 @@ final class AIGeneratedPageStoreTests: XCTestCase {
     setup.insert(first)
     try setup.save()
 
-    let store = AIGeneratedPageStore(modelContext: setup)
+    let store = AIGeneratedPageStore(
+      modelContext: setup,
+      isDocumentInitialsUnavailable: { _ in false }
+    )
     _ = try store.save(
       content: "Generated",
       title: "Generated",
@@ -354,7 +361,8 @@ final class AIGeneratedPageStoreTests: XCTestCase {
     let store = AIGeneratedPageStore(
       modelContext: ModelContext(container),
       markerEventCenter: center,
-      languageCodeProvider: { "en" }
+      languageCodeProvider: { "en" },
+      isDocumentInitialsUnavailable: { _ in false }
     )
     let promptID = UUID()
     let context = cacheContext(selectedText: "source")
@@ -415,7 +423,8 @@ final class AIGeneratedPageStoreTests: XCTestCase {
     let store = AIGeneratedPageStore(
       modelContext: ModelContext(container),
       markerEventCenter: center,
-      languageCodeProvider: { "en" }
+      languageCodeProvider: { "en" },
+      isDocumentInitialsUnavailable: { _ in false }
     )
     let promptID = UUID()
     let context = cacheContext(selectedText: "source")
@@ -477,7 +486,10 @@ final class AIGeneratedPageStoreTests: XCTestCase {
    */
   func testRegenerationValidationLeavesPersistedPagesUntouched() throws {
     let container = try makeContainer()
-    let store = AIGeneratedPageStore(modelContext: ModelContext(container))
+    let store = AIGeneratedPageStore(
+      modelContext: ModelContext(container),
+      isDocumentInitialsUnavailable: { _ in false }
+    )
     let promptID = UUID()
     let context = cacheContext(selectedText: "source")
     let source = try store.save(

--- a/Sources/BibleCore/Tests/BibleCoreTests/MyDocumentManagementTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/MyDocumentManagementTests.swift
@@ -5,7 +5,26 @@ import SwiftData
 import XCTest
 @testable import BibleCore
 
+@MainActor
 final class MyDocumentManagementTests: XCTestCase {
+    /**
+     Persists one management fixture while explicitly declaring that no external book owns it.
+
+     - Parameters:
+       - store: Production management store whose coordinator and strict save path are exercised.
+       - session: Test-owned draft advanced only after the save succeeds.
+     - Side effects: Commits the draft and its remote-sync journal to the test container.
+     - Failure modes: Propagates validation, coordinator, journal, and SwiftData failures.
+     - Important: This no-owner admission exists only in the test target; production must capture
+       the complete native, SQLite, EPUB, and My Documents registry.
+     */
+    private func saveFixture(
+        _ store: MyDocumentLibraryStore,
+        session: inout MyDocumentManagementSession
+    ) throws {
+        try store.save(&session, checkingInitialsWith: { _ in false })
+    }
+
     /**
      Verifies Cancel restores the complete pre-edit graph rather than leaking eager mutations.
 
@@ -198,12 +217,12 @@ final class MyDocumentManagementTests: XCTestCase {
         let store = MyDocumentLibraryStore(modelContext: ModelContext(container))
         var session = try store.loadSession()
         let priorID = try session.createDocument(name: "Original", initials: "PriorOwner")
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         _ = try session.createDocument(name: "Candidate", initials: "FutureOwner")
         try session.renameDocument(id: priorID, name: "FutureOwner")
 
-        XCTAssertThrowsError(try store.save(&session)) { error in
+        XCTAssertThrowsError(try saveFixture(store, session: &session)) { error in
             XCTAssertEqual(
                 error as? MyDocumentManagementError,
                 .duplicateInitials("FutureOwner")
@@ -251,7 +270,7 @@ final class MyDocumentManagementTests: XCTestCase {
             description: "Edited after restore"
         )
 
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let persisted = try store.loadSession().documents
         XCTAssertEqual(persisted.count, 2)
@@ -266,7 +285,7 @@ final class MyDocumentManagementTests: XCTestCase {
 
      - Setup: Creates and saves two documents whose initials are composed/decomposed UTF-16
        spellings of the same visible text, and separately supplies the composed spelling through
-       the legacy reservation set while creating the decomposed spelling.
+       the additional reservation set while creating the decomposed spelling.
      - Expected result: Android-distinct spellings coexist and persist, while a byte-for-byte UTF-16
        duplicate remains rejected.
      - Failure meaning: Swift `String`/`Set` canonical equivalence is still imposing a stricter
@@ -305,7 +324,7 @@ final class MyDocumentManagementTests: XCTestCase {
             )
         }
 
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let persisted = try store.loadSession().documents.map(\.initials)
         XCTAssertEqual(persisted.count, 2)
@@ -346,7 +365,7 @@ final class MyDocumentManagementTests: XCTestCase {
         let store = MyDocumentLibraryStore(modelContext: ModelContext(container))
         var session = try store.loadSession()
         try session.setDocumentDescription(id: document.id, description: "Unrelated edit")
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let persisted = try store.loadSession().documents
         let restored = try XCTUnwrap(persisted.first { $0.id == document.id })
@@ -422,7 +441,7 @@ final class MyDocumentManagementTests: XCTestCase {
         try session.movePages(documentID: firstID, fromOffsets: [1], toOffset: 0)
         session.moveDocuments(fromOffsets: [1], toOffset: 0)
 
-        try writeStore.save(&session)
+        try saveFixture(writeStore, session: &session)
         XCTAssertFalse(session.isDirty)
 
         let readContext = ModelContext(container)
@@ -446,7 +465,7 @@ final class MyDocumentManagementTests: XCTestCase {
         let initialStore = MyDocumentLibraryStore(modelContext: initialContext)
         var initialSession = try initialStore.loadSession()
         let documentID = try initialSession.createDocument(name: "Persisted")
-        try initialStore.save(&initialSession)
+        try saveFixture(initialStore, session: &initialSession)
 
         var draft = try initialStore.loadSession()
         try draft.renameDocument(id: documentID, name: "Unsaved")
@@ -473,7 +492,7 @@ final class MyDocumentManagementTests: XCTestCase {
         let store = MyDocumentLibraryStore(modelContext: sceneContext)
         var session = try store.loadSession()
         _ = try session.createDocument(name: "Managed")
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         sceneContext.rollback()
         let verificationContext = ModelContext(container)
@@ -507,7 +526,7 @@ final class MyDocumentManagementTests: XCTestCase {
             contentType: .markdown,
             content: "Updated"
         )
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let refreshedReaderStore = MyDocumentStore(modelContext: ModelContext(container))
         let payload = try XCTUnwrap(
@@ -568,7 +587,7 @@ final class MyDocumentManagementTests: XCTestCase {
             contentType: .markdown,
             content: "Updated"
         )
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let verificationContext = ModelContext(container)
         let cacheRows = try verificationContext.fetch(FetchDescriptor<AiPageCacheEntry>())
@@ -637,7 +656,7 @@ final class MyDocumentManagementTests: XCTestCase {
         try concurrentContext.save()
 
         try session.renameDocument(id: document.id, name: "Renamed Study")
-        try store.save(&session)
+        try saveFixture(store, session: &session)
 
         let verificationContext = ModelContext(container)
         let savedDocuments = try verificationContext.fetch(FetchDescriptor<MyDocument>())

--- a/Sources/BibleCore/Tests/BibleCoreTests/MyDocumentTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/MyDocumentTests.swift
@@ -41,7 +41,8 @@ final class MyDocumentStoreTests: XCTestCase {
         let container = try makeMyDocumentModelContainer()
         let context = ModelContext(container)
         let store = MyDocumentStore(modelContext: context)
-        store.insert(MyDocument(name: "My Document", initials: "MYDOC"))
+        context.insert(MyDocument(name: "My Document", initials: "MYDOC"))
+        try context.save()
 
         XCTAssertNil(store.rawContentPayload(bookInitials: "MYDOC", pageKey: "missing"))
         XCTAssertNil(store.rawContentPayload(bookInitials: "UNKNOWN", pageKey: "intro"))
@@ -185,10 +186,12 @@ final class MyDocumentStoreTests: XCTestCase {
         ))
 
         let payload = try XCTUnwrap(store.rawContentPayload(bookInitials: "MYDOC", pageKey: "intro"))
+        let committedPage = try XCTUnwrap(store.page(bookInitials: "MYDOC", pageId: pageId))
+        let committedDocument = try XCTUnwrap(store.document(initials: "MYDOC"))
         XCTAssertEqual(payload.content, "Edited **markdown**")
         XCTAssertEqual(payload.title, "Renamed")
-        XCTAssertGreaterThan(page.updatedAt, createdAt)
-        XCTAssertGreaterThan(document.updatedAt, createdAt)
+        XCTAssertGreaterThan(committedPage.updatedAt, createdAt)
+        XCTAssertGreaterThan(committedDocument.updatedAt, createdAt)
 
         XCTAssertTrue(store.savePageContent(
             bookInitials: "MYDOC",
@@ -239,7 +242,7 @@ final class MyDocumentStoreTests: XCTestCase {
         XCTAssertEqual(payload.contentType, "HTML")
         XCTAssertEqual(payload.content, "<p>Edited</p>")
         XCTAssertEqual(payload.title, "Intro")
-        XCTAssertNotNil(page.pageContent)
+        XCTAssertNotNil(store.page(bookInitials: "MYDOC", pageId: pageId)?.pageContent)
     }
 
     /**
@@ -326,7 +329,7 @@ final class MyDocumentStoreTests: XCTestCase {
 
             let store = MyDocumentStore(
                 modelContext: context,
-                savePageContentChanges: { throw ForcedMyDocumentSaveError() }
+                savePageContentChanges: { _ in throw ForcedMyDocumentSaveError() }
             )
 
             XCTAssertFalse(store.savePageContent(
@@ -507,6 +510,155 @@ final class MyDocumentStoreTests: XCTestCase {
         )
         XCTAssertTrue(try context.fetch(deletedContentDescriptor).isEmpty)
         XCTAssertTrue(try context.fetch(deletedCacheDescriptor).isEmpty)
+    }
+
+    /**
+     Verifies page edits and deletions cannot publish an unrelated staged My Documents identity.
+
+     - Setup: Persists two admitted AI pages, stages a third unsaved document in the store's read
+       context, then invokes the production page edit and delete APIs.
+     - Expected result: Both intended page mutations commit through operation-owned contexts while a
+       fresh context cannot observe the staged document identity.
+     - Failure meaning: A reader page action can again hitchhike an unadmitted My Documents graph
+       through the remote-sync journal boundary.
+     - Side effects: Writes only to an in-memory SwiftData container.
+     */
+    func testPageMutationsDoNotPublishUnrelatedPendingDocument() throws {
+        let container = try makeMyDocumentModelContainer()
+        let context = ModelContext(container)
+        let editablePageID = try XCTUnwrap(
+            UUID(uuidString: "10101010-1010-1010-1010-101010101010")
+        )
+        let deletedPageID = try XCTUnwrap(
+            UUID(uuidString: "20202020-2020-2020-2020-202020202020")
+        )
+        let promptID = try XCTUnwrap(
+            UUID(uuidString: "30303030-3030-3030-3030-303030303030")
+        )
+        let document = MyDocument(name: "Admitted", initials: "ADMITTED")
+        let editablePage = MyDocumentPage(
+            id: editablePageID,
+            title: "Before",
+            pageKey: "edit",
+            sourcePromptId: promptID
+        )
+        let editableContent = MyDocumentPageContent(
+            pageId: editablePageID,
+            content: "Before content"
+        )
+        let deletedPage = MyDocumentPage(
+            id: deletedPageID,
+            title: "Delete",
+            pageKey: "delete",
+            sourcePromptId: promptID
+        )
+        editablePage.document = document
+        editablePage.pageContent = editableContent
+        editableContent.page = editablePage
+        deletedPage.document = document
+        document.pages = [editablePage, deletedPage]
+        context.insert(document)
+        try context.save()
+
+        let staged = MyDocument(name: "Unadmitted", initials: "COLLISION")
+        context.insert(staged)
+        let store = MyDocumentStore(modelContext: context)
+
+        XCTAssertTrue(store.savePageContent(
+            bookInitials: "ADMITTED",
+            pageId: editablePageID,
+            content: "After content",
+            title: "After"
+        ))
+        guard case .deleted = store.deleteAIPage(pageId: deletedPageID) else {
+            return XCTFail("Expected the persisted AI page deletion to succeed")
+        }
+        XCTAssertTrue(context.hasChanges)
+
+        let verificationContext = ModelContext(container)
+        let verificationStore = MyDocumentStore(modelContext: verificationContext)
+        let updated = try XCTUnwrap(verificationStore.page(
+            bookInitials: "ADMITTED",
+            pageId: editablePageID
+        ))
+        XCTAssertEqual(updated.title, "After")
+        XCTAssertEqual(updated.pageContent?.content, "After content")
+        XCTAssertNil(verificationStore.page(pageId: deletedPageID))
+        XCTAssertNil(verificationStore.document(initials: "COLLISION"))
+    }
+
+    /**
+     Verifies registration, exact lookup, and marker inventories expose only committed rows.
+
+     - Setup: Stages an unsaved document, generated page, and source marker in the store's retained
+       caller context.
+     - Expected result: Registration omits the document, exact document/page lookup reports it
+       missing, and marker inventories remain empty until save; every API then exposes the commit.
+     - Failure meaning: A pane-local draft can enter Android BookSet ownership or reader markers
+       before strict registry admission publishes it.
+     - Side effects: Stages, then commits, rows in an in-memory SwiftData container.
+     */
+    func testPersistedOwnerAndMarkerReadsIgnoreCallerStagedGraph() throws {
+        let container = try makeMyDocumentModelContainer()
+        let context = ModelContext(container)
+        let store = MyDocumentStore(modelContext: context)
+        let pageID = try XCTUnwrap(
+            UUID(uuidString: "40404040-4040-4040-4040-404040404040")
+        )
+        let promptID = try XCTUnwrap(
+            UUID(uuidString: "50505050-5050-5050-5050-505050505050")
+        )
+        let document = MyDocument(name: "Draft", initials: "DRAFT")
+        let page = MyDocumentPage(
+            id: pageID,
+            title: "Draft Page",
+            pageKey: "draft",
+            sourcePromptId: promptID
+        )
+        let marker = AiPageCacheEntry(
+            pageId: pageID,
+            sourcePromptId: promptID,
+            kjvOrdinalStart: 1,
+            kjvOrdinalEnd: 2,
+            sourceBookInitials: "KJV",
+            sourceBookKey: "Gen.1.1"
+        )
+        page.document = document
+        marker.page = page
+        page.aiPageCacheEntries = [marker]
+        document.pages = [page]
+        context.insert(document)
+        context.insert(page)
+        context.insert(marker)
+
+        XCTAssertTrue(try store.documentsInRegistrationOrder().isEmpty)
+        XCTAssertThrowsError(try store.exactDocument(initials: "DRAFT")) { error in
+            XCTAssertEqual(
+                error as? MyDocumentExactLookupError,
+                .documentNotFound(initials: "DRAFT")
+            )
+        }
+        XCTAssertThrowsError(try store.exactPage(bookInitials: "DRAFT", pageKey: "draft"))
+        XCTAssertTrue(store.aiDocMarkers(
+            bookInitials: "KJV",
+            pageKey: "Gen.1.1"
+        ).isEmpty)
+        XCTAssertTrue(store.aiDocMarkers(kjvaRange: 1...2).isEmpty)
+        XCTAssertTrue(context.hasChanges)
+
+        try context.save()
+
+        XCTAssertEqual(try store.documentsInRegistrationOrder().map(\.initials), ["DRAFT"])
+        XCTAssertEqual(try store.exactDocument(initials: "DRAFT").id, document.id)
+        XCTAssertEqual(
+            try store.exactPage(bookInitials: "DRAFT", pageKey: "draft").id,
+            pageID
+        )
+        XCTAssertEqual(
+            store.aiDocMarkers(bookInitials: "KJV", pageKey: "Gen.1.1").map(\.pageId),
+            [pageID]
+        )
+        XCTAssertEqual(store.aiDocMarkers(kjvaRange: 1...2).map(\.pageId), [pageID])
     }
 
     private func makeMyDocumentModelContainer() throws -> ModelContainer {

--- a/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncMyDocumentRestoreTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/RemoteSyncMyDocumentRestoreTests.swift
@@ -19,28 +19,6 @@ private let myDocumentRestoreSQLiteTransient = unsafeBitCast(-1, to: sqlite3_des
  per test; failures indicate Android backup parity or local My Documents data-safety drift.
  */
 final class RemoteSyncMyDocumentRestoreTests: XCTestCase {
-    /**
-     Verifies local My Documents insertion keeps Android bridge initials unique after
-     removing SwiftData's CloudKit-incompatible unique constraint.
-
-     The bridge resolves documents by initials, so allowing two local documents with the same
-     initials would make reader actions nondeterministic and later Android-compatible exports
-     fail against their unique initials index. The store should reject the duplicate before it
-     reaches SwiftData persistence.
-     */
-    func testMyDocumentStoreRejectsDuplicateInitials() throws {
-        let container = try makeModelContainer()
-        let modelContext = ModelContext(container)
-        let store = MyDocumentStore(modelContext: modelContext)
-
-        XCTAssertTrue(store.insert(MyDocument(name: "First", initials: "MYDOC")))
-        XCTAssertFalse(store.insert(MyDocument(name: "Duplicate", initials: "MYDOC")))
-
-        let documents = try modelContext.fetch(FetchDescriptor<MyDocument>())
-        XCTAssertEqual(documents.map(\.name), ["First"])
-        XCTAssertEqual(store.document(initials: "MYDOC")?.name, "First")
-    }
-
     func testRemoteSyncMyDocumentRestoreReplacesLocalGraphAndPreservesAIContext() throws {
         let container = try makeModelContainer()
         let modelContext = ModelContext(container)

--- a/Sources/BibleUI/Sources/BibleUI/AI/AgentDomainAdapter.swift
+++ b/Sources/BibleUI/Sources/BibleUI/AI/AgentDomainAdapter.swift
@@ -127,7 +127,7 @@ public final class BibleUIAgentDomainAdapter: BibleUIAgentToolExecuting {
     let documentAccessPolicy: any BibleUIAgentDocumentAccessPolicy
     let windowDocumentRouter: any BibleUIAgentWindowDocumentRouting
     /// Throwing live-registry admission check used before Agent-created My Documents publish.
-    let strictMyDocumentInitialsUnavailable: ((String) throws -> Bool)?
+    let strictMyDocumentInitialsUnavailable: (String) throws -> Bool
 
     /**
      Creates production routing over existing app stores and runtime services.
@@ -143,8 +143,8 @@ public final class BibleUIAgentDomainAdapter: BibleUIAgentToolExecuting {
        - windowManager: Active workspace/window state owner.
        - documentAccessPolicy: Global AI document exclusion policy.
        - windowDocumentRouter: App-owned live pane navigation operation.
-       - strictMyDocumentInitialsUnavailable: Optional production-only fresh throwing registry
-         lookup. Isolated adapters may omit it and retain their injected legacy inventory fixtures.
+       - strictMyDocumentInitialsUnavailable: Required fresh throwing registry lookup. Tests that
+         intentionally have no installed owners must inject an explicit no-owner closure.
      - Side effects: None; dependencies retain their existing ownership.
      - Failure modes: None.
      */
@@ -159,7 +159,7 @@ public final class BibleUIAgentDomainAdapter: BibleUIAgentToolExecuting {
         windowManager: WindowManager,
         documentAccessPolicy: any BibleUIAgentDocumentAccessPolicy,
         windowDocumentRouter: any BibleUIAgentWindowDocumentRouting,
-        strictMyDocumentInitialsUnavailable: ((String) throws -> Bool)? = nil
+        strictMyDocumentInitialsUnavailable: @escaping (String) throws -> Bool
     ) {
         self.swordManager = swordManager
         self.sqliteLibrary = sqliteLibrary

--- a/Sources/BibleUI/Sources/BibleUI/AI/AgentMyDocumentAccess.swift
+++ b/Sources/BibleUI/Sources/BibleUI/AI/AgentMyDocumentAccess.swift
@@ -374,23 +374,13 @@ extension BibleUIAgentDomainAdapter {
 
      - Parameter initials: Explicit or generated My Documents candidate initials.
      - Returns: True when installed, EPUB, or existing My Documents registration owns the token;
-       metadata failures also return true so creation and persistence fail closed.
+       draft-time callers map metadata failures to true so candidate generation fails closed.
      - Side effects: Reads current installed/local metadata without opening document content.
-     - Failure modes: None exposed; persistence failures conservatively reserve the candidate.
+     - Failure modes: Propagates incomplete-registry reads so commit-time persistence cannot publish
+       an identity without authoritative ownership proof.
      */
     private func isDocumentInitialsUnavailable(_ initials: String) throws -> Bool {
-        if let strictMyDocumentInitialsUnavailable {
-            return try strictMyDocumentInitialsUnavailable(initials)
-        }
-        guard let session = try? myDocumentLibraryStore.loadSession() else { return true }
-        let registrations = localGeneralBookRegistrations(
-            documents: session.documents,
-            epubs: EpubReader.installedEpubs()
-        )
-        return readableInstalledModuleResolver().hasRegisteredDocument(
-            named: initials,
-            localRegistrations: registrations
-        )
+        try strictMyDocumentInitialsUnavailable(initials)
     }
 
     /** Maps throwing production registry preflight to conservative draft-time availability. */

--- a/Sources/BibleUI/Sources/BibleUI/MyDocuments/MyDocumentsListView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/MyDocuments/MyDocumentsListView.swift
@@ -60,7 +60,7 @@ public struct MyDocumentsListView: View {
      Creates a standalone My Documents route using the application palette.
 
      - Parameters:
-       - reservedInitials: Legacy installed identities compared with Java-exact UTF-16 semantics.
+       - reservedInitials: Additional installed identities compared with Java-exact UTF-16 semantics.
        - isInitialsUnavailable: Live Android registry lookup for full-name/case-tier collisions.
        - moduleStoreRootURL: Canonical SWORD root used by the live lookup and global mutation gate.
        - onDismiss: Optional owner callback used when the manager is a reader destination.
@@ -69,7 +69,7 @@ public struct MyDocumentsListView: View {
      */
     public init(
         reservedInitials: Set<String> = [],
-        isInitialsUnavailable: @escaping (String) throws -> Bool = { _ in false },
+        isInitialsUnavailable: @escaping (String) throws -> Bool,
         moduleStoreRootURL: URL = URL(
             fileURLWithPath: SwordManager.defaultModulePath(),
             isDirectory: true

--- a/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift
@@ -112,7 +112,7 @@ private enum ExternalDocumentRegistryAdmissionError: LocalizedError {
  - installer errors are converted to `.failed` so callers can show the existing localized feedback
  */
 public struct ExternalDocumentImportService: Sendable {
-    /// Legacy closure used to install SWORD ZIP modules; retained for source-compatible tests.
+    /// Isolated SWORD ZIP installer injected by focused routing tests.
     public typealias ModuleInstaller = @Sendable (URL) throws -> String
 
     /// Closure used to inspect SWORD ZIP layout, storage demand, and destination conflicts.
@@ -128,9 +128,6 @@ public struct ExternalDocumentImportService: Sendable {
     /// Closure used to install EPUB archives; injectable for focused tests.
     public typealias EpubInstaller = @Sendable (URL) throws -> String
 
-    /// Legacy initials-only predicate retained for source-compatible focused installer tests.
-    public typealias EpubInitialsUnavailable = @Sendable (String) -> Bool
-
     /**
      Throwing live admission that can distinguish an exact EPUB update from another owner.
 
@@ -143,7 +140,7 @@ public struct ExternalDocumentImportService: Sendable {
     ) throws -> Void
 
     /**
-     Installs one EPUB using the resolved legacy or lock-aware production path.
+     Installs one EPUB using the injected test path or lock-aware production path.
 
      - Parameters:
        - url: Candidate archive URL.
@@ -169,7 +166,7 @@ public struct ExternalDocumentImportService: Sendable {
     ) throws -> String
 
     /**
-     Legacy Android backup installer retained for source-compatible focused tests.
+     Android backup installer injected by focused routing tests.
 
      The closure receives an archive URL and returns a restore report or throws. It has no overwrite
      policy input, so production callers must leave this injection `nil` and use the policy-aware
@@ -225,8 +222,8 @@ public struct ExternalDocumentImportService: Sendable {
      EPUB installer that evaluates complete-registry admission at its mutation boundary.
 
      The production implementation delegates to `EpubReader`'s library-lock-owned admission API.
-     A legacy injected `EpubInstaller` is wrapped with a synchronous precheck immediately before
-     invocation; that compatibility path does not promise cross-call serialization.
+     An injected test `EpubInstaller` is wrapped with a synchronous precheck immediately before
+     invocation; the injected installer owns any cross-call serialization required by its fixture.
      */
     private let epubInstaller: RegistryAdmittingEpubInstaller
 
@@ -255,27 +252,24 @@ public struct ExternalDocumentImportService: Sendable {
       Creates a document import service.
 
       - Parameters:
-          - moduleInstaller: Optional source-compatible installer used by focused tests. Production
+          - moduleInstaller: Optional isolated installer used by focused tests. Production
               callers leave it `nil` so policy-aware installation remains authoritative.
           - moduleInspector: Read-only inspector for ZIP-backed SWORD modules.
           - moduleInstallerWithPolicy: Optional policy-aware installer. The default mutates the
               app's SWORD module storage, reports durable phases, and returns the module identifier.
-          - epubInstaller: Optional legacy installer for isolated routing tests. When supplied, the
-              resolved typed admission runs synchronously immediately before this closure, but the
-              injected closure owns serialization. This compatibility boundary cannot make a
-              caller-provided installer atomic across concurrent invocations.
-          - epubCandidateAdmission: Preferred throwing complete-registry validator. Production
+          - epubInstaller: Optional installer for isolated routing tests. When supplied, typed
+              admission runs synchronously immediately before this closure, while the injected
+              closure owns serialization.
+          - epubCandidateAdmission: Throwing complete-registry validator. Production
               callers use `androidRegistryAware(modelContext:swordManager:)`, which rebuilds live
               ownership on every invocation and permits only an exact same-identifier EPUB update.
-          - epubInitialsUnavailable: Legacy initials-only validator wrapped as a typed rejecting
-              admission when `epubCandidateAdmission` is absent.
           - moduleStoreRootURL: Canonical SWORD root whose global coordinator serializes the
               production EPUB admission, staging, pointer publication, and rollback boundary.
           - fontInstaller: Installer for TTF font files. The default copies the font into the SWORD
               `ttf` directory and writes Android-style addon metadata.
           - androidFamilyFileInstaller: Installer for image, prompt, MyBible, MySword, and e-Sword
               files. The default streams one file through the Android backup transaction.
-          - androidModuleBackupInstaller: Optional source-compatible Android backup installer used
+          - androidModuleBackupInstaller: Optional isolated Android backup installer used
               by focused tests. Production callers leave it `nil` so overwrite policy remains
               authoritative.
           - androidModuleBackupInspector: Read-only Android backup inspector that validates every
@@ -289,15 +283,14 @@ public struct ExternalDocumentImportService: Sendable {
       - Side effects: none during initialization; installer closures perform file I/O when invoked.
       - Failure modes: This initializer cannot fail.
       */
-    public init(
+    init(
         moduleInstaller: ModuleInstaller? = nil,
         moduleInspector: @escaping ModuleInspector = { url in
             try ModuleRepository().inspectLocalSwordZip(at: url)
         },
         moduleInstallerWithPolicy: ModuleInstallerWithPolicy? = nil,
         epubInstaller: EpubInstaller? = nil,
-        epubCandidateAdmission: EpubCandidateAdmission? = nil,
-        epubInitialsUnavailable: @escaping EpubInitialsUnavailable = { _ in false },
+        epubCandidateAdmission: @escaping EpubCandidateAdmission,
         moduleStoreRootURL: URL = URL(
             fileURLWithPath: SwordManager.defaultModulePath(),
             isDirectory: true
@@ -330,11 +323,6 @@ public struct ExternalDocumentImportService: Sendable {
                 )
             }
         }
-        let resolvedEpubAdmission: EpubCandidateAdmission = epubCandidateAdmission ?? { candidate in
-            guard !epubInitialsUnavailable(candidate.initials) else {
-                throw ExternalDocumentRegistryAdmissionError.epubIdentityOwned(candidate.initials)
-            }
-        }
         if let epubInstaller {
             self.epubInstaller = { url, admission in
                 try admission(EpubReader.installCandidate(forEpubURL: url))
@@ -350,7 +338,7 @@ public struct ExternalDocumentImportService: Sendable {
                 return EpubReader(identifier: identifier)?.title ?? identifier
             }
         }
-        self.epubCandidateAdmission = resolvedEpubAdmission
+        self.epubCandidateAdmission = epubCandidateAdmission
         self.fontInstaller = fontInstaller
         self.androidFamilyFileInstaller = androidFamilyFileInstaller ?? { url, fileName, family, policy in
             let report = try AndroidModuleBackupService().restoreExternalFile(
@@ -734,7 +722,7 @@ public struct ExternalDocumentImportService: Sendable {
       - Side effects: Mutates local EPUB extracted storage and index files through `EpubReader`.
       - Failure modes: A complete-registry identity owner rejects the candidate before production
           staging; EPUB validation, ZIP parsing, index creation, and file-I/O errors are captured in
-          the returned failure result. Legacy injected installers receive a pre-invocation check but
+          the returned failure result. Injected test installers receive a pre-invocation check but
           retain responsibility for cross-call serialization.
       */
     private func installEpub(at url: URL) -> ExternalDocumentImportResult {

--- a/Sources/BibleUI/Tests/BibleUITests/AgentMyDocumentIdentityTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/AgentMyDocumentIdentityTests.swift
@@ -118,6 +118,37 @@ final class AgentMyDocumentIdentityTests: BibleUISwordFixtureTestCase {
         XCTAssertFalse(ordinaryIDWithAIInitials)
     }
 
+    /**
+     Verifies Agent document creation fails closed when the complete registry cannot be read.
+
+     - Setup: Builds the production adapter with an injected throwing registry proof and an empty My
+     Documents store, then requests one page whose default destination would create AI Documents.
+     - Expected: Creation throws and a fresh context contains no document graph.
+     - Failure meaning: The adapter has regained its former omission-tolerant inventory fallback and
+       can publish an identity without the Android BookSet ownership proof.
+     - Side effects: Allocates isolated in-memory stores and one temporary search database.
+     */
+    func testDocumentCreationRequiresSuccessfulStrictRegistryProof() throws {
+        struct RegistryUnavailable: Error {}
+
+        let container = try makeMyDocumentModelContainer()
+        let context = ModelContext(container)
+        let adapter = try makeAdapter(
+            myDocumentContext: context,
+            strictMyDocumentInitialsUnavailable: { _ in throw RegistryUnavailable() }
+        )
+
+        XCTAssertThrowsError(try adapter.addMyDocumentPage(
+            documentID: nil,
+            initials: nil,
+            title: "Rejected",
+            content: "Rejected content",
+            contentType: .markdown,
+            context: AgentExecutionContext(promptId: UUID())
+        ))
+        XCTAssertTrue(try ModelContext(container).fetch(FetchDescriptor<MyDocument>()).isEmpty)
+    }
+
     /** Inserts one exact document/page/content graph without generation-time normalization. */
     @discardableResult
     private func insertDocument(
@@ -139,8 +170,21 @@ final class AgentMyDocumentIdentityTests: BibleUISwordFixtureTestCase {
         return document
     }
 
-    /** Builds the real adapter around the supplied My Documents persistence container. */
-    private func makeAdapter(myDocumentContext: ModelContext) throws -> BibleUIAgentDomainAdapter {
+    /**
+     Builds the real adapter around a supplied My Documents container and explicit registry proof.
+
+     - Parameters:
+       - myDocumentContext: Isolated persistence context used by the adapter stores.
+       - strictMyDocumentInitialsUnavailable: Complete-registry lookup; the default explicitly
+         models a test fixture with no installed owner.
+     - Returns: A production adapter with transient supporting stores.
+     - Side effects: Allocates in-memory stores and registers temporary search-database cleanup.
+     - Throws: SWORD fixture, SwiftData, or search service construction failures.
+     */
+    private func makeAdapter(
+        myDocumentContext: ModelContext,
+        strictMyDocumentInitialsUnavailable: @escaping (String) throws -> Bool = { _ in false }
+    ) throws -> BibleUIAgentDomainAdapter {
         let manager = try XCTUnwrap(SwordManager(modulePath: makeTemporarySwordFixturePath()))
         let bookmarkContext = ModelContext(try makeBookmarkListModelContainer())
         let workspaceContext = ModelContext(try makeWorkspaceModelContainer())
@@ -163,7 +207,8 @@ final class AgentMyDocumentIdentityTests: BibleUISwordFixtureTestCase {
                 workspaceStore: WorkspaceStore(modelContext: workspaceContext)
             ),
             documentAccessPolicy: AgentMyDocumentAllowAllPolicy(),
-            windowDocumentRouter: AgentMyDocumentUnusedWindowRouter()
+            windowDocumentRouter: AgentMyDocumentUnusedWindowRouter(),
+            strictMyDocumentInitialsUnavailable: strictMyDocumentInitialsUnavailable
         )
     }
 

--- a/Sources/BibleUI/Tests/BibleUITests/AgentSearchSourceIdentityTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/AgentSearchSourceIdentityTests.swift
@@ -265,7 +265,8 @@ final class AgentSearchSourceIdentityTests: BibleUISwordFixtureTestCase {
                 workspaceStore: WorkspaceStore(modelContext: workspaceContext)
             ),
             documentAccessPolicy: AllowEveryAgentDocumentPolicy(),
-            windowDocumentRouter: UnusedAgentWindowDocumentRouter()
+            windowDocumentRouter: UnusedAgentWindowDocumentRouter(),
+            strictMyDocumentInitialsUnavailable: { _ in false }
         )
     }
 

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUIEpubTestSupport.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUIEpubTestSupport.swift
@@ -1,0 +1,28 @@
+// BibleUIEpubTestSupport.swift -- low-level EPUB fixtures isolated from production publication APIs
+
+import Foundation
+import SwordKit
+@testable import BibleCore
+
+/**
+ Installs one EPUB fixture into the app-default test library without constructing UI import state.
+
+ - Parameter epubURL: Test-owned archive URL that remains readable for the duration of installation.
+ - Returns: Stable fixture identifier used by `EpubReader` open and cleanup calls.
+ - Side effects: Acquires the production module-store mutation coordinator, writes one staged EPUB
+   generation into the simulator test container, and publishes its current-generation pointer.
+ - Throws: Propagates archive, validation, indexing, coordinator, and filesystem failures.
+ - Important: This helper exists only in the `BibleUITests` target. It intentionally supplies a
+   no-op registry validator so controller tests can seed backend state without restoring the removed
+   production bypass. Every caller must delete the returned identifier or reset its app container.
+ */
+func installDefaultLibraryEpubFixture(epubURL: URL) throws -> String {
+    try EpubReader.install(
+        epubURL: epubURL,
+        moduleStoreRootURL: URL(
+            fileURLWithPath: SwordManager.defaultModulePath(),
+            isDirectory: true
+        ),
+        admittingCandidateWith: { _ in }
+    )
+}

--- a/Sources/BibleUI/Tests/BibleUITests/EpubReaderControllerParityTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/EpubReaderControllerParityTests.swift
@@ -32,7 +32,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testBookmarkInventoryAdmitsEpubBeforeCollidingMyDocument() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let epubContent = try XCTUnwrap(reader.content(forKey: "1"))
@@ -88,7 +88,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testGenericSpeechAdmitsEpubBeforeCollidingMyDocument() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
 
@@ -134,7 +134,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testDeferredEpubSpeechSynchronizationRejectsNewOwnerWithoutReadOrMutation() async throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let modulePath = try makeTemporarySwordFixturePath()
@@ -218,7 +218,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testDeferredEpubSpeechSynchronizationKeepsUnownedLocalSuccess() async throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let manager = try XCTUnwrap(SwordManager(modulePath: makeTemporarySwordFixturePath()))
@@ -276,7 +276,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testRestoreUsesGeneralBookIdentityAndRendersPersistedNumericKey() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let expected = try XCTUnwrap(reader.content(forKey: "2"))
@@ -330,7 +330,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testRebuiltEpubGenerationAdoptionPreservesKeyAndRejectsDifferentDocument() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let controller = BibleReaderController(bridge: BibleBridge(), initializesSword: false)
         let window = makeWindow(category: DocumentCategory.bible.pageManagerKey)
@@ -355,7 +355,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
         defer {
             try? FileManager.default.removeItem(at: foreignArchiveURL.deletingLastPathComponent())
         }
-        let foreignIdentifier = try EpubReader.install(epubURL: foreignArchiveURL)
+        let foreignIdentifier = try installDefaultLibraryEpubFixture(epubURL: foreignArchiveURL)
         defer { try? EpubReader.delete(identifier: foreignIdentifier) }
         let foreignReader = try XCTUnwrap(EpubReader(identifier: foreignIdentifier))
 
@@ -378,7 +378,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testRestoreMigratesLegacyEpubHrefIntoGeneralBookState() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let controller = BibleReaderController(bridge: BibleBridge(), initializesSword: false)
@@ -414,7 +414,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testInternalLinkRequiresMatchingInitialsAndNavigatesToIndexedAnchor() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let (bridge, recordedScripts) = makeRecordingBridge()
@@ -467,7 +467,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testInternalLinkRejectsStaleEpubAfterNativeOwnerAppearsBeforeReadOrMutation() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let modulePath = try makeTemporarySwordFixturePath()
@@ -534,7 +534,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testCommittedEpubDeletionReturnsActivePaneToBibleState() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let controller = BibleReaderController(bridge: BibleBridge(), initializesSword: false)
         let window = makeWindow(category: DocumentCategory.bible.pageManagerKey)
@@ -573,7 +573,7 @@ final class EpubReaderControllerParityTests: BibleUISwordFixtureTestCase {
     func testEpubBookmarkCommitRejectsGenerationReplacementAfterPlanWithoutMutation() throws {
         let archiveURL = try makeArchive()
         defer { try? FileManager.default.removeItem(at: archiveURL.deletingLastPathComponent()) }
-        let identifier = try EpubReader.install(epubURL: archiveURL)
+        let identifier = try installDefaultLibraryEpubFixture(epubURL: archiveURL)
         defer { try? EpubReader.delete(identifier: identifier) }
         let reader = try XCTUnwrap(EpubReader(identifier: identifier))
         let target = BookmarkNavigationTarget.generic(.init(

--- a/Sources/BibleUI/Tests/BibleUITests/ExternalAndroidModuleBackupImportParityTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ExternalAndroidModuleBackupImportParityTests.swift
@@ -268,6 +268,7 @@ final class ExternalAndroidModuleBackupImportParityTests: XCTestCase {
         let moduleRoot = fixture.moduleRoot
         let stagingRoot = fixture.stagingRoot
         return ExternalDocumentImportService(
+            epubCandidateAdmission: { _ in },
             androidModuleBackupInspector: { archiveURL in
                 try AndroidModuleBackupService(
                     moduleDirectory: moduleRoot,

--- a/Sources/BibleUI/Tests/BibleUITests/ExternalDocumentImportTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ExternalDocumentImportTests.swift
@@ -319,10 +319,17 @@ private final class ExternalDocumentModulePolicyProbe: @unchecked Sendable {
 private enum ExternalDocumentImportTestError: LocalizedError {
     /// Simulates an installer rejecting a handled document.
     case rejected
+    /// Simulates complete-registry ownership of one EPUB identity.
+    case epubIdentityOwned(String)
 
     /// User-visible error body returned to the service.
     var errorDescription: String? {
-        "installer rejected file"
+        switch self {
+        case .rejected:
+            "installer rejected file"
+        case .epubIdentityOwned(let initials):
+            "Cannot import this EPUB because an installed document already owns module identity \(initials)."
+        }
     }
 }
 
@@ -449,7 +456,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
        - probe: Probe that records module, EPUB, and TTF installer calls.
        - androidModuleBackupDetector: Optional archive classifier override for renamed backup ZIPs.
        - epubArchiveDetector: Optional ZIP classifier override for EPUB fallback tests.
-       - epubInitialsUnavailable: Complete-registry EPUB admission predicate.
+       - epubCandidateAdmission: Typed EPUB admission predicate evaluated before fixture mutation.
      - Returns: Service instance with deterministic installer outputs.
      - Side effects: none during construction.
      - Failure modes: This helper cannot fail.
@@ -458,14 +465,14 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         probe: ExternalDocumentImportProbe,
         androidModuleBackupDetector: ExternalDocumentImportService.AndroidModuleBackupDetector? = nil,
         epubArchiveDetector: ExternalDocumentImportService.EpubArchiveDetector? = nil,
-        epubInitialsUnavailable: @escaping ExternalDocumentImportService.EpubInitialsUnavailable = {
-            _ in false
+        epubCandidateAdmission: @escaping ExternalDocumentImportService.EpubCandidateAdmission = {
+            _ in
         }
     ) -> ExternalDocumentImportService {
         ExternalDocumentImportService(
             moduleInstaller: { url in try probe.installModule(from: url) },
             epubInstaller: { url in try probe.installEpub(from: url) },
-            epubInitialsUnavailable: epubInitialsUnavailable,
+            epubCandidateAdmission: epubCandidateAdmission,
             fontInstaller: { url, displayName in try probe.installFont(from: url, displayName: displayName) },
             androidModuleBackupInstaller: { url in try probe.installAndroidModuleBackup(from: url) },
             androidModuleBackupDetector: androidModuleBackupDetector,
@@ -491,7 +498,11 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         )
         let service = makeExternalDocumentImportService(
             probe: probe,
-            epubInitialsUnavailable: { $0 == expectedInitials }
+            epubCandidateAdmission: { candidate in
+                guard candidate.initials != expectedInitials else {
+                    throw ExternalDocumentImportTestError.epubIdentityOwned(candidate.initials)
+                }
+            }
         )
 
         let result = service.importDocument(at: url)
@@ -1430,6 +1441,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
             moduleInstallerWithPolicy: { url, policy, progressState in
                 try probe.install(url, policy: policy, progressState: progressState)
             },
+            epubCandidateAdmission: { _ in },
             androidModuleBackupDetector: { _ in false },
             epubArchiveDetector: { _ in false }
         )
@@ -1461,6 +1473,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
             moduleInstallerWithPolicy: { url, policy, progressState in
                 try probe.install(url, policy: policy, progressState: progressState)
             },
+            epubCandidateAdmission: { _ in },
             androidModuleBackupDetector: { _ in false },
             epubArchiveDetector: { _ in false }
         )
@@ -1628,6 +1641,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         let probe = ExternalDocumentImportProbe()
         let service = ExternalDocumentImportService(
             moduleInstaller: { url in try probe.installModule(from: url) },
+            epubCandidateAdmission: { _ in },
             androidModuleBackupInstaller: { url in
                 _ = try probe.installAndroidModuleBackup(from: url)
                 return try AndroidModuleBackupService(
@@ -1738,6 +1752,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         let service = ExternalDocumentImportService(
             moduleInstaller: { _ in "unexpected-module" },
             epubInstaller: { _ in "unexpected-epub" },
+            epubCandidateAdmission: { _ in },
             fontInstaller: { _, _ in "unexpected-font" },
             androidFamilyFileInstaller: { url, displayName, family, policy in
                 try probe.install(
@@ -2047,6 +2062,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         let service = ExternalDocumentImportService(
             moduleInstaller: { _ in throw ExternalDocumentImportTestError.rejected },
             epubInstaller: { url in try probe.installEpub(from: url) },
+            epubCandidateAdmission: { _ in },
             fontInstaller: { url, displayName in try probe.installFont(from: url, displayName: displayName) },
             epubArchiveDetector: { url in probe.detectNonEpubArchive(url) }
         )
@@ -2104,6 +2120,7 @@ final class ExternalDocumentImportTests: BibleUISwordFixtureTestCase {
         let service = ExternalDocumentImportService(
             moduleInstaller: { _ in throw ExternalDocumentImportTestError.rejected },
             epubInstaller: { _ in "unused" },
+            epubCandidateAdmission: { _ in },
             fontInstaller: { _, _ in "unused" }
         )
 

--- a/Sources/BibleUI/Tests/BibleUITests/MyDocumentReaderParityTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/MyDocumentReaderParityTests.swift
@@ -357,18 +357,18 @@ final class MyDocumentReaderParityTests: BibleUISwordFixtureTestCase {
     }
 
     /**
-     Verifies committed AI marker additions, updates, and deletion reach initiating and sibling panes.
+     Verifies committed AI marker updates and deletions reach every open pane.
 
-     - Setup: Connects two controllers and one reader-facing store to an isolated typed event center,
-       then inserts, edits, and deletes one generated page with AI cache metadata.
-     - Expected result: Both bridges receive matching marker upserts for add/update and the same page
-       identifier deletion, including the updated title.
-     - Failure meaning: Vue marker state can remain stale in either the pane that initiated a change
-       or another open pane.
-     - Side effects: Persists an in-memory My Documents graph and records bridge JavaScript emissions.
+     - Setup: Persists an admitted generated-page fixture directly in the test container and gives
+       one controller the production reader/bridge store.
+     - Expected result: Editing through the bridge broadcasts the updated title to the initiating
+       and sibling panes; deleting the page broadcasts its stable marker identity to both.
+     - Failure meaning: Existing AI Documents content can change without synchronizing open reader
+       marker state.
+     - Side effects: Writes only to an in-memory SwiftData container and records bridge scripts.
      */
     @MainActor
-    func testAIDocMarkerChangesPropagateToInitiatingAndSiblingPanes() throws {
+    func testAIDocMarkerUpdatesAndDeletesPropagateToInitiatingAndSiblingPanes() throws {
         let eventCenter = MyDocumentAIDocMarkerEventCenter()
         let (initiatingBridge, initiatingScripts) = makeRecordingBridge()
         let (siblingBridge, siblingScripts) = makeRecordingBridge()
@@ -413,16 +413,8 @@ final class MyDocumentReaderParityTests: BibleUISwordFixtureTestCase {
         document.pages = [page]
         cache.page = page
 
-        XCTAssertTrue(store.insert(document))
-        for scripts in [initiatingScripts(), siblingScripts()] {
-            let markers = try XCTUnwrap(
-                bridgeEmissionPayload(
-                    from: scripts,
-                    event: "add_or_update_ai_doc_markers"
-                ) as? [[String: Any]]
-            )
-            XCTAssertEqual(markers.first?["title"] as? String, "Initial title")
-        }
+        context.insert(document)
+        try context.save()
 
         let initiatingUpdateBaseline = initiatingScripts().count
         let siblingUpdateBaseline = siblingScripts().count

--- a/scripts/check_repo_standards.py
+++ b/scripts/check_repo_standards.py
@@ -258,6 +258,85 @@ def _mask_swift_comments_and_strings(text: str) -> str:
     return "".join(masked)
 
 
+def _swift_parenthesized_end(text: str, start: int) -> int | None:
+    """Return the exclusive end of one balanced Swift parenthesized region.
+
+    The input is masked Swift source and `start` points at `(`. Nested parentheses are counted;
+    comments and strings have already been removed by the caller. The helper returns `None` for an
+    unterminated region and performs no I/O or mutation.
+    """
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "(":
+            depth += 1
+        elif text[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
+def _swift_top_level_arguments(text: str) -> list[str]:
+    """Split a masked Swift parameter/call body at top-level commas.
+
+    Parentheses, brackets, braces, and generic angle brackets keep their contained commas together.
+    The returned strings preserve source spelling for label/default checks. Malformed nesting fails
+    closed by returning the unsplit remainder as one argument; the helper has no side effects.
+    """
+    if not text.strip():
+        return []
+    arguments: list[str] = []
+    start = 0
+    depths = {"(": 0, "[": 0, "{": 0, "<": 0}
+    closing = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for index, character in enumerate(text):
+        if character in depths:
+            depths[character] += 1
+        elif character in closing:
+            opener = closing[character]
+            depths[opener] = max(0, depths[opener] - 1)
+        elif character == "," and not any(depths.values()):
+            arguments.append(text[start:index])
+            start = index + 1
+    arguments.append(text[start:])
+    return arguments
+
+
+def _swift_function_ranges(masked_source: str) -> list[tuple[str, int, int]]:
+    """Return named Swift function body ranges from masked source.
+
+    The result contains `(name, declarationStart, bodyEnd)` tuples for declarations with a braced
+    body. Nested functions are retained so the smallest containing range identifies exact publisher
+    ownership. Malformed declarations are skipped; no source is changed.
+    """
+    ranges: list[tuple[str, int, int]] = []
+    pattern = re.compile(
+        r"(?:\bfunc\s+([A-Za-z_][A-Za-z0-9_]*)|\b(init))\s*\("
+    )
+    for match in pattern.finditer(masked_source):
+        parameter_start = masked_source.find("(", match.start())
+        parameter_end = _swift_parenthesized_end(masked_source, parameter_start)
+        if parameter_end is None:
+            continue
+        body_start = masked_source.find("{", parameter_end)
+        if body_start == -1:
+            continue
+        body_end = _matching_brace_end(masked_source, body_start)
+        ranges.append((match.group(1) or match.group(2), match.start(), body_end))
+    return ranges
+
+
+def _enclosing_swift_function_name(
+    function_ranges: list[tuple[str, int, int]],
+    position: int,
+) -> str | None:
+    """Return the innermost named function containing one source position, if any."""
+    containing = [item for item in function_ranges if item[1] <= position < item[2]]
+    if not containing:
+        return None
+    return min(containing, key=lambda item: item[2] - item[1])[0]
+
+
 def _matching_brace_end(text: str, open_brace_index: int) -> int:
     """Return the exclusive end offset of a brace-delimited block.
 
@@ -308,18 +387,428 @@ def find_legacy_root_sidebar_shell(text: str) -> list[int]:
     return issues
 
 
+def find_unsafe_direct_document_publishers(
+    text: str,
+    relative_path: str = "",
+) -> list[int]:
+    """Return declaration lines for document publishers that bypass global admission.
+
+    The input is one production Swift file plus its optional repository-relative path. Comments and
+    strings are masked before matching so documentation cannot trigger or suppress the guard. The
+    result covers EPUB publishers whose later admission/lease parameters can be omitted, direct My
+    Documents graph publishers, omission-tolerant registry dependencies, type aliases that obscure
+    audited publisher ownership, and calls outside exact function boundaries. The helper performs
+    no filesystem access or mutation.
+    """
+    masked_source = _mask_swift_comments_and_strings(text)
+    function_ranges = _swift_function_ranges(masked_source)
+    forbidden_patterns = (
+        re.compile(
+            r"\btypealias\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*"
+            r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*EpubReader\b"
+        ),
+        re.compile(
+            r"\btypealias\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*"
+            r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\b"
+        ),
+        re.compile(
+            r"\btypealias\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*"
+            r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*ExternalDocumentImportService\b"
+        ),
+        re.compile(
+            r"\bEpubReader\s*\.\s*(?:install|installAndroidModuleBackup)\b(?!\s*\()"
+        ),
+        re.compile(r"\bMyDocument\s*\.\s*init\b(?!\s*\()"),
+        re.compile(r"\bExternalDocumentImportService\s*\.\s*init\b(?!\s*\()"),
+        re.compile(r"\bSelf\s*\(\s*epubCandidateAdmission\s*:"),
+        re.compile(
+            r"\bfunc\s+insert\s*\(\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*|_)\s+)?"
+            r"(?:[A-Za-z_][A-Za-z0-9_]*|_)\s*:\s*"
+            r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MyDocument\b"
+        ),
+        re.compile(r"\bisDocumentInitialsUnavailable\s*:[^,\n=]+="),
+        re.compile(r"\bstrictMyDocumentInitialsUnavailable\s*:[^,\n=]+[?=]"),
+        re.compile(r"\bepubCandidateAdmission\s*:[^,\n=]+="),
+    )
+    matches = [
+        text.count("\n", 0, match.start()) + 1
+        for pattern in forbidden_patterns
+        for match in pattern.finditer(masked_source)
+    ]
+
+    install_declaration = re.compile(
+        r"(?P<modifiers>(?:(?:"
+        r"@[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^)]*\))?"
+        r"|public|internal|private|fileprivate|package|static|class|final|nonisolated"
+        r"|override|required|convenience|mutating|nonmutating|distributed|borrowing|consuming"
+        r")\s+)*)"
+        r"\bfunc\s+(?P<name>install|installAndroidModuleBackup)\s*\("
+    )
+    for declaration in install_declaration.finditer(masked_source):
+        declaration_name = declaration.group("name")
+        parameter_start = masked_source.find("(", declaration.start())
+        parameter_end = _swift_parenthesized_end(masked_source, parameter_start)
+        if parameter_end is None:
+            matches.append(text.count("\n", 0, declaration.start()) + 1)
+            continue
+        parameters = _swift_top_level_arguments(
+            masked_source[parameter_start + 1:parameter_end - 1]
+        )
+        labels: set[str] = set()
+        parameter_types: dict[str, str] = {}
+        for parameter in parameters:
+            declaration_part, separator, type_part = parameter.partition(":")
+            identifiers = re.findall(r"[A-Za-z_][A-Za-z0-9_]*|_", declaration_part)
+            if identifiers:
+                label = identifiers[0]
+                labels.add(label)
+                if separator:
+                    parameter_types[label] = type_part.strip()
+        modifiers = declaration.group("modifiers")
+        is_public = re.search(r"\bpublic\b", modifiers) is not None
+        has_default = any("=" in parameter for parameter in parameters)
+        line = text.count("\n", 0, declaration.start()) + 1
+
+        if declaration_name == "install":
+            is_epub_install = (
+                "epubURL" in labels
+                or relative_path.endswith("/EpubReader.swift")
+                or relative_path.endswith("/EpubReaderLibrary.swift")
+            )
+            if not is_epub_install:
+                continue
+            if is_public:
+                required_labels = {
+                    "epubURL",
+                    "moduleStoreRootURL",
+                    "admittingCandidateWith",
+                }
+                admission_type = parameter_types.get("admittingCandidateWith", "")
+                has_strict_admission_type = re.fullmatch(
+                    r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*InstallAdmission",
+                    admission_type,
+                ) is not None
+                if (
+                    has_default
+                    or not required_labels.issubset(labels)
+                    or not has_strict_admission_type
+                ):
+                    matches.append(line)
+                continue
+            is_explicit_root_boundary = (
+                relative_path.endswith("/EpubReaderLibrary.swift")
+                and "epubURL" in labels
+                and "libraryRootURL" in labels
+                and not has_default
+            )
+            if not is_explicit_root_boundary:
+                matches.append(line)
+            continue
+
+        is_android_epub_publisher = (
+            "epubDirectoryURL" in labels
+            or relative_path.endswith("/EpubAndroidModuleBackup.swift")
+            or not relative_path
+        )
+        if not is_android_epub_publisher:
+            continue
+        is_internal_explicit_root_boundary = (
+            not is_public
+            and relative_path.endswith("/EpubAndroidModuleBackup.swift")
+            and {"epubDirectoryURL", "libraryRootURL"}.issubset(labels)
+            and not has_default
+        )
+        if not is_internal_explicit_root_boundary:
+            matches.append(line)
+
+    function_declaration = re.compile(r"\bfunc\s+[A-Za-z_][A-Za-z0-9_]*\s*\(")
+    my_document_extension_ranges: list[tuple[int, int]] = []
+    my_document_extension = re.compile(
+        r"\bextension\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\s*\{"
+    )
+    for extension in my_document_extension.finditer(masked_source):
+        body_start = masked_source.find("{", extension.start())
+        my_document_extension_ranges.append(
+            (extension.start(), _matching_brace_end(masked_source, body_start))
+        )
+
+    for declaration in function_declaration.finditer(masked_source):
+        parameter_start = masked_source.find("(", declaration.start())
+        parameter_end = _swift_parenthesized_end(masked_source, parameter_start)
+        if parameter_end is None:
+            continue
+        parameters = _swift_top_level_arguments(
+            masked_source[parameter_start + 1:parameter_end - 1]
+        )
+        body_start = masked_source.find("{", parameter_end)
+        if body_start == -1:
+            continue
+        body_end = _matching_brace_end(masked_source, body_start)
+        signature = masked_source[parameter_end:body_start]
+        body = masked_source[body_start:body_end]
+        returns_document = re.search(
+            r"->\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\b",
+            signature,
+        ) is not None
+        returns_self_in_document_extension = (
+            re.search(r"->\s*Self\b", signature) is not None
+            and any(start <= declaration.start() < end for start, end in my_document_extension_ranges)
+        )
+        constructs_return_value = (
+            re.search(r"(?:\breturn\s+)?\.\s*init\s*\(", body) is not None
+            or (
+                returns_self_in_document_extension
+                and re.search(r"\bSelf\s*\(", body) is not None
+            )
+        )
+        if (returns_document or returns_self_in_document_extension) and constructs_return_value:
+            matches.append(text.count("\n", 0, declaration.start()) + 1)
+
+        document_parameters: list[tuple[str, bool]] = []
+        for parameter in parameters:
+            if ":" not in parameter:
+                continue
+            declaration_part, type_part = parameter.split(":", 1)
+            names = re.findall(r"[A-Za-z_][A-Za-z0-9_]*", declaration_part)
+            if not names:
+                continue
+            is_factory = re.search(
+                r"\([^)]*\)\s*(?:(?:async|throws|rethrows)\s+)*->\s*"
+                r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\b",
+                type_part,
+            ) is not None
+            is_document = re.search(
+                r"(?<!->\s)(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\b",
+                type_part,
+            ) is not None
+            if is_factory or is_document:
+                document_parameters.append((names[-1], is_factory))
+        if not document_parameters:
+            continue
+        publishes_document_parameter = False
+        for name, is_factory in document_parameters:
+            if not is_factory:
+                publishes_document_parameter = re.search(
+                    rf"\.\s*insert\s*\(\s*{re.escape(name)}\s*\)",
+                    body,
+                ) is not None
+            else:
+                publishes_document_parameter = re.search(
+                    rf"\.\s*insert\s*\(\s*(?:(?:try[!?]?|await)\s+)*"
+                    rf"{re.escape(name)}\s*\(",
+                    body,
+                ) is not None
+                if not publishes_document_parameter:
+                    aliases = re.findall(
+                        rf"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)"
+                        rf"(?:\s*:\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument)?"
+                        rf"\s*=\s*(?:(?:try[!?]?|await)\s+)*"
+                        rf"{re.escape(name)}\s*\(",
+                        body,
+                    )
+                    publishes_document_parameter = any(
+                        re.search(
+                            rf"\.\s*insert\s*\(\s*{re.escape(alias)}\s*\)",
+                            body,
+                        )
+                        for alias in aliases
+                    )
+            if publishes_document_parameter:
+                break
+        if publishes_document_parameter:
+            matches.append(text.count("\n", 0, declaration.start()) + 1)
+
+    typed_document_factory = re.compile(
+        r"\b(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*"
+        r"(?:(?:@[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^)]*\))?)\s+)*"
+        r"\([^)]*\)\s*"
+        r"(?:(?:async|throws|rethrows)\s+)*->\s*"
+        r"(?:(?:[A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)*MyDocument\s*=\s*\{"
+    )
+    for declaration in typed_document_factory.finditer(masked_source):
+        body_start = masked_source.find("{", declaration.start())
+        body_end = _matching_brace_end(masked_source, body_start)
+        body = masked_source[body_start:body_end]
+        if re.search(
+            r"(?:\breturn\s+)?(?:\.\s*init|\bMyDocument(?:\s*\.\s*init)?)\s*\(",
+            body,
+        ):
+            matches.append(text.count("\n", 0, declaration.start()) + 1)
+
+    if relative_path.endswith("/MyDocumentStore.swift"):
+        matches.extend(
+            text.count("\n", 0, match.start()) + 1
+            for match in re.finditer(r"\bfunc\s+save\s*\(\s*\)", masked_source)
+        )
+
+    if relative_path.endswith("/MyDocumentLibraryStore.swift"):
+        fail_open_save = re.compile(
+            r"\bpublic\s+func\s+save\s*\("
+            r"(?:(?!\n\s*\)\s*(?:async\s+)?throws)[\s\S])*?"
+            r"\bisInitialsUnavailable\s*:"
+        )
+        matches.extend(
+            text.count("\n", 0, match.start()) + 1
+            for match in fail_open_save.finditer(masked_source)
+        )
+
+    if relative_path.endswith("/MyDocumentsListView.swift"):
+        matches.extend(
+            text.count("\n", 0, match.start()) + 1
+            for match in re.finditer(
+                r"\bisInitialsUnavailable\s*:[^,\n=]+=",
+                masked_source,
+            )
+        )
+
+    audited_calls = {
+        "installAndroidModuleBackup": [
+            (
+                "Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupRestoreAvailability.swift",
+                "validatePublishedState",
+                {"epubDirectoryURL", "libraryRootURL"},
+            ),
+            (
+                "Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift",
+                "restorePlannedArchive",
+                {"epubDirectoryURL", "libraryRootURL"},
+            ),
+        ],
+        "install": [
+            (
+                "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift",
+                "init",
+                {"epubURL", "moduleStoreRootURL", "admittingCandidateWith"},
+            ),
+        ],
+    }
+    epub_call = re.compile(r"\bEpubReader\s*\.\s*(installAndroidModuleBackup|install)\s*\(")
+    for call in epub_call.finditer(masked_source):
+        call_name = call.group(1)
+        argument_start = masked_source.find("(", call.start())
+        argument_end = _swift_parenthesized_end(masked_source, argument_start)
+        arguments = "" if argument_end is None else masked_source[argument_start + 1:argument_end - 1]
+        parsed_arguments = _swift_top_level_arguments(arguments)
+        labeled_arguments: dict[str, str] = {}
+        for argument in parsed_arguments:
+            label_match = re.match(
+                r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([\s\S]*)",
+                argument,
+            )
+            if label_match:
+                labeled_arguments[label_match.group(1)] = label_match.group(2).strip()
+        labels = set(labeled_arguments)
+        enclosing_function = _enclosing_swift_function_name(function_ranges, call.start())
+        is_audited_call = any(
+            relative_path == expected_path
+            and enclosing_function == expected_function
+            and required_labels.issubset(labels)
+            for expected_path, expected_function, required_labels in audited_calls[call_name]
+        )
+        if (
+            call_name == "install"
+            and relative_path
+            == "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift"
+            and enclosing_function == "init"
+            and labeled_arguments.get("admittingCandidateWith") != "admission"
+        ):
+            is_audited_call = False
+        if not is_audited_call:
+            matches.append(text.count("\n", 0, call.start()) + 1)
+
+    import_service_constructor = re.compile(
+        r"(?:\bExternalDocumentImportService\s*(?:\.\s*init)?|\.\s*init)\s*\("
+    )
+    for constructor in import_service_constructor.finditer(masked_source):
+        argument_start = masked_source.find("(", constructor.start())
+        argument_end = _swift_parenthesized_end(masked_source, argument_start)
+        arguments = "" if argument_end is None else masked_source[argument_start + 1:argument_end - 1]
+        parsed_arguments = _swift_top_level_arguments(arguments)
+        labeled_arguments: dict[str, str] = {}
+        for argument in parsed_arguments:
+            label_match = re.match(
+                r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([\s\S]*)",
+                argument,
+            )
+            if label_match:
+                labeled_arguments[label_match.group(1)] = label_match.group(2).strip()
+        if (
+            "epubCandidateAdmission" not in labeled_arguments
+            and not re.match(r"\bExternalDocumentImportService", constructor.group(0))
+        ):
+            continue
+        admission = labeled_arguments.get("epubCandidateAdmission", "")
+        is_strict_factory = (
+            relative_path
+            == "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift"
+            and _enclosing_swift_function_name(function_ranges, constructor.start())
+            == "androidRegistryAware"
+            and re.search(
+                r"\blet\s+snapshot\s*=\s*try\s+"
+                r"BibleReaderInstalledDocumentRegistrySnapshot\s*\.\s*capture\s*\(",
+                admission,
+            ) is not None
+            and re.search(
+                r"\bguard\s+snapshot\s*\.\s*admitsEpub\s*\(\s*candidate\s*\)"
+                r"\s*else\s*\{[\s\S]*\bthrow\b",
+                admission,
+            ) is not None
+        )
+        if not is_strict_factory:
+            matches.append(text.count("\n", 0, constructor.start()) + 1)
+
+    audited_constructors = {
+        (
+            "Sources/BibleCore/Sources/BibleCore/AI/AIGeneratedPageStore.swift",
+            "resolveOrCreateAIDocument",
+        ),
+        (
+            "Sources/BibleCore/Sources/BibleCore/Database/MyDocumentLibraryStore.swift",
+            "saveUnderExclusiveLease",
+        ),
+        (
+            "Sources/BibleCore/Sources/BibleCore/Services/RemoteSyncMyDocumentRestoreService.swift",
+            "stageLocalMyDocuments",
+        ),
+    }
+    my_document_constructor = re.compile(
+        r"(?:\bMyDocument\s*(?:\.\s*init)?\s*\(|:\s*MyDocument\s*=\s*\.\s*init\s*\()"
+    )
+    for constructor in my_document_constructor.finditer(masked_source):
+        owner = (
+            relative_path,
+            _enclosing_swift_function_name(function_ranges, constructor.start()),
+        )
+        if owner not in audited_constructors:
+            matches.append(text.count("\n", 0, constructor.start()) + 1)
+
+    if relative_path.endswith("/MyDocumentStore.swift"):
+        matches.extend(
+            text.count("\n", 0, match.start()) + 1
+            for match in re.finditer(
+                r"savePendingGraphChanges\s*\([\s\S]*?modelContext\s*:\s*modelContext",
+                masked_source,
+            )
+        )
+
+    return sorted(set(matches))
+
+
 def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
     """Validate static source contracts that should run outside XCTest.
 
-    The current guard keeps the `ContentView` legacy root sidebar regression out of the app-host
-    bundle. It reports a missing file as a failure so project-layout moves must deliberately update
-    the guard instead of silently dropping coverage.
+    The guards keep the `ContentView` legacy root sidebar regression out of the app-host bundle and
+    prevent production Swift sources from recreating direct EPUB/My Documents publication APIs that
+    bypass Android-compatible global ownership admission. Missing fixed-path files fail closed, and
+    the document publisher scan follows every non-test Swift file under `Sources` and `AndBible`
+    across moves.
     """
     content_view_path = repo_root / "AndBible/ContentView.swift"
     relative_path = "AndBible/ContentView.swift"
+    issues: list[SourceGuardIssue] = []
 
     if not content_view_path.exists():
-        return [
+        issues.append(
             SourceGuardIssue(
                 path=relative_path,
                 line=1,
@@ -328,21 +817,44 @@ def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
                     "if the project layout changes."
                 ),
             )
-        ]
-
-    source = content_view_path.read_text(encoding="utf-8")
-    return [
-        SourceGuardIssue(
-            path=relative_path,
-            line=line,
-            message=(
-                "ContentView.swift appears to contain the legacy root sidebar shell pattern: "
-                "NavigationSplitView with contentTabBible/contentSettingsLink in the same root "
-                "layout region."
-            ),
         )
-        for line in find_legacy_root_sidebar_shell(source)
-    ]
+    else:
+        source = content_view_path.read_text(encoding="utf-8")
+        issues.extend(
+            SourceGuardIssue(
+                path=relative_path,
+                line=line,
+                message=(
+                    "ContentView.swift appears to contain the legacy root sidebar shell pattern: "
+                    "NavigationSplitView with contentTabBible/contentSettingsLink in the same root "
+                    "layout region."
+                ),
+            )
+            for line in find_legacy_root_sidebar_shell(source)
+        )
+
+    for source_root_name in ("Sources", "AndBible"):
+        sources_root = repo_root / source_root_name
+        if not sources_root.exists():
+            continue
+        for path in sorted(sources_root.rglob("*.swift")):
+            relative = path.relative_to(repo_root)
+            if "Tests" in relative.parts:
+                continue
+            source = path.read_text(encoding="utf-8")
+            issues.extend(
+                SourceGuardIssue(
+                    path=str(relative),
+                    line=line,
+                    message=(
+                        "Production source declares a direct EPUB/My Documents publisher outside "
+                        "the shared global mutation and Android ownership-admission boundary."
+                    ),
+                )
+                for line in find_unsafe_direct_document_publishers(source, str(relative))
+            )
+
+    return issues
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/test_check_repo_standards.py
+++ b/scripts/test_check_repo_standards.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -14,7 +15,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_repo_standards import (
     find_legacy_root_sidebar_shell,
     find_multiline_slash_docblocks,
+    find_unsafe_direct_document_publishers,
     validate_commit_message,
+    validate_source_guards,
 )
 
 
@@ -191,6 +194,351 @@ class RepoStandardsTests(unittest.TestCase):
             ]
         )
         self.assertEqual(find_legacy_root_sidebar_shell(text), [])
+
+    def test_find_unsafe_direct_document_publishers_flags_bypass_apis(self) -> None:
+        text = "\n".join(
+            [
+                "public static func install(epubURL source: Foundation.URL) throws -> String { fatalError() }",
+                "internal func insert(_ graph: BibleCore.MyDocument) -> Bool { true }",
+                "public static func installAndroidModuleBackup(_ source: URL) throws -> String { fatalError() }",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [1, 2, 3])
+
+    def test_find_unsafe_direct_document_publishers_flags_fail_open_dependencies(self) -> None:
+        text = "\n".join(
+            [
+                "public func save() {}",
+                "isDocumentInitialsUnavailable: @escaping (String) throws -> Bool = { _ in false },",
+                "epubCandidateAdmission: EpubCandidateAdmission? = nil,",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleCore/Sources/BibleCore/Database/MyDocumentStore.swift",
+            ),
+            [1, 2, 3],
+        )
+
+    def test_find_unsafe_direct_document_publishers_flags_optional_library_admission(self) -> None:
+        text = "\n".join(
+            [
+                "public func save(",
+                "  _ session: inout Session,",
+                "  isInitialsUnavailable: ((String) -> Bool)? = nil",
+                ") throws {}",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleCore/Sources/BibleCore/Database/MyDocumentLibraryStore.swift",
+            ),
+            [1],
+        )
+
+    def test_find_unsafe_direct_document_publishers_enforces_audited_call_sites(self) -> None:
+        unsafe_text = "\n".join(
+            [
+                "_ = try EpubReader.installAndroidModuleBackup(epubDirectoryURL: source, libraryRootURL: root)",
+                "_ = try EpubReader.install(epubURL: source, moduleStoreRootURL: root, admittingCandidateWith: check)",
+                "let document = MyDocument(name: name, initials: initials)",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(unsafe_text, "Sources/Unsafe.swift"),
+            [1, 2, 3],
+        )
+        audited_text = "\n".join(
+            [
+                "func validatePublishedState() throws {",
+                "  _ = try EpubReader.installAndroidModuleBackup(",
+                "    epubDirectoryURL: source, libraryRootURL: root",
+                "  )",
+                "}",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                audited_text,
+                "Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupRestoreAvailability.swift",
+            ),
+            [],
+        )
+
+    def test_find_unsafe_direct_document_publishers_rejects_aliases_defaults_and_factories(self) -> None:
+        text = "\n".join(
+            [
+                "typealias Reader = EpubReader",
+                "_ = try Reader.install(epubURL: source, moduleStoreRootURL: root, admittingCandidateWith: check)",
+                "func install(epubURL: URL, libraryRootURL: URL = defaultRoot) throws {}",
+                "func publish(_ graph: MyDocument) { modelContext.insert(graph) }",
+                "let document: MyDocument = .init(name: name, initials: initials)",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(text, "AndBible/UnsafePublisher.swift"),
+            [1, 3, 4, 5],
+        )
+
+    def test_find_unsafe_direct_document_publishers_rejects_extra_call_in_audited_file(self) -> None:
+        text = "\n".join(
+            [
+                "func initForTests() throws {",
+                "  _ = try EpubReader.install(",
+                "    epubURL: source, moduleStoreRootURL: root, admittingCandidateWith: check",
+                "  )",
+                "}",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift",
+            ),
+            [2],
+        )
+
+    def test_validate_source_guards_scans_app_host_publishers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app_root = root / "AndBible"
+            app_root.mkdir(parents=True)
+            (app_root / "ContentView.swift").write_text(
+                "struct ContentView {}\n",
+                encoding="utf-8",
+            )
+            (app_root / "UnsafePublisher.swift").write_text(
+                "typealias Reader = EpubReader\n",
+                encoding="utf-8",
+            )
+
+            issues = validate_source_guards(root)
+
+        self.assertEqual(
+            [(issue.path, issue.line) for issue in issues],
+            [("AndBible/UnsafePublisher.swift", 1)],
+        )
+
+    def test_find_unsafe_direct_document_publishers_allows_strict_and_test_calls(self) -> None:
+        text = "\n".join(
+            [
+                "public static func install(",
+                "    epubURL: URL,",
+                "    moduleStoreRootURL: URL,",
+                "    admittingCandidateWith admission: InstallAdmission",
+                ") throws -> String { fatalError() }",
+                "modelContext.insert(document)",
+                "// public static func install(epubURL: URL) throws -> String",
+                "let example = \"func insert(_ document: MyDocument)\"",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [])
+
+    def test_find_unsafe_direct_document_publishers_requires_public_epub_admission(self) -> None:
+        text = "public static func install(epubURL: URL, libraryRootURL: URL) throws -> String { fatalError() }"
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleCore/Sources/BibleCore/Formats/EpubReaderLibrary.swift",
+            ),
+            [1],
+        )
+
+    def test_find_unsafe_direct_document_publishers_requires_strict_admission_type(self) -> None:
+        text = "\n".join(
+            [
+                "public static func install(epubURL: URL, moduleStoreRootURL: URL, admittingCandidateWith: Bool) throws {}",
+                "public static func install(epubURL: URL, moduleStoreRootURL: URL, admittingCandidateWith: InstallAdmission?) throws {}",
+                "public static func install(epubURL: URL, moduleStoreRootURL: URL, admittingCandidateWith: (() -> Void)?) throws {}",
+                "public static func install(epubURL: URL, moduleStoreRootURL: URL, admittingCandidateWith: BibleCore.EpubReader.InstallAdmission) throws {}",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleCore/Sources/BibleCore/Formats/EpubReader.swift",
+            ),
+            [1, 2, 3],
+        )
+
+    def test_find_unsafe_direct_document_publishers_keeps_backup_root_api_internal(self) -> None:
+        text = (
+            "public static func installAndroidModuleBackup("
+            "epubDirectoryURL: URL, libraryRootURL: URL) throws -> String { fatalError() }"
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleCore/Sources/BibleCore/Formats/EpubAndroidModuleBackup.swift",
+            ),
+            [1],
+        )
+
+    def test_find_unsafe_direct_document_publishers_reads_multiline_public_modifiers(self) -> None:
+        epub_text = "\n".join(
+            [
+                "public",
+                "static func install(epubURL: URL, libraryRootURL: URL) throws -> String { fatalError() }",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                epub_text,
+                "Sources/BibleCore/Sources/BibleCore/Formats/EpubReaderLibrary.swift",
+            ),
+            [1],
+        )
+        backup_text = "\n".join(
+            [
+                "public",
+                "static func installAndroidModuleBackup(",
+                "  epubDirectoryURL: URL, libraryRootURL: URL",
+                ") throws -> String { fatalError() }",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                backup_text,
+                "Sources/BibleCore/Sources/BibleCore/Formats/EpubAndroidModuleBackup.swift",
+            ),
+            [1],
+        )
+
+    def test_find_unsafe_direct_document_publishers_ignores_unrelated_installers(self) -> None:
+        text = "func install(font: Font) throws {}"
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [])
+
+    def test_find_unsafe_direct_document_publishers_rejects_qualified_aliases(self) -> None:
+        text = "\n".join(
+            [
+                "typealias Reader = BibleCore.EpubReader",
+                "typealias Document = BibleCore.MyDocument",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [1, 2])
+
+    def test_find_unsafe_direct_document_publishers_rejects_publisher_references(self) -> None:
+        text = "\n".join(
+            [
+                "let publish = EpubReader.install",
+                "let makeDocument = MyDocument.init",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [1, 2])
+
+    def test_find_unsafe_direct_document_publishers_rejects_factory_insertion(self) -> None:
+        text = "\n".join(
+            [
+                "func publish(factory: () -> MyDocument) { modelContext.insert(factory()) }",
+                "func publishNamed(factory: (String, String) -> MyDocument) {",
+                "  let graph: MyDocument = factory(name, initials)",
+                "  modelContext.insert(graph)",
+                "}",
+                "func publishThrowing(factory: (String, String) throws -> MyDocument) throws {",
+                "  modelContext.insert(try factory(name, initials))",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [1, 2, 6])
+
+    def test_find_unsafe_direct_document_publishers_rejects_document_factories(self) -> None:
+        text = "\n".join(
+            [
+                "func makeDocument() -> MyDocument { .init(name: name, initials: initials) }",
+                "let make: () -> MyDocument = { .init(name: name, initials: initials) }",
+                "let parameterized: (String, String) -> MyDocument = { name, initials in",
+                "  .init(name: name, initials: initials)",
+                "}",
+                "let attributed: @Sendable () -> MyDocument = {",
+                "  .init(name: name, initials: initials)",
+                "}",
+                "extension MyDocument {",
+                "  static func make() -> Self { Self(name: name, initials: initials) }",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [1, 2, 3, 6, 10])
+
+    def test_find_unsafe_direct_document_publishers_rejects_noop_audited_admission(self) -> None:
+        text = "\n".join(
+            [
+                "init(moduleStoreRootURL: URL, admission: InstallAdmission) {",
+                "  _ = try EpubReader.install(",
+                "    epubURL: url, moduleStoreRootURL: moduleStoreRootURL,",
+                "    admittingCandidateWith: { _ in }",
+                "  )",
+                "}",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(
+                text,
+                "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift",
+            ),
+            [2],
+        )
+
+    def test_find_unsafe_direct_document_publishers_rejects_import_service_bypass(self) -> None:
+        text = "\n".join(
+            [
+                "ExternalDocumentImportService(epubCandidateAdmission: { _ in })",
+                "ExternalDocumentImportService.init(epubCandidateAdmission: { _ in })",
+                "let service: ExternalDocumentImportService = .init(epubCandidateAdmission: { _ in })",
+            ]
+        )
+        self.assertEqual(
+            find_unsafe_direct_document_publishers(text, "AndBible/UnsafeImport.swift"),
+            [1, 2, 3],
+        )
+
+    def test_find_unsafe_direct_document_publishers_rejects_import_service_self_factory(self) -> None:
+        text = "\n".join(
+            [
+                "extension ExternalDocumentImportService {",
+                "  static func unsafe() -> Self {",
+                "    Self(epubCandidateAdmission: { _ in })",
+                "  }",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(text), [3])
+
+    def test_find_unsafe_direct_document_publishers_requires_strict_import_factory(self) -> None:
+        unsafe_text = "\n".join(
+            [
+                "func androidRegistryAware() -> ExternalDocumentImportService {",
+                "  ExternalDocumentImportService(epubCandidateAdmission: { _ in })",
+                "}",
+            ]
+        )
+        path = "Sources/BibleUI/Sources/BibleUI/Shared/ExternalDocumentImportService.swift"
+        self.assertEqual(find_unsafe_direct_document_publishers(unsafe_text, path), [2])
+
+        ignored_text = "\n".join(
+            [
+                "func androidRegistryAware() -> ExternalDocumentImportService {",
+                "  ExternalDocumentImportService(epubCandidateAdmission: { candidate in",
+                "    let snapshot = try? BibleReaderInstalledDocumentRegistrySnapshot.capture()",
+                "    _ = snapshot?.admitsEpub(candidate)",
+                "  })",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(ignored_text, path), [2])
+
+        strict_text = "\n".join(
+            [
+                "func androidRegistryAware() -> ExternalDocumentImportService {",
+                "  ExternalDocumentImportService(epubCandidateAdmission: { candidate in",
+                "    let snapshot = try BibleReaderInstalledDocumentRegistrySnapshot.capture()",
+                "    guard snapshot.admitsEpub(candidate) else { throw AdmissionError() }",
+                "  })",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unsafe_direct_document_publishers(strict_text, path), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Remove dormant and fail-open EPUB/My Documents publication entry points so every production identity publication follows the shared global mutation lease and complete Android-style installed-book admission contract.

## Scope

- Remove public default-library EPUB and arbitrary MyDocument graph publishers.
- Require strict registry admission in UI, Agent, and AI-document creation paths.
- Isolate persisted MyDocument ownership, exact lookup, marker reads, and page mutations from caller-staged SwiftData graphs.
- Confine low-level EPUB installation to an explicit test-only seam.
- Add repository-wide guards against practical alias, factory, initializer, and no-op admission bypasses.

Authoritative RemoteSync graph replacement is intentionally unchanged.

## Contract references

- Issue #398 acceptance criteria.
- Android Books registration behavior: only committed/admitted installed identities participate in ownership resolution.
- Shared ModuleStoreMutationCoordinator plus complete native, SQLite, EPUB, and My Documents registry admission.
- Repository commit, docblock, and engineering guardrail contracts.

## Change details

- Delete unsafe public EPUB and MyDocument compatibility publishers instead of preserving legacy behavior.
- Make the ExternalDocumentImportService dependency-injection initializer internal; production callers use the public androidRegistryAware factory.
- Require nonoptional strict admission dependencies throughout production creation/import wiring.
- Execute MyDocument page reads and writes through operation-owned contexts so pane-local drafts cannot hitchhike into ownership or persistence.
- Extend source guardrails across Sources and AndBible with adversarial regression probes.

## Validation evidence

- BibleCore publication/restore matrix: 102 passed, 0 failed.
- BibleUI import/reader matrix: 64 passed, 0 failed.
- Focused persisted ownership/marker tests: 11 passed, 0 failed.
- Source-guard regression suite: 32 passed, 0 failed.
- Live source guards: passed.
- Swift docblocks: 797 tracked files passed.
- BibleUI package build: passed.
- Full AndBible iOS simulator build: passed.
- Git diff and commit-message guardrails: passed.
- Independent adversarial review: pass, no remaining #398 blocker.

## Risks / follow-ups

- This intentionally removes source-level compatibility APIs. Repository production callers were migrated or already used strict paths; test-only low-level use is explicit.
- The source guard is deliberately fail-closed for document publisher aliases and factories.
- No migration or behavior change is made to authoritative RemoteSync replacement.
- This PR must not be merged until required CI is green and explicit merge authorization is given.

## Issue closure

Closes #398