### PR TITLE
fix(addons): align prompt discovery with Android admission

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/AI/PromptRepository.swift
+++ b/Sources/BibleCore/Sources/BibleCore/AI/PromptRepository.swift
@@ -67,9 +67,10 @@ public protocol SwordPromptPackProviding {
 /**
  Discovers Android `AndBibleProvidesPrompts` files through an installed `SwordManager`.
 
- Each referenced filename is constrained to its adjusted module payload directory inside the SWORD
- root. Traversal, absolute paths, unreadable files, and malformed packs are skipped rather than
- weakening the precedence of remaining installed packs.
+ Add-on admission, duplicate ownership, and ordering come from the shared Android `Books.installed()`
+ projection. Each referenced filename is constrained to its adjusted module payload directory inside
+ the SWORD root. Traversal, absolute paths, unreadable files, and malformed packs are skipped rather
+ than weakening the precedence of remaining installed packs.
  */
 public final class SwordPromptPackProvider: SwordPromptPackProviding {
     /// Upper bound preventing an installed prompt pack from exhausting memory during parsing.
@@ -95,24 +96,21 @@ public final class SwordPromptPackProvider: SwordPromptPackProviding {
     }
 
     /**
-     Loads prompt packs referenced by installed SWORD module metadata.
+     Loads prompt packs referenced by Android-admitted add-on metadata.
 
-     - Returns: Parsed packs sorted by module initials.
-     - Side effects: Enumerates installed modules and reads referenced CSV files.
+     - Returns: Parsed packs in pinned JSword installed TreeSet order.
+     - Side effects: Reads the manager's shared admitted add-on projection and referenced CSV files.
      - Throws: This production implementation skips per-module failures and does not throw.
      */
     public func loadPromptPacks() throws -> [SwordPromptPack] {
-        return swordManager.installedModules()
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-            .compactMap { info in
-                guard let module = swordManager.module(named: info.name),
-                      let rawFilename = module.configEntry("AndBibleProvidesPrompts")?
-                        .trimmingCharacters(in: .whitespacesAndNewlines),
+        return swordManager.admittedAddonModules()
+            .compactMap { addon in
+                guard let rawFilename = addon.promptFileName,
                       !rawFilename.isEmpty,
-                      rawFilename.lowercased().hasSuffix(".csv"),
+                      let locationURL = addon.locationURL,
                       let fileURL = promptFileURL(
                         filename: rawFilename,
-                        dataPath: module.configEntry("DataPath")
+                        locationURL: locationURL
                       ) else {
                     return nil
                 }
@@ -121,7 +119,7 @@ public final class SwordPromptPackProvider: SwordPromptPackProviding {
                       let prompts = try? PromptCSVParser.parse(data: data) else {
                     return nil
                 }
-                return SwordPromptPack(moduleName: info.name, prompts: prompts)
+                return SwordPromptPack(moduleName: addon.moduleInfo.name, prompts: prompts)
             }
     }
 
@@ -139,33 +137,25 @@ public final class SwordPromptPackProvider: SwordPromptPackProviding {
     /**
      Resolves a prompt-pack file relative to Android's adjusted module location.
 
-     Directory DataPath values are the module location. Single-file driver paths use their parent
-     directory. Standalone prompt modules therefore resolve ./prompts/<file>, while ordinary add-ons
-     can colocate a pack with their own payload. Absolute paths and parent traversal are rejected.
+     - Parameters:
+       - filename: Singular first `AndBibleProvidesPrompts` value from installed metadata.
+       - locationURL: Filesystem-adjusted JSword book location supplied by shared admission.
+     - Returns: Standardized readable-candidate URL below the manager root, or nil for an unsafe
+       absolute/traversing/escaped path. File readability is checked by the caller.
+     - Side effects: Resolves filesystem symlinks without mutation.
+     - Failure modes: Absolute paths, parent traversal, and symlink escapes return nil.
      */
-    private func promptFileURL(filename: String, dataPath: String?) -> URL? {
+    private func promptFileURL(filename: String, locationURL: URL) -> URL? {
         let normalizedFilename = filename.replacingOccurrences(of: "\\", with: "/")
         guard !normalizedFilename.hasPrefix("/"),
               !normalizedFilename.split(separator: "/", omittingEmptySubsequences: false)
                 .contains(where: { $0 == ".." }) else {
             return nil
         }
-        let rawDataPath = dataPath?
-            .replacingOccurrences(of: "\\", with: "/")
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let basePath: String
-        if rawDataPath.isEmpty || rawDataPath.hasSuffix("/") {
-            basePath = rawDataPath
-        } else {
-            let parent = (rawDataPath as NSString).deletingLastPathComponent
-            basePath = parent == "." ? "" : parent
-        }
-        let separator = basePath.isEmpty || basePath.hasSuffix("/") ? "" : "/"
-        let relativePath = "\(basePath)\(separator)\(normalizedFilename)"
         let root = URL(fileURLWithPath: swordManager.modulePath, isDirectory: true)
             .resolvingSymlinksInPath()
             .standardizedFileURL
-        let resolved = root.appendingPathComponent(relativePath)
+        let resolved = locationURL.appendingPathComponent(normalizedFilename)
             .resolvingSymlinksInPath()
             .standardizedFileURL
         let rootPrefix = root.path.hasSuffix("/") ? root.path : "\(root.path)/"

--- a/Sources/BibleCore/Tests/BibleCoreTests/AIPromptAndModelBehaviorTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AIPromptAndModelBehaviorTests.swift
@@ -1,13 +1,15 @@
 import Foundation
 import SwiftData
+import SwordKit
 import XCTest
 @testable import BibleCore
 
 /**
  Protects Android v23 prompt identity, source precedence, credential placement, and model fallback.
 
- Every test uses an in-memory AI-only SwiftData container and a non-Keychain secret double, so the
- suite performs no network, disk, CloudKit, backup, or system-Keychain side effects.
+ Tests use in-memory AI-only SwiftData containers and a non-Keychain secret double. Prompt-pack
+ parity fixtures additionally create and remove isolated temporary SWORD trees; the suite performs
+ no network, CloudKit, backup, or system-Keychain side effects.
  */
 @MainActor
 final class AIPromptAndModelBehaviorTests: XCTestCase {
@@ -400,6 +402,117 @@ final class AIPromptAndModelBehaviorTests: XCTestCase {
         XCTAssertEqual(prompt.permissionMode, .askOncePerRun)
         XCTAssertFalse(prompt.strictContextMatching)
         XCTAssertTrue(prompt.bibleOnly)
+    }
+
+    /**
+     Verifies prompt discovery and repository lookup share Android add-on admission and BookSet order.
+
+     - Setup: Installs slashless-directory Alpha and file-prefix Zulu add-ons, writes one readable
+       standalone CSV with no config, and adds too-new and malformed-minimum config books.
+     - Expected: Only compatible payload-admitted packs load in abbreviation order; repository list
+       and direct lookup attribute the same prompt identities to those exact installed modules.
+     - Side effects: Creates and removes a temporary SWORD tree and creates an in-memory AI store.
+     - Failure meaning: Prompt UI/execution can expose a book Android filters out or choose a
+       different duplicate/order owner from the installed add-on inventory.
+     */
+    func testPromptRepositoryUsesSharedAdmittedAddonProjection() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        let alphaID = UUID(uuidString: "10000000-0000-4000-8000-000000000001")!
+        let zuluID = UUID(uuidString: "10000000-0000-4000-8000-000000000002")!
+        let futureID = UUID(uuidString: "10000000-0000-4000-8000-000000000003")!
+        let malformedID = UUID(uuidString: "10000000-0000-4000-8000-000000000004")!
+        let standaloneID = UUID(uuidString: "10000000-0000-4000-8000-000000000005")!
+        let definitions: [(file: String, initials: String, abbreviation: String, minimum: String?, id: UUID)] = [
+            ("a-zulu.conf", "ZULUPROMPT", "Zulu", nil, zuluID),
+            ("z-alpha.conf", "ALPHAPROMPT", "Alpha", nil, alphaID),
+            ("future.conf", "FUTUREPROMPT", "Future", "1116", futureID),
+            ("malformed.conf", "MALFORMEDPROMPT", "Malformed", "later", malformedID),
+        ]
+        for definition in definitions {
+            let promptFileName = definition.initials == "ALPHAPROMPT"
+                ? "prompts.pack"
+                : "prompts.csv"
+            let payloadDirectory = moduleRoot.appendingPathComponent(
+                "addons/\(definition.initials.lowercased())",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: payloadDirectory, withIntermediateDirectories: true)
+            let csv = """
+            id;name;description;promptTemplate
+            \(definition.id.uuidString);\(definition.initials);Installed prompt;Run \(definition.initials)
+            """
+            try csv.write(
+                to: payloadDirectory.appendingPathComponent(promptFileName),
+                atomically: true,
+                encoding: .utf8
+            )
+            let dataPath: String
+            if definition.initials == "ALPHAPROMPT" {
+                dataPath = "./addons/alphaprompt"
+            } else if definition.initials == "ZULUPROMPT" {
+                dataPath = "./addons/zuluprompt/module"
+                try Data().write(to: payloadDirectory.appendingPathComponent("module.dat"))
+            } else {
+                dataPath = "./addons/\(definition.initials.lowercased())/"
+            }
+            var config = [
+                "[\(definition.initials)]",
+                "Description=\(definition.initials)",
+                "Abbreviation=\(definition.abbreviation)",
+                "Category=And Bible",
+                "ModDrv=RawGenBook",
+                "DataPath=\(dataPath)",
+                "AndBibleProvidesPrompts=\(promptFileName)",
+            ]
+            if let minimum = definition.minimum {
+                config.append("AndBibleMinimumVersion=\(minimum)")
+            }
+            try (config.joined(separator: "\n") + "\n").write(
+                to: configDirectory.appendingPathComponent(definition.file),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let promptsDirectory = moduleRoot.appendingPathComponent("prompts", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: promptsDirectory,
+            withIntermediateDirectories: true
+        )
+        try """
+        id;name;description;promptTemplate
+        \(standaloneID.uuidString);Standalone;Installed prompt;Run standalone
+        """.write(
+            to: promptsDirectory.appendingPathComponent("Study Pack.csv"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let provider = SwordPromptPackProvider(swordManager: manager)
+        XCTAssertEqual(
+            try provider.loadPromptPacks().map(\.moduleName),
+            ["ALPHAPROMPT", "Prompts_Study Pack", "ZULUPROMPT"]
+        )
+
+        let container = try makeAIContainer()
+        let repository = PromptRepository(
+            settingsStore: AISettingsStore(modelContext: ModelContext(container)),
+            packProvider: provider,
+            builtInPrompts: { [] }
+        )
+        XCTAssertEqual(
+            try repository.allPromptsIncludingHidden().map(\.prompt.id),
+            [alphaID, standaloneID, zuluID]
+        )
+        XCTAssertEqual(try repository.entryById(alphaID)?.origin, .swordPack(moduleName: "ALPHAPROMPT"))
+        XCTAssertNil(try repository.entryById(futureID))
+        XCTAssertNil(try repository.entryById(malformedID))
     }
 }
 

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderController.swift
@@ -8392,6 +8392,20 @@ public final class BibleReaderController: NSObject, BibleBridgeDelegate {
     }
 
     /**
+     Returns installed document-picker rows with Android's exact display abbreviations.
+
+     - Returns: Globally admitted native and SQLite books preserving final JSword TreeSet ownership
+       metadata; the chooser applies its visible category filter.
+     - Side effects: Captures one fresh installed resolver; no content is read and reader state is
+       unchanged.
+     - Failure modes: Missing, unsupported, and shadowed rows are omitted by registry admission
+       rather than reconstructed from stale controller arrays.
+     */
+    func installedBookPresentationsForDocumentPicker() -> [BibleReaderInstalledBookPresentation] {
+        installedModuleResolver().registeredBookPresentations()
+    }
+
+    /**
      Authorizes one installed AI window-document request and validates its optional key atomically.
 
      - Parameters:

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInstalledScriptureSource.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderInstalledScriptureSource.swift
@@ -724,6 +724,21 @@ struct BibleReaderLocalDocumentRegistration<LocalDocument> {
 }
 
 /**
+ One installed chooser book retaining Android's display abbreviation after global admission.
+
+ The reader uses `ModuleInfo` for content/category actions, while Android's document chooser renders
+ and sorts the separate JSword abbreviation. Values are immutable and already reflect native-first
+ plus custom-driver registration ownership.
+ */
+struct BibleReaderInstalledBookPresentation {
+    /// Inclusive installed owner metadata used by reader actions and secondary display text.
+    let info: ModuleInfo
+
+    /// JSword abbreviation used by Android as primary row text and locale-aware sort input.
+    let abbreviation: String
+}
+
+/**
  Resolves Android's single global installed-book registry across native and SQLite backends.
 
  Each custom SQLite driver first asks the current registry for its proposed initials and skips
@@ -910,19 +925,16 @@ struct BibleReaderInstalledModuleResolver {
         swordManager: SwordManager?,
         sqliteModules: [BibleReaderSQLiteModuleHandle]
     ) {
-        let installedSnapshot = swordManager?.installedModules() ?? []
-        self.nativeRegistrations = installedSnapshot.compactMap { info in
+        let installedSnapshot = swordManager?.installedBookRegistrations() ?? []
+        self.nativeRegistrations = installedSnapshot.compactMap { installedBook in
+            let info = installedBook.moduleInfo
             guard !BibleReaderSQLiteModuleCatalog.isSQLiteProjection(info) else { return nil }
             let installedModule = swordManager?.module(named: info.name)
             let readableModule = (!info.isEncrypted || info.isUnlocked) ? installedModule : nil
-            let configuredAbbreviation = installedModule?.configEntry("Abbreviation")
             return NativeRegistration(
                 info: info,
                 readableModule: readableModule,
-                abbreviation: BibleReaderJSwordConfigValue.abbreviation(
-                    configuredAbbreviation,
-                    initials: info.name
-                )
+                abbreviation: installedBook.abbreviation
             )
         }
         self.sqliteModules = sqliteModules
@@ -1160,6 +1172,23 @@ struct BibleReaderInstalledModuleResolver {
      */
     func registeredBookMetadata() -> [ModuleInfo] {
         jswordSortedRegistrations.map(\.info)
+    }
+
+    /**
+     Returns globally admitted installed books with Android's chooser abbreviation retained.
+
+     - Returns: Native and SQLite registrations in final installed TreeSet order.
+     - Side effects: Replays immutable custom admission and comparator replacement only.
+     - Failure modes: Rejected custom candidates remain absent; locked native owners retain metadata
+       and abbreviation without exposing a readable content handle.
+     */
+    func registeredBookPresentations() -> [BibleReaderInstalledBookPresentation] {
+        jswordSortedRegistrations.map {
+            BibleReaderInstalledBookPresentation(
+                info: $0.info,
+                abbreviation: $0.abbreviation
+            )
+        }
     }
 
     /**

--- a/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift
@@ -39,7 +39,7 @@ struct BibleReaderModulePicker: View {
 
     /// Single installed document selected by Android's contextual action mode.
     private enum ContextualDocument: Equatable {
-        /// Installed SWORD/SQLite module initials.
+        /// Stable chooser-row identity for one installed SWORD/SQLite/add-on book.
         case module(String)
 
         /// Installed EPUB stable library identifier.
@@ -83,6 +83,9 @@ struct BibleReaderModulePicker: View {
 
     /// Confirmation payload for destructive Android document actions.
     @State private var pendingRowActionConfirmation: ModuleBrowserRowActionConfirmation?
+
+    /// Exact admitted add-on owner awaiting Android's destructive delete confirmation.
+    @State private var pendingAddonUninstall: SwordAdmittedAddonModule?
 
     /// Success-only EPUB deletion state shared with the reader reconciliation boundary.
     @State private var epubDeletionState = EpubLibraryDeletionState()
@@ -204,21 +207,54 @@ struct BibleReaderModulePicker: View {
     /**
      All installed modules Android's document-type spinner can expose.
 
-     - Returns: Installed Bible, commentary, dictionary, general book, map, and add-on modules,
-       de-duplicated only by Java-exact UTF-16 initials while preserving registry order.
+     - Returns: Installed Bible, commentary, dictionary, general book, map, and every comparator-
+       distinct add-on supplied by the shared Android compatibility/BookSet projection.
      */
     private var allSelectableModules: [ModuleInfo] {
-        let documentModules = Self.documentCategoryFilterOrder
-            .flatMap { controller.installedModules(for: $0) }
-        let addonModules = controller.swordManager?.installedModules(category: .addon) ?? []
+        selectableDocumentModules.map(\.info) + selectableAddons.map(\.moduleInfo)
+    }
 
-        return Self.javaExactDistinctModules(documentModules + addonModules)
+    /**
+     Returns non-add-on installed documents gathered once per Android document category.
+
+     - Side effects: Reads current controller inventory without changing reader state.
+     - Failure modes: Categories with no installed owner contribute no rows.
+     */
+    private var selectableDocumentModules: [BibleReaderInstalledBookPresentation] {
+        controller.installedBookPresentationsForDocumentPicker().filter {
+            Self.documentCategory(for: $0.info.category) != nil
+        }
+    }
+
+    /**
+     Returns shared payload-admitted add-ons with JSword abbreviation and identity metadata intact.
+
+     - Side effects: May populate the current manager's immutable add-on projection cache.
+     - Failure modes: Missing manager state and rejected add-ons produce no rows.
+     */
+    private var selectableAddons: [SwordAdmittedAddonModule] {
+        Self.selectableAddonModules(from: controller.swordManager)
+    }
+
+    /**
+     Returns the shared Android-admitted add-on inventory for picker presentation.
+
+     - Parameter swordManager: Current installed-module manager, or nil before module startup.
+     - Returns: Admitted add-on metadata in pinned JSword TreeSet order, or an empty list without a
+       manager.
+     - Side effects: May populate the manager's installed add-on projection cache.
+     - Failure modes: Invalid, unsupported, or future add-ons are omitted fail closed by SwordKit.
+     */
+    static func selectableAddonModules(
+        from swordManager: SwordManager?
+    ) -> [SwordAdmittedAddonModule] {
+        swordManager?.admittedAddonModules() ?? []
     }
 
     /**
      Returns only EPUBs that own their Android book identity in the current combined registry.
 
-     The on-disk EPUB library can contain a legacy or concurrently imported package whose initials
+     The on-disk EPUB library can contain a stale or concurrently imported package whose initials
      are rejected by an earlier native, SQLite, EPUB, or My Documents registration. Android never
      exposes that package through `ChooseDocument`, because the corresponding `Book` was not added
      to `Books.installed()`. Resolving each candidate through the controller keeps the picker on the
@@ -251,13 +287,18 @@ struct BibleReaderModulePicker: View {
 
     /// Android chooser rows before filters are applied, including only globally admitted EPUBs.
     private var allRows: [DocumentChooserRow] {
-        Self.allRows(from: allSelectableModules, epubs: selectableEpubs)
+        Self.allRows(
+            installedBooks: selectableDocumentModules,
+            admittedAddons: selectableAddons,
+            epubs: selectableEpubs
+        )
     }
 
     /// Rows after applying Android-compatible admission, type, language, and free-text filters.
     private var filteredDocumentRows: [DocumentChooserRow] {
         Self.filteredRows(
-            allSelectableModules,
+            installedBooks: selectableDocumentModules,
+            admittedAddons: selectableAddons,
             epubs: selectableEpubs,
             selectedFilter: selectedFilter,
             selectedLanguage: selectedLanguage,
@@ -265,10 +306,15 @@ struct BibleReaderModulePicker: View {
         )
     }
 
-    /// Installed row currently driving Android's contextual document menu.
+    /// Exact installed row currently driving Android's contextual document menu.
+    private var contextualRow: DocumentChooserRow? {
+        guard case .module(let rowID) = contextualDocument else { return nil }
+        return allRows.first(where: { $0.id == rowID })
+    }
+
+    /// Installed metadata currently driving Android's contextual document menu.
     private var contextualModule: ModuleInfo? {
-        guard case .module(let moduleName) = contextualDocument else { return nil }
-        return Self.javaExactModule(named: moduleName, in: allSelectableModules)
+        contextualRow?.moduleInfo
     }
 
     /// Installed EPUB currently driving Android's contextual document menu.
@@ -467,6 +513,29 @@ struct BibleReaderModulePicker: View {
                         },
                     ]
                 )
+            } else if let addon = pendingAddonUninstall {
+                let confirmation = confirmation(.uninstall, for: addon.moduleInfo)
+                ModulePickerDecisionDialog(
+                    title: confirmation.title,
+                    message: confirmation.message,
+                    actions: [
+                        .init(
+                            id: "confirm",
+                            title: confirmation.confirmButtonTitle,
+                            role: .destructive
+                        ) {
+                            pendingAddonUninstall = nil
+                            uninstallInstalledAddon(addon)
+                        },
+                        .init(
+                            id: "cancel",
+                            title: confirmation.cancelButtonTitle,
+                            role: nil
+                        ) {
+                            pendingAddonUninstall = nil
+                        },
+                    ]
+                )
             } else if let confirmation = pendingRowActionConfirmation {
                 ModulePickerDecisionDialog(title: confirmation.title, message: confirmation.message, actions: [
                     .init(id: "confirm", title: confirmation.confirmButtonTitle, role: .destructive) {
@@ -575,6 +644,7 @@ struct BibleReaderModulePicker: View {
     @ViewBuilder
     private var androidTopAppBar: some View {
         if let contextualModule {
+            let contextualDeletion = contextualRow.flatMap(Self.deletionSelection)
             AndroidDocumentContextActionBar(
                 actions: contextualModuleActions,
                 surfacePalette: surfacePalette,
@@ -586,7 +656,17 @@ struct BibleReaderModulePicker: View {
                 },
                 onDelete: {
                     clearContextualModuleSelection()
-                    pendingRowActionConfirmation = confirmation(.uninstall, for: contextualModule)
+                    switch contextualDeletion {
+                    case .addon(let addon):
+                        pendingAddonUninstall = addon
+                    case .module(let module):
+                        pendingRowActionConfirmation = confirmation(
+                            .uninstall,
+                            for: module
+                        )
+                    case nil:
+                        break
+                    }
                 },
                 onUnlock: {
                     clearContextualModuleSelection()
@@ -810,7 +890,19 @@ struct BibleReaderModulePicker: View {
     private func androidDocumentRow(_ row: DocumentChooserRow) -> some View {
         switch row {
         case .module(let module):
-            moduleRow(module)
+            moduleRow(
+                module.info,
+                rowID: row.id,
+                primaryTitle: row.primaryTitle,
+                accessibilityIdentifier: row.moduleAccessibilityIdentifier
+            )
+        case .addon(let addon):
+            moduleRow(
+                addon.moduleInfo,
+                rowID: row.id,
+                primaryTitle: row.primaryTitle,
+                accessibilityIdentifier: row.moduleAccessibilityIdentifier
+            )
         case .epub(let epub):
             epubRow(epub)
         case .pseudoDocument(let document):
@@ -869,15 +961,28 @@ struct BibleReaderModulePicker: View {
     /**
      Builds one installed module row with Android list-item columns and row actions.
 
-     - Parameter module: Installed module metadata from the active controller.
+     - Parameters:
+       - module: Installed module metadata from the active controller.
+       - rowID: Comparator-distinct chooser identity retained through contextual selection.
+       - primaryTitle: Android `Book.abbreviation` text rendered above the book name.
+       - accessibilityIdentifier: Exact row identifier exposed to UI automation.
      - Returns: Tappable row that switches or opens the selected document.
+     - Side effects: User gestures may open About, start contextual selection, or invoke reader
+       switching through the existing picker callbacks.
+     - Failure modes: Locked and stale modules remain visible; selection preflights fail closed in
+       the controller without dismissing the picker.
      */
-    private func moduleRow(_ module: ModuleInfo) -> some View {
+    private func moduleRow(
+        _ module: ModuleInfo,
+        rowID: String,
+        primaryTitle: String,
+        accessibilityIdentifier: String
+    ) -> some View {
         let actions = Self.rowActions(for: module, installedModules: allSelectableModules)
         return androidRowContainer(
-            accessibilityIdentifier: "modulePickerRow::\(module.name)",
-            isSelected: isContextualModuleSelected(module.name),
-            onLongPress: { beginContextualModuleSelection(module) },
+            accessibilityIdentifier: accessibilityIdentifier,
+            isSelected: isContextualModuleSelected(rowID),
+            onLongPress: { beginContextualModuleSelection(rowID: rowID) },
             leading: {
                 AndroidDocumentListLeadingColumn(
                     category: module.category,
@@ -893,7 +998,7 @@ struct BibleReaderModulePicker: View {
             },
             center: {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(module.name)
+                    Text(primaryTitle)
                         .font(.system(size: 16, weight: .regular))
                         .foregroundStyle(surfacePalette.foregroundColor)
                         .lineLimit(1)
@@ -912,7 +1017,7 @@ struct BibleReaderModulePicker: View {
                 .frame(width: 48, alignment: .trailing)
             },
             selection: {
-                handleModuleRowTap(module)
+                handleModuleRowTap(module, rowID: rowID)
             }
         )
     }
@@ -1087,14 +1192,16 @@ struct BibleReaderModulePicker: View {
     /**
      Enters Android's single-choice contextual mode for an installed chooser row.
 
-     - Parameter module: Long-pressed installed module.
+     - Parameter rowID: Comparator-distinct chooser identity for the long-pressed row.
      - Side effects: Closes the ordinary overflow popup and replaces the app bar with contextual
        document actions.
-     - Failure modes: none; the module remains validated against `allSelectableModules` when read.
+     - Failure modes: A stale or comparator-colliding row ID absent from the current `allRows`
+       snapshot is ignored before contextual state changes.
      */
-    private func beginContextualModuleSelection(_ module: ModuleInfo) {
+    private func beginContextualModuleSelection(rowID: String) {
+        guard allRows.contains(where: { $0.id == rowID && $0.moduleInfo != nil }) else { return }
         showOverflowMenu = false
-        contextualDocument = .module(module.name)
+        contextualDocument = .module(rowID)
     }
 
     /**
@@ -1115,31 +1222,33 @@ struct BibleReaderModulePicker: View {
     /**
      Applies Android row-tap behavior in normal or contextual mode.
 
-     - Parameter module: Tapped installed module.
+     - Parameters:
+       - module: Tapped installed module.
+       - rowID: Comparator-distinct chooser identity for the rendered row.
      - Side effects: Selects the document normally when no contextual action mode exists; otherwise
        changes the single selected contextual row or closes contextual mode when the same row is tapped.
      - Failure modes: Ordinary document selection retains the existing unlock and key-validation paths.
      */
-    private func handleModuleRowTap(_ module: ModuleInfo) {
+    private func handleModuleRowTap(_ module: ModuleInfo, rowID: String) {
         guard hasContextualDocumentSelection else {
             select(module)
             return
         }
-        let selection = ContextualDocument.module(module.name)
-        contextualDocument = isContextualModuleSelected(module.name) ? nil : selection
+        let selection = ContextualDocument.module(rowID)
+        contextualDocument = isContextualModuleSelected(rowID) ? nil : selection
     }
 
     /**
-     Tests contextual module selection with Java `String.equals` identity.
+     Tests contextual module selection with the row's comparator-distinct encoded identity.
 
-     - Parameter initials: Installed module initials represented by the row being rendered/tapped.
-     - Returns: True only when the selected module has the same UTF-16 code units.
+     - Parameter rowID: Stable ASCII chooser identity represented by the rendered/tapped row.
+     - Returns: True only when the same comparator-distinct row owns contextual selection.
      - Side effects: None.
-     - Failure modes: None; canonically equivalent Swift strings intentionally remain distinct.
+     - Failure modes: None; row IDs encode Java-exact fields before reaching this comparison.
      */
-    private func isContextualModuleSelected(_ initials: String) -> Bool {
-        guard case .module(let selectedInitials) = contextualDocument else { return false }
-        return SwordJavaStringIdentity.equals(selectedInitials, initials)
+    private func isContextualModuleSelected(_ rowID: String) -> Bool {
+        guard case .module(let selectedRowID) = contextualDocument else { return false }
+        return selectedRowID == rowID
     }
 
     /**
@@ -1586,6 +1695,40 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
+     Uninstalls the exact config or generated CSV owner selected from Android's Add-ons filter.
+
+     - Parameter addon: Admitted add-on row retaining its opaque installed deletion identity.
+     - Side effects: Deletes the shared initials-based Search index first, then transactionally
+       removes only the selected config/payload or standalone prompt CSV off the main actor.
+     - Failure modes: Stale owner, path/ownership, filesystem, and rollback failures are retained
+       as the row-action error; no same-initials fallback is attempted.
+     */
+    private func uninstallInstalledAddon(_ addon: SwordAdmittedAddonModule) {
+        let repository = repository
+        let searchIndexService = searchIndexService
+
+        Task {
+            do {
+                try await ModuleSearchIndexUninstaller.uninstall(
+                    moduleName: addon.moduleInfo.name,
+                    deleteSearchIndex: { moduleName in
+                        await searchIndexService.deleteIndex(for: moduleName)
+                    },
+                    removeModule: { _ in
+                        try await Task.detached(priority: .userInitiated) {
+                            try repository.uninstallAddon(addon.removalTarget)
+                        }.value
+                    }
+                )
+            } catch {
+                await MainActor.run {
+                    rowActionErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    /**
      Commits the EPUB deletion confirmed from Android's shared document action mode.
 
      - Side effects: Removes the published EPUB, notifies the reader owner only after durable
@@ -1944,49 +2087,12 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Removes repeated installed rows with Java `String.equals` identity while preserving order.
-
-     - Parameter modules: Category-concatenated installed module snapshots.
-     - Returns: First occurrence of each exact UTF-16 initials value; composed/decomposed and
-       case-variant names remain distinct just as they do in JSword's exact-name maps.
-     - Side effects: None.
-     - Failure modes: None; Swift strings expose valid UTF-16 views.
-     */
-    static func javaExactDistinctModules(_ modules: [ModuleInfo]) -> [ModuleInfo] {
-        var seenInitials: [String] = []
-        return modules.filter { module in
-            guard !seenInitials.contains(where: {
-                SwordJavaStringIdentity.equals($0, module.name)
-            }) else {
-                return false
-            }
-            seenInitials.append(module.name)
-            return true
-        }
-    }
-
-    /**
-     Selects one installed row with Java `String.equals` identity.
-
-     - Parameters:
-       - initials: Exact module initials retained by picker state.
-       - modules: Current selectable module rows.
-     - Returns: The first row with the same UTF-16 code units, or nil when that exact identity is
-       no longer installed.
-     - Side effects: None.
-     - Failure modes: None; canonically equivalent Swift strings intentionally do not alias.
-     */
-    static func javaExactModule(named initials: String, in modules: [ModuleInfo]) -> ModuleInfo? {
-        modules.first { SwordJavaStringIdentity.equals($0.name, initials) }
-    }
-
-    /**
      Builds a SwiftUI row ID that cannot canonically fold Java-distinct module identities.
 
      - Parameters:
        - namespace: Stable backend namespace such as `module` or `epub`.
        - value: Exact JSword initials value.
-     - Returns: The legacy readable ASCII ID for ASCII values, or a lowercase UTF-16 hexadecimal
+     - Returns: A readable ASCII ID for ASCII values, or a lowercase UTF-16 hexadecimal
        ID for non-ASCII values so composed/decomposed spellings remain distinct to SwiftUI.
      - Side effects: None.
      - Failure modes: None; every Swift string has a valid UTF-16 view.
@@ -2000,86 +2106,86 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Builds all Android chooser rows from installed modules and visible pseudo-documents.
+     Encodes one comparator-distinct installed add-on identity for SwiftUI and contextual state.
+
+     - Parameter addon: Shared admitted add-on retaining TreeSet abbreviation/identity fields.
+     - Returns: ASCII ID containing length-delimited hexadecimal UTF-16 abbreviation, initials, and
+       full-name fields; books retained by JSword cannot collide through Swift normalization.
+     - Side effects: None.
+     - Failure modes: None; every source field exposes valid UTF-16 code units.
+     */
+    private static func addonRowID(_ addon: SwordAdmittedAddonModule) -> String {
+        let fields = [
+            addon.abbreviation,
+            addon.moduleInfo.name,
+            addon.moduleInfo.description,
+        ].map { value -> String in
+            let units = Array(value.utf16)
+            let encoded = units.map { String($0, radix: 16) }.joined(separator: "-")
+            return "\(units.count):\(encoded)"
+        }
+        return "addon:\(fields.joined(separator: ":"))"
+    }
+
+    /**
+     Builds Android chooser rows from globally admitted books retaining exact abbreviations.
 
      - Parameters:
-       - modules: Installed SWORD module snapshots.
+       - installedBooks: Native/SQLite books after global ownership and BookSet projection.
+       - admittedAddons: Shared payload-admitted add-ons retaining abbreviation/BookSet identity.
        - epubs: Installed EPUB general-book adapters.
      - Returns: Installed module/EPUB rows plus My Notes, StudyPads, and Compare pseudo-document rows.
+     - Side effects: None.
+     - Failure modes: None; caller-owned immutable metadata is projected without content reads.
      */
-    static func allRows(from modules: [ModuleInfo], epubs: [EpubInfo] = []) -> [DocumentChooserRow] {
-        modules.map(DocumentChooserRow.module) +
+    static func allRows(
+        installedBooks: [BibleReaderInstalledBookPresentation],
+        admittedAddons: [SwordAdmittedAddonModule] = [],
+        epubs: [EpubInfo] = []
+    ) -> [DocumentChooserRow] {
+        installedBooks.map(DocumentChooserRow.module) +
+            admittedAddons.map(DocumentChooserRow.addon) +
             epubs.map(DocumentChooserRow.epub) +
             visibleAndroidPseudoDocuments.map(DocumentChooserRow.pseudoDocument)
     }
 
     /**
-     Filters and sorts chooser rows using Android `DocumentSelectionBase` semantics.
+     Filters and sorts globally admitted chooser books using Android presentation metadata.
 
      - Parameters:
-       - modules: Complete installed SWORD-module set.
+       - installedBooks: Installed books retaining exact JSword abbreviations.
+       - admittedAddons: Shared payload-admitted add-ons retaining abbreviation/BookSet identity.
        - epubs: Installed EPUB general-book adapters.
        - selectedFilter: Android document-type filter.
        - selectedLanguage: ISO language filter, or empty for all languages.
-       - searchText: Free-text search over initials, description, category, and language.
-     - Returns: Filtered rows sorted by Android category/status order and localized initials.
+       - searchText: Free-text search over initials, abbreviation, name, category, and language.
+     - Returns: Filtered rows stably sorted by Android status/category and language-locale-lowercased
+       abbreviation.
+     - Side effects: None.
+     - Failure modes: None; empty or unmatched inventories return an empty array.
      */
     static func filteredRows(
-        _ modules: [ModuleInfo],
+        installedBooks: [BibleReaderInstalledBookPresentation],
+        admittedAddons: [SwordAdmittedAddonModule] = [],
         epubs: [EpubInfo] = [],
         selectedFilter: DocumentTypeFilter,
         selectedLanguage: String,
         searchText: String
     ) -> [DocumentChooserRow] {
         let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return allRows(from: modules, epubs: epubs).filter { row in
+        let matchingRows = allRows(
+            installedBooks: installedBooks,
+            admittedAddons: admittedAddons,
+            epubs: epubs
+        ).filter { row in
             rowMatchesFilter(row, selectedFilter: selectedFilter) &&
             rowMatchesLanguage(row, selectedLanguage: selectedLanguage) &&
             rowMatchesSearch(row, searchText: trimmedSearch)
         }
-        .sorted(by: sortRows)
-    }
-
-    /**
-     Filters and sorts installed modules using the legacy module-only projection.
-
-     - Parameters:
-       - modules: Complete installed-module set.
-       - selectedCategory: Optional document-type filter, with `nil` meaning all types.
-       - selectedLanguage: ISO language filter, or empty for all languages.
-       - searchText: Free-text search over initials, description, category, and language.
-     - Returns: Filtered normal reader modules sorted by Android category order and initials.
-     */
-    static func filteredModules(
-        _ modules: [ModuleInfo],
-        selectedCategory: DocumentCategory?,
-        selectedLanguage: String,
-        searchText: String
-    ) -> [ModuleInfo] {
-        let selectedFilter = selectedCategory.map(DocumentTypeFilter.category) ?? .all
-        return filteredRows(
-            modules,
-            selectedFilter: selectedFilter,
-            selectedLanguage: selectedLanguage,
-            searchText: searchText
-        )
-        .compactMap { row in
-            guard case .module(let module) = row,
-                  documentCategory(for: module.category) != nil else {
-                return nil
-            }
-            return module
-        }
-    }
-
-    /**
-     Builds the alphabetized language list shown in the chooser language filter.
-
-     - Parameter modules: Complete installed-module set.
-     - Returns: Unique ISO language codes sorted by localized display name.
-     */
-    static func availableLanguages(from modules: [ModuleInfo]) -> [String] {
-        availableLanguages(from: allRows(from: modules))
+        return matchingRows.enumerated().sorted { lhs, rhs in
+            let comparison = rowSortComparison(lhs.element, rhs.element)
+            return comparison == 0 ? lhs.offset < rhs.offset : comparison < 0
+        }.map(\.element)
     }
 
     /**
@@ -2092,23 +2198,6 @@ struct BibleReaderModulePicker: View {
         Array(Set(rows.map(\.language))).sorted {
             displayName(for: $0).localizedCaseInsensitiveCompare(displayName(for: $1)) == .orderedAscending
         }
-    }
-
-    /**
-     Tests whether the selected Android document type has no installed modules at all.
-
-     - Parameters:
-       - modules: Complete installed-module set.
-       - selectedCategory: Optional document-type filter, with `nil` meaning all types.
-     - Returns: `true` only when a concrete type is selected and that type has no modules before
-       language or free-text filters run.
-     */
-    static func shouldShowCategoryEmptyState(
-        _ modules: [ModuleInfo],
-        selectedCategory: DocumentCategory?
-    ) -> Bool {
-        let selectedFilter = selectedCategory.map(DocumentTypeFilter.category) ?? .all
-        return shouldShowFilterEmptyState(allRows(from: modules), selectedFilter: selectedFilter)
     }
 
     /**
@@ -2358,27 +2447,51 @@ struct BibleReaderModulePicker: View {
     }
 
     /**
-     Sorts chooser rows using Android's document status, pseudo-document, category, and initials order.
+     Compares chooser rows using Android's document status, category, and abbreviation order.
 
      - Parameters:
        - lhs: Left row.
        - rhs: Right row.
-     - Returns: `true` when `lhs` should precede `rhs`.
+     - Returns: Negative, zero, or positive in Android chooser order; zero retains stable input order.
      */
-    private static func sortRows(_ lhs: DocumentChooserRow, _ rhs: DocumentChooserRow) -> Bool {
+    private static func rowSortComparison(
+        _ lhs: DocumentChooserRow,
+        _ rhs: DocumentChooserRow
+    ) -> Int {
         let lhsInstalledRank = lhs.isRealInstalledDocument ? 0 : 1
         let rhsInstalledRank = rhs.isRealInstalledDocument ? 0 : 1
         if lhsInstalledRank != rhsInstalledRank {
-            return lhsInstalledRank < rhsInstalledRank
+            return lhsInstalledRank - rhsInstalledRank
         }
 
         let lhsRank = categoryRank(for: lhs)
         let rhsRank = categoryRank(for: rhs)
         if lhsRank != rhsRank {
-            return lhsRank < rhsRank
+            return lhsRank - rhsRank
         }
 
-        return lhs.sortTitle.localizedCaseInsensitiveCompare(rhs.sortTitle) == .orderedAscending
+        let lhsKey = lhs.sortAbbreviation.lowercased(with: Locale(identifier: lhs.language))
+        let rhsKey = rhs.sortAbbreviation.lowercased(with: Locale(identifier: rhs.language))
+        return javaStringCompare(lhsKey, rhsKey)
+    }
+
+    /**
+     Compares strings by Java `String.compareTo` unsigned UTF-16 ordering.
+
+     - Parameters:
+       - lhs: Left Android chooser sort key.
+       - rhs: Right Android chooser sort key.
+     - Returns: First UTF-16 unit difference, then length difference when one is a prefix.
+     - Side effects: None.
+     - Failure modes: None; every Swift string exposes valid UTF-16 code units.
+     */
+    private static func javaStringCompare(_ lhs: String, _ rhs: String) -> Int {
+        let left = lhs.utf16
+        let right = rhs.utf16
+        for (leftUnit, rightUnit) in zip(left, right) where leftUnit != rightUnit {
+            return Int(leftUnit) - Int(rightUnit)
+        }
+        return left.count - right.count
     }
 
     /**
@@ -2428,12 +2541,15 @@ struct BibleReaderModulePicker: View {
     /**
      One row in the Android document chooser.
 
-     Rows are either installed SWORD modules or the visible `FakeBookFactory` pseudo-documents that
-     Android includes in `ChooseDocument`.
+     Rows retain installed SWORD documents, comparator-distinct add-ons, imported EPUBs, and the
+     visible `FakeBookFactory` pseudo-documents that Android includes in `ChooseDocument`.
      */
     enum DocumentChooserRow: Identifiable, Equatable {
         /// Installed local module row.
-        case module(ModuleInfo)
+        case module(BibleReaderInstalledBookPresentation)
+
+        /// Payload-admitted And Bible add-on retaining JSword abbreviation and full identity.
+        case addon(SwordAdmittedAddonModule)
 
         /// Imported EPUB exposed through Android's general-book contract.
         case epub(EpubInfo)
@@ -2447,8 +2563,10 @@ struct BibleReaderModulePicker: View {
             case .module(let module):
                 return BibleReaderModulePicker.javaExactRowID(
                     namespace: "module",
-                    value: module.name
+                    value: module.info.name
                 )
+            case .addon(let addon):
+                return BibleReaderModulePicker.addonRowID(addon)
             case .epub(let epub):
                 return BibleReaderModulePicker.javaExactRowID(
                     namespace: "epub",
@@ -2463,7 +2581,9 @@ struct BibleReaderModulePicker: View {
         var documentCategory: DocumentCategory? {
             switch self {
             case .module(let module):
-                return BibleReaderModulePicker.documentCategory(for: module.category)
+                return BibleReaderModulePicker.documentCategory(for: module.info.category)
+            case .addon:
+                return nil
             case .epub:
                 return .generalBook
             case .pseudoDocument(let document):
@@ -2475,7 +2595,9 @@ struct BibleReaderModulePicker: View {
         var language: String {
             switch self {
             case .module(let module):
-                return module.language
+                return module.info.language
+            case .addon(let addon):
+                return addon.moduleInfo.language
             case .epub(let epub):
                 return epub.language
             case .pseudoDocument(let document):
@@ -2485,26 +2607,71 @@ struct BibleReaderModulePicker: View {
 
         /// Whether the row is an Android AND_BIBLE add-on.
         var isAndroidAddon: Bool {
+            if case .addon = self { return true }
             guard case .module(let module) = self else { return false }
-            return module.category == .addon
+            return module.info.category == .addon
         }
 
         /// Whether Android would rank the row as a real installed SWORD document before fake rows.
         var isRealInstalledDocument: Bool {
             if case .epub = self { return true }
+            if case .addon = self { return true }
             guard case .module(let module) = self else { return false }
-            return BibleReaderModulePicker.documentCategory(for: module.category) != nil || module.category == .addon
+            return BibleReaderModulePicker.documentCategory(for: module.info.category) != nil
+                || module.info.category == .addon
         }
 
         /// Sort key matching Android's abbreviation-based row ordering.
-        var sortTitle: String {
+        var sortAbbreviation: String {
             switch self {
             case .module(let module):
-                return module.name
+                return module.abbreviation
+            case .addon(let addon):
+                return addon.abbreviation
             case .epub(let epub):
                 return epub.initials
             case .pseudoDocument(let document):
                 return document.title
+            }
+        }
+
+        /**
+         Returns the Android `Book.abbreviation` text rendered as the chooser row's primary label.
+
+         - Returns: The retained JSword abbreviation for installed books/add-ons, or the matching
+           adapter/pseudo-document abbreviation.
+         - Side effects: None.
+         - Failure modes: None; every row case owns a nonoptional display identity.
+         */
+        var primaryTitle: String {
+            switch self {
+            case .module(let module):
+                return module.abbreviation
+            case .addon(let addon):
+                return addon.abbreviation
+            case .epub(let epub):
+                return epub.initials
+            case .pseudoDocument(let document):
+                return document.androidInitials
+            }
+        }
+
+        /**
+         Returns the stable accessibility identifier for an installed module or add-on row.
+
+         - Returns: The established initials-based identifier for ordinary modules, or the exact
+           comparator-distinct add-on row ID when duplicate initials survive Android BookSet replay.
+         - Side effects: None.
+         - Failure modes: None; non-module rows return their stable row identity defensively.
+         */
+        var moduleAccessibilityIdentifier: String {
+            switch self {
+            case .module(let module):
+                return "modulePickerRow::\(module.info.name)"
+            case .addon:
+                return "modulePickerRow::\(id)"
+            case .epub, .pseudoDocument:
+                return id
             }
         }
 
@@ -2513,7 +2680,18 @@ struct BibleReaderModulePicker: View {
             switch self {
             case .module(let module):
                 return [
+                    module.info.name,
+                    module.abbreviation,
+                    module.info.description,
+                    module.info.language,
+                    BibleReaderModulePicker.displayName(for: module.info.language),
+                    BibleReaderModulePicker.moduleCategoryTitle(for: module.info.category)
+                ]
+            case .addon(let addon):
+                let module = addon.moduleInfo
+                return [
                     module.name,
+                    addon.abbreviation,
                     module.description,
                     module.language,
                     BibleReaderModulePicker.displayName(for: module.language),
@@ -2540,16 +2718,60 @@ struct BibleReaderModulePicker: View {
             }
         }
 
+        /// Installed module metadata used by rendering and contextual actions, when applicable.
+        var moduleInfo: ModuleInfo? {
+            switch self {
+            case .module(let module):
+                return module.info
+            case .addon(let addon):
+                return addon.moduleInfo
+            case .epub, .pseudoDocument:
+                return nil
+            }
+        }
+
         /**
          Compares rows by stable identity.
 
          - Parameters:
            - lhs: Left row.
            - rhs: Right row.
-         - Returns: `true` when both rows represent the same module or pseudo-document.
+         - Returns: `true` when both rows represent the same exact module, add-on, EPUB, or
+           pseudo-document identity.
          */
         static func == (lhs: DocumentChooserRow, rhs: DocumentChooserRow) -> Bool {
             lhs.id == rhs.id
+        }
+    }
+
+    /** Exact installed owner retained before the contextual selection state is cleared. */
+    enum InstalledDocumentDeletionSelection {
+        /// Ordinary installed module routed through the established module uninstall boundary.
+        case module(ModuleInfo)
+
+        /// Comparator-distinct add-on routed through its opaque installed-owner token.
+        case addon(SwordAdmittedAddonModule)
+    }
+
+    /**
+     Captures the destructive owner represented by one installed chooser row.
+
+     - Parameter row: Current chooser row before contextual selection state is cleared.
+     - Returns: Ordinary module metadata or the exact admitted add-on owner; EPUB and pseudo rows
+       return nil because their deletion flows are owned by separate boundaries.
+     - Side effects: None; the returned value is immutable and survives subsequent UI-state reset.
+     - Failure modes: None; unsupported row families return nil rather than approximating identity.
+     */
+    static func deletionSelection(
+        for row: DocumentChooserRow
+    ) -> InstalledDocumentDeletionSelection? {
+        switch row {
+        case .module(let module):
+            return .module(module.info)
+        case .addon(let addon):
+            return .addon(addon)
+        case .epub, .pseudoDocument:
+            return nil
         }
     }
 

--- a/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleReaderModulePickerTests.swift
@@ -10,10 +10,27 @@ import XCTest
 
  These tests protect the BibleUI-owned picker filtering, pseudo-document, document-management, and
  full-screen chooser presentation contracts without booting the app. Behavioral access regressions
- use an isolated temporary SWORD tree removed by inherited teardown. Failures indicate visual or
- behavioral drift from Android's document chooser, not app delegate or simulator lifecycle issues.
+ use isolated temporary SWORD trees removed by inherited teardown or local `defer` cleanup.
+ Failures indicate visual or behavioral drift from Android's document chooser, not app delegate or
+ simulator lifecycle issues.
  */
 final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
+    /**
+     Wraps lightweight test metadata in the exact presentation contract consumed by production.
+
+     - Parameter modules: Immutable module fixtures whose initials also serve as abbreviations.
+     - Returns: Installed-book presentations preserving fixture order and metadata.
+     - Side effects: None.
+     - Failure modes: None; every supplied module maps to exactly one presentation.
+     */
+    private func installedBooks(
+        _ modules: [ModuleInfo]
+    ) -> [BibleReaderInstalledBookPresentation] {
+        modules.map {
+            BibleReaderInstalledBookPresentation(info: $0, abbreviation: $0.name)
+        }
+    }
+
     func testBibleReaderModulePickerBuildsForBibleCategory() {
         let controller = BibleReaderController(bridge: BibleBridge(), initializesSword: false)
         let view = BibleReaderModulePicker(
@@ -47,85 +64,78 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
             ModuleInfo(name: "Devotion", description: "Daily devotional", category: .dailyDevotion, language: "en")
         ]
 
+        func filteredModules(
+            category: DocumentCategory?,
+            language: String = "",
+            searchText: String = ""
+        ) -> [ModuleInfo] {
+            BibleReaderModulePicker.filteredRows(
+                installedBooks: installedBooks(modules),
+                selectedFilter: category.map(BibleReaderModulePicker.DocumentTypeFilter.category)
+                    ?? .all,
+                selectedLanguage: language,
+                searchText: searchText
+            ).compactMap { row in
+                guard case .module(let module) = row else { return nil }
+                return module.info
+            }
+        }
+
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                modules,
-                selectedCategory: nil,
-                selectedLanguage: "",
-                searchText: ""
-            ).map(\.name),
+            filteredModules(category: nil).map(\.name),
             ["KJV", "MHC", "StrongsHebrew", "BookA", "MapA"]
         )
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                modules,
-                selectedCategory: .dictionary,
-                selectedLanguage: "",
-                searchText: ""
-            ).map(\.name),
+            filteredModules(category: .dictionary).map(\.name),
             ["StrongsHebrew"]
         )
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                modules,
-                selectedCategory: nil,
-                selectedLanguage: "en",
-                searchText: ""
-            ).map(\.name),
+            filteredModules(category: nil, language: "en").map(\.name),
             ["KJV", "MHC", "MapA"]
         )
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                modules,
-                selectedCategory: .bible,
-                selectedLanguage: "he",
-                searchText: ""
-            ).map(\.name),
+            filteredModules(category: .bible, language: "he").map(\.name),
             []
         )
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                modules,
-                selectedCategory: nil,
-                selectedLanguage: "",
-                searchText: "strong"
-            ).map(\.name),
+            filteredModules(category: nil, searchText: "strong").map(\.name),
             ["StrongsHebrew"]
         )
         XCTAssertEqual(
-            BibleReaderModulePicker.availableLanguages(from: modules),
+            BibleReaderModulePicker.availableLanguages(
+                from: BibleReaderModulePicker.allRows(installedBooks: installedBooks(modules))
+            ),
             ["en", "fr", "he"]
         )
         let bibleOnlyModules = [
             ModuleInfo(name: "KJV", description: "King James Version", category: .bible, language: "en")
         ]
         XCTAssertTrue(
-            BibleReaderModulePicker.shouldShowCategoryEmptyState(
-                bibleOnlyModules,
-                selectedCategory: .dictionary
+            BibleReaderModulePicker.shouldShowFilterEmptyState(
+                BibleReaderModulePicker.allRows(installedBooks: installedBooks(bibleOnlyModules)),
+                selectedFilter: .category(.dictionary)
             )
         )
         XCTAssertFalse(
-            BibleReaderModulePicker.shouldShowCategoryEmptyState(
-                bibleOnlyModules,
-                selectedCategory: .bible
+            BibleReaderModulePicker.shouldShowFilterEmptyState(
+                BibleReaderModulePicker.allRows(installedBooks: installedBooks(bibleOnlyModules)),
+                selectedFilter: .category(.bible)
             )
         )
         XCTAssertFalse(
-            BibleReaderModulePicker.shouldShowCategoryEmptyState(
-                modules,
-                selectedCategory: nil
+            BibleReaderModulePicker.shouldShowFilterEmptyState(
+                BibleReaderModulePicker.allRows(installedBooks: installedBooks(modules)),
+                selectedFilter: .all
             )
         )
     }
 
     /**
-     Preserves Java-distinct composed/decomposed module rows through dedupe and selection lookup.
+     Preserves Java-distinct composed/decomposed module rows through rendering identity.
 
-     - Setup: Supplies two visually equivalent initials with different UTF-16 spellings plus one
-       exact duplicate of the composed spelling.
-     - Expected: Only the exact duplicate is removed; each Java-distinct row has a distinct SwiftUI
-       identity and resolves only from its own exact initials token.
+     - Setup: Supplies two installed rows with visually equivalent initials and different UTF-16
+       spellings.
+     - Expected: Each Java-distinct row has a distinct SwiftUI identity and retains its exact token.
      - Failure meaning: Swift canonical String equality is still collapsing or misrouting an
        installed book that Android exposes as a separate registry identity.
      - Side effects: None.
@@ -148,12 +158,11 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
             language: "fr"
         )
 
-        let distinct = BibleReaderModulePicker.javaExactDistinctModules([
+        let distinct = [
             composedModule,
             decomposedModule,
-            composedModule,
-        ])
-        let rows = BibleReaderModulePicker.allRows(from: distinct)
+        ]
+        let rows = BibleReaderModulePicker.allRows(installedBooks: installedBooks(distinct))
             .filter { row in
                 if case .module = row { return true }
                 return false
@@ -161,18 +170,8 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
 
         XCTAssertEqual(distinct.count, 2)
         XCTAssertNotEqual(try XCTUnwrap(rows.first).id, try XCTUnwrap(rows.last).id)
-        XCTAssertEqual(
-            Array(try XCTUnwrap(
-                BibleReaderModulePicker.javaExactModule(named: composed, in: distinct)
-            ).name.utf16),
-            Array(composed.utf16)
-        )
-        XCTAssertEqual(
-            Array(try XCTUnwrap(
-                BibleReaderModulePicker.javaExactModule(named: decomposed, in: distinct)
-            ).name.utf16),
-            Array(decomposed.utf16)
-        )
+        XCTAssertTrue(SwordJavaStringIdentity.equals(try XCTUnwrap(rows.first?.moduleInfo).name, composed))
+        XCTAssertTrue(SwordJavaStringIdentity.equals(try XCTUnwrap(rows.last?.moduleInfo).name, decomposed))
     }
 
     /**
@@ -193,7 +192,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
 
         XCTAssertEqual(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .all,
                 selectedLanguage: "",
                 searchText: ""
@@ -209,7 +208,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         )
         XCTAssertEqual(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .category(.commentary),
                 selectedLanguage: "",
                 searchText: ""
@@ -218,7 +217,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         )
         XCTAssertEqual(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .category(.generalBook),
                 selectedLanguage: "",
                 searchText: ""
@@ -227,7 +226,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         )
         XCTAssertEqual(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .addons,
                 selectedLanguage: "en",
                 searchText: ""
@@ -236,7 +235,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         )
         XCTAssertTrue(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .category(.bible),
                 selectedLanguage: "",
                 searchText: "notes"
@@ -244,13 +243,178 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         )
         XCTAssertEqual(
             BibleReaderModulePicker.filteredRows(
-                modules,
+                installedBooks: installedBooks(modules),
                 selectedFilter: .all,
                 selectedLanguage: "",
                 searchText: "notes"
             ).map(\.id),
             ["pseudo:myNotes"]
         )
+    }
+
+    /**
+     Verifies the picker add-on tab consumes the shared Android-admitted add-on projection.
+
+     - Setup: Writes four payload-backed compatible add-ons, including two comparator-distinct books
+       with the same initials and abbreviations opposing initials order, plus future and malformed
+       configs under one temporary manager root.
+     - Expected: Picker inventory contains every compatible JSword row, gives duplicates distinct
+       SwiftUI identities, and uses Android's abbreviation ordering rather than initials ordering.
+     - Side effects: Creates, reads, and removes one isolated SWORD config tree.
+     - Failure meaning: The picker can expose add-ons that prompt/feature execution correctly rejects.
+     */
+    func testPickerAddonInventoryUsesSharedAndroidAdmission() throws {
+        let swordFixtureURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = swordFixtureURL.appendingPathComponent("mods.d", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: swordFixtureURL) }
+        let definitions = [
+            (file: "z-alpha.conf", initials: "ZZZADDON", description: "Alpha row", abbreviation: "Alpha", minimum: "1115"),
+            (file: "b-duplicate.conf", initials: "DUPADDON", description: "Duplicate beta", abbreviation: "Beta", minimum: "1115"),
+            (file: "c-duplicate.conf", initials: "DUPADDON", description: "Duplicate gamma", abbreviation: "Gamma", minimum: "1115"),
+            (file: "a-zulu.conf", initials: "AAAADDON", description: "Zulu row", abbreviation: "Zulu", minimum: "1115"),
+            (file: "future.conf", initials: "FUTURE", description: "Future", abbreviation: "Future", minimum: "1116"),
+            (file: "malformed.conf", initials: "MALFORMED", description: "Malformed", abbreviation: "Malformed", minimum: "later"),
+        ]
+        for definition in definitions {
+            let payloadDirectory = swordFixtureURL.appendingPathComponent(
+                "addons/\(definition.file)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: payloadDirectory,
+                withIntermediateDirectories: true
+            )
+            try """
+            [\(definition.initials)]
+            Description=\(definition.description)
+            Abbreviation=\(definition.abbreviation)
+            Category=And Bible
+            ModDrv=RawGenBook
+            DataPath=./addons/\(definition.file)
+            AndBibleMinimumVersion=\(definition.minimum)
+            """.write(
+                to: configDirectory.appendingPathComponent(definition.file),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        let manager = try XCTUnwrap(SwordManager(modulePath: swordFixtureURL.path))
+        let addons = BibleReaderModulePicker.selectableAddonModules(from: manager)
+
+        XCTAssertEqual(
+            addons.map(\.moduleInfo.name),
+            ["ZZZADDON", "DUPADDON", "DUPADDON", "AAAADDON"]
+        )
+        let rows = BibleReaderModulePicker.filteredRows(
+            installedBooks: [],
+            admittedAddons: addons,
+            selectedFilter: .addons,
+            selectedLanguage: "",
+            searchText: ""
+        )
+        XCTAssertEqual(
+            rows.compactMap(\.moduleInfo).map(\.description),
+            ["Alpha row", "Duplicate beta", "Duplicate gamma", "Zulu row"]
+        )
+        XCTAssertEqual(rows.map(\.primaryTitle), ["Alpha", "Beta", "Gamma", "Zulu"])
+        XCTAssertEqual(Set(rows.map(\.id)).count, 4)
+        XCTAssertEqual(Set(rows.map(\.moduleAccessibilityIdentifier)).count, 4)
+        XCTAssertEqual(Set(addons.map(\.removalTarget)).count, 4)
+        let deletionTargets = rows.compactMap { row -> SwordInstalledAddonRemovalTarget? in
+            guard let selection = BibleReaderModulePicker.deletionSelection(for: row),
+                  case .addon(let addon) = selection else {
+                return nil
+            }
+            return addon.removalTarget
+        }
+        XCTAssertEqual(deletionTargets, addons.map(\.removalTarget))
+    }
+
+    /**
+     Guards the picker delete action against collapsing an admitted add-on back to initials.
+
+     - Setup: Reads the production picker after the behavior-level row-selection oracle above and
+       extracts its exact add-on uninstall function.
+     - Expected result: The app bar captures immutable deletion identity before clearing contextual
+       state, and repository deletion receives the opaque target rather than the module-name API.
+     - Side effects: Reads one source-controlled Swift file without mutation.
+     - Failure meaning: Duplicate-initial or configless Android add-on rows can render distinctly but
+       invoke an ordinary uninstall path that rejects or removes a different installed Book.
+     */
+    func testAddonContextDeleteRetainsOpaqueInstalledOwner() throws {
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift"
+        )
+        let uninstallSource = try BibleUITestSourceLocator.extractFunction(
+            named: "uninstallInstalledAddon",
+            from: source
+        )
+
+        XCTAssertTrue(source.contains("@State private var pendingAddonUninstall"))
+        XCTAssertTrue(
+            source.contains(
+                "let contextualDeletion = contextualRow.flatMap(Self.deletionSelection)"
+            )
+        )
+        XCTAssertTrue(source.contains("case .addon(let addon):"))
+        XCTAssertTrue(source.contains("pendingAddonUninstall = addon"))
+        XCTAssertFalse(source.contains("if let contextualAddon"))
+        XCTAssertTrue(uninstallSource.contains("repository.uninstallAddon(addon.removalTarget)"))
+        XCTAssertFalse(uninstallSource.contains("repository.uninstallModule(named:"))
+    }
+
+    /**
+     Verifies ordinary installed books retain Android abbreviation rendering and locale sorting.
+
+     - Setup: Supplies Turkish-I abbreviations whose locale-lowercase order opposes initials, plus
+       two equal-lowercase abbreviations in a deliberate input order.
+     - Expected: Primary labels use abbreviations, Turkish lowercase controls ordering, and equal
+       keys remain stable instead of falling back to initials.
+     - Side effects: None; projects immutable in-memory installed metadata.
+     - Failure meaning: Non-add-on chooser rows diverge from Android `DocumentSelectionBase` and
+       `DocumentItemAdapter` even though add-on rows appear correct.
+     */
+    func testInstalledBookRowsRenderAndSortByAndroidAbbreviation() {
+        /**
+         Builds one Turkish-language installed presentation for deterministic row sorting.
+
+         - Parameters:
+           - initials: Exact installed module identity.
+           - abbreviation: Android primary label and locale-lowercase sort input.
+         - Returns: Immutable Bible-row presentation.
+         - Side effects: None.
+         - Failure modes: None.
+         */
+        func book(
+            _ initials: String,
+            _ abbreviation: String
+        ) -> BibleReaderInstalledBookPresentation {
+            BibleReaderInstalledBookPresentation(
+                info: ModuleInfo(
+                    name: initials,
+                    description: "\(initials) name",
+                    category: .bible,
+                    language: "tr"
+                ),
+                abbreviation: abbreviation
+            )
+        }
+        let rows = BibleReaderModulePicker.filteredRows(
+            installedBooks: [
+                book("AAA", "I"),
+                book("DDD", "SAME"),
+                book("CCC", "same"),
+                book("ZZZ", "İ"),
+            ],
+            selectedFilter: .category(.bible),
+            selectedLanguage: "",
+            searchText: ""
+        )
+
+        XCTAssertEqual(rows.map(\.primaryTitle), ["İ", "SAME", "same", "I"])
+        XCTAssertEqual(rows.compactMap(\.moduleInfo).map(\.name), ["ZZZ", "DDD", "CCC", "AAA"])
     }
 
     /**
@@ -321,7 +485,7 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
 
         XCTAssertEqual(admitted.map(\.identifier), [admittedFirst.identifier, admittedLast.identifier])
         XCTAssertEqual(
-            BibleReaderModulePicker.allRows(from: [], epubs: admitted).compactMap { row in
+            BibleReaderModulePicker.allRows(installedBooks: [], epubs: admitted).compactMap { row in
                 guard case .epub(let epub) = row else { return nil }
                 return epub.identifier
             },
@@ -715,12 +879,12 @@ final class BibleReaderModulePickerTests: BibleUISwordFixtureTestCase {
         XCTAssertTrue(BibleReaderModulePicker.requiresUnlock(locked))
         XCTAssertFalse(BibleReaderModulePicker.requiresUnlock(unlocked))
         XCTAssertEqual(
-            BibleReaderModulePicker.filteredModules(
-                [locked, unlocked],
-                selectedCategory: .bible,
+            BibleReaderModulePicker.filteredRows(
+                installedBooks: installedBooks([locked, unlocked]),
+                selectedFilter: .category(.bible),
                 selectedLanguage: "",
                 searchText: ""
-            ).map(\.name),
+            ).compactMap(\.moduleInfo).map(\.name),
             ["LOCKED", "OPEN"]
         )
 

--- a/Sources/BibleUI/Tests/BibleUITests/BibleUITestSourceLocator.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/BibleUITestSourceLocator.swift
@@ -67,7 +67,26 @@ enum BibleUITestSourceLocator {
      - Throws: An `NSError` when the declaration is missing or the function body is unbalanced.
      */
     static func extractFunction(named functionName: String, from source: String) throws -> String {
-        guard let functionRange = source.range(of: "func \(functionName)") else {
+        let declarationPrefix = "func \(functionName)"
+        var searchRange = source.startIndex..<source.endIndex
+        var functionRange: Range<String.Index>?
+        while let candidate = source.range(of: declarationPrefix, range: searchRange) {
+            let nextCharacter = candidate.upperBound < source.endIndex
+                ? source[candidate.upperBound]
+                : nil
+            let continuesIdentifier = nextCharacter.map { character in
+                character == "_" || character.unicodeScalars.allSatisfy {
+                    CharacterSet.alphanumerics.contains($0)
+                }
+            } ?? false
+            if !continuesIdentifier {
+                functionRange = candidate
+                break
+            }
+            searchRange = candidate.upperBound..<source.endIndex
+        }
+
+        guard let functionRange else {
             throw NSError(
                 domain: "BibleUITestSourceLocator",
                 code: 2,

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -2505,6 +2505,23 @@ public final class ModuleRepository: @unchecked Sendable {
         }
     }
 
+    /**
+     Uninstalls the exact config or generated CSV owner retained by an admitted add-on row.
+
+     - Parameter target: Opaque installed owner supplied by `SwordManager.admittedAddonModules()`.
+     - Side effects: Acquires the canonical module-store lease and transactionally removes only the
+       selected owner before invalidating inventory and posting the terminal store notification.
+     - Throws: `ModuleRepositoryError.moduleNotFound` for stale owners, or the publisher's unsafe
+       path, ownership, filesystem, cache, and rollback failures.
+     */
+    public func uninstallAddon(_ target: SwordInstalledAddonRemovalTarget) throws {
+        do {
+            try mutationPublisher.uninstallInstalledAddon(target)
+        } catch ModuleStoreMutationError.moduleNotFound {
+            throw ModuleRepositoryError.moduleNotFound(target.moduleName)
+        }
+    }
+
     // MARK: - Install from ZIP
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift
@@ -8,7 +8,275 @@ private enum PreparedModuleStoreUninstall {
     case sword(ModuleStoreTransactionPublisher.InstalledConfigRecord)
 }
 
+/** Exact installed add-on owner captured and revalidated under the mutation lease. */
+private enum PreparedInstalledAddonUninstall {
+    /// One config-backed SWORD add-on and its validated adjusted payload location.
+    case sword(configURL: URL, locationURL: URL?)
+
+    /// One generated `CsvPromptBook` file below the canonical `prompts` directory.
+    case standalonePromptCSV(URL)
+}
+
 extension ModuleStoreTransactionPublisher {
+    /**
+     Transactionally removes the exact owner represented by one admitted add-on row.
+
+     - Parameter target: Opaque config or standalone-CSV identity captured by `SwordManager` from
+       the installed registry generation shown to the user.
+     - Side effects: Acquires the canonical-root lease, revalidates the exact owner, moves its files
+       to rollback storage, invalidates the SWORD cache, and posts one terminal notification.
+     - Throws: Stale/mismatched identity, unsafe path, shared payload ownership, filesystem, cache,
+       or rollback failures. The function never falls back to a same-initials sibling.
+     */
+    func uninstallInstalledAddon(_ target: SwordInstalledAddonRemovalTarget) throws {
+        try coordinator.withExclusiveTransaction(kind: .uninstall, prepare: {
+            guard let currentManager = SwordManager(modulePath: canonicalRootURL.path),
+                  currentManager.admittedAddonModules().contains(where: {
+                      $0.removalTarget == target
+                  }) else {
+                throw ModuleStoreMutationError.moduleNotFound(target.moduleName)
+            }
+
+            switch target.storage {
+            case .swordConfig(
+                let relativePath,
+                let moduleName,
+                let fullName,
+                let abbreviation,
+                let driver,
+                let dataPath,
+                let locationRelativePath
+            ):
+                let configs = SwordModuleConfig.readAll(modulePath: canonicalRootURL.path)
+                guard let config = configs.first(where: {
+                    guard let sourceURL = $0.sourceURL else { return false }
+                    return SwordJavaStringIdentity.equals(
+                        Self.relativePath(of: sourceURL, under: canonicalRootURL),
+                        relativePath
+                    )
+                }),
+                let configURL = config.sourceURL,
+                config.moduleInfo.category == .addon,
+                SwordJavaStringIdentity.equals(config.name, moduleName),
+                SwordJavaStringIdentity.equals(config.description, fullName),
+                SwordJavaStringIdentity.equals(config.modDrv, driver),
+                SwordJavaStringIdentity.equals(config.dataPath, dataPath),
+                SwordJavaStringIdentity.equals(
+                    Self.installedAbbreviation(config: config),
+                    abbreviation
+                ) else {
+                    throw ModuleStoreMutationError.moduleNotFound(moduleName)
+                }
+
+                let adjustedLocation = SwordManager.adjustedModuleLocation(
+                    for: config,
+                    modulePath: canonicalRootURL.path
+                )
+                guard let adjustedLocation,
+                      Self.locationMatches(
+                        adjustedLocation,
+                        expectedRelativePath: locationRelativePath,
+                        rootURL: canonicalRootURL
+                      ) else {
+                    throw ModuleStoreMutationError.moduleNotFound(moduleName)
+                }
+                let locationURL = adjustedLocation.url
+                let canonicalRoot = canonicalRootURL.standardizedFileURL.resolvingSymlinksInPath()
+                if let locationURL,
+                   SwordJavaStringIdentity.equals(locationURL.path, canonicalRoot.path) {
+                    throw ModuleStoreMutationError.invalidConfiguration(relativePath)
+                }
+                if let locationURL,
+                   isProtectedInstalledFamilyRoot(locationURL) {
+                    throw ModuleStoreMutationError.installedOwnershipConflict(
+                        moduleName: moduleName,
+                        owner: locationURL.lastPathComponent
+                    )
+                }
+
+                for other in configs {
+                    guard let otherURL = other.sourceURL,
+                          !SwordJavaStringIdentity.equals(
+                            otherURL.standardizedFileURL.path,
+                            configURL.standardizedFileURL.path
+                          ),
+                          let otherLocation = SwordManager.adjustedModuleLocation(
+                            for: other,
+                            modulePath: canonicalRootURL.path
+                          ).flatMap(\.url),
+                          let locationURL,
+                          Self.pathsOverlap(locationURL, otherLocation) else {
+                        continue
+                    }
+                    throw ModuleStoreMutationError.installedOwnershipConflict(
+                        moduleName: moduleName,
+                        owner: other.name
+                    )
+                }
+                return PreparedInstalledAddonUninstall.sword(
+                    configURL: configURL,
+                    locationURL: locationURL
+                )
+
+            case .standalonePromptCSV(let fileName, let moduleName):
+                return .standalonePromptCSV(
+                    try preparedStandalonePromptCSV(
+                        fileName: fileName,
+                        moduleName: moduleName
+                    )
+                )
+            }
+        }, commit: { (prepared: PreparedInstalledAddonUninstall) in
+            switch prepared {
+            case .sword(let configURL, let locationURL):
+                try performInstalledAddonConfigUninstall(
+                    configURL: configURL,
+                    locationURL: locationURL
+                )
+            case .standalonePromptCSV(let fileURL):
+                try performStandalonePromptCSVUninstall(fileURL: fileURL)
+            }
+        })
+    }
+
+    /**
+     Removes one exact config-backed add-on through rollback storage.
+
+     - Parameters:
+       - configURL: Revalidated direct-root config that produced the selected installed Book.
+       - locationURL: Revalidated JSword-adjusted payload directory, or nil for no-location books.
+     - Side effects: Moves the adjusted location and config to rollback storage, invalidates cache,
+       posts one terminal notification, and removes backup storage after success.
+     - Throws: Filesystem, cache-invalidation, or rollback failures.
+     */
+    private func performInstalledAddonConfigUninstall(
+        configURL: URL,
+        locationURL: URL?
+    ) throws {
+        let backupRoot = canonicalRootURL.appendingPathComponent(
+            ".module-transaction-\(UUID().uuidString).backup",
+            isDirectory: true
+        )
+        var moves: [BackupMove] = []
+        do {
+            let targets = (locationURL.map { [$0] } ?? []) + [configURL]
+            for originalURL in collapsedExistingTargets(targets) {
+                try moveToBackup(originalURL, backupRoot: backupRoot, moves: &moves)
+            }
+            try invalidateModuleCache()
+            if fileManager.fileExists(atPath: backupRoot.path) {
+                try fileManager.removeItem(at: backupRoot)
+            }
+            notifyModuleStoreChanged()
+        } catch {
+            let rollbackFailures = rollback(
+                backupRoot: backupRoot,
+                moves: moves,
+                publishedURLs: []
+            )
+            try throwAfterRollback(original: error, rollbackFailures: rollbackFailures)
+        }
+    }
+
+    /**
+     Produces one exact path relative to a canonical module root.
+
+     - Parameters:
+       - url: Installed config or adjusted location URL.
+       - rootURL: Canonical SWORD root that must contain `url`.
+     - Returns: Exact relative path, an empty string for the root itself, or an impossible sentinel
+       for an escaped path so caller equality fails closed.
+     - Side effects: Resolves symlinks and standardizes paths without mutation.
+     - Failure modes: None exposed; escaped paths return the sentinel rather than throwing.
+     */
+    private static func relativePath(of url: URL, under rootURL: URL) -> String {
+        let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let child = url.standardizedFileURL.resolvingSymlinksInPath()
+        if SwordJavaStringIdentity.equals(root.path, child.path) { return "" }
+        let rootPrefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        guard child.path.hasPrefix(rootPrefix) else { return "\0escaped" }
+        return String(child.path.dropFirst(rootPrefix.count))
+    }
+
+    /**
+     Checks a fresh adjusted location against the opaque row identity.
+
+     - Parameters:
+       - location: Fresh JSword adjusted-location result for the selected config.
+       - expectedRelativePath: Relative location captured with the installed row, or nil when the
+         row had no adjusted location.
+       - rootURL: Canonical SWORD root used for relative-path comparison.
+     - Returns: `true` only when both generations have the same no-location/location state and exact
+       UTF-16 relative path.
+     - Side effects: Resolves paths without mutation.
+     - Failure modes: None; escaped locations compare false.
+     */
+    private static func locationMatches(
+        _ location: SwordManager.AdjustedModuleLocation,
+        expectedRelativePath: String?,
+        rootURL: URL
+    ) -> Bool {
+        switch (location, expectedRelativePath) {
+        case (.noLocation, nil):
+            return true
+        case (.location(let url), .some(let expected)):
+            return SwordJavaStringIdentity.equals(
+                relativePath(of: url, under: rootURL),
+                expected
+            )
+        case (.noLocation, .some), (.location, nil):
+            return false
+        }
+    }
+
+    /**
+     Reports whether two adjusted payload directories overlap.
+
+     - Parameters:
+       - lhs: First standardized installed payload directory.
+       - rhs: Second standardized installed payload directory.
+     - Returns: `true` when either directory equals or contains the other.
+     - Side effects: Resolves symlinks without mutation.
+     - Failure modes: None; callers have already bounded both locations to the canonical root.
+     */
+    private static func pathsOverlap(_ lhs: URL, _ rhs: URL) -> Bool {
+        let left = lhs.standardizedFileURL.resolvingSymlinksInPath().path
+        let right = rhs.standardizedFileURL.resolvingSymlinksInPath().path
+        if SwordJavaStringIdentity.equals(left, right) { return true }
+        let leftPrefix = left.hasSuffix("/") ? left : left + "/"
+        let rightPrefix = right.hasSuffix("/") ? right : right + "/"
+        return left.hasPrefix(rightPrefix) || right.hasPrefix(leftPrefix)
+    }
+
+    /**
+     Reports whether an adjusted location is a shared top-level installed-family root.
+
+     Config-backed add-ons may own dedicated descendants such as `addons/foo`, but cannot remove
+     the roots used by config files, normal SWORD payloads, Android raw-module families, generated
+     resources, or transaction recovery. Those roots can contain owners that do not participate in
+     native config-location overlap checks, including generated standalone prompt CSV books.
+
+     - Parameter locationURL: Fresh JSword-adjusted location bounded by the canonical module root.
+     - Returns: `true` only when the location is exactly one protected top-level family directory.
+     - Side effects: Resolves paths and applies the resolver's deterministic filesystem collision
+       key without mutation.
+     - Failure modes: Escaped, root, and nested paths return false here and are handled by the
+       surrounding containment/root/overlap gates.
+     */
+    private func isProtectedInstalledFamilyRoot(_ locationURL: URL) -> Bool {
+        let relativePath = Self.relativePath(of: locationURL, under: canonicalRootURL)
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.count == 1, let component = components.first, !component.isEmpty else {
+            return false
+        }
+        let key = resolver.filesystemCollisionKey(String(component))
+        let protectedKeys = [
+            "mods.d", "modules", "mybible", "mysword", "esword", "epub", "ttf",
+            "background", "prompts", ".module-recovery",
+        ].map(resolver.filesystemCollisionKey)
+        return protectedKeys.contains(key) || key.hasPrefix(".module-transaction-")
+    }
+
     /**
      Transactionally uninstalls a MyBible sidecar module or a validated SWORD module.
 
@@ -85,6 +353,102 @@ extension ModuleStoreTransactionPublisher {
             )
             try throwAfterRollback(original: error, rollbackFailures: rollbackFailures)
         }
+    }
+
+    /**
+     Resolves and validates one generated `CsvPromptBook` deletion target under the mutation lease.
+
+     - Parameters:
+       - fileName: Exact direct child name captured from the installed prompts enumeration.
+       - moduleName: Exact generated `Prompts_<stem>` initials captured with the row.
+     - Returns: Current regular, non-symlink CSV URL bounded by the canonical prompts directory.
+     - Side effects: Resolves symlinks and reads filesystem metadata without mutation.
+     - Throws: Unsafe/stale path, wrong generated initials, or missing/nonregular file failures.
+     */
+    private func preparedStandalonePromptCSV(
+        fileName: String,
+        moduleName: String
+    ) throws -> URL {
+        guard !fileName.isEmpty,
+              !fileName.contains("/"),
+              (fileName as NSString).lastPathComponent == fileName,
+              SwordJavaStringIdentity.equalsIgnoreCase(
+                (fileName as NSString).pathExtension,
+                "csv"
+              ) else {
+            throw ModuleStoreMutationError.unsafeArchivePath(fileName)
+        }
+        let expectedModuleName = "Prompts_\((fileName as NSString).deletingPathExtension)"
+        guard SwordJavaStringIdentity.equals(expectedModuleName, moduleName) else {
+            throw ModuleStoreMutationError.moduleNotFound(moduleName)
+        }
+
+        let rootURL = canonicalRootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let promptsURL = canonicalRootURL
+            .appendingPathComponent("prompts", isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let rootPrefix = rootURL.path.hasSuffix("/") ? rootURL.path : rootURL.path + "/"
+        guard promptsURL.path.hasPrefix(rootPrefix) else {
+            throw ModuleStoreMutationError.canonicalPathEscape(promptsURL.path)
+        }
+        let fileURL = promptsURL
+            .appendingPathComponent(fileName, isDirectory: false)
+            .standardizedFileURL
+        let canonicalFileURL = fileURL.resolvingSymlinksInPath()
+        let promptsPrefix = promptsURL.path.hasSuffix("/") ? promptsURL.path : promptsURL.path + "/"
+        let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard canonicalFileURL.path.hasPrefix(promptsPrefix),
+              values?.isRegularFile == true,
+              values?.isSymbolicLink != true else {
+            throw ModuleStoreMutationError.moduleNotFound(moduleName)
+        }
+        return fileURL
+    }
+
+    /**
+     Removes one under-lease generated prompt CSV through the publisher rollback machinery.
+
+     - Parameter fileURL: Revalidated regular direct child of the canonical prompts directory.
+     - Side effects: Moves the CSV to rollback storage, invalidates the SWORD cache, posts one
+       terminal notification, and removes rollback storage after success.
+     - Throws: Filesystem, cache-invalidation, or rollback failures.
+     */
+    private func performStandalonePromptCSVUninstall(fileURL: URL) throws {
+        let backupRoot = canonicalRootURL.appendingPathComponent(
+            ".module-transaction-\(UUID().uuidString).backup",
+            isDirectory: true
+        )
+        var moves: [BackupMove] = []
+        do {
+            try moveToBackup(fileURL, backupRoot: backupRoot, moves: &moves)
+            try invalidateModuleCache()
+            if fileManager.fileExists(atPath: backupRoot.path) {
+                try fileManager.removeItem(at: backupRoot)
+            }
+            notifyModuleStoreChanged()
+        } catch {
+            let rollbackFailures = rollback(
+                backupRoot: backupRoot,
+                moves: moves,
+                publishedURLs: []
+            )
+            try throwAfterRollback(original: error, rollbackFailures: rollbackFailures)
+        }
+    }
+
+    /**
+     Returns the exact JSword abbreviation for one installed config.
+
+     - Parameter config: Parsed installed SWORD configuration.
+     - Returns: Java-trimmed first `Abbreviation`, or exact initials when absent/empty.
+     - Side effects: None.
+     - Failure modes: None; initials are always present on a parsed config.
+     */
+    private static func installedAbbreviation(config: SwordModuleConfig) -> String {
+        let abbreviation = config.values["Abbreviation"]?.first
+            .map(SwordJavaStringIdentity.trim)
+        return abbreviation.flatMap { $0.isEmpty ? nil : $0 } ?? config.name
     }
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/SwordAdmittedAddonModule.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordAdmittedAddonModule.swift
@@ -1,0 +1,55 @@
+// SwordAdmittedAddonModule.swift — Shared Android add-on admission projection
+
+import Foundation
+
+/**
+ One installed add-on admitted by Android's shared add-on feature contract.
+
+ Android prompt packs, reading plans, and the Add-ons document picker begin with the same
+ `AndBibleAddonFilter` view of `Books.installed()`. This immutable value exposes the metadata needed
+ by prompt and picker consumers without letting either surface repeat compatibility or ordering
+ decisions. Font discovery remains separately tracked until it joins this projection.
+ */
+public struct SwordAdmittedAddonModule: Sendable {
+    /// Installed-book metadata in pinned JSword TreeSet order.
+    public let moduleInfo: ModuleInfo
+
+    /// JSword abbreviation used by Android's chooser and installed-book ordering.
+    public let abbreviation: String
+
+    /// First case-sensitive `AndBibleProvidesPrompts` value, or nil when the add-on has no pack.
+    public let promptFileName: String?
+
+    /// Filesystem-adjusted JSword book location, or nil when JSword retained no location.
+    public let locationURL: URL?
+
+    /// Exact config or standalone-CSV owner used by Android-equivalent uninstall routing.
+    public let removalTarget: SwordInstalledAddonRemovalTarget
+
+    /**
+     Creates one already-admitted add-on projection.
+
+     - Parameters:
+       - moduleInfo: Supported installed add-on metadata after HashSet and TreeSet replay.
+       - abbreviation: Java-trimmed JSword abbreviation used by Android document sorting.
+       - promptFileName: Singular first prompt-pack property matching JSword `getProperty`.
+       - locationURL: Validated adjusted book location matching JSword directory/file-prefix rules,
+         or nil when a slashless `DataPath` leaves JSword metadata without a feature location.
+       - removalTarget: Opaque installed owner revalidated by the mutation boundary during delete.
+     - Side effects: None.
+     - Failure modes: None; construction is internal to the shared admission pipeline.
+     */
+    init(
+        moduleInfo: ModuleInfo,
+        abbreviation: String,
+        promptFileName: String?,
+        locationURL: URL?,
+        removalTarget: SwordInstalledAddonRemovalTarget
+    ) {
+        self.moduleInfo = moduleInfo
+        self.abbreviation = abbreviation
+        self.promptFileName = promptFileName
+        self.locationURL = locationURL
+        self.removalTarget = removalTarget
+    }
+}

--- a/Sources/SwordKit/Sources/SwordKit/SwordInstalledAddonRemovalTarget.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordInstalledAddonRemovalTarget.swift
@@ -1,0 +1,212 @@
+// SwordInstalledAddonRemovalTarget.swift — Opaque installed add-on deletion ownership
+
+import Foundation
+
+/**
+ Identifies the exact installed owner Android deletes for one admitted add-on row.
+
+ Add-on initials are not a unique deletion key: JSword can retain comparator-distinct books with
+ the same initials, and generated `CsvPromptBook` rows have no `.conf` file at all. Consumers keep
+ this value opaque and return it to `ModuleRepository`, which revalidates the concrete config or CSV
+ owner under the module-store mutation lease before removing anything.
+ */
+public struct SwordInstalledAddonRemovalTarget: Sendable, Hashable {
+    /** Exact storage owner retained from the installed registry generation. */
+    enum Storage: Sendable {
+        /// Direct-root SWORD config plus the metadata that identifies its installed Book.
+        case swordConfig(
+            relativePath: String,
+            moduleName: String,
+            fullName: String,
+            abbreviation: String,
+            driver: String,
+            dataPath: String,
+            locationRelativePath: String?
+        )
+
+        /// Generated `CsvPromptBook` backed by one exact file in the root `prompts` directory.
+        case standalonePromptCSV(fileName: String, moduleName: String)
+    }
+
+    /// Exact installed storage owner; package consumers cannot construct or inspect it.
+    let storage: Storage
+
+    /// Module initials used only for matching search-index cleanup and public error presentation.
+    let moduleName: String
+
+    /**
+     Creates an opaque config-backed removal identity from one admitted installed Book.
+
+     - Parameters:
+       - relativePath: Canonical direct-root config path relative to the SWORD home.
+       - moduleName: Exact JSword initials.
+       - fullName: Exact JSword name participating in Book equality/order.
+       - abbreviation: Exact JSword abbreviation participating in chooser identity/order.
+       - driver: Exact `ModDrv` value that determines the concrete Book class and payload layout.
+       - dataPath: Exact normalized `DataPath` value bound to the installed payload.
+       - locationRelativePath: JSword-adjusted directory relative to the canonical SWORD root, or
+         nil when the installed Book has no adjusted location.
+     - Side effects: None.
+     - Failure modes: None; the mutation boundary independently revalidates every field and path.
+     */
+    init(
+        configRelativePath relativePath: String,
+        moduleName: String,
+        fullName: String,
+        abbreviation: String,
+        driver: String,
+        dataPath: String,
+        locationRelativePath: String?
+    ) {
+        storage = .swordConfig(
+            relativePath: relativePath,
+            moduleName: moduleName,
+            fullName: fullName,
+            abbreviation: abbreviation,
+            driver: driver,
+            dataPath: dataPath,
+            locationRelativePath: locationRelativePath
+        )
+        self.moduleName = moduleName
+    }
+
+    /**
+     Creates an opaque generated-prompt removal identity from its exact CSV owner.
+
+     - Parameters:
+       - fileName: Exact direct child name inside the SWORD root's `prompts` directory.
+       - moduleName: Exact Android-generated `Prompts_<stem>` initials.
+     - Side effects: None.
+     - Failure modes: None; the mutation boundary revalidates the direct-child CSV relationship.
+     */
+    init(standalonePromptFileName fileName: String, moduleName: String) {
+        storage = .standalonePromptCSV(fileName: fileName, moduleName: moduleName)
+        self.moduleName = moduleName
+    }
+
+    /**
+     Compares opaque owners with Java's exact UTF-16 string identity.
+
+     - Parameters:
+       - lhs: First captured installed owner.
+       - rhs: Second captured installed owner.
+     - Returns: `true` only when both targets have the same storage family and every string or
+       optional string has identical raw UTF-16 code units.
+     - Side effects: None.
+     - Failure modes: None; different storage families and nil/value mismatches compare false.
+     */
+    public static func == (
+        lhs: SwordInstalledAddonRemovalTarget,
+        rhs: SwordInstalledAddonRemovalTarget
+    ) -> Bool {
+        switch (lhs.storage, rhs.storage) {
+        case let (
+            .swordConfig(
+                lhsPath,
+                lhsName,
+                lhsFullName,
+                lhsAbbreviation,
+                lhsDriver,
+                lhsDataPath,
+                lhsLocation
+            ),
+            .swordConfig(
+                rhsPath,
+                rhsName,
+                rhsFullName,
+                rhsAbbreviation,
+                rhsDriver,
+                rhsDataPath,
+                rhsLocation
+            )
+        ):
+            return Self.javaStringsAreExactlyEqual(lhsPath, rhsPath)
+                && Self.javaStringsAreExactlyEqual(lhsName, rhsName)
+                && Self.javaStringsAreExactlyEqual(lhsFullName, rhsFullName)
+                && Self.javaStringsAreExactlyEqual(lhsAbbreviation, rhsAbbreviation)
+                && Self.javaStringsAreExactlyEqual(lhsDriver, rhsDriver)
+                && Self.javaStringsAreExactlyEqual(lhsDataPath, rhsDataPath)
+                && Self.javaOptionalStringsAreExactlyEqual(lhsLocation, rhsLocation)
+        case let (
+            .standalonePromptCSV(lhsFileName, lhsName),
+            .standalonePromptCSV(rhsFileName, rhsName)
+        ):
+            return Self.javaStringsAreExactlyEqual(lhsFileName, rhsFileName)
+                && Self.javaStringsAreExactlyEqual(lhsName, rhsName)
+        case (.swordConfig, .standalonePromptCSV), (.standalonePromptCSV, .swordConfig):
+            return false
+        }
+    }
+
+    /**
+     Hashes the exact installed owner without Swift canonical-equivalence folding.
+
+     - Parameter hasher: Standard-library hasher receiving the storage discriminator and raw UTF-16
+       identity of every stored string.
+     - Side effects: Mutates only `hasher`.
+     - Failure modes: None.
+     */
+    public func hash(into hasher: inout Hasher) {
+        switch storage {
+        case let .swordConfig(
+            relativePath,
+            moduleName,
+            fullName,
+            abbreviation,
+            driver,
+            dataPath,
+            locationRelativePath
+        ):
+            hasher.combine(0)
+            hasher.combine(SwordJavaExactStringIdentity(relativePath))
+            hasher.combine(SwordJavaExactStringIdentity(moduleName))
+            hasher.combine(SwordJavaExactStringIdentity(fullName))
+            hasher.combine(SwordJavaExactStringIdentity(abbreviation))
+            hasher.combine(SwordJavaExactStringIdentity(driver))
+            hasher.combine(SwordJavaExactStringIdentity(dataPath))
+            hasher.combine(locationRelativePath.map(SwordJavaExactStringIdentity.init))
+        case let .standalonePromptCSV(fileName, moduleName):
+            hasher.combine(1)
+            hasher.combine(SwordJavaExactStringIdentity(fileName))
+            hasher.combine(SwordJavaExactStringIdentity(moduleName))
+        }
+    }
+
+    /**
+     Compares two nonoptional strings with Java's raw UTF-16 identity.
+
+     - Parameters:
+       - lhs: First stored metadata/path value.
+       - rhs: Second stored metadata/path value.
+     - Returns: `true` only when both raw UTF-16 code-unit sequences match.
+     - Side effects: None.
+     - Failure modes: None.
+     */
+    private static func javaStringsAreExactlyEqual(_ lhs: String, _ rhs: String) -> Bool {
+        SwordJavaExactStringIdentity(lhs) == SwordJavaExactStringIdentity(rhs)
+    }
+
+    /**
+     Compares two optional strings with Java's nil-or-raw-UTF-16 identity.
+
+     - Parameters:
+       - lhs: First optional adjusted-location path.
+       - rhs: Second optional adjusted-location path.
+     - Returns: `true` for two nil values or two code-unit-identical strings.
+     - Side effects: None.
+     - Failure modes: None; nil/value mismatches compare false.
+     */
+    private static func javaOptionalStringsAreExactlyEqual(
+        _ lhs: String?,
+        _ rhs: String?
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case let (.some(lhs), .some(rhs)):
+            return javaStringsAreExactlyEqual(lhs, rhs)
+        case (nil, nil):
+            return true
+        case (.some, nil), (nil, .some):
+            return false
+        }
+    }
+}

--- a/Sources/SwordKit/Sources/SwordKit/SwordInstalledBookRegistration.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordInstalledBookRegistration.swift
@@ -1,0 +1,30 @@
+// SwordInstalledBookRegistration.swift — Installed JSword metadata with comparator fields
+
+/**
+ One installed book exposed with the metadata Android's chooser and BookSet consumers require.
+
+ `ModuleInfo.name` is the exact initials identity, while `abbreviation` is the independently parsed
+ JSword display/comparator field. Keeping both prevents UI and feature consumers from reconstructing
+ abbreviation from initials after installed HashSet/TreeSet ownership has already been resolved.
+ */
+public struct SwordInstalledBookRegistration: Sendable {
+    /// Inclusive installed metadata, including current encrypted/unlocked access state.
+    public let moduleInfo: ModuleInfo
+
+    /// Java-trimmed JSword abbreviation with exact initials fallback already applied.
+    public let abbreviation: String
+
+    /**
+     Creates one installed registration from the shared manager snapshot.
+
+     - Parameters:
+       - moduleInfo: Installed owner metadata after payload and BookSet admission.
+       - abbreviation: Exact JSword abbreviation used by Android display and sorting.
+     - Side effects: None.
+     - Failure modes: None; construction is internal to `SwordManager`'s admitted projection.
+     */
+    init(moduleInfo: ModuleInfo, abbreviation: String) {
+        self.moduleInfo = moduleInfo
+        self.abbreviation = abbreviation
+    }
+}

--- a/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
@@ -79,8 +79,13 @@ public final class SwordManager: @unchecked Sendable {
      cache. Values are immutable after the single config/native capture and read no content.
      */
     private struct NativeModuleRegistrySnapshot {
+        /// Payload-admitted native books eligible for installed-TreeSet projection.
+        let installedBooks: [NativeInstalledBook]
+
         /// Supported native metadata rows eligible for installed-TreeSet projection.
-        let installedRegistrations: [InstalledModuleRegistration]
+        var installedRegistrations: [InstalledModuleRegistration] {
+            installedBooks.map(\.registration)
+        }
 
         /// Ownership-proven registrations keyed by unique exact initials.
         let exactInitials: [SwordJavaExactStringIdentity: NativeModuleRegistration]
@@ -93,6 +98,68 @@ public final class SwordManager: @unchecked Sendable {
 
         /// Ownership-proven registrations in installed JSword TreeSet order for alias lookup.
         let treeSetRegistrations: [NativeModuleRegistration]
+    }
+
+    /**
+     One native book after JSword payload adjustment and driver HashSet admission.
+
+     The parsed config, live access-state registration, and optional adjusted location travel as
+     one immutable owner so feature projections cannot reopen configs and lose cipher state or
+     select a different equality-group member.
+     */
+    private struct NativeInstalledBook {
+        /// Metadata and abbreviation captured from the admitted native owner.
+        let registration: InstalledModuleRegistration
+
+        /// Exact parsed config that produced this installed book.
+        let config: SwordModuleConfig
+
+        /// JSword-adjusted feature location, or nil when slashless `DataPath` retained no location.
+        let locationURL: URL?
+    }
+
+    /**
+     One installed add-on candidate before TreeSet replacement and compatibility filtering.
+
+     Native books arrive after driver HashSet admission. Standalone CSV prompt books are appended
+     later through Android's explicit `Books.addBook` path and therefore bypass the driver HashSet.
+     */
+    private struct InstalledAddonCandidate {
+        /// Metadata and abbreviation participating in installed TreeSet comparison.
+        let registration: InstalledModuleRegistration
+
+        /// Parsed feature metadata supplying minimum version and prompt-pack filename.
+        let config: SwordModuleConfig
+
+        /// Filesystem-adjusted location used by feature consumers, when JSword assigned one.
+        let locationURL: URL?
+
+        /// Exact installed config or generated CSV owner used for deletion.
+        let removalTarget: SwordInstalledAddonRemovalTarget
+    }
+
+    /** One immutable installed generation shared by public inventory and add-on consumers. */
+    private struct InstalledRegistryProjection {
+        /// Supported public books after the complete Android add sequence and TreeSet replay.
+        let registrations: [SwordInstalledBookRegistration]
+
+        /// Installed add-on owners carrying config and location before compatibility filtering.
+        let addonCandidates: [InstalledAddonCandidate]
+    }
+
+    /** Result of JSword `SwordBookMetaData.adjustLocation` payload admission. */
+    enum AdjustedModuleLocation {
+        /// The book remains installed, but a slashless `DataPath` assigned no feature location.
+        case noLocation
+
+        /// The book remains installed with this validated directory location.
+        case location(URL)
+
+        /// Optional URL exposed to installed feature projections.
+        var url: URL? {
+            guard case .location(let url) = self else { return nil }
+            return url
+        }
     }
 
     /**
@@ -181,6 +248,12 @@ public final class SwordManager: @unchecked Sendable {
     /// One manager-lifetime config/registry capture, invalidated by unlock and explicit refresh.
     private var nativeRegistrySnapshotCache: NativeModuleRegistrySnapshot?
 
+    /// Complete installed generation shared by public book and feature projections.
+    private var installedRegistryProjectionCache: InstalledRegistryProjection?
+
+    /// Android-admitted add-ons in installed TreeSet order, invalidated with installed inventory.
+    private var admittedAddonModulesCache: [SwordAdmittedAddonModule]?
+
     /// Current-session unlock overrides keyed by the exact canonical initials that were verified.
     private var sessionUnlockedModuleNames: Set<SwordJavaExactStringIdentity> = []
 
@@ -203,6 +276,8 @@ public final class SwordManager: @unchecked Sendable {
     deinit {
         SwordRuntime.sync {
             nativeRegistrySnapshotCache = nil
+            installedRegistryProjectionCache = nil
+            admittedAddonModulesCache = nil
             moduleCache.removeAll()
             SWMgr_delete(handle)
         }
@@ -235,40 +310,93 @@ public final class SwordManager: @unchecked Sendable {
      in inventory so they can expose Android's unlock action. Android custom drivers restored from
      Android module backups, such as `MyBibleDictionary`, are stored as `.conf` rows plus SQLite
      payloads but are not opened by libsword. Manifest-installed MyBible packages are stored in iOS'
-     sidecar package directory. Android exposes both families through `Books.installed().books`;
-     iOS mirrors that inventory here by projecting readable custom modules into `ModuleInfo` rows.
+     sidecar package directory. Configless CSV files in `prompts` become Android `CsvPromptBook`
+     registrations. Android exposes all of these families through `Books.installed().books`; iOS
+     mirrors that inventory here through one cached installed-registry projection.
 
      - Returns: SWORD modules and readable Android custom modules projected through JSword's
        category/abbreviation/initials/name TreeSet comparator. Canonically equivalent Java-distinct
        UTF-16 spellings and comparator-distinct duplicate-initial metadata remain separate books.
-     - Side effects: Reads `mods.d` configs, sidecar metadata, and checks custom payload files.
+     - Side effects: Reads `mods.d` configs, sidecar metadata, checks custom payload files, and
+       enumerates readable direct-child CSV files in the `prompts` directory.
      - Failure modes: Malformed configs, modules libsword cannot resolve, and custom rows without
        readable payloads are skipped.
      - Note: Locked encrypted modules remain visible with `isUnlocked == false`; a key verified in
        this manager session overrides only that module's stale native metadata snapshot.
      */
     public func installedModules() -> [ModuleInfo] {
-        let swordModules = nativeModuleRegistrySnapshot().installedRegistrations
-        let restoredCustomModules = Self.androidCustomInstalledRegistrations(modulePath: modulePath)
-        let packageModules = Self.admittedMyBiblePackageRegistrations(
-            Self.myBiblePackageRegistrations(modulePath: modulePath),
-            after: swordModules + restoredCustomModules
-        )
+        installedBookRegistrations().map(\.moduleInfo)
+    }
 
-        let merged = Self.mergedInstalledModules(
-            swordModules: swordModules,
-            customModules: restoredCustomModules + packageModules
-        )
-        // Exclude modules SWORD cannot fully use (e.g. a Bible with an unrecognized versification),
-        // mirroring Android's `Books.installed()`, which never contains an unsupported book. Such a
-        // module is then invisible everywhere — not readable, not in pickers, and shown as
-        // not-installed in Downloads (so it appears re-downloadable, which overwrites a broken conf).
-        // Uninstall/index operate by name and are unaffected. See ADR-0010.
-        //
-        // `isSupported` reads SWORD's versification manager per Bible module; run the whole filter in
-        // one serialization hop (re-entrant `SwordRuntime.sync`) so a large library costs a single
-        // queue round-trip rather than one per module.
-        return SwordRuntime.sync { merged.filter(\.isSupported) }
+    /**
+     Lists installed books with the exact JSword abbreviation retained through registry admission.
+
+     - Returns: Comparator-distinct native, Android custom, and generated standalone prompt books
+       in installed TreeSet order, carrying inclusive access state and display abbreviation.
+     - Side effects: Builds the same cached native snapshot, reads custom payload metadata, and
+       enumerates standalone prompt CSV files exactly as `installedModules()`; no content is read.
+     - Failure modes: Malformed, unsupported, payload-missing, and shadowed books are omitted by the
+       shared installed registry rather than approximated by consumers.
+     */
+    public func installedBookRegistrations() -> [SwordInstalledBookRegistration] {
+        installedRegistryProjection().registrations
+    }
+
+    /**
+     Builds one installed generation for every public inventory and add-on feature consumer.
+
+     - Returns: Supported TreeSet registrations plus config/location-bearing add-on owners captured
+       from the same native/custom/package/standalone add sequence.
+     - Side effects: On first access, reads installed configs, package metadata, payload paths, and
+       the standalone prompts directory; later access reuses the immutable manager snapshot.
+     - Failure modes: Malformed, unsupported, payload-missing, shadowed, and unreadable books are
+       omitted fail closed; an unreadable standalone directory contributes no synthetic books.
+     */
+    private func installedRegistryProjection() -> InstalledRegistryProjection {
+        SwordRuntime.sync {
+            if let installedRegistryProjectionCache { return installedRegistryProjectionCache }
+
+            let nativeSnapshot = nativeModuleRegistrySnapshot()
+            let swordModules = nativeSnapshot.installedRegistrations
+            let restoredCustomModules = Self.androidCustomInstalledRegistrations(modulePath: modulePath)
+            let packageModules = Self.admittedMyBiblePackageRegistrations(
+                Self.myBiblePackageRegistrations(modulePath: modulePath),
+                after: swordModules + restoredCustomModules
+            )
+            var installedRegistrations = swordModules + restoredCustomModules + packageModules
+            var addonCandidates: [InstalledAddonCandidate] = nativeSnapshot.installedBooks.compactMap { book in
+                guard book.registration.info.category == .addon else { return nil }
+                return InstalledAddonCandidate(
+                    registration: book.registration,
+                    config: book.config,
+                    locationURL: book.locationURL,
+                    removalTarget: Self.configRemovalTarget(
+                        config: book.config,
+                        registration: book.registration,
+                        locationURL: book.locationURL,
+                        modulePath: modulePath
+                    )
+                )
+            }
+            addonCandidates.append(contentsOf: Self.standalonePromptCandidates(
+                modulePath: modulePath,
+                installedRegistrations: &installedRegistrations
+            ))
+            let registrations = Self.installedRegistrationOrderProjection(installedRegistrations)
+                .filter(\.info.isSupported)
+                .map {
+                    SwordInstalledBookRegistration(
+                        moduleInfo: $0.info,
+                        abbreviation: $0.abbreviation
+                    )
+                }
+            let projection = InstalledRegistryProjection(
+                registrations: registrations,
+                addonCandidates: addonCandidates
+            )
+            installedRegistryProjectionCache = projection
+            return projection
+        }
     }
 
     /// List installed modules filtered by category.
@@ -402,6 +530,8 @@ public final class SwordManager: @unchecked Sendable {
             SWMgr_setCipherKey(handle, canonicalName, cipherKey)
             sessionUnlockedModuleNames.insert(SwordJavaExactStringIdentity(canonicalName))
             nativeRegistrySnapshotCache = nil
+            installedRegistryProjectionCache = nil
+            admittedAddonModulesCache = nil
             return true
         }
     }
@@ -783,10 +913,11 @@ public final class SwordManager: @unchecked Sendable {
        order. Subsequent lookups reuse the same immutable snapshot until unlock or `refresh()`.
      - Side effects: On first access, reads installed configs, asks libsword for exact handles, and
        populates the exact-keyed module cache only for raw-unique identities. No content is read.
-     - Failure modes: Custom, missing, cross-resolved, and unsupported configs are omitted from
-       native inventory. Duplicate identity detection occurs before those filters, preventing one
-       filtered config from making a surviving backend appear safely owned. Exact full-name
-       collisions remain individually readable by initials but fail closed through the name map.
+     - Failure modes: Custom, payload-invalid, missing, cross-resolved, and unsupported configs are
+       omitted before driver HashSet ownership. Duplicate exact-initial detection still covers the
+       raw config set, preventing a filtered duplicate from making content ownership appear safe.
+       Exact full-name collisions remain individually readable by initials but fail closed through
+       the name map.
      - Important: All native work executes through the re-entrant `SwordRuntime` serialization gate.
      - Complexity: O(N log N) once per cache lifetime; cached exact lookup is O(1).
      */
@@ -808,11 +939,15 @@ public final class SwordManager: @unchecked Sendable {
                 Self.javaStringCompare($0.sourceURL?.path ?? "", $1.sourceURL?.path ?? "") < 0
             }
             var nativeHashIdentities: Set<NativeSwordBookHashIdentity> = []
-            var installedRegistrations: [InstalledModuleRegistration] = []
+            var installedBooks: [NativeInstalledBook] = []
             var resolvableRegistrations: [NativeModuleRegistration] = []
             for config in deterministicConfigs {
                 guard !config.isAndroidCustomDriver,
                       let configURL = config.sourceURL,
+                      let adjustedLocation = Self.adjustedModuleLocation(
+                        for: config,
+                        modulePath: modulePath
+                      ),
                       let moduleHandle = SWMgr_getModuleByName(handle, config.name) else {
                     continue
                 }
@@ -844,11 +979,15 @@ public final class SwordManager: @unchecked Sendable {
                     .map(SwordJavaStringIdentity.trim)
                 let abbreviation = configuredAbbreviation.flatMap { $0.isEmpty ? nil : $0 }
                     ?? info.name
-                installedRegistrations.append(
-                    InstalledModuleRegistration(
-                        info: info,
-                        abbreviation: abbreviation,
-                        fullName: config.description
+                installedBooks.append(
+                    NativeInstalledBook(
+                        registration: InstalledModuleRegistration(
+                            info: info,
+                            abbreviation: abbreviation,
+                            fullName: config.description
+                        ),
+                        config: config,
+                        locationURL: adjustedLocation.url
                     )
                 )
 
@@ -891,7 +1030,7 @@ public final class SwordManager: @unchecked Sendable {
                 }
             }
             let snapshot = NativeModuleRegistrySnapshot(
-                installedRegistrations: installedRegistrations,
+                installedBooks: installedBooks,
                 exactInitials: exactInitials,
                 exactFullNames: exactFullNames,
                 ambiguousExactFullNames: Set(
@@ -988,25 +1127,6 @@ public final class SwordManager: @unchecked Sendable {
         guard SwordJavaExactStringIdentity(module.info.name) == identity else { return nil }
         moduleCache[identity] = module
         return module
-    }
-
-    /**
-     Merges libsword and Android custom-driver registrations through JSword TreeSet semantics.
-
-     - Parameters:
-       - swordModules: Modules enumerated by libsword.
-       - customModules: Config-projected custom modules.
-     - Returns: Comparator-distinct modules sorted by pinned category, abbreviation, exact initials,
-       and exact full name. Same-initials books with different comparator fields remain installed.
-     - Side effects: Loads the pinned Android character table used by the sort comparator.
-     - Failure modes: none.
-     */
-    private static func mergedInstalledModules(
-        swordModules: [InstalledModuleRegistration],
-        customModules: [InstalledModuleRegistration]
-    ) -> [ModuleInfo] {
-        installedRegistrationOrderProjection(swordModules + customModules)
-            .map(\.info)
     }
 
     /**
@@ -1281,16 +1401,18 @@ public final class SwordManager: @unchecked Sendable {
         let compatibleVersion = applicationVersionNumber
             ?? androidCompatibilityVersionNumber
 
-        let configs = addonConfigsInInstalledOrder(
-            SwordModuleConfig.readAll(modulePath: modulePath),
+        guard let manager = SwordManager(modulePath: modulePath) else { return [] }
+        let candidates = manager.admittedAddonCandidates(
             applicationVersionNumber: compatibleVersion
         )
-        for config in configs {
+        for candidate in candidates {
+            let config = candidate.config
             let planFileNames = config.values["AndBibleProvidesReadingPlan"] ?? []
             for fileName in planFileNames {
-                guard let fileURL = readingPlanProviderFileURL(
+                guard let locationURL = candidate.locationURL,
+                      let fileURL = readingPlanProviderFileURL(
                     fileName: fileName,
-                    config: config,
+                    locationURL: locationURL,
                     modulePath: modulePath
                 ) else {
                     continue
@@ -1321,6 +1443,323 @@ public final class SwordManager: @unchecked Sendable {
     }
 
     /**
+     Returns installed add-ons admitted by Android's shared feature filter and registry ordering.
+
+     This is the common source for prompt packs and the Add-ons document picker. It applies pinned
+     current-stable Android compatibility, supported-book admission, native driver HashSet identity,
+     and JSword TreeSet replacement/order once, preventing feature surfaces from scanning or sorting
+     raw SWORD configs independently.
+
+     - Returns: Admitted add-on metadata and feature-file fields in installed TreeSet order.
+     - Side effects: On first access, reads installed config files, enumerates standalone prompt CSV
+       files, and caches the immutable result for this manager. `refresh()` invalidates the cache.
+     - Failure modes: Malformed or unsupported configs and malformed/too-new minimum versions fail
+       closed and are omitted. An unreadable config directory omits config-backed rows, while
+       independently readable standalone prompt books may remain installed.
+     */
+    public func admittedAddonModules() -> [SwordAdmittedAddonModule] {
+        SwordRuntime.sync {
+            if let admittedAddonModulesCache { return admittedAddonModulesCache }
+            let modules = admittedAddonModules(
+                applicationVersionNumber: Self.androidCompatibilityVersionNumber
+            )
+            admittedAddonModulesCache = modules
+            return modules
+        }
+    }
+
+    /**
+     Projects installed configs through Android's add-on admission and BookSet contract.
+
+     - Parameters:
+       - modulePath: SWORD module root containing the installed `mods.d` configs.
+       - applicationVersionNumber: Exact Android version-code boundary used by deterministic tests.
+     - Returns: Admitted add-ons in pinned JSword TreeSet order, with singular prompt metadata.
+     - Side effects: Reads local config files and the pinned Android comparison table.
+     - Failure modes: Missing, malformed, unsupported, or future configs are omitted fail closed.
+     */
+    static func admittedAddonModules(
+        modulePath: String,
+        applicationVersionNumber: Int
+    ) -> [SwordAdmittedAddonModule] {
+        guard let manager = SwordManager(modulePath: modulePath) else { return [] }
+        return manager.admittedAddonModules(applicationVersionNumber: applicationVersionNumber)
+    }
+
+    /**
+     Projects only books that entered this manager's installed registry through Android admission.
+
+     - Parameter applicationVersionNumber: Android compatibility version used by feature filtering.
+     - Returns: Payload-admitted add-ons in installed TreeSet order with adjusted locations.
+     - Side effects: Builds the manager's native registry snapshot, reads configs, and checks custom
+       payload metadata; document content is not read.
+     - Failure modes: Missing payloads, unsafe locations, unsupported drivers, and incompatible
+       add-ons are omitted fail closed.
+     */
+    private func admittedAddonModules(
+        applicationVersionNumber: Int
+    ) -> [SwordAdmittedAddonModule] {
+        admittedAddonCandidates(
+            applicationVersionNumber: applicationVersionNumber
+        ).map { candidate in
+            SwordAdmittedAddonModule(
+                moduleInfo: candidate.registration.info,
+                abbreviation: candidate.registration.abbreviation,
+                promptFileName: candidate.config.values["AndBibleProvidesPrompts"]?.first,
+                locationURL: candidate.locationURL,
+                removalTarget: candidate.removalTarget
+            )
+        }
+    }
+
+    /**
+     Builds the shared installed add-on owners before consumer-specific field projection.
+
+     - Parameter applicationVersionNumber: Android compatibility version used by feature filtering.
+     - Returns: Final installed TreeSet owners carrying their exact config, access state, and
+       adjusted location.
+     - Side effects: Builds the manager's native registry snapshot and enumerates standalone CSV
+       prompt files; document content is not read.
+     - Failure modes: Invalid native payloads, rejected custom owners, duplicate standalone
+       identities, and incompatible final owners are omitted fail closed.
+     */
+    private func admittedAddonCandidates(
+        applicationVersionNumber: Int
+    ) -> [InstalledAddonCandidate] {
+        return Self.addonCandidatesInInstalledOrder(
+            installedRegistryProjection().addonCandidates,
+            applicationVersionNumber: applicationVersionNumber
+        )
+    }
+
+    /**
+     Synthesizes Android's configless CSV books under `modulesDir/prompts` after driver registration.
+
+     - Parameters:
+       - modulePath: Installed SWORD root containing the optional readable `prompts` directory.
+       - installedRegistrations: Current Books registry in add order; accepted synthetic books are
+         appended so later files replay Android's `Books.getBook(initials)` preflight.
+     - Returns: Readable CSV prompt books in filesystem enumeration order with exact Android
+       generated metadata and their prompts-directory location.
+     - Side effects: Enumerates the prompts directory and reads file metadata without CSV content.
+     - Failure modes: Missing/unreadable directories, non-files, non-CSV extensions, unreadable
+       files, malformed generated metadata, and an existing lookup owner are omitted fail closed.
+     */
+    private static func standalonePromptCandidates(
+        modulePath: String,
+        installedRegistrations: inout [InstalledModuleRegistration]
+    ) -> [InstalledAddonCandidate] {
+        let fileManager = FileManager.default
+        let promptDirectory = URL(fileURLWithPath: modulePath, isDirectory: true)
+            .appendingPathComponent("prompts", isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: promptDirectory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              fileManager.isReadableFile(atPath: promptDirectory.path),
+              let files = try? fileManager.contentsOfDirectory(
+                at: promptDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: []
+              ) else {
+            return []
+        }
+
+        var candidates: [InstalledAddonCandidate] = []
+        for fileURL in files {
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            guard values?.isRegularFile == true,
+                  fileManager.isReadableFile(atPath: fileURL.path),
+                  SwordJavaStringIdentity.equalsIgnoreCase(fileURL.pathExtension, "csv") else {
+                continue
+            }
+            let packName = fileURL.deletingPathExtension().lastPathComponent
+            let initials = "Prompts_\(packName)"
+            guard installedRegistration(named: initials, in: installedRegistrations) == nil else {
+                continue
+            }
+            let content = """
+            [\(initials)]
+            Description=\(packName) prompts
+            Category=And Bible
+            ModDrv=RawGenBook
+            DataPath=./prompts/
+            Encoding=UTF-8
+            AndBibleProvidesPrompts=\(fileURL.lastPathComponent)
+            AndBibleMinimumVersion=892
+            """
+            guard let config = SwordModuleConfig.parse(content, sourceURL: fileURL),
+                  SwordJavaStringIdentity.equals(config.name, initials),
+                  config.values["AndBibleProvidesPrompts"]?.first == fileURL.lastPathComponent else {
+                continue
+            }
+            let registration = installedRegistration(for: config)
+            installedRegistrations.append(registration)
+            candidates.append(
+                InstalledAddonCandidate(
+                    registration: registration,
+                    config: config,
+                    locationURL: promptDirectory.standardizedFileURL,
+                    removalTarget: SwordInstalledAddonRemovalTarget(
+                        standalonePromptFileName: fileURL.lastPathComponent,
+                        moduleName: initials
+                    )
+                )
+            )
+        }
+        return candidates
+    }
+
+    /**
+     Captures the exact installed config owner used by add-on deletion.
+
+     - Parameters:
+       - config: Parsed, payload-admitted native config with a concrete source file.
+       - registration: Installed Book metadata and abbreviation produced from that config.
+       - locationURL: JSword-adjusted installed location, or nil when metadata retained none.
+       - modulePath: Canonical manager root used to express the config as a bounded relative path.
+     - Returns: Opaque config-backed removal identity.
+     - Side effects: Resolves standardized filesystem paths without mutation.
+     - Failure modes: None; native admission already requires a direct-root source config. A
+       defensive nonrelative source produces a path that the mutation boundary rejects fail closed.
+     */
+    private static func configRemovalTarget(
+        config: SwordModuleConfig,
+        registration: InstalledModuleRegistration,
+        locationURL: URL?,
+        modulePath: String
+    ) -> SwordInstalledAddonRemovalTarget {
+        let rootURL = URL(fileURLWithPath: modulePath, isDirectory: true).standardizedFileURL
+        let configURL = config.sourceURL?.standardizedFileURL
+        let rootPrefix = rootURL.path.hasSuffix("/") ? rootURL.path : rootURL.path + "/"
+        let relativePath: String
+        if let configURL, configURL.path.hasPrefix(rootPrefix) {
+            relativePath = String(configURL.path.dropFirst(rootPrefix.count))
+        } else {
+            relativePath = configURL?.lastPathComponent ?? ""
+        }
+        let standardizedLocation = locationURL?.standardizedFileURL
+        let locationRelativePath: String?
+        if let standardizedLocation, standardizedLocation.path.hasPrefix(rootPrefix) {
+            locationRelativePath = String(standardizedLocation.path.dropFirst(rootPrefix.count))
+        } else {
+            locationRelativePath = nil
+        }
+        return SwordInstalledAddonRemovalTarget(
+            configRelativePath: relativePath,
+            moduleName: registration.info.name,
+            fullName: registration.fullName,
+            abbreviation: registration.abbreviation,
+            driver: config.modDrv,
+            dataPath: config.dataPath,
+            locationRelativePath: locationRelativePath
+        )
+    }
+
+    /**
+     Resolves one `Books.getBook` token against the current installed add sequence.
+
+     - Parameters:
+       - name: Exact initials/name or Java case-insensitive alias proposed by a synthetic book.
+       - registrations: Books in Android add order before the new synthetic book.
+     - Returns: The surviving exact-initials owner, exact-name owner, then first TreeSet alias.
+     - Side effects: Loads the pinned Android case-fold table for TreeSet alias comparison.
+     - Failure modes: Empty or unmatched names return nil without changing the registry.
+     */
+    private static func installedRegistration(
+        named name: String,
+        in registrations: [InstalledModuleRegistration]
+    ) -> InstalledModuleRegistration? {
+        var surviving: [InstalledModuleRegistration] = []
+        for registration in registrations {
+            let identity = installedBookSetIdentity(registration)
+            surviving.removeAll { installedBookSetIdentity($0) == identity }
+            surviving.append(registration)
+        }
+        return surviving.last { SwordJavaStringIdentity.equals($0.info.name, name) }
+            ?? surviving.last { SwordJavaStringIdentity.equals($0.fullName, name) }
+            ?? surviving.sorted { installedModuleComparison($0, $1) < 0 }.first {
+                SwordJavaStringIdentity.equalsIgnoreCase($0.info.name, name)
+                    || SwordJavaStringIdentity.equalsIgnoreCase($0.fullName, name)
+            }
+    }
+
+    /**
+     Resolves JSword's filesystem-adjusted book location for one installed config.
+
+     JSword treats an existing `DataPath` directory as the book location even without a trailing
+     slash. A declared directory must exist; otherwise `DataPath` is a file prefix whose `.dat`
+     sentinel must exist and whose parent becomes the location.
+
+     - Parameters:
+       - config: Payload-admitted config whose first raw `DataPath` owns the book location.
+       - modulePath: SWORD root that bounds all accepted feature files.
+     - Returns: An admitted location state, including explicit no-location for slashless paths, or
+       nil when JSword would reject the payload.
+     - Side effects: Resolves symlinks and reads filesystem metadata without mutation.
+     - Failure modes: An absent `DataPath`, escaped paths, and missing declared directories or
+       prefix sentinels return nil.
+     */
+    static func adjustedModuleLocation(
+        for config: SwordModuleConfig,
+        modulePath: String
+    ) -> AdjustedModuleLocation? {
+        let root = URL(fileURLWithPath: modulePath, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        guard let rawDataPath = config.values["DataPath"]?.first else { return nil }
+        let trimmedDataPath = SwordJavaStringIdentity.trim(rawDataPath)
+        guard !trimmedDataPath.isEmpty else { return .noLocation }
+        if !trimmedDataPath.contains("/") {
+            return .noLocation
+        }
+        let relativeDataPathWithShape = trimmedDataPath.hasPrefix("./")
+            ? String(trimmedDataPath.dropFirst(2))
+            : trimmedDataPath
+        let declaredDirectory = relativeDataPathWithShape.hasSuffix("/")
+        let relativeDataPath = declaredDirectory
+            ? String(relativeDataPathWithShape.dropLast())
+            : relativeDataPathWithShape
+        let dataURL = root.appendingPathComponent(relativeDataPath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let rootPrefix = root.path.hasSuffix("/") ? root.path : "\(root.path)/"
+        guard dataURL == root || dataURL.path.hasPrefix(rootPrefix) else { return nil }
+
+        var isDirectory: ObjCBool = false
+        let dataPathExists = FileManager.default.fileExists(
+            atPath: dataURL.path,
+            isDirectory: &isDirectory
+        )
+        let location: URL
+        if dataPathExists && isDirectory.boolValue {
+            location = dataURL
+        } else {
+            guard !declaredDirectory else { return nil }
+            let sentinelURL = URL(fileURLWithPath: dataURL.path + ".dat")
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+            guard sentinelURL.path.hasPrefix(rootPrefix) else { return nil }
+            var sentinelIsDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(
+                atPath: sentinelURL.path,
+                isDirectory: &sentinelIsDirectory
+            ), !sentinelIsDirectory.boolValue else {
+                return nil
+            }
+            location = dataURL.deletingLastPathComponent()
+        }
+        guard location == root || location.path.hasPrefix(rootPrefix) else { return nil }
+        var locationIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: location.path,
+            isDirectory: &locationIsDirectory
+        ), locationIsDirectory.boolValue else {
+            return nil
+        }
+        return .location(location)
+    }
+
+    /**
      Android current-stable version code whose add-on feature contract this iOS build implements.
 
      Pinned And Bible commit `00b4ea24` declares version code 1115. This deliberately does not read
@@ -1331,42 +1770,38 @@ public final class SwordManager: @unchecked Sendable {
     private static let androidCompatibilityVersionNumber = 1115
 
     /**
-     Filters and orders configs through Android's `AndBibleAddonFilter` plus installed TreeSet.
+     Replays installed TreeSet ownership before applying Android's add-on feature filter.
+
+     Native candidates have already passed `SwordBookDriver` payload and HashSet admission;
+     standalone CSV candidates entered later through Android's direct `Books.addBook` path. Android
+     filters the final `Books.installed()` TreeSet, so compatibility cannot resurrect an earlier
+     comparator-equal owner when the later owner is too new.
 
      - Parameters:
-       - configs: Parsed installed configs in the captured platform enumeration sequence.
+       - candidates: Installed native and synthetic candidates in Android add order.
        - applicationVersionNumber: Android version-code compatibility supported by this build.
-     - Returns: Comparator-distinct admitted add-on configs in pinned installed-book order.
+     - Returns: Comparator-distinct final TreeSet owners that pass add-on admission, in pinned
+       installed-book order.
      - Side effects: Loads the pinned Android character table for category and abbreviation matching.
      - Failure modes: Missing minimum version defaults to zero; malformed/overflowing minimum values
        fail closed instead of reproducing Android's process-level `NumberFormatException`.
      */
-    private static func addonConfigsInInstalledOrder(
-        _ configs: [SwordModuleConfig],
+    private static func addonCandidatesInInstalledOrder(
+        _ candidates: [InstalledAddonCandidate],
         applicationVersionNumber: Int
-    ) -> [SwordModuleConfig] {
-        let deterministicConfigs = configs.sorted {
-            javaStringCompare($0.sourceURL?.path ?? "", $1.sourceURL?.path ?? "") < 0
-        }
-        var nativeBooks: Set<NativeSwordBookHashIdentity> = []
-        var surviving: [InstalledBookSetIdentity: (SwordModuleConfig, InstalledModuleRegistration)] = [:]
-        for config in deterministicConfigs where addonConfigIsAdmitted(
-            config,
-            applicationVersionNumber: applicationVersionNumber
-        ) {
-            let registration = installedRegistration(for: config)
-            let nativeIdentity = NativeSwordBookHashIdentity(
-                bookClass: nativeSwordBookClassIdentity(for: config),
-                categoryOrdinal: jswordCategoryOrdinal(registration.info.category),
-                initials: SwordJavaExactStringIdentity(registration.info.name),
-                fullName: SwordJavaExactStringIdentity(registration.fullName)
-            )
-            guard nativeBooks.insert(nativeIdentity).inserted else { continue }
-            surviving[installedBookSetIdentity(registration)] = (config, registration)
+    ) -> [InstalledAddonCandidate] {
+        var surviving: [InstalledBookSetIdentity: InstalledAddonCandidate] = [:]
+        for candidate in candidates {
+            surviving[installedBookSetIdentity(candidate.registration)] = candidate
         }
         return surviving.values.sorted {
-            installedModuleComparison($0.1, $1.1) < 0
-        }.map(\.0)
+            installedModuleComparison($0.registration, $1.registration) < 0
+        }.filter {
+            addonConfigIsAdmitted(
+                $0.config,
+                applicationVersionNumber: applicationVersionNumber
+            )
+        }
     }
 
     /**
@@ -1601,19 +2036,19 @@ public final class SwordManager: @unchecked Sendable {
     }
 
     /**
-     Resolves one `AndBibleProvidesReadingPlan` file reference for a module config.
+     Resolves one `AndBibleProvidesReadingPlan` file reference from an adjusted JSword location.
 
      - Parameters:
        - fileName: Config value containing the provider file name.
-       - config: Parsed provider module config.
+       - locationURL: Payload-admitted location assigned by JSword metadata adjustment.
        - modulePath: SWORD module root.
      - Returns: Validated provider file URL, or `nil` when the file is unavailable or unsafe.
      - Side effects: Checks file metadata on disk.
-     - Failure modes: Missing `DataPath`, escaped provider paths, and unreadable files return `nil`.
+     - Failure modes: Escaped provider paths and unreadable files return `nil`.
      */
     private static func readingPlanProviderFileURL(
         fileName: String,
-        config: SwordModuleConfig,
+        locationURL: URL,
         modulePath: String
     ) -> URL? {
         let normalizedFileName = fileName
@@ -1621,32 +2056,18 @@ public final class SwordManager: @unchecked Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedFileName.isEmpty else { return nil }
 
-        let basePath = readingPlanProviderBasePath(config.dataPath)
-        let separator = basePath.isEmpty || basePath.hasSuffix("/") ? "" : "/"
-        return readableURL(
-            "\(basePath)\(separator)\(normalizedFileName)",
-            modulePath: modulePath,
-            isDirectory: false
-        )
-    }
-
-    /**
-     Derives the Android add-on resource base from a module `DataPath`.
-
-     JSword exposes add-on files relative to the adjusted module location. Directory `DataPath`
-     values are already that location; single-file driver paths resolve through their parent
-     directory, which is where add-on sidecar resources live.
-
-     - Parameter dataPath: Normalized SWORD config `DataPath`.
-     - Returns: Relative provider-file base path under the SWORD root.
-     - Side effects: none.
-     - Failure modes: none.
-     */
-    private static func readingPlanProviderBasePath(_ dataPath: String) -> String {
-        let path = dataPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !path.isEmpty, !path.hasSuffix("/") else { return path }
-        let parent = (path as NSString).deletingLastPathComponent
-        return parent == "." ? "" : parent
+        let root = URL(fileURLWithPath: modulePath, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let resolved = locationURL.appendingPathComponent(normalizedFileName)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let rootPrefix = root.path.hasSuffix("/") ? root.path : "\(root.path)/"
+        guard resolved.path.hasPrefix(rootPrefix),
+              FileManager.default.isReadableFile(atPath: resolved.path) else {
+            return nil
+        }
+        return resolved
     }
 
     /**
@@ -1751,12 +2172,17 @@ public final class SwordManager: @unchecked Sendable {
     // MARK: - Module Refresh
 
     /**
-     Re-scan the module directory for changes.
-     Call after installing or uninstalling modules.
+     Invalidates Swift-owned snapshots after an installed-module state change.
+
+     - Side effects: Clears native, complete installed-registry, add-on, and module-wrapper caches.
+     - Failure modes: None. The underlying libsword manager is immutable; callers must construct a
+       new `SwordManager` to discover newly installed native handles.
      */
     public func refresh() {
         SwordRuntime.sync {
             nativeRegistrySnapshotCache = nil
+            installedRegistryProjectionCache = nil
+            admittedAddonModulesCache = nil
             moduleCache.removeAll()
         }
         // Recreate is the simplest way to refresh libsword's module list.

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -561,7 +561,7 @@ final class SwordManagerTests: XCTestCase {
         Abbreviation=Zulu
         Category=Lexicons / Dictionaries
         ModDrv=RawGenBook
-        DataPath=./modules/genbook/rawgenbook/class-genbook/class-genbook
+        DataPath=./modules/genbook/rawgenbook/class-genbook/
         Encoding=UTF-8
         Lang=en
         Versification=KJV
@@ -2006,6 +2006,7 @@ final class SwordManagerTests: XCTestCase {
             atomically: true,
             encoding: .utf8
         )
+        try Data().write(to: dictionaryDirectory.appendingPathComponent("module.dat"))
         try "1=Luke.1\n".write(
             to: genBookDirectory.appendingPathComponent("genbook_class.properties"),
             atomically: true,
@@ -2052,6 +2053,717 @@ final class SwordManagerTests: XCTestCase {
             "Shared cross-class provider",
             "Shared cross-class provider",
         ])
+    }
+
+    /**
+     Verifies the shared add-on feature inventory applies Android admission and TreeSet identity.
+
+     - Setup: Writes supported, duplicate, future, malformed-minimum, and wrong-category configs;
+       supported case/NFC-NFD variants; and comparator-equal cross-class compatible/future books in
+       deliberately opposite file/order fields.
+     - Expected result: Only admitted HashSet-distinct add-ons survive; Java-distinct variants remain
+       separate in abbreviation/initials TreeSet order, the first singular prompt property is
+       retained, and filtering the future TreeSet owner does not resurrect its compatible sibling.
+     - Side effects: Creates, reads, and removes one isolated temporary SWORD config tree.
+     - Failure meaning: Prompt, picker, and other add-on consumers can observe different books from
+       Android's `AndBibleAddonFilter`/`Books.installed()` projection.
+     */
+    func testAdmittedAddonModulesShareAndroidAdmissionIdentityAndOrder() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        let composed = "CAF\u{00C9}"
+        let decomposed = "CAFE\u{0301}"
+        let definitions: [(file: String, initials: String, abbreviation: String, category: String, minimum: String?, prompts: [String])] = [
+            ("z-alpha.conf", "ALPHA", "Alpha", "And Bible", nil, ["first.csv", "ignored.csv"]),
+            ("zz-alpha-duplicate.conf", "ALPHA", "Zulu duplicate", "And Bible", nil, ["duplicate.csv"]),
+            ("a-composed.conf", composed, "Beta", "And Bible", "1115", ["composed.csv"]),
+            ("b-decomposed.conf", decomposed, "Beta", "And Bible", "1115", ["decomposed.csv"]),
+            ("c-case-upper.conf", "CASE", "Gamma", "And Bible", "1115", ["upper.csv"]),
+            ("d-case-lower.conf", "case", "Gamma", "And Bible", "1115", ["lower.csv"]),
+            ("future.conf", "FUTURE", "Future", "And Bible", "1116", ["future.csv"]),
+            ("malformed.conf", "MALFORMED", "Malformed", "And Bible", "later", ["bad.csv"]),
+            ("wrong.conf", "WRONG", "Wrong", "Generic Books", nil, ["wrong.csv"]),
+        ]
+        for definition in definitions {
+            let payloadDirectory = moduleRoot.appendingPathComponent(
+                "addons/\(definition.file)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: payloadDirectory,
+                withIntermediateDirectories: true
+            )
+            var lines = [
+                "[\(definition.initials)]",
+                "Description=\(definition.initials) add-on",
+                "Abbreviation=\(definition.abbreviation)",
+                "Category=\(definition.category)",
+                "ModDrv=RawGenBook",
+                "DataPath=./addons/\(definition.file)",
+                "Encoding=UTF-8",
+            ]
+            if let minimum = definition.minimum {
+                lines.append("AndBibleMinimumVersion=\(minimum)")
+            }
+            lines.append(contentsOf: definition.prompts.map { "AndBibleProvidesPrompts=\($0)" })
+            try (lines.joined(separator: "\n") + "\n").write(
+                to: configDirectory.appendingPathComponent(definition.file),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        try """
+        [MISSINGDRIVER]
+        Description=Missing driver
+        Category=And Bible
+        AndBibleProvidesPrompts=missing.csv
+        """.write(
+            to: configDirectory.appendingPathComponent("missing-driver.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        [GHOST]
+        Description=Missing payload add-on
+        Abbreviation=Ghost
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./addons/missing-payload
+        AndBibleProvidesPrompts=ghost.csv
+        """.write(
+            to: configDirectory.appendingPathComponent("ghost.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let rawTextPrefix = moduleRoot.appendingPathComponent("addons/rawtext-prefix")
+        try Data().write(to: URL(fileURLWithPath: rawTextPrefix.path + ".dat"))
+        try """
+        [PREFIXTEXT]
+        Description=RawText prefix add-on
+        Abbreviation=Epsilon
+        Category=And Bible
+        ModDrv=RawText
+        DataPath=./addons/rawtext-prefix
+        AndBibleMinimumVersion=1115
+        AndBibleProvidesPrompts=rawtext.csv
+        """.write(
+            to: configDirectory.appendingPathComponent("rawtext-prefix.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let compatibleReplacementDirectory = moduleRoot.appendingPathComponent(
+            "addons/replaced-compatible",
+            isDirectory: true
+        )
+        let futureReplacementDirectory = moduleRoot.appendingPathComponent(
+            "addons/replaced-future",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: compatibleReplacementDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: futureReplacementDirectory,
+            withIntermediateDirectories: true
+        )
+        try """
+        [REPLACED]
+        Description=Comparator replacement
+        Abbreviation=Delta
+        Category=And Bible
+        ModDrv=RawLD
+        DataPath=./addons/replaced-compatible/
+        Version=1.0
+        AndBibleMinimumVersion=1115
+        AndBibleProvidesPrompts=compatible.csv
+        """.write(
+            to: configDirectory.appendingPathComponent("a-compatible-replacement.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        [REPLACED]
+        Description=Comparator replacement
+        Abbreviation=Delta
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./addons/replaced-future/
+        Version=2.0
+        AndBibleMinimumVersion=1116
+        AndBibleProvidesPrompts=future-replacement.csv
+        """.write(
+            to: configDirectory.appendingPathComponent("z-future-replacement.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let replacedOwners = manager.installedModules().filter {
+            SwordJavaStringIdentity.equals($0.name, "REPLACED")
+        }
+        XCTAssertEqual(replacedOwners.map(\.version), ["2.0"])
+        let modules = manager.admittedAddonModules()
+
+        XCTAssertEqual(
+            modules.map(\.moduleInfo.name),
+            ["ALPHA", decomposed, composed, "PREFIXTEXT", "CASE", "case"]
+        )
+        XCTAssertEqual(modules.map(\.promptFileName), [
+            "first.csv", "decomposed.csv", "composed.csv", "rawtext.csv", "upper.csv",
+            "lower.csv",
+        ])
+        XCTAssertEqual(
+            modules.first?.locationURL,
+            moduleRoot.appendingPathComponent("addons/z-alpha.conf", isDirectory: true)
+                .standardizedFileURL
+        )
+        XCTAssertEqual(Set(modules.map { SwordJavaExactStringIdentity($0.moduleInfo.name) }).count, 6)
+    }
+
+    /**
+     Verifies JSword payload adjustment rejects a broken native row before driver HashSet ownership.
+
+     - Setup: Writes equality-identical RawGenBook configs in path order, first without `DataPath`,
+       then with a missing payload, and finally with an existing directory.
+     - Expected result: The valid later config becomes the sole installed/admitted owner and carries
+       its adjusted directory location.
+     - Side effects: Creates, reads, and removes one isolated SWORD tree.
+     - Failure meaning: A ghost config can consume the native HashSet slot and hide a valid Android
+       installed add-on.
+     */
+    func testAddonPayloadAdmissionPrecedesNativeHashSetOwnership() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let validDirectory = moduleRoot.appendingPathComponent("addons/valid", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: validDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        /**
+         Writes one equality-identical add-on config with a caller-selected payload path.
+
+         - Parameters:
+           - file: Config filename controlling deterministic native enumeration.
+           - dataPath: Optional raw `DataPath`; nil deliberately omits the required property.
+         - Side effects: Atomically writes one config below the fixture root.
+         - Throws: Propagates filesystem encoding/write failures.
+         */
+        func writeConfig(file: String, dataPath: String?) throws {
+            var lines = [
+                "[PAYLOADWIN]",
+                "Description=Payload equality owner",
+                "Abbreviation=Payload",
+                "Category=And Bible",
+                "ModDrv=RawGenBook",
+            ]
+            if let dataPath {
+                lines.append("DataPath=\(dataPath)")
+            }
+            lines.append("AndBibleMinimumVersion=1115")
+            try lines.joined(separator: "\n").write(
+                to: configDirectory.appendingPathComponent(file),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        try writeConfig(file: "a-missing.conf", dataPath: nil)
+        try writeConfig(file: "b-broken.conf", dataPath: "./addons/missing/")
+        try writeConfig(file: "z-valid.conf", dataPath: "./addons/valid/")
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        XCTAssertEqual(
+            manager.installedModules().filter { $0.name == "PAYLOADWIN" }.map(\.name),
+            ["PAYLOADWIN"]
+        )
+        let addon = try XCTUnwrap(
+            manager.admittedAddonModules().first { $0.moduleInfo.name == "PAYLOADWIN" }
+        )
+        XCTAssertEqual(addon.locationURL, validDirectory.standardizedFileURL)
+    }
+
+    /**
+     Verifies adjusted-location parity distinguishes no-location metadata from an explicit root.
+
+     - Setup: Writes one add-on with slashless `DataPath=foo` and one with `DataPath=./`.
+     - Expected result: Both books remain installed, but only the explicit root owns a feature-file
+       location; the slashless book cannot borrow files from the module root.
+     - Side effects: Creates, reads, and removes one isolated SWORD tree.
+     - Failure meaning: Prompt/plan discovery can read files from a location JSword never assigned.
+     */
+    func testAddonAdjustedLocationDistinguishesSlashlessPathFromExplicitRoot() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        try """
+        [NOLOCATION]
+        Description=No location
+        Abbreviation=No location
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=foo
+        """.write(
+            to: configDirectory.appendingPathComponent("no-location.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        [ROOTLOCATION]
+        Description=Root location
+        Abbreviation=Root location
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./
+        """.write(
+            to: configDirectory.appendingPathComponent("root-location.conf"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let addons = manager.admittedAddonModules()
+        XCTAssertNil(addons.first { $0.moduleInfo.name == "NOLOCATION" }?.locationURL)
+        XCTAssertEqual(
+            addons.first { $0.moduleInfo.name == "ROOTLOCATION" }?.locationURL,
+            moduleRoot.standardizedFileURL
+        )
+    }
+
+    /**
+     Verifies configless prompt CSV files become Android synthetic installed books.
+
+     - Setup: Writes one readable mixed-case-extension CSV under `prompts` and no `.conf` file.
+     - Expected result: Installed module/registration inventory and the admitted add-on projection
+       expose the same synthetic Android identity, metadata, prompt filename, and parent location.
+     - Side effects: Creates, reads, and removes one isolated SWORD tree.
+     - Failure meaning: Manually installed Android prompt packs remain invisible on iOS.
+     */
+    func testStandalonePromptCSVIsSynthesizedWithoutConfig() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let promptDirectory = moduleRoot.appendingPathComponent("prompts", isDirectory: true)
+        try FileManager.default.createDirectory(at: promptDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+        try "id;name;description;promptTemplate\n".write(
+            to: promptDirectory.appendingPathComponent("Study Pack.CSV"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        XCTAssertEqual(manager.installedModules().map(\.name), ["Prompts_Study Pack"])
+        let installed = manager.installedBookRegistrations()
+        XCTAssertEqual(installed.count, 1)
+        XCTAssertEqual(installed.first?.moduleInfo.name, "Prompts_Study Pack")
+        XCTAssertEqual(installed.first?.abbreviation, "Prompts_Study Pack")
+        let addons = manager.admittedAddonModules()
+        XCTAssertEqual(addons.count, 1)
+        let addon = try XCTUnwrap(addons.first)
+        XCTAssertEqual(addon.moduleInfo.name, "Prompts_Study Pack")
+        XCTAssertEqual(addon.moduleInfo.description, "Study Pack prompts")
+        XCTAssertEqual(addon.abbreviation, "Prompts_Study Pack")
+        XCTAssertEqual(addon.promptFileName, "Study Pack.CSV")
+        XCTAssertEqual(addon.locationURL, promptDirectory.standardizedFileURL)
+    }
+
+    /**
+     Verifies Android synthetic prompt uninstall deletes the exact CSV owner without a config.
+
+     - Setup: Synthesizes one configless `CsvPromptBook`, captures its opaque installed owner, and
+       invokes the production repository deletion API.
+     - Expected result: The CSV is removed transactionally, no config is required, a fresh manager
+       exposes no installed/add-on row, and no transaction backup remains.
+     - Side effects: Creates and removes one isolated SWORD root and performs one real deletion.
+     - Failure meaning: The picker can advertise Android's Uninstall action for a generated prompt
+       book but route it into the ordinary config lookup and fail with `moduleNotFound`.
+     */
+    func testStandalonePromptCSVUninstallDeletesExactGeneratedBookOwner() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let promptDirectory = moduleRoot.appendingPathComponent("prompts", isDirectory: true)
+        let csvURL = promptDirectory.appendingPathComponent("Delete Me.csv")
+        try FileManager.default.createDirectory(at: promptDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+        try "id;name;description;promptTemplate\n".write(
+            to: csvURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let addon = try XCTUnwrap(manager.admittedAddonModules().first)
+        let repository = ModuleRepository(
+            basePath: moduleRoot.appendingPathComponent("install-manager").path,
+            swordPath: moduleRoot.path
+        )
+
+        try repository.uninstallAddon(addon.removalTarget)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: csvURL.path))
+        let refreshed = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        XCTAssertTrue(refreshed.installedModules().isEmpty)
+        XCTAssertTrue(refreshed.admittedAddonModules().isEmpty)
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: moduleRoot.path)
+                .contains { $0.hasPrefix(".module-transaction-") }
+        )
+    }
+
+    /**
+     Verifies duplicate-initial add-on uninstall retains the selected concrete config owner.
+
+     - Setup: Installs two JSword-retained RawGenBook add-ons with exact-equal initials but distinct
+       names, abbreviations, config files, and payload directories, then selects the Beta row.
+     - Expected result: Repository deletion removes only Beta's config/payload; Gamma survives and a
+       fresh admitted projection contains only the Gamma row.
+     - Side effects: Creates and removes one isolated SWORD tree and performs one real transaction.
+     - Failure meaning: Destructive picker actions collapse comparator-distinct rows back to initials
+       and delete, reject, or otherwise target the wrong Android Book.
+     */
+    func testAddonUninstallTargetsSelectedComparatorDistinctConfigOwner() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let betaDirectory = moduleRoot.appendingPathComponent("addons/beta", isDirectory: true)
+        let gammaDirectory = moduleRoot.appendingPathComponent("addons/gamma", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: betaDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: gammaDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        let betaConfigURL = configDirectory.appendingPathComponent("beta.conf")
+        let gammaConfigURL = configDirectory.appendingPathComponent("gamma.conf")
+        try """
+        [DUPDELETE]
+        Description=Duplicate beta owner
+        Abbreviation=Beta
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./addons/beta/
+        AndBibleMinimumVersion=1115
+        """.write(to: betaConfigURL, atomically: true, encoding: .utf8)
+        try """
+        [DUPDELETE]
+        Description=Duplicate gamma owner
+        Abbreviation=Gamma
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./addons/gamma/
+        AndBibleMinimumVersion=1115
+        """.write(to: gammaConfigURL, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let addons = manager.admittedAddonModules()
+        XCTAssertEqual(addons.map(\.abbreviation), ["Beta", "Gamma"])
+        let beta = try XCTUnwrap(addons.first { $0.abbreviation == "Beta" })
+        let repository = ModuleRepository(
+            basePath: moduleRoot.appendingPathComponent("install-manager").path,
+            swordPath: moduleRoot.path
+        )
+
+        try repository.uninstallAddon(beta.removalTarget)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: betaConfigURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: betaDirectory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: gammaConfigURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: gammaDirectory.path))
+        XCTAssertThrowsError(try repository.uninstallAddon(beta.removalTarget)) { error in
+            guard case ModuleRepositoryError.moduleNotFound(let name) = error else {
+                return XCTFail("Expected stale exact-owner rejection, received \(error)")
+            }
+            XCTAssertEqual(name, "DUPDELETE")
+        }
+        let refreshed = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        XCTAssertEqual(refreshed.admittedAddonModules().map(\.abbreviation), ["Gamma"])
+    }
+
+    /**
+     Verifies opaque deletion tokens preserve Java-distinct canonical spellings.
+
+     - Setup: Constructs generated-prompt targets whose filenames and initials use composed and
+       decomposed spellings that Swift normally treats as canonically equivalent.
+     - Expected result: Equality distinguishes the tokens and a `Set` retains both owners.
+     - Side effects: None.
+     - Failure meaning: Picker confirmation or fresh-owner revalidation can collapse one installed
+       Android Book into its canonically equivalent sibling.
+     */
+    func testAddonRemovalTargetHashingUsesExactJavaStringIdentity() {
+        let composed = SwordInstalledAddonRemovalTarget(
+            standalonePromptFileName: "\u{00E9}.csv",
+            moduleName: "Prompts_\u{00E9}"
+        )
+        let decomposed = SwordInstalledAddonRemovalTarget(
+            standalonePromptFileName: "e\u{0301}.csv",
+            moduleName: "Prompts_e\u{0301}"
+        )
+
+        XCTAssertNotEqual(composed, decomposed)
+        XCTAssertEqual(Set([composed, decomposed]).count, 2)
+    }
+
+    /**
+     Verifies a stale token cannot delete a config replaced in the current installed TreeSet.
+
+     - Setup: Captures a RawLD add-on token, then installs a later RawGenBook with comparator-equal
+       metadata and a distinct payload/config before invoking repository deletion.
+     - Expected result: Under-lease registry replay rejects the stale token and leaves both configs
+       and payloads byte-for-byte present; the fresh installed projection exposes the replacement.
+     - Side effects: Creates and removes one isolated SWORD tree and attempts one real transaction.
+     - Failure meaning: A row captured before module-store replacement can delete a Book that is no
+       longer the owner visible through Android's `Books.installed()` TreeSet.
+     */
+    func testAddonUninstallRejectsOwnerReplacedAfterRowCapture() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let dictionaryDirectory = moduleRoot.appendingPathComponent(
+            "addons/original",
+            isDirectory: true
+        )
+        let replacementDirectory = moduleRoot.appendingPathComponent(
+            "addons/replacement",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: configDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: dictionaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        let originalConfigURL = configDirectory.appendingPathComponent("a-original.conf")
+        let originalPrefixURL = dictionaryDirectory.appendingPathComponent("module")
+        try Data().write(to: URL(fileURLWithPath: originalPrefixURL.path + ".dat"))
+        try """
+        [CURRENTOWNER]
+        Description=Current owner
+        Abbreviation=Current
+        Category=And Bible
+        ModDrv=RawLD
+        DataPath=./addons/original/module
+        AndBibleMinimumVersion=1115
+        """.write(to: originalConfigURL, atomically: true, encoding: .utf8)
+
+        let initialManager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let staleTarget = try XCTUnwrap(
+            initialManager.admittedAddonModules().first?.removalTarget
+        )
+
+        try FileManager.default.createDirectory(
+            at: replacementDirectory,
+            withIntermediateDirectories: true
+        )
+        let replacementConfigURL = configDirectory.appendingPathComponent("z-replacement.conf")
+        try """
+        [CURRENTOWNER]
+        Description=Current owner
+        Abbreviation=Current
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./addons/replacement/
+        AndBibleMinimumVersion=1115
+        """.write(to: replacementConfigURL, atomically: true, encoding: .utf8)
+
+        let currentManager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let currentAddons = currentManager.admittedAddonModules()
+        XCTAssertEqual(currentAddons.count, 1)
+        XCTAssertEqual(currentAddons.first?.locationURL, replacementDirectory.standardizedFileURL)
+        XCTAssertNotEqual(currentAddons.first?.removalTarget, staleTarget)
+
+        let repository = ModuleRepository(
+            basePath: moduleRoot.appendingPathComponent("install-manager").path,
+            swordPath: moduleRoot.path
+        )
+        XCTAssertThrowsError(try repository.uninstallAddon(staleTarget)) { error in
+            guard case ModuleRepositoryError.moduleNotFound(let name) = error else {
+                return XCTFail("Expected stale owner rejection, received \(error)")
+            }
+            XCTAssertEqual(name, "CURRENTOWNER")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: originalConfigURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: originalPrefixURL.path + ".dat"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: replacementConfigURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: replacementDirectory.path))
+    }
+
+    /**
+     Verifies add-on deletion cannot remove a shared Android installed-family root.
+
+     - Setup: Installs one config-backed add-on whose adjusted location is the canonical `prompts`
+       root alongside a separately synthesized standalone CSV prompt Book.
+     - Expected result: Deletion rejects the shared root and preserves the config, directory, and
+       standalone CSV owner without creating rollback residue.
+     - Side effects: Creates and removes one isolated SWORD tree and attempts one real transaction.
+     - Failure meaning: Deleting a config-backed add-on can silently erase independently registered
+       raw-family books that do not own a SWORD config location.
+     */
+    func testAddonUninstallRejectsSharedInstalledFamilyRoot() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        let promptsDirectory = moduleRoot.appendingPathComponent("prompts", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: configDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: promptsDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        let csvURL = promptsDirectory.appendingPathComponent("Other.csv")
+        try "id;name;description;promptTemplate\n".write(
+            to: csvURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let configURL = configDirectory.appendingPathComponent("shared-root.conf")
+        try """
+        [SHAREDROOT]
+        Description=Shared prompts root
+        Abbreviation=Shared prompts root
+        Category=And Bible
+        ModDrv=RawGenBook
+        DataPath=./prompts/
+        AndBibleMinimumVersion=1115
+        AndBibleProvidesPrompts=Other.csv
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        let addon = try XCTUnwrap(
+            manager.admittedAddonModules().first {
+                SwordJavaStringIdentity.equals($0.moduleInfo.name, "SHAREDROOT")
+            }
+        )
+        XCTAssertNotNil(
+            manager.admittedAddonModules().first {
+                SwordJavaStringIdentity.equals($0.moduleInfo.name, "Prompts_Other")
+            }
+        )
+        let repository = ModuleRepository(
+            basePath: moduleRoot.appendingPathComponent("install-manager").path,
+            swordPath: moduleRoot.path
+        )
+
+        XCTAssertThrowsError(try repository.uninstallAddon(addon.removalTarget)) { error in
+            guard case ModuleStoreMutationError.installedOwnershipConflict(
+                let moduleName,
+                let owner
+            ) = error else {
+                return XCTFail("Expected protected-root rejection, received \(error)")
+            }
+            XCTAssertEqual(moduleName, "SHAREDROOT")
+            XCTAssertEqual(owner, "prompts")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: configURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: csvURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: promptsDirectory.path))
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: moduleRoot.path)
+                .contains { $0.hasPrefix(".module-transaction-") }
+        )
+    }
+
+    /**
+     Verifies admitted add-ons retain live cipher state and invalidate their cached projection.
+
+     - Setup: Converts a genuine encrypted RawLD fixture to an And Bible book, captures it locked,
+       then unlocks it with the fixture key after the projection cache is populated.
+     - Expected result: Installed and add-on projections agree on abbreviation/encryption state,
+       and the post-unlock add-on projection reports the same owner as unlocked.
+     - Side effects: Creates encrypted fixture files and atomically persists the verified key.
+     - Failure meaning: Picker unlock affordances or feature inventory can remain stale/diverge from
+       the installed registry.
+     */
+    func testAdmittedAddonProjectionRetainsAndRefreshesCipherState() throws {
+        let fixture = try makeEncryptedRawLDFixture(moduleName: "LOCKEDADDON")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var config = try String(contentsOf: fixture.configURL, encoding: .utf8)
+        config = config.replacingOccurrences(
+            of: "Category=Lexicons / Dictionaries",
+            with: "Category=And Bible\nAbbreviation=Locked feature"
+        )
+        try config.write(to: fixture.configURL, atomically: true, encoding: .utf8)
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: fixture.root.path))
+        let installedBefore = try XCTUnwrap(
+            manager.installedBookRegistrations().first { $0.moduleInfo.name == "LOCKEDADDON" }
+        )
+        let addonBefore = try XCTUnwrap(
+            manager.admittedAddonModules().first { $0.moduleInfo.name == "LOCKEDADDON" }
+        )
+        XCTAssertEqual(installedBefore.abbreviation, "Locked feature")
+        XCTAssertTrue(installedBefore.moduleInfo.isEncrypted)
+        XCTAssertFalse(installedBefore.moduleInfo.isUnlocked)
+        XCTAssertEqual(addonBefore.moduleInfo.isEncrypted, installedBefore.moduleInfo.isEncrypted)
+        XCTAssertEqual(addonBefore.moduleInfo.isUnlocked, installedBefore.moduleInfo.isUnlocked)
+
+        XCTAssertTrue(manager.unlockModule(named: "LOCKEDADDON", withCipherKey: fixture.cipherKey))
+        let addonAfter = try XCTUnwrap(
+            manager.admittedAddonModules().first { $0.moduleInfo.name == "LOCKEDADDON" }
+        )
+        XCTAssertTrue(addonAfter.moduleInfo.isEncrypted)
+        XCTAssertTrue(addonAfter.moduleInfo.isUnlocked)
+    }
+
+    /**
+     Verifies manager-lifetime add-on projection caches compatibility until explicit invalidation.
+
+     - Setup: Reads one installed add-on, rewrites its minimum version above the supported Android
+       boundary, then invalidates Swift-owned snapshots.
+     - Expected result: Repeated access keeps the captured generation stable, while `refresh()`
+       reparses the installed config and omits the now-incompatible book.
+     - Side effects: Creates, mutates, reads, and removes one isolated SWORD config tree.
+     - Failure meaning: Prompt and picker calls can disagree within one installed-state generation,
+       or explicit invalidation leaves stale Android compatibility admission behind.
+     */
+    func testAdmittedAddonModulesCacheUntilManagerRefresh() throws {
+        let moduleRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configDirectory = moduleRoot.appendingPathComponent("mods.d", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: moduleRoot) }
+
+        func writeAddon(_ initials: String, minimumVersion: Int) throws {
+            try FileManager.default.createDirectory(
+                at: moduleRoot.appendingPathComponent("addons/\(initials.lowercased())"),
+                withIntermediateDirectories: true
+            )
+            try """
+            [\(initials)]
+            Description=\(initials)
+            Category=And Bible
+            ModDrv=RawGenBook
+            DataPath=./addons/\(initials.lowercased())/
+            AndBibleMinimumVersion=\(minimumVersion)
+            """.write(
+                to: configDirectory.appendingPathComponent("\(initials.lowercased()).conf"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        try writeAddon("FIRST", minimumVersion: 1115)
+        let manager = try XCTUnwrap(SwordManager(modulePath: moduleRoot.path))
+        XCTAssertEqual(manager.admittedAddonModules().map(\.moduleInfo.name), ["FIRST"])
+
+        try writeAddon("FIRST", minimumVersion: 1116)
+        XCTAssertEqual(manager.admittedAddonModules().map(\.moduleInfo.name), ["FIRST"])
+
+        manager.refresh()
+        XCTAssertTrue(manager.admittedAddonModules().isEmpty)
     }
 
     /**

--- a/scripts/check_repo_standards.py
+++ b/scripts/check_repo_standards.py
@@ -794,14 +794,162 @@ def find_unsafe_direct_document_publishers(
     return sorted(set(matches))
 
 
+def find_unshared_addon_feature_discovery(
+    text: str,
+    relative_path: str = "",
+) -> list[int]:
+    """Return lines that recreate prompt/picker add-on discovery outside SwordKit admission.
+
+    Comments and strings are masked; the helper performs no filesystem access or mutation. Prompt
+    and picker consumers may not enumerate or reopen raw installed modules, and production helpers
+    outside the explicit SwordKit infrastructure allowlist may not scan raw configs or request the
+    unfiltered add-on category instead of consuming the shared compatibility/BookSet projection.
+    """
+    masked_source = _mask_swift_comments_and_strings(text)
+    patterns: tuple[re.Pattern[str], ...] = ()
+    required_function: str | None = None
+    function_ranges = _swift_function_ranges(masked_source)
+    raw_config_allowed_owners = {
+        (
+            "Sources/SwordKit/Sources/SwordKit/SwordManager.swift",
+            "moduleConfigURL",
+        ),
+        (
+            "Sources/SwordKit/Sources/SwordKit/SwordManager.swift",
+            "nativeModuleRegistrySnapshot",
+        ),
+        (
+            "Sources/SwordKit/Sources/SwordKit/SwordManager.swift",
+            "androidCustomInstalledRegistrations",
+        ),
+        (
+            "Sources/SwordKit/Sources/SwordKit/TtfFontRepository.swift",
+            "configuredFontPackPathKeys",
+        ),
+        (
+            "Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift",
+            "uninstall",
+        ),
+        (
+            "Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+Uninstall.swift",
+            "uninstallInstalledAddon",
+        ),
+    }
+    config_reader_names = {"SwordModuleConfig"}
+    config_reader_names.update(
+        match.group(1)
+        for match in re.finditer(
+            r"\btypealias\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+            r"(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*SwordModuleConfig\b",
+            masked_source,
+        )
+    )
+    config_reader_pattern = re.compile(
+        r"\b(?:" + "|".join(map(re.escape, sorted(config_reader_names)))
+        + r")\s*\.\s*readAll\b"
+    )
+    matches = set()
+    for match in config_reader_pattern.finditer(masked_source):
+        owner = (
+            relative_path,
+            _enclosing_swift_function_name(function_ranges, match.start()),
+        )
+        if owner not in raw_config_allowed_owners:
+            matches.add(text.count("\n", 0, match.start()) + 1)
+    if not relative_path.endswith("/SwordManager.swift"):
+        non_addon_category = (
+            r"(?:ModuleCategory\s*\.\s*|\.\s*)?"
+            r"(?:bible|commentary|dictionary|generalBook|map|dailyDevotion|glossary|"
+            r"questionable|essays|images|unknown)\s*\)"
+        )
+        patterns += (
+            re.compile(
+                r"\.\s*installedModules\s*\(\s*category\s*:(?!\s*"
+                + non_addon_category
+                + r")\s*"
+            ),
+            re.compile(
+                r"\.\s*installedModules\s*\([^)]*\)\s*\.\s*filter\b"
+                r"[\s\S]{0,240}?\.\s*category\s*==\s*\.\s*addon\b"
+            ),
+        )
+        for method_reference in re.finditer(
+            r"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)"
+            r"(?:\s*:[^=\n]+)?\s*=\s*"
+            r"[A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)*"
+            r"\s*\.\s*installedModules\b(?!\s*\()",
+            masked_source,
+        ):
+            alias = method_reference.group(1)
+            if re.search(
+                rf"\b{re.escape(alias)}\s*\(",
+                masked_source[method_reference.end():],
+            ):
+                matches.add(text.count("\n", 0, method_reference.start()) + 1)
+    if relative_path.endswith("/PromptRepository.swift"):
+        required_function = "loadPromptPacks"
+        patterns += (
+            re.compile(r"\binstalledModules\b"),
+            re.compile(r"\bSwordModuleConfig\b"),
+            re.compile(r"\bmodule\s*\(\s*named\s*:"),
+            re.compile(r"\blocalizedCaseInsensitiveCompare\s*\("),
+            re.compile(
+                r"\b(?!admittedAddonModules\b)[A-Za-z_][A-Za-z0-9_]*addon[A-Za-z0-9_]*"
+                r"\s*\(\s*swordManager\b",
+                re.IGNORECASE,
+            ),
+        )
+    elif relative_path.endswith("/BibleReaderModulePicker.swift"):
+        required_function = "selectableAddonModules"
+        patterns += (
+            re.compile(
+                r"\.\s*installedModules\s*\(\s*category\s*:\s*\.\s*addon\s*\)"
+            ),
+            re.compile(
+                r"\binstalledModules\s*\([^)]*\)\s*\.\s*filter\b[\s\S]{0,240}?\.\s*addon\b"
+            ),
+        )
+
+    matches.update(
+        text.count("\n", 0, match.start()) + 1
+        for pattern in patterns
+        for match in pattern.finditer(masked_source)
+    )
+    if required_function is not None:
+        required_function_ranges = [
+            item for item in _swift_function_ranges(masked_source)
+            if item[0] == required_function
+        ]
+        if not required_function_ranges:
+            matches.add(1)
+        else:
+            _, start, end = required_function_ranges[-1]
+            function_source = masked_source[start:end]
+            if len(re.findall(r"\badmittedAddonModules\s*\(", function_source)) != 1:
+                matches.add(text.count("\n", 0, start) + 1)
+            forbidden_function_calls = (
+                r"\binstalledModules\s*\(",
+                r"\bSwordModuleConfig\b",
+                r"\bmodule\s*\(\s*named\s*:",
+                r"\b(?!admittedAddonModules\b|selectableAddonModules\b)"
+                r"[A-Za-z_][A-Za-z0-9_]*addon[A-Za-z0-9_]*\s*\(",
+            )
+            for pattern in forbidden_function_calls:
+                for match in re.finditer(pattern, function_source, re.IGNORECASE):
+                    matches.add(text.count("\n", 0, start + match.start()) + 1)
+
+    return sorted(matches)
+
+
 def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
     """Validate static source contracts that should run outside XCTest.
 
-    The guards keep the `ContentView` legacy root sidebar regression out of the app-host bundle and
+    The guards keep the `ContentView` legacy root sidebar regression out of the app-host bundle,
     prevent production Swift sources from recreating direct EPUB/My Documents publication APIs that
-    bypass Android-compatible global ownership admission. Missing fixed-path files fail closed, and
-    the document publisher scan follows every non-test Swift file under `Sources` and `AndBible`
-    across moves.
+    bypass Android-compatible global ownership admission, and keep prompt/picker add-on discovery on
+    SwordKit's shared installed BookSet projection. Missing fixed-path files fail closed, and the
+    publisher/add-on scans follow every non-test Swift file under `Sources` and `AndBible` across
+    moves while narrowing infrastructure exceptions to audited functions.
     """
     content_view_path = repo_root / "AndBible/ContentView.swift"
     relative_path = "AndBible/ContentView.swift"
@@ -852,6 +1000,17 @@ def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
                     ),
                 )
                 for line in find_unsafe_direct_document_publishers(source, str(relative))
+            )
+            issues.extend(
+                SourceGuardIssue(
+                    path=str(relative),
+                    line=line,
+                    message=(
+                        "Production prompt/picker code bypasses SwordKit's shared Android add-on "
+                        "compatibility and installed BookSet projection."
+                    ),
+                )
+                for line in find_unshared_addon_feature_discovery(source, str(relative))
             )
 
     return issues

--- a/scripts/test_check_repo_standards.py
+++ b/scripts/test_check_repo_standards.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_repo_standards import (
     find_legacy_root_sidebar_shell,
     find_multiline_slash_docblocks,
+    find_unshared_addon_feature_discovery,
     find_unsafe_direct_document_publishers,
     validate_commit_message,
     validate_source_guards,
@@ -539,6 +540,114 @@ class RepoStandardsTests(unittest.TestCase):
             ]
         )
         self.assertEqual(find_unsafe_direct_document_publishers(strict_text, path), [])
+
+    def test_find_unshared_addon_feature_discovery_rejects_prompt_rescans(self) -> None:
+        path = "Sources/BibleCore/Sources/BibleCore/AI/PromptRepository.swift"
+        unsafe_text = "\n".join(
+            [
+                "func loadPromptPacks() {",
+                "  let admitted = swordManager.admittedAddonModules()",
+                "  let manager = swordManager",
+                "  let rows = manager.installedModules()",
+                "    .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }",
+                "  let raw = SwordModuleConfig.readAll(modulePath: swordManager.modulePath)",
+                "  let module = manager.module(named: name)",
+                "  let hidden = rescanInstalledAddons(swordManager)",
+                "  let discover = manager.installedModules",
+                "  _ = discover()",
+                "}",
+            ]
+        )
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(unsafe_text, path),
+            [4, 5, 6, 7, 8, 9],
+        )
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(
+                "func loadPromptPacks() {\n"
+                "  let addons = swordManager.admittedAddonModules()\n"
+                "}",
+                path,
+            ),
+            [],
+        )
+
+    def test_find_unshared_addon_feature_discovery_rejects_picker_raw_addons(self) -> None:
+        path = "Sources/BibleUI/Sources/BibleUI/Bible/BibleReaderModulePicker.swift"
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(
+                "func selectableAddonModules() {\n"
+                "  let shared = manager.admittedAddonModules()\n"
+                "  let addons = manager.installedModules(category: .addon)\n"
+                "}",
+                path,
+            ),
+            [3],
+        )
+
+    def test_find_unshared_addon_feature_discovery_rejects_external_helpers(self) -> None:
+        path = "Sources/BibleCore/Sources/BibleCore/AI/AddonRescan.swift"
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(
+                "func rescan(_ manager: SwordManager) {\n"
+                "  _ = SwordModuleConfig.readAll(modulePath: manager.modulePath)\n"
+                "  _ = manager.installedModules(category: .addon)\n"
+                "}",
+                path,
+            ),
+            [2, 3],
+        )
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(
+                "func selectableAddonModules() {\n"
+                "  let addons = manager.admittedAddonModules()\n"
+                "}",
+                path,
+            ),
+            [],
+        )
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(
+                "func selectableAddonModules() {\n"
+                "  let shared = manager.admittedAddonModules()\n"
+                "  let rows = manager.installedModules().filter { $0.category == .addon }\n"
+                "}",
+                path,
+            ),
+            [3],
+        )
+
+        indirection_text = "\n".join(
+            [
+                "typealias Reader = SwordModuleConfig",
+                "func raw(_ root: String) { _ = Reader.readAll(modulePath: root) }",
+                "func choose(_ manager: SwordManager, _ category: ModuleCategory) {",
+                "  _ = manager.installedModules(category: category)",
+                "}",
+                "func alias(_ manager: SwordManager) {",
+                "  let get: () -> [ModuleInfo] = manager.installedModules",
+                "  _ = get().filter { $0.category == .addon }",
+                "}",
+            ]
+        )
+        self.assertEqual(
+            find_unshared_addon_feature_discovery(indirection_text, path),
+            [2, 4, 7],
+        )
+
+    def test_find_unshared_addon_feature_discovery_scopes_infrastructure_exceptions(self) -> None:
+        path = "Sources/SwordKit/Sources/SwordKit/TtfFontRepository.swift"
+        text = "\n".join(
+            [
+                "func configuredFontPackPathKeys() {",
+                "  _ = SwordModuleConfig.readAll(modulePath: swordPath)",
+                "}",
+                "func rescanAddons() {",
+                "  _ = SwordModuleConfig.readAll(modulePath: swordPath)",
+                "}",
+            ]
+        )
+        self.assertEqual(find_unshared_addon_feature_discovery(text, path), [5])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Align AI prompt add-on discovery, installed inventory, picker presentation, and add-on deletion with the same current Android and JSword admission contract.

## Scope
- Replace independent prompt and picker discovery with one shared installed-registration and admitted-add-on projection.
- Preserve JSword payload admission, driver HashSet behavior, BookSet replacement and ordering, Android compatibility filtering, and standalone prompt CSV synthesis.
- Carry exact installed-owner identity through picker actions and transactional deletion.
- Remove initials-only compatibility paths and guard against future discovery forks.

## Contract references
- Issue #396 acceptance criteria.
- Current Android AndBible add-on filtering and CsvPromptBook installation behavior.
- Current JSword SwordBookDriver, Books installed registry, and BookSet ordering/replacement behavior.
- Java UTF-16 String identity for module ownership and action routing.

## Change details
- Added a cached installed registry generation shared by public installed inventory and admitted add-on consumers.
- Routed PromptRepository and BibleReaderModulePicker through that projection.
- Rendered and ordered chooser rows by Android book abbreviation behavior while retaining comparator-distinct owners.
- Added exact, coordinator-owned uninstall targets for config-backed and standalone CSV add-ons.
- Revalidated current installed ownership under the mutation lease and rejected stale replacements, shared paths, protected family roots, and overlapping payloads before mutation.
- Added rollback-safe deletion and source guardrails that prevent raw add-on rediscovery outside the owning projection.

## Validation evidence
- SwordKit simulator suite: 264 passed, 0 failed.
- SwordManagerTests: 60 passed, 0 failed.
- BibleReaderModulePickerTests: 23 passed, 0 failed.
- AIPromptAndModelBehaviorTests: 11 passed, 0 failed.
- Focused ownership and deletion tests: 5 passed, 0 failed.
- Focused picker state-capture tests: 2 passed, 0 failed.
- Full AndBible iPhone 17 Simulator build succeeded.
- Repository guard tests: 36 passed.
- Source guards, docblocks for 799 tracked Swift files, and git diff checks passed.
- Independent adversarial re-review: PASS with no remaining source-backed blocker.

## Risks and follow-ups
- Risk is concentrated in the central installed registry and destructive add-on actions.
- Mitigations include a single cached registry generation, under-lease owner replay, protected-root and overlap checks, rollback coverage, full SwordKit tests, focused UI tests, and independent review.
- No legacy compatibility shim is retained; behavior follows current Android and JSword contracts.
- No merge is performed by this PR creation.

Closes #396