### PR TITLE
fix(backups): pin Android manifest compatibility version

### DIFF
--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidBackupManifestCodec.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidBackupManifestCodec.swift
@@ -1,6 +1,7 @@
 // AndroidBackupManifestCodec.swift -- Shared Android backup-manifest contract
 
 import Foundation
+import SwordKit
 
 /** Normalized fields carried by Android's `AndBibleBackupManifest.json`. */
 struct AndroidBackupManifestPayload: Sendable, Equatable {
@@ -13,7 +14,7 @@ struct AndroidBackupManifestPayload: Sendable, Equatable {
     /// Manifest schema version when explicitly encoded.
     let manifestVersion: Int?
 
-    /// Producing application build when explicitly encoded.
+    /// Producing Android application version code when explicitly encoded.
     let andBibleVersion: Int?
 }
 
@@ -63,18 +64,25 @@ enum AndroidBackupManifestCodec {
     }
 
     /**
-     Returns the integer application build Android records as `andBibleVersion`.
+     Encodes a manifest produced by iOS with the one pinned Android compatibility version.
 
-     - Parameter bundle: Bundle owning `CFBundleVersion`; command-line test hosts may omit it.
-     - Returns: Parsed numeric build, or Android-compatible sentinel `0` when unavailable.
-     - Side effects: Reads bundle metadata only.
-     - Failure modes: None; nonnumeric values resolve to zero.
+     - Parameters:
+       - backupType: Android `BackupType` enum name.
+       - contains: Ordered Android `DbType` names, or nil for a literal JSON `null`.
+     - Returns: UTF-8 JSON bytes accepted by Android's kotlinx serializer.
+     - Side effects: None; iOS bundle metadata is never read.
+     - Failure modes: Rethrows JSON string/array encoding failures.
      */
-    static func producerVersion(bundle: Bundle = .main) -> Int {
-        let value = bundle.object(forInfoDictionaryKey: "CFBundleVersion")
-        if let number = value as? NSNumber { return number.intValue }
-        if let string = value as? String, let number = Int(string) { return number }
-        return 0
+    static func encodeProducedBackup(
+        backupType: String,
+        contains: [String]?
+    ) throws -> Data {
+        try encode(
+            backupType: backupType,
+            contains: contains,
+            manifestVersion: supportedManifestVersion,
+            andBibleVersion: AndBibleAndroidCompatibility.currentVersionCode
+        )
     }
 
     /**
@@ -84,12 +92,12 @@ enum AndroidBackupManifestCodec {
        - backupType: Android `BackupType` enum name.
        - contains: Ordered Android `DbType` names, or nil for a literal JSON `null`.
        - manifestVersion: Manifest schema version.
-       - andBibleVersion: Integer producer build.
+       - andBibleVersion: Android application compatibility version code.
      - Returns: UTF-8 JSON bytes accepted by Android's kotlinx serializer.
      - Side effects: None.
      - Failure modes: Rethrows JSON string/array encoding failures.
      */
-    static func encode(
+    private static func encode(
         backupType: String,
         contains: [String]?,
         manifestVersion: Int = supportedManifestVersion,

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidDatabaseBackupService.swift
@@ -754,10 +754,9 @@ public final class AndroidDatabaseBackupService {
         settingsStore: SettingsStore
     ) throws -> AndroidDatabaseBackupFileExport {
         let exportCategories = exportableDatabaseCategories()
-        let manifestData = try AndroidBackupManifestCodec.encode(
+        let manifestData = try AndroidBackupManifestCodec.encodeProducedBackup(
             backupType: "DB_BACKUP",
-            contains: exportCategories.map(\.rawValue),
-            andBibleVersion: AndroidBackupManifestCodec.producerVersion()
+            contains: exportCategories.map(\.rawValue)
         )
         var entries: [ZipArchiveWriterFileEntry] = [
             ZipArchiveWriterFileEntry(name: Self.manifestFileName, data: manifestData),

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupArchiveExporter.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupArchiveExporter.swift
@@ -14,9 +14,6 @@ internal final class AndroidModuleBackupArchiveExporter {
     /// Android's required literal first ZIP member for module backups.
     private static let manifestFileName = AndroidBackupManifestCodec.fileName
 
-    /// Producer build number emitted in Android's complete four-field manifest contract.
-    private let producerVersion: Int
-
     /// File manager used for archive writes, compatibility reads, and cleanup.
     private let fileManager: FileManager
 
@@ -34,7 +31,6 @@ internal final class AndroidModuleBackupArchiveExporter {
        - moduleDirectory: Canonical local module root mirrored by Android backup paths.
        - temporaryDirectory: Scratch directory that owns generated archives.
        - epubLibraryRootURL: Optional native EPUB library override for isolated hosts and tests.
-       - producerVersion: Integer app build written as Android's `andBibleVersion` field.
      - Side effects: none; directories and archives are created only during export.
      - Failure modes: This initializer cannot fail.
      */
@@ -42,12 +38,10 @@ internal final class AndroidModuleBackupArchiveExporter {
         fileManager: FileManager,
         moduleDirectory: URL,
         temporaryDirectory: URL,
-        epubLibraryRootURL: URL?,
-        producerVersion: Int
+        epubLibraryRootURL: URL?
     ) {
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory
-        self.producerVersion = producerVersion
         self.inventoryBuilder = AndroidModuleBackupExportInventoryBuilder(
             fileManager: fileManager,
             moduleDirectory: moduleDirectory,
@@ -147,13 +141,18 @@ internal final class AndroidModuleBackupArchiveExporter {
         try inventoryBuilder.installedContentCatalog()
     }
 
-    /// Full Android kotlinx-serialization field set in declaration order, including nullable data.
+    /**
+     Encodes the complete Android module-backup manifest with the shared compatibility authority.
+
+     - Returns: Kotlin-order JSON containing all four fields and a literal null category set.
+     - Side effects: None; the value reads neither bundle metadata nor the filesystem.
+     - Failure modes: Propagates JSON encoding failures from the shared manifest codec.
+     */
     private var manifestData: Data {
         get throws {
-            try AndroidBackupManifestCodec.encode(
+            try AndroidBackupManifestCodec.encodeProducedBackup(
                 backupType: "MODULE_BACKUP",
-                contains: nil,
-                andBibleVersion: producerVersion
+                contains: nil
             )
         }
     }

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidModuleBackupService.swift
@@ -359,7 +359,6 @@ public final class AndroidModuleBackupService {
        - epubLibraryRootURL: Optional explicit EPUB library used by isolated hosts and tests. The
          app default remains the Documents EPUB library when omitted.
        - storagePreflight: Shared Android-compatible capacity policy applied before staging.
-       - producerVersion: Optional integer producer build; defaults to the current app bundle build.
      - Side effects: none. Live module directories are created only inside a mutation transaction.
      - Failure modes: none.
      */
@@ -368,8 +367,7 @@ public final class AndroidModuleBackupService {
         moduleDirectory: URL? = nil,
         temporaryDirectory: URL? = nil,
         epubLibraryRootURL: URL? = nil,
-        storagePreflight: ModuleStoragePreflight = ModuleStoragePreflight(),
-        producerVersion: Int? = nil
+        storagePreflight: ModuleStoragePreflight = ModuleStoragePreflight()
     ) {
         let resolvedModuleDirectory = moduleDirectory
             ?? URL(fileURLWithPath: SwordManager.defaultModulePath(), isDirectory: true)
@@ -387,8 +385,7 @@ public final class AndroidModuleBackupService {
             fileManager: fileManager,
             moduleDirectory: resolvedModuleDirectory,
             temporaryDirectory: temporaryDirectory ?? fileManager.temporaryDirectory,
-            epubLibraryRootURL: epubLibraryRootURL,
-            producerVersion: producerVersion ?? AndroidBackupManifestCodec.producerVersion()
+            epubLibraryRootURL: epubLibraryRootURL
         )
     }
 

--- a/Sources/BibleCore/Sources/BibleCore/Services/AndroidStudyPadArchiveService.swift
+++ b/Sources/BibleCore/Sources/BibleCore/Services/AndroidStudyPadArchiveService.swift
@@ -147,8 +147,6 @@ public final class AndroidStudyPadArchiveService {
     private let temporaryDirectory: URL
     private let databaseBackupService: AndroidDatabaseBackupService
     private let bookmarkRestoreService: RemoteSyncBookmarkRestoreService
-    private let producerVersion: Int
-
     /**
      Creates a Study Pad archive service from the shared backup/restore collaborators.
 
@@ -157,7 +155,6 @@ public final class AndroidStudyPadArchiveService {
        - temporaryDirectory: Optional scratch root.
        - databaseBackupService: Existing archive loader/apply engine.
        - bookmarkRestoreService: Existing Room snapshot reader used for pre-import counts.
-       - producerVersion: Optional integer producer build; defaults to the current app bundle build.
      - Side effects: none.
      - Failure modes: none.
      */
@@ -165,8 +162,7 @@ public final class AndroidStudyPadArchiveService {
         fileManager: FileManager = .default,
         temporaryDirectory: URL? = nil,
         databaseBackupService: AndroidDatabaseBackupService? = nil,
-        bookmarkRestoreService: RemoteSyncBookmarkRestoreService = RemoteSyncBookmarkRestoreService(),
-        producerVersion: Int? = nil
+        bookmarkRestoreService: RemoteSyncBookmarkRestoreService = RemoteSyncBookmarkRestoreService()
     ) {
         self.fileManager = fileManager
         self.temporaryDirectory = temporaryDirectory ?? fileManager.temporaryDirectory
@@ -175,7 +171,6 @@ public final class AndroidStudyPadArchiveService {
             temporaryDirectory: temporaryDirectory
         )
         self.bookmarkRestoreService = bookmarkRestoreService
-        self.producerVersion = producerVersion ?? AndroidBackupManifestCodec.producerVersion()
     }
 
     /**
@@ -214,10 +209,9 @@ public final class AndroidStudyPadArchiveService {
 
         try projectSelectedStudyPads(in: databaseURL, labelIDs: selectedIDSet)
 
-        let manifestData = try AndroidBackupManifestCodec.encode(
+        let manifestData = try AndroidBackupManifestCodec.encodeProducedBackup(
             backupType: Self.backupType,
-            contains: [AndroidDatabaseBackupCategory.bookmarks.rawValue],
-            andBibleVersion: producerVersion
+            contains: [AndroidDatabaseBackupCategory.bookmarks.rawValue]
         )
         let archiveURL = temporaryURL(prefix: "android-study-pad-export-", suffix: ".abdb.zip")
         do {

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidBackupManifestCodecTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidBackupManifestCodecTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import XCTest
+@testable import BibleCore
+import SwordKit
+
+/**
+ Verifies the shared Android backup-manifest producer and restore version contracts.
+
+ Produced manifests must use the one pinned Android compatibility code regardless of iOS bundle
+ metadata. Restore must continue preserving explicit Android values and distinguishing an absent
+ field for callers that apply Android defaults. The suite performs bounded in-memory JSON work only
+ and has no filesystem, bundle, or database side effects.
+ */
+final class AndroidBackupManifestCodecTests: XCTestCase {
+    /**
+     Verifies iOS-produced manifests cannot substitute local or TestFlight build metadata.
+
+     - Setup: Encodes a module manifest through the only production encoder; no Bundle input exists.
+     - Expected result: The manifest carries the shared pinned Android version code and all four
+       Android fields.
+     - Side effects: Allocates bounded JSON data only.
+     - Failure meaning: A backup producer has regained an independent or iOS-derived version seam.
+     */
+    func testProducedManifestUsesSharedAndroidCompatibilityCode() throws {
+        let data = try AndroidBackupManifestCodec.encodeProducedBackup(
+            backupType: "MODULE_BACKUP",
+            contains: nil
+        )
+        let manifest = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        XCTAssertEqual(manifest["backupType"] as? String, "MODULE_BACKUP")
+        XCTAssertTrue(manifest.keys.contains("contains"))
+        XCTAssertEqual(manifest["manifestVersion"] as? Int, 1)
+        XCTAssertEqual(
+            manifest["andBibleVersion"] as? Int,
+            AndBibleAndroidCompatibility.currentVersionCode
+        )
+    }
+
+    /**
+     Verifies restore decoding keeps Android-supplied values and existing missing-field behavior.
+
+     - Setup: Decodes one manifest with an explicit future Android version and one without the field
+       through both raw and Android-defaulting paths.
+     - Expected result: The explicit value survives, raw absence remains nil, and Android-defaulted
+       absence remains the established zero sentinel.
+     - Side effects: Allocates bounded JSON data only.
+     - Failure meaning: Producer cleanup has accidentally changed restore compatibility semantics.
+     */
+    func testRestorePreservesExplicitAndMissingAndroidVersions() throws {
+        let explicit = try AndroidBackupManifestCodec.decode(
+            Data(#"{"backupType":"DB_BACKUP","andBibleVersion":99999}"#.utf8)
+        )
+        let absentData = Data(#"{"backupType":"DB_BACKUP"}"#.utf8)
+        let absent = try AndroidBackupManifestCodec.decode(absentData)
+        let defaulted = try AndroidBackupManifestCodec.decodeUsingAndroidDefaults(absentData)
+
+        XCTAssertEqual(explicit.andBibleVersion, 99_999)
+        XCTAssertNil(absent.andBibleVersion)
+        XCTAssertEqual(defaulted.andBibleVersion, 0)
+    }
+}

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidDatabaseBackupTests.swift
@@ -508,6 +508,10 @@ final class AndroidDatabaseBackupTests: XCTestCase {
         XCTAssertEqual(manifest["backupType"] as? String, "DB_BACKUP")
         XCTAssertEqual(manifest["manifestVersion"] as? Int, 1)
         XCTAssertEqual(manifest["contains"] as? [String], expectedCategories.map(\.rawValue))
+        XCTAssertEqual(
+            manifest["andBibleVersion"] as? Int,
+            AndBibleAndroidCompatibility.currentVersionCode
+        )
 
         let loadedArchive = try service.loadArchive(from: export.data)
         defer { service.cleanup(loadedArchive) }

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidModuleBackupTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidModuleBackupTests.swift
@@ -1137,10 +1137,7 @@ final class AndroidModuleBackupTests: XCTestCase {
             moduleName: "KJV",
             data: Data("exported".utf8)
         )
-        let service = AndroidModuleBackupService(
-            moduleDirectory: moduleRoot,
-            producerVersion: 777
-        )
+        let service = AndroidModuleBackupService(moduleDirectory: moduleRoot)
 
         let export = try service.exportArchiveFile(moduleNames: ["KJV"])
         defer { try? FileManager.default.removeItem(at: export.fileURL) }
@@ -1152,7 +1149,7 @@ final class AndroidModuleBackupTests: XCTestCase {
         let entriesByName = Dictionary(uniqueKeysWithValues: entries.map { ($0.name, $0.data) })
         XCTAssertEqual(
             String(data: try XCTUnwrap(entriesByName["AndBibleBackupManifest.json"]), encoding: .utf8),
-            #"{"backupType":"MODULE_BACKUP","contains":null,"manifestVersion":1,"andBibleVersion":777}"#
+            #"{"backupType":"MODULE_BACKUP","contains":null,"manifestVersion":1,"andBibleVersion":\#(AndBibleAndroidCompatibility.currentVersionCode)}"#
         )
         XCTAssertEqual(
             String(data: try XCTUnwrap(entriesByName["mods.d/kjv.conf"]), encoding: .utf8),

--- a/Sources/BibleCore/Tests/BibleCoreTests/AndroidStudyPadArchiveServiceTests.swift
+++ b/Sources/BibleCore/Tests/BibleCoreTests/AndroidStudyPadArchiveServiceTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftData
 import XCTest
 @testable import BibleCore
+import SwordKit
 
 /** Android `STUDYPAD_EXPORT` manifest, projection, filename, and import-routing contract tests. */
 final class AndroidStudyPadArchiveServiceTests: XCTestCase {
@@ -12,7 +13,7 @@ final class AndroidStudyPadArchiveServiceTests: XCTestCase {
      Setup:
      - seeds selected and excluded labels, each with bookmark and text-entry content
      - gives the selected bookmarks an excluded primary label to exercise Android's repair step
-     - exports with a deterministic producer build
+     - exports through the production pinned Android compatibility authority
 
      Expected result:
      - the manifest is the literal first member and carries all four Android fields
@@ -118,10 +119,7 @@ final class AndroidStudyPadArchiveServiceTests: XCTestCase {
 
         let scratch = try makeScratchDirectory()
         defer { try? FileManager.default.removeItem(at: scratch) }
-        let service = AndroidStudyPadArchiveService(
-            temporaryDirectory: scratch,
-            producerVersion: 777
-        )
+        let service = AndroidStudyPadArchiveService(temporaryDirectory: scratch)
         let export = try service.exportArchiveFile(labelIDs: [selectedLabel.id], modelContext: context)
         defer { service.cleanup(export) }
 
@@ -143,7 +141,10 @@ final class AndroidStudyPadArchiveServiceTests: XCTestCase {
         XCTAssertEqual(manifest["backupType"] as? String, "STUDYPAD_EXPORT")
         XCTAssertEqual(manifest["contains"] as? [String], ["BOOKMARKS"])
         XCTAssertEqual(manifest["manifestVersion"] as? Int, 1)
-        XCTAssertEqual(manifest["andBibleVersion"] as? Int, 777)
+        XCTAssertEqual(
+            manifest["andBibleVersion"] as? Int,
+            AndBibleAndroidCompatibility.currentVersionCode
+        )
 
         let inspection = try service.inspectImport(at: export.fileURL)
         defer { service.cleanup(inspection) }

--- a/Sources/SwordKit/Sources/SwordKit/AndBibleAndroidCompatibility.swift
+++ b/Sources/SwordKit/Sources/SwordKit/AndBibleAndroidCompatibility.swift
@@ -1,0 +1,17 @@
+// AndBibleAndroidCompatibility.swift — Pinned Android application compatibility authority
+
+/**
+ Owns the Android application version code whose behavior this iOS build implements.
+
+ The value is pinned to And Bible current-stable commit `00b4ea24`. It is intentionally independent
+ of iOS marketing and build metadata: local builds use small unrelated numbers and TestFlight uses
+ dotted UTC stamps, neither of which carries Android compatibility meaning. Add-on admission and
+ every Android-compatible backup producer consume this one authority.
+
+ Advancing the code requires parity review of Android behavior introduced after the pinned commit.
+ The type performs no I/O, has no mutable state, and cannot fail.
+ */
+public enum AndBibleAndroidCompatibility {
+    /// Android current-stable version code implemented by this iOS build.
+    public static let currentVersionCode = 1115
+}

--- a/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/SwordManager.swift
@@ -1383,27 +1383,42 @@ public final class SwordManager: @unchecked Sendable {
      admitted only from `And Bible` books whose minimum version is compatible, then traversed in
      the installed TreeSet order that defines Android's duplicate-plan ownership.
 
-     - Parameters:
-       - modulePath: SWORD module root containing `mods.d` and module payloads.
-       - applicationVersionNumber: Android version-code compatibility implemented by this iOS build.
-         Nil uses the pinned current-stable compatibility level; tests may inject an exact boundary.
+     - Parameter modulePath: SWORD module root containing `mods.d` and module payloads.
      - Returns: Readable admitted providers in first-plan TreeSet order, with a later TreeSet book
        replacing an earlier provider that declares the same plan code.
      - Side effects: Reads local config files and checks provider file metadata.
      - Failure modes: Missing configs, unreadable files, and escaped paths are skipped.
      */
     public static func readingPlanProviders(
-        modulePath: String = SwordManager.defaultModulePath(),
-        applicationVersionNumber: Int? = nil
+        modulePath: String = SwordManager.defaultModulePath()
+    ) -> [SwordReadingPlanProvider] {
+        readingPlanProviders(
+            modulePath: modulePath,
+            applicationVersionNumber: AndBibleAndroidCompatibility.currentVersionCode
+        )
+    }
+
+    /**
+     Reads Android add-on reading-plan providers at an explicit compatibility boundary for tests.
+
+     - Parameters:
+       - modulePath: Isolated SWORD root containing provider configs and payloads.
+       - applicationVersionNumber: Exact Android version code used for admission.
+     - Returns: Providers resolved with the same installed BookSet and duplicate-plan rules as the
+       production overload.
+     - Side effects: Reads local config files and checks provider file metadata.
+     - Failure modes: Missing configs, unreadable files, and escaped paths are skipped.
+     */
+    static func readingPlanProviders(
+        modulePath: String,
+        applicationVersionNumber: Int
     ) -> [SwordReadingPlanProvider] {
         var providersByCode: [String: SwordReadingPlanProvider] = [:]
         var orderedCodes: [String] = []
-        let compatibleVersion = applicationVersionNumber
-            ?? androidCompatibilityVersionNumber
 
         guard let manager = SwordManager(modulePath: modulePath) else { return [] }
         let candidates = manager.admittedAddonCandidates(
-            applicationVersionNumber: compatibleVersion
+            applicationVersionNumber: applicationVersionNumber
         )
         for candidate in candidates {
             let config = candidate.config
@@ -1461,7 +1476,7 @@ public final class SwordManager: @unchecked Sendable {
         SwordRuntime.sync {
             if let admittedAddonModulesCache { return admittedAddonModulesCache }
             let modules = admittedAddonModules(
-                applicationVersionNumber: Self.androidCompatibilityVersionNumber
+                applicationVersionNumber: AndBibleAndroidCompatibility.currentVersionCode
             )
             admittedAddonModulesCache = modules
             return modules
@@ -1758,16 +1773,6 @@ public final class SwordManager: @unchecked Sendable {
         }
         return .location(location)
     }
-
-    /**
-     Android current-stable version code whose add-on feature contract this iOS build implements.
-
-     Pinned And Bible commit `00b4ea24` declares version code 1115. This deliberately does not read
-     `CFBundleVersion`: iOS local builds use `1`, while release automation uses dotted UTC stamps, so
-     neither value represents Android add-on compatibility. Advancing this constant requires parity
-     review of add-on features introduced after the pinned Android version.
-     */
-    private static let androidCompatibilityVersionNumber = 1115
 
     /**
      Replays installed TreeSet ownership before applying Android's add-on feature filter.

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -6,6 +6,20 @@ import SQLite3
 
 final class SwordManagerTests: XCTestCase {
     /**
+     Verifies the shared authority stays pinned to the Android current-stable version code.
+
+     - Setup: Reads the public compatibility authority used by add-on admission and backup
+       manifests without constructing a manager or reading bundle metadata.
+     - Expected result: The value equals Android commit 00b4ea24 version code 1115.
+     - Side effects: None.
+     - Failure meaning: iOS has silently changed the compatibility boundary without the required
+       Android parity review.
+     */
+    func testAndroidCompatibilityAuthorityPinsCurrentStableVersionCode() {
+        XCTAssertEqual(AndBibleAndroidCompatibility.currentVersionCode, 1115)
+    }
+
+    /**
      Verifies the public exact-string key follows Java UTF-16 identity rather than Swift equality.
 
      - Setup: Constructs keys for canonically equivalent composed/decomposed spellings and one exact
@@ -1816,8 +1830,8 @@ final class SwordManagerTests: XCTestCase {
 
      - Setup: Writes readable providers for a missing-minimum add-on, future add-on, non-add-on,
        malformed-minimum add-on, and unsupported-driver add-on.
-     - Expected result: At compatibility version 1112 only the supported `And Bible` config whose
-       missing minimum defaults to zero is admitted.
+     - Expected result: At the shared current-stable compatibility code only the supported
+       `And Bible` config whose missing minimum defaults to zero is admitted.
      - Side effects: Creates and removes one isolated SWORD config/provider tree.
      - Failure meaning: iOS exposes plans Android filters out or rejects Android-compatible add-ons.
      */
@@ -1833,7 +1847,12 @@ final class SwordManagerTests: XCTestCase {
 
         let definitions: [(String, String, String, String?)] = [
             ("ADMITTED", "And Bible", "RawGenBook", nil),
-            ("FUTURE", "And Bible", "RawGenBook", "1113"),
+            (
+                "FUTURE",
+                "And Bible",
+                "RawGenBook",
+                String(AndBibleAndroidCompatibility.currentVersionCode + 1)
+            ),
             ("WRONGCATEGORY", "Generic Books", "RawGenBook", nil),
             ("MALFORMED", "And Bible", "RawGenBook", "not-a-number"),
             ("UNSUPPORTED", "And Bible", "UnknownDriver", nil),
@@ -1872,10 +1891,7 @@ final class SwordManagerTests: XCTestCase {
             )
         }
 
-        let providers = SwordManager.readingPlanProviders(
-            modulePath: moduleRoot.path,
-            applicationVersionNumber: 1112
-        )
+        let providers = SwordManager.readingPlanProviders(modulePath: moduleRoot.path)
 
         XCTAssertEqual(providers.map(\.planCode), ["admitted"])
         XCTAssertEqual(providers.first?.name, "ADMITTED provider")

--- a/scripts/check_repo_standards.py
+++ b/scripts/check_repo_standards.py
@@ -941,6 +941,31 @@ def find_unshared_addon_feature_discovery(
     return sorted(matches)
 
 
+def find_ios_bundle_version_reads(
+    text: str,
+    relative_path: str = "",
+) -> list[int]:
+    """Return production lines that read iOS version keys outside display metadata.
+
+    The raw key spellings are intentionally matched even in string literals because they are the
+    Info.plist API inputs. The one display-metadata owner is allowlisted by exact repository path;
+    every Android compatibility and backup producer must instead consume the shared pinned Android
+    version-code authority. The helper performs no filesystem access or mutation.
+    """
+    if relative_path == (
+        "Sources/BibleUI/Sources/BibleUI/Shared/AndBibleAppVersionMetadata.swift"
+    ):
+        return []
+    return sorted({
+        text.count("\n", 0, match.start()) + 1
+        for pattern in (
+            re.compile(r'"CFBundleVersion"'),
+            re.compile(r'"CFBundleShortVersionString"'),
+        )
+        for match in pattern.finditer(text)
+    })
+
+
 def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
     """Validate static source contracts that should run outside XCTest.
 
@@ -949,7 +974,9 @@ def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
     bypass Android-compatible global ownership admission, and keep prompt/picker add-on discovery on
     SwordKit's shared installed BookSet projection. Missing fixed-path files fail closed, and the
     publisher/add-on scans follow every non-test Swift file under `Sources` and `AndBible` across
-    moves while narrowing infrastructure exceptions to audited functions.
+    moves while narrowing infrastructure exceptions to audited functions. iOS marketing/build
+    metadata access remains confined to its display-only owner so Android manifests and admission
+    cannot reuse unrelated bundle version values.
     """
     content_view_path = repo_root / "AndBible/ContentView.swift"
     relative_path = "AndBible/ContentView.swift"
@@ -1011,6 +1038,18 @@ def validate_source_guards(repo_root: Path) -> list[SourceGuardIssue]:
                     ),
                 )
                 for line in find_unshared_addon_feature_discovery(source, str(relative))
+            )
+            issues.extend(
+                SourceGuardIssue(
+                    path=str(relative),
+                    line=line,
+                    message=(
+                        "Production code reads iOS bundle version metadata outside the display "
+                        "metadata owner. Android compatibility and backup manifests must consume "
+                        "AndBibleAndroidCompatibility instead."
+                    ),
+                )
+                for line in find_ios_bundle_version_reads(source, str(relative))
             )
 
     return issues

--- a/scripts/test_check_repo_standards.py
+++ b/scripts/test_check_repo_standards.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_repo_standards import (
     find_legacy_root_sidebar_shell,
     find_multiline_slash_docblocks,
+    find_ios_bundle_version_reads,
     find_unshared_addon_feature_discovery,
     find_unsafe_direct_document_publishers,
     validate_commit_message,
@@ -23,7 +24,12 @@ from check_repo_standards import (
 
 
 class RepoStandardsTests(unittest.TestCase):
-    """Covers the locked commit message shape and Swift docblock style checks."""
+    """Covers commit, docblock, and production-source guard contracts.
+
+    Tests use in-memory snippets plus context-managed temporary repository fixtures where a
+    path-sensitive scan is required. Failures mean the guardrails can reject valid source or permit
+    a known architecture/parity regression. Temporary fixtures are removed by their context owners.
+    """
 
     def test_valid_commit_message_passes(self) -> None:
         message = "\n".join(
@@ -113,6 +119,28 @@ class RepoStandardsTests(unittest.TestCase):
             ]
         )
         self.assertEqual(find_multiline_slash_docblocks(text), [1])
+
+    def test_find_ios_bundle_version_reads_enforces_display_only_owner(self) -> None:
+        forbidden = "\n".join(
+            [
+                'let local = bundle.infoDictionary?["CFBundleVersion"]',
+                'let release = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString")',
+            ]
+        )
+        self.assertEqual(
+            find_ios_bundle_version_reads(
+                forbidden,
+                "Sources/BibleCore/Sources/BibleCore/Services/AndroidBackupManifestCodec.swift",
+            ),
+            [1, 2],
+        )
+        self.assertEqual(
+            find_ios_bundle_version_reads(
+                forbidden,
+                "Sources/BibleUI/Sources/BibleUI/Shared/AndBibleAppVersionMetadata.swift",
+            ),
+            [],
+        )
 
     def test_find_multiline_slash_docblocks_allows_single_line_comment(self) -> None:
         text = "\n".join(


### PR DESCRIPTION
## Summary

Pins Android-compatible backup manifests and add-on admission to the current Android version-code contract instead of deriving compatibility from iOS bundle metadata.

## Scope

- Module backup manifest production
- Android database backup manifest production
- StudyPad backup manifest production
- Shared add-on and reading-plan compatibility admission
- Repository guardrails for iOS bundle-version reads

This PR is stacked on #407 and should be rebased to main after that parent lands. It must not be merged independently before the parent branch.

## Contract references

- Current Android source at commit 00b4ea24 uses AndroidManifest versionCode 1115.
- AndroidBackupManifest.andBibleVersion defaults to the Android application version number.
- Android behavior is the source of truth; obsolete producer-version compatibility overrides are intentionally removed.

## Change details

- Added one public SwordKit Android compatibility authority with version code 1115.
- Routed module, database, and StudyPad produced manifests through the shared authority.
- Routed default add-on and reading-plan admission through the same authority.
- Removed public producerVersion parameters and the public application-version override.
- Added source guards that confine CFBundle version reads to display-only app metadata.
- Kept restore decoding behavior unchanged for explicit, absent, and legacy zero manifest values.

## Validation evidence

- SwordManagerTests: 61 passed, 0 failed.
- Android backup manifest and service classes: 75 passed, 0 failed.
- Swift builds passed for SwordKit, BibleCore, BibleCoreTests, and BibleUI.
- Full AndBible iPhone 17 simulator build passed.
- Repository guard tests: 37 passed, 0 failed.
- Live source guards, 802 docblocks, and git diff checks passed.

## Risks and follow-ups

- Public producer-version overrides were removed intentionally; this is a source-level API break for callers relying on non-Android values.
- The constant must advance only when the pinned Android compatibility source advances.
- GitNexus impact remained unavailable because the shared index WAL was unreadable; all manifest producers and callers were manually audited and the full relevant test classes were run.

Closes #397