### PR TITLE
fix(mybible): align remote catalog identity with Android

### DIFF
--- a/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
+++ b/Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift
@@ -1891,7 +1891,7 @@ public struct ModuleBrowserView: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(module.name)
+                        Text(module.abbreviation)
                             .font(.system(size: 16, weight: .regular))
                             .foregroundStyle(surfacePalette.foregroundColor)
                             .lineLimit(1)
@@ -1937,7 +1937,7 @@ public struct ModuleBrowserView: View {
             handleRemoteModuleRowTap(module, status: status)
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(module.name)
+        .accessibilityLabel(module.abbreviation)
         .accessibilityValue(Self.downloadStatusAccessibilityToken(status))
         .accessibilityAddTraits(Self.primaryRowTapStartsDownload(status) ? .isButton : [])
         .accessibilityIdentifier("moduleBrowserRow::\(module.installIdentity.rawValue)")
@@ -2478,7 +2478,8 @@ public struct ModuleBrowserView: View {
                 return false
             }
             guard !query.isEmpty else { return true }
-            return module.name.localizedCaseInsensitiveContains(query) ||
+            return module.abbreviation.localizedCaseInsensitiveContains(query) ||
+                module.name.localizedCaseInsensitiveContains(query) ||
                 module.description.localizedCaseInsensitiveContains(query) ||
                 module.language.localizedCaseInsensitiveContains(query) ||
                 module.sourceName.localizedCaseInsensitiveContains(query)
@@ -2548,8 +2549,8 @@ public struct ModuleBrowserView: View {
        - selectedLanguage: Current language filter; Android only prioritizes recommended rows when
          a concrete language is active.
        - recommendedDocuments: Android recommended metadata.
-     - Returns: Modules sorted by install state, installed state, recommendation, category, and
-       localized initials.
+     - Returns: Modules sorted by install state, installed state, recommendation, category, and the
+       Android locale-lowercased abbreviation key; equal keys retain catalog input order.
 
      Side effects:
      - none
@@ -2566,7 +2567,9 @@ public struct ModuleBrowserView: View {
     ) -> [RemoteModuleInfo] {
         let installedModulesByName = installedModuleLookup(from: installedModules)
 
-        return modules.sorted { lhs, rhs in
+        return modules.enumerated().sorted { lhsEntry, rhsEntry in
+            let lhs = lhsEntry.element
+            let rhs = rhsEntry.element
             let lhsStatus = displayStatus(
                 for: lhs,
                 installedModulesByName: installedModulesByName,
@@ -2603,8 +2606,19 @@ public struct ModuleBrowserView: View {
                 return lhsCategoryRank < rhsCategoryRank
             }
 
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-        }
+            let lhsAbbreviation = lhs.abbreviation.lowercased(
+                with: Locale(identifier: lhs.language)
+            )
+            let rhsAbbreviation = rhs.abbreviation.lowercased(
+                with: Locale(identifier: rhs.language)
+            )
+            let lhsUnits = Array(lhsAbbreviation.utf16)
+            let rhsUnits = Array(rhsAbbreviation.utf16)
+            if lhsUnits != rhsUnits {
+                return lhsUnits.lexicographicallyPrecedes(rhsUnits)
+            }
+            return lhsEntry.offset < rhsEntry.offset
+        }.map(\.element)
     }
 
     /**

--- a/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/ModuleBrowserDownloadsTests.swift
@@ -1044,6 +1044,127 @@ final class ModuleBrowserDownloadsTests: XCTestCase {
     }
 
     /**
+     Verifies Downloads keeps MyBible remote identity separate from Android's visible abbreviation.
+
+     - Setup: Builds remote rows whose initials oppose their abbreviations, Turkish abbreviations
+       whose locale-lowercase order differs from locale-independent case order, and equal lowercase
+       keys, then reads the row-rendering source boundary.
+     - Expected result: Sorting and search use Android's per-book locale-lowercased abbreviation and
+       preserve catalog order for equal keys, while installation identity remains exact initials;
+       primary text and accessibility expose the same abbreviation.
+     - Side effects: Reads package source only for the rendering assertion.
+     - Failure meaning: MyBible catalog identity is displayed or ordered as initials even though
+       Android's Download adapter renders `Book.abbreviation`.
+     */
+    func testModuleBrowserUsesAndroidRemoteAbbreviationForDisplaySearchAndOrder() throws {
+        let modules = [
+            RemoteModuleInfo(
+                name: "MyBible-OMEGA_SQLite3",
+                abbreviation: "Alpha",
+                description: "First",
+                category: .bible,
+                language: "en",
+                sourceName: "MyBible"
+            ),
+            RemoteModuleInfo(
+                name: "MyBible-BETA_SQLite3",
+                abbreviation: "Zulu",
+                description: "Second",
+                category: .bible,
+                language: "en",
+                sourceName: "MyBible"
+            ),
+        ]
+
+        let sorted = ModuleBrowserView.sortedDownloadModules(
+            modules,
+            installedModules: [],
+            downloadActivities: [:],
+            selectedLanguage: "",
+            recommendedDocuments: nil
+        )
+        XCTAssertEqual(sorted.map(\.name), [
+            "MyBible-OMEGA_SQLite3",
+            "MyBible-BETA_SQLite3",
+        ])
+        let filtered = ModuleBrowserView.filteredDownloadModules(
+            modules,
+            selectedCategory: nil,
+            selectedLanguage: "",
+            searchText: "Alpha",
+            installedModules: [],
+            downloadActivities: [:],
+            recommendedDocuments: nil,
+            badDocuments: nil
+        )
+        XCTAssertEqual(filtered.map(\.name), ["MyBible-OMEGA_SQLite3"])
+
+        let turkish = [
+            RemoteModuleInfo(
+                name: "TURKISH-DOTLESS",
+                abbreviation: "I",
+                description: "Dotless lowercase",
+                category: .bible,
+                language: "tr",
+                sourceName: "MyBible"
+            ),
+            RemoteModuleInfo(
+                name: "TURKISH-DOTTED",
+                abbreviation: "İ",
+                description: "Dotted lowercase",
+                category: .bible,
+                language: "tr",
+                sourceName: "MyBible"
+            ),
+        ]
+        XCTAssertEqual(
+            ModuleBrowserView.sortedDownloadModules(
+                turkish,
+                installedModules: [],
+                downloadActivities: [:],
+                selectedLanguage: "",
+                recommendedDocuments: nil
+            ).map(\.name),
+            ["TURKISH-DOTTED", "TURKISH-DOTLESS"]
+        )
+
+        let stableEqualKeys = [
+            RemoteModuleInfo(
+                name: "SECOND-BY-INITIALS",
+                abbreviation: "ALPHA",
+                description: "First catalog row",
+                category: .bible,
+                language: "en",
+                sourceName: "MyBible"
+            ),
+            RemoteModuleInfo(
+                name: "FIRST-BY-INITIALS",
+                abbreviation: "Alpha",
+                description: "Second catalog row",
+                category: .bible,
+                language: "en",
+                sourceName: "MyBible"
+            ),
+        ]
+        XCTAssertEqual(
+            ModuleBrowserView.sortedDownloadModules(
+                stableEqualKeys,
+                installedModules: [],
+                downloadActivities: [:],
+                selectedLanguage: "",
+                recommendedDocuments: nil
+            ).map(\.name),
+            ["SECOND-BY-INITIALS", "FIRST-BY-INITIALS"]
+        )
+
+        let source = try BibleUITestSourceLocator.source(
+            at: "Sources/BibleUI/Sources/BibleUI/Downloads/ModuleBrowserView.swift"
+        )
+        XCTAssertTrue(source.contains("Text(module.abbreviation)"))
+        XCTAssertTrue(source.contains(".accessibilityLabel(module.abbreviation)"))
+    }
+
+    /**
      Verifies same-repository malformed versions stay updateable while blank versions compare as 1.0.
 
      Android constructs both values with JSword `Version`; a constructor failure deliberately

--- a/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstallManager.swift
@@ -24,8 +24,11 @@ public enum RemoteModuleAvailability: String, Sendable {
 
 /// Information about a remotely available module.
 public struct RemoteModuleInfo: Sendable, Identifiable {
-    /// Module abbreviation (e.g., "KJV").
+    /// Exact module initials used for installation and installed-owner lookup (e.g., "KJV").
     public let name: String
+
+    /// Android-visible remote-book abbreviation; ordinary SWORD rows fall back to `name`.
+    public let abbreviation: String
 
     /// Full description.
     public let description: String
@@ -57,8 +60,27 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
     /// Convenience flag for install controls.
     public var isInstallable: Bool { availability == .installable }
 
+    /**
+     Creates one immutable remote Downloads row.
+
+     - Parameters:
+       - name: Exact module initials used for installation and installed-owner lookup.
+       - abbreviation: Android-visible book abbreviation, or `nil` to use `name` for ordinary SWORD
+         catalogs whose metadata does not provide a distinct abbreviation.
+       - description: Full user-visible book name.
+       - category: Android/JSword book category.
+       - language: Book language code.
+       - sourceName: Exact repository identity.
+       - availability: Whether the package can be installed.
+       - unavailableReason: User-visible reason for an unavailable row.
+       - version: Catalog version used for update comparison.
+       - installSizeBytes: Reported installed byte count, when available.
+     - Side effects: None.
+     - Failure modes: None; source adapters validate unsupported metadata before construction.
+     */
     public init(
         name: String,
+        abbreviation: String? = nil,
         description: String,
         category: ModuleCategory,
         language: String,
@@ -69,6 +91,7 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
         installSizeBytes: Int64? = nil
     ) {
         self.name = name
+        self.abbreviation = abbreviation ?? name
         self.description = description
         self.category = category
         self.language = language
@@ -84,8 +107,8 @@ public struct RemoteModuleInfo: Sendable, Identifiable {
  Android default SWORD repository definition.
 
  Android stores built-in repositories in `app/src/main/res/raw/repositories.txt` as independent
- package and catalog directories. iOS still writes `InstallMgr.conf` in the legacy SWORD-compatible
- row shape, but this definition is the shared source of truth for Downloads package installs so iOS
+ package and catalog directories. iOS writes the required SWORD-compatible `InstallMgr.conf` row,
+ while this definition remains the shared source of truth for Downloads package installs so iOS
  does not reconstruct package URLs from catalog paths later.
  */
 private struct AndroidDefaultRepositorySource: Sendable {

--- a/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleBookReader.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleBookReader.swift
@@ -121,9 +121,10 @@ enum InstalledMyBibleBookReader {
         defer { sqlite3_close(database) }
 
         guard let metadata = databaseMetadata(from: database) else { return nil }
-        let baseName = androidNameWithoutExtension(payloadURL.lastPathComponent)
-        let initials = "MyBible-" + sanitizeAndroidMyBibleModuleName(baseName)
-        let abbreviation = androidAbbreviation(from: baseName)
+        let filenameIdentity = MyBibleAndroidFilenameIdentity(
+            fileName: payloadURL.lastPathComponent
+        )
+        let initials = filenameIdentity.initials
         let driver = moduleDriver(for: metadata.category)
         let moduleInfo = ModuleInfo(
             name: initials,
@@ -140,7 +141,7 @@ enum InstalledMyBibleBookReader {
         )
         return InstalledMyBibleBookRegistration(
             info: moduleInfo,
-            abbreviation: abbreviation,
+            abbreviation: filenameIdentity.abbreviation,
             moduleDirectoryURL: payloadURL.deletingLastPathComponent(),
             databaseURL: payloadURL
         )
@@ -349,53 +350,6 @@ enum InstalledMyBibleBookReader {
         guard valueUnits.count >= suffixUnits.count else { return false }
         let candidate = String(decoding: valueUnits.suffix(suffixUnits.count), as: UTF16.self)
         return SwordJavaStringIdentity.equalsIgnoreCase(candidate, suffix)
-    }
-
-    /**
-     Removes exactly the last dot extension like Kotlin `File.nameWithoutExtension`.
-
-     - Parameter fileName: Exact final path component of the payload.
-     - Returns: Text before the last dot, the full name when no dot exists, or an empty string for a
-       leading-dot-only basename.
-     - Side effects: None.
-     - Failure modes: None.
-     */
-    private static func androidNameWithoutExtension(_ fileName: String) -> String {
-        guard let dot = fileName.lastIndex(of: ".") else { return fileName }
-        return String(fileName[..<dot])
-    }
-
-    /**
-     Derives Android's unsanitized MyBible abbreviation from one payload basename.
-
-     - Parameter baseName: Filename after removing only its final extension.
-     - Returns: Exact text before the first dot, including an empty value for a leading dot.
-     - Side effects: None.
-     - Failure modes: None; basenames without a dot are returned unchanged.
-     */
-    private static func androidAbbreviation(from baseName: String) -> String {
-        guard let dot = baseName.firstIndex(of: ".") else { return baseName }
-        return String(baseName[..<dot])
-    }
-
-    /**
-     Applies Android's historical MyBible `[^a-zA-z0-9]` replacement exactly.
-
-     Java's `A-z` range spans ASCII values 65 through 122, so it deliberately preserves the six
-     punctuation characters between `Z` and `a` in addition to letters, digits, and underscore.
-
-     - Parameter value: Exact payload basename before initials are prefixed.
-     - Returns: ASCII digits and code points `A...z` unchanged; every other Unicode scalar becomes
-       one underscore.
-     - Side effects: None.
-     - Failure modes: None; every Swift string has a finite Unicode-scalar projection.
-     */
-    private static func sanitizeAndroidMyBibleModuleName(_ value: String) -> String {
-        value.unicodeScalars.map { scalar in
-            let code = scalar.value
-            let accepted = (48...57).contains(code) || (65...122).contains(code)
-            return accepted ? String(scalar) : "_"
-        }.joined()
     }
 
     /**

--- a/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleRepository.swift
@@ -299,7 +299,7 @@ private final class ModuleFileDownloadDelegate: NSObject, URLSessionDownloadDele
 /**
  Configuration for a remote module source consumed by Downloads.
 
- The struct keeps the legacy SWORD tuple (`type`, `host`, `catalogPath`) while also carrying
+ The struct keeps the required SWORD tuple (`type`, `host`, `catalogPath`) while also carrying
  Android custom-repository metadata. SWORD rows use `sword-https` by default and can be projected
  into `InstallMgr.conf`; MyBible rows use `mybible-https` and are refreshed from their manifest
  URL without pretending to be SWORD sources.
@@ -403,8 +403,11 @@ public struct SourceConfig: Sendable, Identifiable {
  - Note: The struct is immutable and performs no file or network I/O.
  */
 public struct CatalogModule: Sendable, Identifiable {
-    /// Module initials shown in Downloads and used as install identity.
+    /// Exact module initials used as install identity.
     public let name: String
+
+    /// Android-visible remote-book abbreviation; ordinary SWORD rows fall back to `name`.
+    public let abbreviation: String
 
     /// User-visible module description.
     public let description: String
@@ -450,6 +453,7 @@ public struct CatalogModule: Sendable, Identifiable {
 
      - Parameters:
        - name: Module initials shown in Downloads.
+       - abbreviation: Android-visible remote-book abbreviation, defaulting to `name`.
        - description: User-visible module description.
        - category: Download category.
        - language: Module language code.
@@ -467,6 +471,7 @@ public struct CatalogModule: Sendable, Identifiable {
      */
     public init(
         name: String,
+        abbreviation: String? = nil,
         description: String,
         category: ModuleCategory,
         language: String,
@@ -481,6 +486,7 @@ public struct CatalogModule: Sendable, Identifiable {
         packageFileName: String? = nil
     ) {
         self.name = name
+        self.abbreviation = abbreviation ?? name
         self.description = description
         self.category = category
         self.language = language
@@ -499,6 +505,7 @@ public struct CatalogModule: Sendable, Identifiable {
     public var remoteModuleInfo: RemoteModuleInfo {
         RemoteModuleInfo(
             name: name,
+            abbreviation: abbreviation,
             description: description,
             category: category,
             language: language,
@@ -970,6 +977,8 @@ public final class ModuleRepository: @unchecked Sendable {
 
     private struct CachedModule: Codable {
         var name: String
+        /// Persisted Android-visible abbreviation; absent older cache rows fall back to initials.
+        var abbreviation: String?
         var description: String
         var category: String
         var language: String
@@ -1003,6 +1012,7 @@ public final class ModuleRepository: @unchecked Sendable {
                 let cat = ModuleCategory(typeString: m.category, modDrv: m.modDrv)
                 let entry = CatalogModule(
                     name: m.name,
+                    abbreviation: m.abbreviation,
                     description: m.description,
                     category: cat,
                     language: m.language,
@@ -1034,6 +1044,7 @@ public final class ModuleRepository: @unchecked Sendable {
             modules: entries.map { e in
                 CachedModule(
                     name: e.name,
+                    abbreviation: e.abbreviation,
                     description: e.description,
                     category: e.category.rawValue,
                     language: e.language,
@@ -1158,11 +1169,15 @@ public final class ModuleRepository: @unchecked Sendable {
             let normalizedDownloadURL = Self.normalizedMyBibleDownloadURL(module.downloadURL)
             guard let downloadURL = normalizedDownloadURL else { return nil }
             let languageCode = module.languageCode.trimmingCharacters(in: .whitespacesAndNewlines)
+            let filenameIdentity = MyBibleAndroidFilenameIdentity(fileName: module.fileName)
 
             return CatalogModule(
-                name: Self.myBibleModuleInitials(fileName: module.fileName),
+                name: filenameIdentity.initials,
+                abbreviation: filenameIdentity.abbreviation,
                 description: module.description,
-                category: Self.myBibleCategory(fileName: module.fileName),
+                category: MyBibleAndroidFilenameIdentity.category(
+                    forPackageFileName: module.fileName
+                ),
                 language: languageCode.isEmpty
                     ? "en"
                     : languageCode,
@@ -1188,7 +1203,8 @@ public final class ModuleRepository: @unchecked Sendable {
      Normalizes Android MyBible module download URLs while preserving HTTPS-only behavior.
 
      Android rewrites cached `http://` MyBible module URLs to HTTPS before exposing module rows.
-     iOS mirrors that compatibility path, then drops rows that still cannot produce an HTTPS URL.
+     iOS mirrors that current Android rewrite, then drops rows that still cannot produce an HTTPS
+     URL.
 
      - Parameter rawURL: Manifest `download_url` value.
      - Returns: HTTPS URL suitable for package download, or `nil` when the row is unsupported.
@@ -1208,55 +1224,6 @@ public final class ModuleRepository: @unchecked Sendable {
         return url
     }
 
-    /**
-     Builds Android-compatible MyBible module initials from a package filename.
-
-     - Parameter fileName: Manifest `file_name`, usually a `.SQLite3.zip` package.
-     - Returns: Initials prefixed with `MyBible-` and sanitized for local identifiers.
-     - Side effects: none.
-     - Failure modes: empty filenames collapse to `MyBible-module`.
-     */
-    private static func myBibleModuleInitials(fileName: String) -> String {
-        let base = ((fileName as NSString).deletingPathExtension as NSString).lastPathComponent
-        let fallback = base.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "module" : base
-        return "MyBible-" + sanitizeMyBibleModuleName(fallback)
-    }
-
-    /**
-     Maps Android MyBible filename conventions to common module categories.
-
-     - Parameter fileName: Manifest package filename.
-     - Returns: Commentaries for `.commentaries`, dictionaries for `.dictionaries`, otherwise Bible.
-     - Side effects: none.
-     - Failure modes: unknown filename families intentionally fall back to Bible, matching Android's
-       default category behavior.
-     */
-    private static func myBibleCategory(fileName: String) -> ModuleCategory {
-        let lowercased = fileName.lowercased()
-        if lowercased.contains(".commentaries") {
-            return .commentary
-        }
-        if lowercased.contains(".dictionaries") {
-            return .dictionary
-        }
-        return .bible
-    }
-
-    /**
-     Sanitizes MyBible package basenames using Android's identifier policy.
-
-     - Parameter name: Package basename without its outer archive extension.
-     - Returns: ASCII alphanumerics preserved and every other scalar replaced with `_`.
-     - Side effects: none.
-     - Failure modes: none.
-     */
-    private static func sanitizeMyBibleModuleName(_ name: String) -> String {
-        let allowed = CharacterSet.alphanumerics
-        return String(name.unicodeScalars.map { scalar in
-            allowed.contains(scalar) ? Character(scalar) : "_"
-        })
-    }
-
     // MARK: - Module Installation
 
     /**
@@ -1267,7 +1234,7 @@ public final class ModuleRepository: @unchecked Sendable {
      transient missing raw files cannot publish partial Bible or commentary data.
 
      - Parameters:
-       - moduleName: Module abbreviation from the refreshed catalog, such as `KJV`.
+       - moduleName: Exact module initials from the refreshed catalog, such as `KJV`.
        - source: Remote source whose in-memory catalog entry supplies package metadata and module
          layout.
        - progress: Optional callback receiving normalized completion in the range `0.0...1.0`.
@@ -3298,6 +3265,7 @@ public final class ModuleRepository: @unchecked Sendable {
 
         return CatalogModule(
             name: config.name,
+            abbreviation: config.values["Abbreviation"]?.first ?? config.name,
             description: config.description,
             category: config.category,
             language: config.language,

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledRegistrationReader.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreInstalledRegistrationReader.swift
@@ -411,7 +411,7 @@ public enum ModuleStoreInstalledRegistrationReader {
                 && ["mybiblebible", "mybiblecommentary", "mybibledictionary"].contains(driver)
                 && databaseCategory.map(categoryMatches) == true
                 && config.name.caseInsensitiveCompare(
-                    "MyBible-" + sanitizeMyBibleModuleName(stem)
+                    "MyBible-" + MyBibleAndroidFilenameIdentity.sanitizeModuleName(stem)
                 ) == .orderedSame
                 && markerEquals("AndBibleMyBibleModule", "1")
                 && markerEquals("AndBibleDbFile", relativePath)
@@ -422,7 +422,7 @@ public enum ModuleStoreInstalledRegistrationReader {
                 && ["myswordbible", "myswordcommentary", "mysworddictionary"].contains(driver)
                 && databaseCategory.map(categoryMatches) == true
                 && config.name.caseInsensitiveCompare(
-                    "MySword-" + sanitizeMyBibleModuleName(stem)
+                    "MySword-" + sanitizeMySwordModuleName(stem)
                 ) == .orderedSame
                 && markerEquals("AndBibleMySwordModule", "1")
                 && markerEquals("AndBibleDbFile", relativePath)
@@ -489,8 +489,16 @@ public enum ModuleStoreInstalledRegistrationReader {
         }
     }
 
-    /** Applies Android's historical MyBible/MySword `[^a-zA-z0-9]` replacement. */
-    private static func sanitizeMyBibleModuleName(_ value: String) -> String {
+    /**
+     Applies Android's historical MySword `[^a-zA-z0-9]` replacement.
+
+     - Parameter value: Exact payload basename before the `MySword-` prefix.
+     - Returns: ASCII digits and code points `A...z` unchanged; every other Unicode scalar becomes
+       one underscore.
+     - Side effects: None.
+     - Failure modes: None; every Swift string has a finite Unicode-scalar projection.
+     */
+    private static func sanitizeMySwordModuleName(_ value: String) -> String {
         value.unicodeScalars.map { scalar in
             let code = scalar.value
             return (48...57).contains(code) || (65...122).contains(code)

--- a/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+MyBible.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleStoreTransactionPublisher+MyBible.swift
@@ -10,23 +10,34 @@ extension ModuleStoreTransactionPublisher {
        - stagingDirectory: Isolated directory containing payload and `module.json`.
        - moduleName: Safe MyBible initials used as the final directory name.
        - onCommitStarted: Callback invoked after cancellation closes and before live-tree work.
-     - Side effects: Replaces the live MyBible directory transactionally and posts one notification.
-     - Throws: Cancellation before mutation, unsafe paths, missing staged metadata/payload, or
-       filesystem/rollback errors.
+     - Side effects: Replaces the live MyBible directory, removes the one proven pre-parity owner in
+       the same rollback transaction when present, and posts one notification.
+     - Throws: Cancellation before mutation, unsafe paths, missing or identity-mismatched staged
+       metadata/payload, or filesystem/rollback errors.
      */
     public func publishStagedMyBibleInstall(
         from stagingDirectory: URL,
         moduleName: String,
         onCommitStarted: (() -> Void)? = nil
     ) throws {
-        let safeName = try resolver.safeModuleName(moduleName)
+        let safeName = try safeMyBibleDirectoryName(moduleName)
         try coordinator.withExclusiveTransaction(kind: .remoteMyBible, prepare: {
             let stagingCanonical = stagingDirectory.standardizedFileURL.resolvingSymlinksInPath()
             try validateIsolatedStagingRoot(stagingCanonical)
-            guard fileManager.fileExists(
-                atPath: stagingCanonical.appendingPathComponent("module.json").path
-            ) else {
+            let stagedMetadataURL = stagingCanonical.appendingPathComponent("module.json")
+            guard let stagedMetadataData = try? Data(contentsOf: stagedMetadataURL),
+                  let stagedMetadata = try? JSONDecoder().decode(
+                    InstalledMyBibleModule.self,
+                    from: stagedMetadataData
+                  ) else {
                 throw ModuleStoreMutationError.stagedFileMissing("module.json")
+            }
+            let stagedIdentity = MyBibleAndroidFilenameIdentity(
+                fileName: stagedMetadata.packageFileName
+            )
+            guard SwordJavaStringIdentity.equals(stagedMetadata.name, safeName),
+                  SwordJavaStringIdentity.equals(stagedIdentity.initials, safeName) else {
+                throw ModuleStoreMutationError.invalidConfiguration("module.json")
             }
             let children = try fileManager.contentsOfDirectory(
                 at: stagingCanonical,
@@ -40,10 +51,30 @@ extension ModuleStoreTransactionPublisher {
             try resolver.validateCanonicalContainment(of: myBibleRoot, beneath: canonicalRootURL)
             let finalURL = myBibleRoot.appendingPathComponent(safeName, isDirectory: true)
             try resolver.validateCanonicalContainment(of: finalURL, beneath: myBibleRoot)
+            let obsoleteName = try safeMyBibleDirectoryName(
+                MyBibleAndroidFilenameIdentity.obsoletePreParityIOSDirectoryName(
+                    forPackageFileName: stagedMetadata.packageFileName
+                )
+            )
+            let obsoleteURL = myBibleRoot.appendingPathComponent(obsoleteName, isDirectory: true)
+            try resolver.validateCanonicalContainment(of: obsoleteURL, beneath: myBibleRoot)
+            let obsoleteURLs: [URL]
+            if SwordJavaExactStringIdentity(obsoleteName) == SwordJavaExactStringIdentity(safeName) {
+                obsoleteURLs = []
+            } else if let provenObsoleteURL = try obsoleteMyBibleModuleURL(
+                obsoleteURL,
+                expectedModuleName: obsoleteName,
+                expectedPackageFileName: stagedMetadata.packageFileName
+            ) {
+                obsoleteURLs = [provenObsoleteURL]
+            } else {
+                obsoleteURLs = []
+            }
             return (
                 stagingCanonical: stagingCanonical,
                 myBibleRoot: myBibleRoot,
-                finalURL: finalURL
+                finalURL: finalURL,
+                obsoleteURLs: obsoleteURLs
             )
         }, commit: { prepared in
             onCommitStarted?()
@@ -51,21 +82,24 @@ extension ModuleStoreTransactionPublisher {
                 ".module-transaction-\(UUID().uuidString).backup",
                 isDirectory: true
             )
-            var backupMove: BackupMove?
+            var backupMoves: [BackupMove] = []
             var createdDirectories: [URL] = []
             do {
                 try createLiveDirectory(prepared.myBibleRoot, tracking: &createdDirectories)
-                if fileManager.fileExists(atPath: prepared.finalURL.path) {
+                for existingURL in [prepared.finalURL] + prepared.obsoleteURLs
+                    where fileManager.fileExists(atPath: existingURL.path) {
                     let backupURL = backupRoot.appendingPathComponent(
-                        "mybible/\(safeName)",
+                        "mybible/\(existingURL.lastPathComponent)",
                         isDirectory: true
                     )
                     try fileManager.createDirectory(
                         at: backupURL.deletingLastPathComponent(),
                         withIntermediateDirectories: true
                     )
-                    try fileManager.moveItem(at: prepared.finalURL, to: backupURL)
-                    backupMove = BackupMove(originalURL: prepared.finalURL, backupURL: backupURL)
+                    try fileManager.moveItem(at: existingURL, to: backupURL)
+                    backupMoves.append(
+                        BackupMove(originalURL: existingURL, backupURL: backupURL)
+                    )
                 }
                 try fileManager.copyItem(at: prepared.stagingCanonical, to: prepared.finalURL)
                 if fileManager.fileExists(atPath: backupRoot.path) {
@@ -75,7 +109,7 @@ extension ModuleStoreTransactionPublisher {
             } catch {
                 let rollbackFailures = rollback(
                     backupRoot: backupRoot,
-                    moves: backupMove.map { [$0] } ?? [],
+                    moves: backupMoves,
                     publishedURLs: [prepared.finalURL],
                     createdDirectories: createdDirectories
                 )
@@ -85,12 +119,91 @@ extension ModuleStoreTransactionPublisher {
     }
 
     /**
+     Validates one direct MyBible directory component.
+
+     Android's historical sanitizer deliberately preserves backslash, which is an ordinary filename
+     character on iOS rather than a path separator. The general SWORD module validator rejects it
+     because archive paths are cross-platform; this family-specific boundary admits it while still
+     rejecting every iOS path/control escape.
+
+     - Parameter moduleName: Exact Android-derived MyBible initials.
+     - Returns: The unchanged direct component.
+     - Side effects: None.
+     - Failure modes: Empty, dot, slash, percent, null, or line-break values throw
+       `ModuleStoreMutationError.unsafeModuleName`.
+     */
+    private func safeMyBibleDirectoryName(_ moduleName: String) throws -> String {
+        guard !moduleName.isEmpty,
+              moduleName != ".",
+              moduleName != "..",
+              !moduleName.contains("/"),
+              !moduleName.contains("%"),
+              !moduleName.contains("\0"),
+              !moduleName.contains("\n"),
+              !moduleName.contains("\r") else {
+            throw ModuleStoreMutationError.unsafeModuleName(moduleName)
+        }
+        return moduleName
+    }
+
+    /**
+     Resolves an obsolete pre-parity directory only when it belongs to the staged manifest package.
+
+     - Parameters:
+       - moduleURL: Canonical-contained candidate directory derived from the old iOS identity.
+       - expectedModuleName: Exact pre-parity owner stored in the sidecar before filesystem Unicode
+         decomposition.
+       - expectedPackageFileName: Exact manifest filename decoded from staged metadata.
+     - Returns: The unchanged directory when its valid sidecar names the same exact package, or nil
+       when the path is absent or belongs to another package.
+     - Side effects: Reads directory and sidecar file metadata plus bounded JSON content.
+     - Failure modes: Filesystem metadata errors propagate; symlinks, malformed sidecars, and
+       different package identities fail closed without becoming removal targets.
+     */
+    private func obsoleteMyBibleModuleURL(
+        _ moduleURL: URL,
+        expectedModuleName: String,
+        expectedPackageFileName: String
+    ) throws -> URL? {
+        guard fileManager.fileExists(atPath: moduleURL.path) else { return nil }
+        let directoryValues = try moduleURL.resourceValues(
+            forKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        )
+        guard directoryValues.isDirectory == true,
+              directoryValues.isSymbolicLink != true else {
+            return nil
+        }
+        let metadataURL = moduleURL.appendingPathComponent("module.json")
+        let metadataValues = try metadataURL.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+        )
+        guard metadataValues.isRegularFile == true,
+              metadataValues.isSymbolicLink != true,
+              let fileSize = metadataValues.fileSize,
+              fileSize <= 1_024 * 1_024,
+              let data = try? Data(contentsOf: metadataURL),
+              let metadata = try? JSONDecoder().decode(InstalledMyBibleModule.self, from: data),
+              SwordJavaStringIdentity.equals(metadata.name, expectedModuleName),
+              fileSystemComponent(
+                moduleURL.lastPathComponent,
+                representsExactOwner: expectedModuleName
+              ),
+              SwordJavaStringIdentity.equals(
+                metadata.packageFileName,
+                expectedPackageFileName
+              ) else {
+            return nil
+        }
+        return moduleURL
+    }
+
+    /**
      Resolves a valid installed MyBible sidecar without mutating the live tree.
 
      - Parameter moduleName: Validated MyBible initials.
-     Direct sidecar-directory initials are retained for catalog/uninstall compatibility. When the
-     visible installed initials instead come from the actual database filename, the method scans
-     valid sidecars in deterministic raw UTF-16 path order and returns that payload owner.
+     Direct sidecar-directory initials are the remote package owner. When visible installed initials
+     instead come from the actual database filename, the method scans valid sidecars in
+     deterministic raw UTF-16 path order and returns that payload owner.
 
      - Returns: The contained module directory, or `nil` when no direct or database-derived identity
        matches.
@@ -104,7 +217,13 @@ extension ModuleStoreTransactionPublisher {
         let moduleURL = myBibleRoot.appendingPathComponent(moduleName, isDirectory: true)
         try resolver.validateCanonicalContainment(of: moduleURL, beneath: myBibleRoot)
         if fileManager.fileExists(atPath: moduleURL.path) {
-            return try validatedMyBibleModuleURL(moduleURL, moduleName: moduleName)
+            let validated = try validatedMyBibleModule(moduleURL, moduleName: moduleName)
+            guard SwordJavaStringIdentity.equals(validated.sidecar.name, moduleName) else {
+                throw ModuleStoreMutationError.invalidConfiguration(
+                    "mybible/\(moduleName)/module.json"
+                )
+            }
+            return validated.url
         }
 
         guard fileManager.fileExists(atPath: myBibleRoot.path) else { return nil }
@@ -117,17 +236,19 @@ extension ModuleStoreTransactionPublisher {
         }
         let requestedIdentity = SwordJavaExactStringIdentity(moduleName)
         for directory in directories {
-            let values = try directory.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
-            guard values.isDirectory == true, values.isSymbolicLink != true else { continue }
-            let metadataURL = directory.appendingPathComponent("module.json")
-            guard let data = try? Data(contentsOf: metadataURL),
-                  let sidecar = try? JSONDecoder().decode(InstalledMyBibleModule.self, from: data),
-                  InstalledMyBibleBookReader.registrations(in: directory, sidecar: sidecar).contains(
+            guard let validated = try? validatedMyBibleModule(
+                directory,
+                moduleName: moduleName
+            ),
+                  InstalledMyBibleBookReader.registrations(
+                    in: validated.url,
+                    sidecar: validated.sidecar
+                  ).contains(
                     where: { SwordJavaExactStringIdentity($0.info.name) == requestedIdentity }
                   ) else {
                 continue
             }
-            return try validatedMyBibleModuleURL(directory, moduleName: moduleName)
+            return validated.url
         }
         return nil
     }
@@ -138,14 +259,15 @@ extension ModuleStoreTransactionPublisher {
      - Parameters:
        - moduleURL: Candidate direct or database-derived module directory.
        - moduleName: Requested installed initials used in diagnostics.
-     - Returns: The unchanged canonical-contained directory.
-     - Side effects: Reads directory and `module.json` file metadata.
-     - Throws: Invalid/symlink directories and missing/malformed sidecar files fail closed.
+     - Returns: The unchanged canonical-contained directory and its decoded sidecar.
+     - Side effects: Reads directory and bounded `module.json` metadata.
+     - Throws: Invalid/symlink directories, missing/malformed sidecars, and sidecars whose exact
+       remote owner differs from the directory component fail closed.
      */
-    private func validatedMyBibleModuleURL(
+    private func validatedMyBibleModule(
         _ moduleURL: URL,
         moduleName: String
-    ) throws -> URL {
+    ) throws -> (url: URL, sidecar: InstalledMyBibleModule) {
         let myBibleRoot = canonicalRootURL.appendingPathComponent("mybible", isDirectory: true)
         try resolver.validateCanonicalContainment(of: moduleURL, beneath: myBibleRoot)
         let moduleValues = try moduleURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
@@ -156,12 +278,47 @@ extension ModuleStoreTransactionPublisher {
         guard fileManager.fileExists(atPath: metadataURL.path) else {
             throw ModuleStoreMutationError.invalidConfiguration("mybible/\(moduleName)/module.json")
         }
-        let metadataValues = try metadataURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        let metadataValues = try metadataURL.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+        )
         guard metadataValues.isRegularFile == true,
-              metadataValues.isSymbolicLink != true else {
+              metadataValues.isSymbolicLink != true,
+              let fileSize = metadataValues.fileSize,
+              fileSize <= 1_024 * 1_024,
+              let data = try? Data(contentsOf: metadataURL),
+              let metadata = try? JSONDecoder().decode(InstalledMyBibleModule.self, from: data),
+              fileSystemComponent(
+                moduleURL.lastPathComponent,
+                representsExactOwner: metadata.name
+              ) else {
             throw ModuleStoreMutationError.invalidConfiguration("mybible/\(moduleName)/module.json")
         }
-        return moduleURL
+        return (moduleURL, metadata)
+    }
+
+    /**
+     Tests whether a URL directory component represents one exact sidecar owner on Apple filesystems.
+
+     Foundation exposes filesystem path components in decomposed Unicode form even when the app
+     supplied a composed Java string. The sidecar remains the authoritative raw identity; this
+     comparison permits only canonical composition differences needed to bind that identity to its
+     storage directory. It deliberately performs no case folding.
+
+     - Parameters:
+       - component: Directory component returned by Foundation URL handling.
+       - owner: Exact Java-visible owner stored in the sidecar.
+     - Returns: `true` only when both strings have identical canonical decomposition.
+     - Side effects: None.
+     - Failure modes: None; every Swift string supports deterministic canonical decomposition.
+     */
+    private func fileSystemComponent(
+        _ component: String,
+        representsExactOwner owner: String
+    ) -> Bool {
+        SwordJavaStringIdentity.equals(
+            component.decomposedStringWithCanonicalMapping,
+            owner.decomposedStringWithCanonicalMapping
+        )
     }
 
     /** Removes one prevalidated MyBible directory through rollback storage. */

--- a/Sources/SwordKit/Sources/SwordKit/MyBibleAndroidFilenameIdentity.swift
+++ b/Sources/SwordKit/Sources/SwordKit/MyBibleAndroidFilenameIdentity.swift
@@ -1,0 +1,147 @@
+// MyBibleAndroidFilenameIdentity.swift -- Android MyBible filename projection
+
+import Foundation
+
+/**
+ Projects one MyBible filename through Android's current filename-owned identity contract.
+
+ Android's MyBible installer derives remote initials and abbreviation from
+ `File(file_name).nameWithoutExtension`, then replaces characters through the historical
+ `[^a-zA-z0-9]` expression. Installed payload projection uses the same basename operations on the
+ opened SQLite filename. Keeping that behavior in one immutable value prevents catalog and
+ installed-package identity from drifting again.
+
+ Construction performs no file access and cannot fail. Values preserve Java-visible spelling; no
+ normalization, locale folding, or trimming is applied.
+ */
+struct MyBibleAndroidFilenameIdentity: Equatable, Sendable {
+    /// Exact final path component with only its last extension removed.
+    let nameWithoutExtension: String
+
+    /// Android module initials, including the `MyBible-` family prefix.
+    let initials: String
+
+    /// Exact basename segment before the first dot used as Android's visible abbreviation.
+    let abbreviation: String
+
+    /**
+     Creates Android's filename-owned MyBible identity.
+
+     - Parameter fileName: Manifest path or installed payload filename evaluated with Android's
+       slash-separated `File.name` behavior.
+     - Returns: A complete immutable identity through the initialized value.
+     - Side effects: None.
+     - Failure modes: None; empty and leading-dot filenames intentionally produce empty components
+       exactly as Android does.
+     */
+    init(fileName: String) {
+        let leafName = Self.androidFileName(fileName)
+        let baseName = Self.removingLastExtension(leafName)
+        nameWithoutExtension = baseName
+        initials = "MyBible-" + Self.sanitizeModuleName(baseName)
+        abbreviation = Self.abbreviation(from: baseName)
+    }
+
+    /**
+     Infers Android's remote MyBible category from one manifest filename.
+
+     - Parameter fileName: Exact manifest `file_name`, including any directory prefix.
+     - Returns: Commentary for the exact lowercase `.commentaries` marker, dictionary for the exact
+       lowercase `.dictionaries` marker, and Bible otherwise.
+     - Side effects: None.
+     - Failure modes: None; missing and differently cased markers deliberately fall back to Bible.
+     */
+    static func category(forPackageFileName fileName: String) -> ModuleCategory {
+        if fileName.contains(".commentaries") {
+            return .commentary
+        }
+        if fileName.contains(".dictionaries") {
+            return .dictionary
+        }
+        return .bible
+    }
+
+    /**
+     Applies Android's historical MyBible `[^a-zA-z0-9]` replacement.
+
+     Java's `A-z` range spans ASCII values 65 through 122, preserving `[\\]^_\`` in addition to
+     letters and digits.
+
+     - Parameter value: Exact basename before the `MyBible-` prefix is added.
+     - Returns: ASCII digits and code points `A...z` unchanged; every other Unicode scalar becomes
+       one underscore.
+     - Side effects: None.
+     - Failure modes: None; every Swift string has a finite Unicode-scalar projection.
+     */
+    static func sanitizeModuleName(_ value: String) -> String {
+        value.unicodeScalars.map { scalar in
+            let code = scalar.value
+            let accepted = (48...57).contains(code) || (65...122).contains(code)
+            return accepted ? String(scalar) : "_"
+        }.joined()
+    }
+
+    /**
+     Reproduces the retired iOS remote identity only to locate its one-way migration source.
+
+     Builds before Android parity removed only the archive extension through `NSString`, selected
+     the final path component, trimmed an empty basename to `module`, and preserved every Unicode
+     scalar accepted by Foundation's `alphanumerics` set. The result must never be used for catalog,
+     lookup, or new publication identity.
+
+     - Parameter fileName: Exact manifest package filename stored in the installed sidecar.
+     - Returns: The single pre-parity iOS directory name eligible for proven atomic removal.
+     - Side effects: None.
+     - Failure modes: None; the retired empty-name fallback is reproduced only for migration.
+     */
+    static func obsoletePreParityIOSDirectoryName(forPackageFileName fileName: String) -> String {
+        let baseName = ((fileName as NSString).deletingPathExtension as NSString).lastPathComponent
+        let value = baseName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "module"
+            : baseName
+        let allowed = CharacterSet.alphanumerics
+        let sanitized = value.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? String(scalar) : "_"
+        }.joined()
+        return "MyBible-" + sanitized
+    }
+
+    /**
+     Selects Android/Linux `File.name` without treating a backslash as a path separator.
+
+     - Parameter fileName: Exact manifest or payload filename.
+     - Returns: Text after the last forward slash, or the unchanged input when no slash exists.
+     - Side effects: None.
+     - Failure modes: None; a trailing slash produces an empty filename.
+     */
+    private static func androidFileName(_ fileName: String) -> String {
+        guard let slash = fileName.lastIndex(of: "/") else { return fileName }
+        return String(fileName[fileName.index(after: slash)...])
+    }
+
+    /**
+     Mirrors Kotlin's `nameWithoutExtension` operation.
+
+     - Parameter fileName: One slash-free filename.
+     - Returns: Text before the final dot, or the unchanged filename when no dot exists.
+     - Side effects: None.
+     - Failure modes: None; a leading dot yields an empty value.
+     */
+    private static func removingLastExtension(_ fileName: String) -> String {
+        guard let dot = fileName.lastIndex(of: ".") else { return fileName }
+        return String(fileName[..<dot])
+    }
+
+    /**
+     Derives Android's visible MyBible abbreviation.
+
+     - Parameter baseName: Filename after removing only its final extension.
+     - Returns: Exact text before the first dot, including an empty value for a leading dot.
+     - Side effects: None.
+     - Failure modes: None; basenames without a dot are returned unchanged.
+     */
+    private static func abbreviation(from baseName: String) -> String {
+        guard let dot = baseName.firstIndex(of: ".") else { return baseName }
+        return String(baseName[..<dot])
+    }
+}

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleRepositoryDownloadTests.swift
@@ -64,11 +64,27 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
               "update_info": "http upgraded"
             },
             {
+              "file_name": "nested/Å-[x]^_.commentaries.SQLite3.zip",
+              "description": "Exact commentary identity",
+              "download_url": "https://mybible.example/exact-commentary.zip",
+              "language_code": "en",
+              "update_date": "2026-05-03",
+              "update_info": "android filename contract"
+            },
+            {
+              "file_name": "upper.COMMENTARIES.SQLite3.zip",
+              "description": "Case-sensitive Bible marker",
+              "download_url": "https://mybible.example/upper.zip",
+              "language_code": "en",
+              "update_date": "2026-05-04",
+              "update_info": "case-sensitive marker"
+            },
+            {
               "file_name": "ignored.SQLite3.zip",
               "description": "Unsupported URL",
               "download_url": "ftp://mybible.example/ignored.SQLite3.zip",
               "language_code": "en",
-              "update_date": "2026-05-03",
+              "update_date": "2026-05-05",
               "update_info": "ignored"
             }
           ]
@@ -97,18 +113,56 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
 
         let modules = try await repository.refreshCatalog(for: source)
 
-        XCTAssertEqual(modules.map(\.name), ["MyBible-finrk_SQLite3", "MyBible-legacy_SQLite3"])
+        XCTAssertEqual(modules.map(\.name), [
+            "MyBible-finrk_SQLite3",
+            "MyBible-legacy_SQLite3",
+            "MyBible-__[x]^__commentaries_SQLite3",
+            "MyBible-upper_COMMENTARIES_SQLite3",
+        ])
         XCTAssertEqual(modules.first?.description, "Finnish RK")
         XCTAssertEqual(modules.first?.category, .bible)
         XCTAssertEqual(modules.first?.language, "fi")
         XCTAssertEqual(modules.first?.sourceName, "Example MyBible")
+        XCTAssertEqual(modules[2].abbreviation, "Å-[x]^_")
+        XCTAssertEqual(modules[2].category, .commentary)
+        XCTAssertEqual(modules[3].abbreviation, "upper")
+        XCTAssertEqual(modules[3].category, .bible)
+
+        let cachedModules = repository.loadCachedCatalogs()
+        let cachedCommentary = try XCTUnwrap(
+            cachedModules.first { $0.name == "MyBible-__[x]^__commentaries_SQLite3" }
+        )
+        XCTAssertEqual(cachedCommentary.abbreviation, "Å-[x]^_")
+        XCTAssertEqual(cachedCommentary.category, .commentary)
     }
 
     /**
-     Verifies SWORD-compatible Android custom-driver catalog rows classify by driver.
+     Verifies Android's historical remote MyBible sanitizer without filesystem or manifest noise.
+
+     - Setup: Projects a basename containing every punctuation value between ASCII `Z` and `a`, a
+       backslash, and a non-ASCII letter.
+     - Expected result: `[\\]^_\`` and ASCII letters remain exact while the non-ASCII letter and
+       hyphen become underscores.
+     - Side effects: None.
+     - Failure meaning: iOS has replaced Android's pinned `[^a-zA-z0-9]` behavior with a Unicode or
+       conventional ASCII-alphanumeric sanitizer.
+     */
+    func testMyBibleRemoteIdentityPreservesAndroidHistoricalASCIIRange() {
+        let identity = MyBibleAndroidFilenameIdentity(
+            fileName: "nested/Å-[\\]^_`.SQLite3.zip"
+        )
+
+        XCTAssertEqual(identity.nameWithoutExtension, "Å-[\\]^_`.SQLite3")
+        XCTAssertEqual(identity.initials, "MyBible-__[\\]^_`_SQLite3")
+        XCTAssertEqual(identity.abbreviation, "Å-[\\]^_`")
+    }
+
+    /**
+     Verifies SWORD-compatible Android custom-driver catalog rows retain JSword metadata.
 
      Android registers `MyBibleDictionary` as a dictionary `BookType`, so a repository or restored
-     catalog row with `Category=Unknown` must still appear in Downloads' dictionary filters.
+     catalog row with `Category=Unknown` must still appear in Downloads' dictionary filters. Its
+     explicit `Abbreviation` must also survive as the primary Android Downloads label.
 
      - Setup: Serves a `mods.d.tar.gz` containing a BDBT-style `MyBibleDictionary` config.
      - Expected result: Catalog refresh returns BDBT as a dictionary.
@@ -133,6 +187,7 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
             modDrv: "MyBibleDictionary",
             dataPath: "./modules/texts/MyBible/BDBT/",
             extraConf: """
+            Abbreviation=BDBT Short
             Feature=GreekDef
             Feature=HebrewDef
             """
@@ -162,6 +217,7 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
         let bdbt = try XCTUnwrap(modules.first { $0.name == "BDBT" })
 
         XCTAssertEqual(bdbt.category, .dictionary)
+        XCTAssertEqual(bdbt.abbreviation, "BDBT Short")
         XCTAssertEqual(bdbt.language, "en")
         XCTAssertEqual(bdbt.sourceName, "AndBible")
     }
@@ -309,6 +365,151 @@ final class ModuleRepositoryDownloadTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: moduleDir.path))
         XCTAssertEqual(repository.loadInstalledMyBibleModules().map(\.name), ["MyBible-companion"])
         await fulfillment(of: [notificationExpectation], timeout: 0.2)
+    }
+
+    /**
+     Verifies a remote install atomically replaces the pre-parity iOS directory identity.
+
+     - Setup: Seeds a valid previously downloaded package under the old Unicode-alphanumeric
+       directory, then refreshes and installs the same manifest package through Android's current
+       filename projection.
+     - Expected result: The old package remains discoverable by its payload-owned installed identity;
+       after update, the catalog, new directory, sidecar, package lookup, and visible abbreviation
+       share Android's exact remote identity and the proven old directory is removed in the same
+       publication transaction.
+     - Side effects: Creates and removes one isolated SWORD root and serves a manifest/package from
+       the in-process URL protocol.
+     - Failure meaning: Existing iOS downloads become orphaned/duplicated, or catalog and installed
+       package identity diverge after adopting Android's historical sanitizer.
+     */
+    func testModuleRepositoryMigratesPreParityMyBibleDirectoryAtomically() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let swordDir = tempDir.appendingPathComponent("sword", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let packageFileName = "nested/Å-[x]^_.commentaries.SQLite3.zip"
+        let currentName = "MyBible-__[x]^__commentaries_SQLite3"
+        let obsoleteName = "MyBible-Å__x____commentaries_SQLite3"
+        let payloadFileName = "Å-[x]^_.commentaries.SQLite3"
+        let databaseURL = tempDir.appendingPathComponent(payloadFileName)
+        try makeMyBibleFixtureDatabase(at: databaseURL)
+        let packageData = makeModuleRepositoryZip([
+            (payloadFileName, try Data(contentsOf: databaseURL))
+        ])
+
+        let oldDirectory = swordDir
+            .appendingPathComponent("mybible", isDirectory: true)
+            .appendingPathComponent(obsoleteName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: oldDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(
+            at: databaseURL,
+            to: oldDirectory.appendingPathComponent(payloadFileName)
+        )
+        let oldSidecar = InstalledMyBibleModule(
+            name: obsoleteName,
+            description: "Old iOS package",
+            category: ModuleCategory.commentary.rawValue,
+            language: "fi",
+            version: "2026-05-01",
+            sourceName: "Example MyBible",
+            packageFileName: packageFileName,
+            downloadURL: "https://mybible.example/exact-commentary.zip",
+            installedAt: Date(timeIntervalSince1970: 0)
+        )
+        try JSONEncoder().encode(oldSidecar).write(
+            to: oldDirectory.appendingPathComponent("module.json"),
+            options: .atomic
+        )
+
+        let manifestData = """
+        {
+          "url": "https://mybible.example/manifest.json",
+          "file_name": "Example MyBible",
+          "description": "Example MyBible catalog",
+          "modules": [
+            {
+              "file_name": "nested/Å-[x]^_.commentaries.SQLite3.zip",
+              "description": "Exact commentary identity",
+              "download_url": "https://mybible.example/exact-commentary.zip",
+              "language_code": "fi",
+              "update_date": "2026-05-01",
+              "update_info": "android filename contract"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        let source = SourceConfig(
+            name: "Example MyBible",
+            type: "HTTP",
+            host: "mybible.example",
+            catalogPath: "/manifest.json",
+            repositoryType: SourceConfig.myBibleHTTPSRepositoryType,
+            manifestURL: URL(string: "https://mybible.example/manifest.json")
+        )
+        ModuleRepositoryDownloadMockURLProtocol.requestHandler = { request in
+            let data = request.url?.path == "/manifest.json" ? manifestData : packageData
+            return (
+                HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!,
+                data
+            )
+        }
+        defer { ModuleRepositoryDownloadMockURLProtocol.requestHandler = nil }
+
+        let repository = ModuleRepository(
+            basePath: tempDir.appendingPathComponent("repository", isDirectory: true).path,
+            swordPath: swordDir.path,
+            session: makeModuleRepositoryDownloadMockSession()
+        )
+        let publisher = ModuleStoreTransactionPublisher(moduleRootURL: swordDir)
+        let preMigrationInventory = repository.loadInstalledMyBibleModules()
+        XCTAssertEqual(preMigrationInventory.count, 1)
+        let preMigrationInstalled = try XCTUnwrap(preMigrationInventory.first)
+        XCTAssertEqual(
+            try publisher.myBibleModuleURLIfPresent(
+                moduleName: preMigrationInstalled.name
+            ),
+            oldDirectory
+        )
+        let rows = try await repository.refreshCatalog(for: source)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.name, currentName)
+        XCTAssertEqual(row.abbreviation, "Å-[x]^_")
+        XCTAssertEqual(row.category, .commentary)
+
+        try await repository.installModule(named: currentName, from: source)
+
+        let currentDirectory = oldDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent(currentName, isDirectory: true)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldDirectory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: currentDirectory.path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: currentDirectory.appendingPathComponent(payloadFileName).path
+        ))
+        let currentSidecarData = try Data(
+            contentsOf: currentDirectory.appendingPathComponent("module.json")
+        )
+        let currentSidecar = try JSONDecoder().decode(
+            InstalledMyBibleModule.self,
+            from: currentSidecarData
+        )
+        XCTAssertEqual(currentSidecar.name, currentName)
+        XCTAssertEqual(currentSidecar.packageFileName, packageFileName)
+        XCTAssertEqual(
+            try publisher.myBibleModuleURLIfPresent(moduleName: currentName),
+            currentDirectory
+        )
+        XCTAssertEqual(repository.loadInstalledMyBibleModules().count, 1)
     }
 
     /**

--- a/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreTransactionTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/ModuleStoreTransactionTests.swift
@@ -184,9 +184,12 @@ final class ModuleStoreTransactionTests: XCTestCase {
     func testMyBibleVersusUninstallSerializesDeterministically() async throws {
         let context = try makeContext()
         defer { try? FileManager.default.removeItem(at: context.parent) }
+        let moduleName = "MyBible-race_SQLite3"
         let staging = context.parent.appendingPathComponent("mybible-staging", isDirectory: true)
         try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
-        try Data("{}".utf8).write(to: staging.appendingPathComponent("module.json"))
+        try myBibleSidecarData(name: moduleName, packageFileName: "race.SQLite3.zip").write(
+            to: staging.appendingPathComponent("module.json")
+        )
         try Data("sqlite".utf8).write(to: staging.appendingPathComponent("race.SQLite3"))
 
         try await assertSerialized(
@@ -195,15 +198,172 @@ final class ModuleStoreTransactionTests: XCTestCase {
             secondKind: .uninstall,
             first: { try context.firstPublisher.publishStagedMyBibleInstall(
                 from: staging,
-                moduleName: "RACE"
+                moduleName: moduleName
             ) },
-            second: { try context.secondPublisher.uninstall(moduleName: "RACE") }
+            second: { try context.secondPublisher.uninstall(moduleName: moduleName) }
         )
 
         XCTAssertFalse(FileManager.default.fileExists(
-            atPath: context.root.appendingPathComponent("mybible/RACE").path
+            atPath: context.root.appendingPathComponent("mybible/\(moduleName)").path
         ))
         try assertNoTransactionBackups(in: context.root)
+    }
+
+    /**
+     Verifies one-way MyBible identity migration rolls the old directory back on publish failure.
+
+     - Setup: Seeds a proven pre-parity directory, stages the same manifest package under Android's
+       current identity, and injects a failure while copying the replacement directory.
+     - Expected result: Publication throws, the old directory and payload are restored byte-for-byte,
+       no new directory survives, and transaction backup storage is removed.
+     - Side effects: Creates and removes one isolated module root and exercises real rollback moves.
+     - Failure meaning: A failed update can erase the only installed copy while migrating durable
+       MyBible package identity.
+     */
+    func testMyBibleIdentityMigrationRollsBackObsoleteDirectoryOnCopyFailure() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.parent) }
+        let packageFileName = "nested/Å-[x]^_.commentaries.SQLite3.zip"
+        let obsoleteName = "MyBible-Å__x____commentaries_SQLite3"
+        let currentName = "MyBible-__[x]^__commentaries_SQLite3"
+        let myBibleRoot = context.root.appendingPathComponent("mybible", isDirectory: true)
+        let obsoleteDirectory = myBibleRoot.appendingPathComponent(
+            obsoleteName,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: obsoleteDirectory,
+            withIntermediateDirectories: true
+        )
+        try myBibleSidecarData(
+            name: obsoleteName,
+            packageFileName: packageFileName
+        ).write(to: obsoleteDirectory.appendingPathComponent("module.json"))
+        try Data("old".utf8).write(
+            to: obsoleteDirectory.appendingPathComponent("old.SQLite3")
+        )
+
+        let staging = context.parent.appendingPathComponent(
+            "mybible-migration-staging",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        try myBibleSidecarData(
+            name: currentName,
+            packageFileName: packageFileName
+        ).write(to: staging.appendingPathComponent("module.json"))
+        try Data("new".utf8).write(to: staging.appendingPathComponent("new.SQLite3"))
+
+        let faultManager = ModuleStoreMyBibleCopyFaultFileManager(
+            failingDirectoryName: currentName,
+            requiredBackedUpURL: obsoleteDirectory
+        )
+        let publisher = ModuleStoreTransactionPublisher(
+            moduleRootURL: context.root,
+            fileManager: faultManager
+        )
+        XCTAssertThrowsError(
+            try publisher.publishStagedMyBibleInstall(
+                from: staging,
+                moduleName: currentName
+            )
+        )
+
+        XCTAssertTrue(faultManager.observedRequiredOwnerBackedUp)
+        XCTAssertEqual(
+            try String(
+                contentsOf: obsoleteDirectory.appendingPathComponent("old.SQLite3"),
+                encoding: .utf8
+            ),
+            "old"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: myBibleRoot.appendingPathComponent(currentName).path
+        ))
+        try assertNoTransactionBackups(in: context.root)
+    }
+
+    /**
+     Verifies MyBible publication requires one exact Android remote identity across every boundary.
+
+     - Setup: Stages one sidecar whose declared name differs from the destination and another whose
+       package filename projects different Android initials.
+     - Expected result: Both publications fail before the live MyBible root is created.
+     - Side effects: Creates and removes isolated staging directories only.
+     - Failure meaning: A caller can publish catalog, directory, and sidecar identities that Android
+       would treat as different books, defeating exact owner lookup and one-way migration.
+     */
+    func testMyBiblePublicationRejectsMismatchedSidecarAndPackageIdentityBeforeMutation() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.parent) }
+        let moduleName = "MyBible-expected_SQLite3"
+        let variants = [
+            (suffix: "sidecar", sidecarName: "MyBible-other_SQLite3", package: "expected.SQLite3.zip"),
+            (suffix: "package", sidecarName: moduleName, package: "other.SQLite3.zip"),
+        ]
+
+        for variant in variants {
+            let staging = context.parent.appendingPathComponent(
+                "mybible-identity-\(variant.suffix)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+            try myBibleSidecarData(
+                name: variant.sidecarName,
+                packageFileName: variant.package
+            ).write(to: staging.appendingPathComponent("module.json"))
+            try Data("sqlite".utf8).write(to: staging.appendingPathComponent("expected.SQLite3"))
+
+            XCTAssertThrowsError(try context.firstPublisher.publishStagedMyBibleInstall(
+                from: staging,
+                moduleName: moduleName
+            )) { error in
+                guard case ModuleStoreMutationError.invalidConfiguration("module.json") = error else {
+                    return XCTFail("Expected exact identity rejection, received \(error)")
+                }
+            }
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: context.root.appendingPathComponent("mybible").path
+        ))
+        try assertNoTransactionBackups(in: context.root)
+    }
+
+    /**
+     Verifies direct MyBible lookup rejects a sidecar owned by a different remote identity.
+
+     - Setup: Creates a live directory under the requested Android initials but writes a valid
+       sidecar whose exact name belongs to another book.
+     - Expected result: Lookup throws `invalidConfiguration` instead of authorizing the directory.
+     - Side effects: Creates and removes one isolated live MyBible directory.
+     - Failure meaning: A mismatched sidecar can masquerade as the catalog or uninstall owner merely
+       by occupying its durable path.
+     */
+    func testMyBibleLookupRejectsSidecarWhoseExactOwnerDiffersFromDirectory() throws {
+        let context = try makeContext()
+        defer { try? FileManager.default.removeItem(at: context.parent) }
+        let requestedName = "MyBible-expected_SQLite3"
+        let moduleDirectory = context.root
+            .appendingPathComponent("mybible", isDirectory: true)
+            .appendingPathComponent(requestedName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: moduleDirectory,
+            withIntermediateDirectories: true
+        )
+        try myBibleSidecarData(
+            name: "MyBible-other_SQLite3",
+            packageFileName: "expected.SQLite3.zip"
+        ).write(to: moduleDirectory.appendingPathComponent("module.json"))
+        try Data("sqlite".utf8).write(to: moduleDirectory.appendingPathComponent("expected.SQLite3"))
+
+        XCTAssertThrowsError(
+            try context.firstPublisher.myBibleModuleURLIfPresent(moduleName: requestedName)
+        ) { error in
+            guard case ModuleStoreMutationError.invalidConfiguration = error else {
+                return XCTFail("Expected mismatched sidecar rejection, received \(error)")
+            }
+        }
     }
 
     /** Verifies TTF addon publication shares the SWORD writer's canonical-root lease. */
@@ -298,7 +458,11 @@ final class ModuleStoreTransactionTests: XCTestCase {
             at: sqliteStaging,
             withIntermediateDirectories: true
         )
-        try Data("{}".utf8).write(to: sqliteStaging.appendingPathComponent("module.json"))
+        let sqliteModuleName = "MyBible-race_SQLite3"
+        try myBibleSidecarData(
+            name: sqliteModuleName,
+            packageFileName: "race.SQLite3.zip"
+        ).write(to: sqliteStaging.appendingPathComponent("module.json"))
         try Data("sqlite".utf8).write(to: sqliteStaging.appendingPathComponent("race.SQLite3"))
         try await assertSerialized(
             root: context.root,
@@ -307,7 +471,7 @@ final class ModuleStoreTransactionTests: XCTestCase {
             first: {
                 try context.firstPublisher.publishStagedMyBibleInstall(
                     from: sqliteStaging,
-                    moduleName: "EPUBSQLITE"
+                    moduleName: sqliteModuleName
                 )
             },
             second: {
@@ -341,7 +505,7 @@ final class ModuleStoreTransactionTests: XCTestCase {
 
         XCTAssertEqual(try payloadString(context.root, native.payloadPath), "native")
         XCTAssertTrue(FileManager.default.fileExists(atPath: context.root.appendingPathComponent(
-            "mybible/EPUBSQLITE/module.json"
+            "mybible/\(sqliteModuleName)/module.json"
         ).path))
         try assertNoTransactionBackups(in: context.root)
     }
@@ -1421,6 +1585,33 @@ final class ModuleStoreTransactionTests: XCTestCase {
         )
     }
 
+    /**
+     Encodes one valid MyBible sidecar for transaction-only fixtures.
+
+     - Parameters:
+       - name: Exact directory/install identity represented by the sidecar.
+       - packageFileName: Exact manifest package identity used to authorize migration.
+     - Returns: JSON data accepted by the production publisher.
+     - Side effects: None.
+     - Failure modes: Encoding errors propagate to the test.
+     */
+    private func myBibleSidecarData(
+        name: String,
+        packageFileName: String
+    ) throws -> Data {
+        try JSONEncoder().encode(InstalledMyBibleModule(
+            name: name,
+            description: "Transaction fixture",
+            category: ModuleCategory.bible.rawValue,
+            language: "en",
+            version: "1.0",
+            sourceName: "Fixture",
+            packageFileName: packageFileName,
+            downloadURL: "https://fixture.invalid/\(packageFileName)",
+            installedAt: Date(timeIntervalSince1970: 0)
+        ))
+    }
+
     /** Builds and validates an isolated staged install fixture. */
     private func makeStagedInstall(
         context: ModuleStoreTestContext,
@@ -1663,6 +1854,71 @@ private final class ModuleStoreConfigCopyFaultFileManager: FileManager, @uncheck
             throw CocoaError(.fileWriteNoPermission)
         }
         try super.moveItem(at: srcURL, to: dstURL)
+    }
+}
+
+/**
+ Test-only file manager that injects one deterministic MyBible publication failure.
+
+ The publisher first backs up the proven pre-parity owner, then this probe rejects the replacement
+ directory copy so the test can verify transactional rollback. It performs no work until a copy is
+ requested and otherwise delegates exactly to `FileManager`.
+ */
+private final class ModuleStoreMyBibleCopyFaultFileManager: FileManager, @unchecked Sendable {
+    /// Exact final MyBible directory name whose staged copy must fail.
+    private let failingDirectoryName: String
+
+    /// Obsolete live owner that must already be absent when the replacement copy begins.
+    private let requiredBackedUpURL: URL
+
+    /// Synchronizes the observation read after the injected publication failure.
+    private let observationLock = NSLock()
+
+    /// Whether the publisher had moved the required obsolete owner before attempting replacement.
+    private var storedObservedRequiredOwnerBackedUp = false
+
+    /// Thread-safe observation proving migration entered rollback storage before replacement.
+    var observedRequiredOwnerBackedUp: Bool {
+        observationLock.withLock { storedObservedRequiredOwnerBackedUp }
+    }
+
+    /**
+     Creates a file manager that rejects one chosen final MyBible directory.
+
+     - Parameters:
+       - failingDirectoryName: Exact destination directory component to reject.
+       - requiredBackedUpURL: Obsolete owner that must be absent before the rejected copy.
+     - Side effects: Initializes only in-memory test state.
+     - Failure modes: None.
+     */
+    init(failingDirectoryName: String, requiredBackedUpURL: URL) {
+        self.failingDirectoryName = failingDirectoryName
+        self.requiredBackedUpURL = requiredBackedUpURL
+        super.init()
+    }
+
+    /**
+     Copies ordinary files while rejecting the selected staged MyBible destination.
+
+     - Parameters:
+       - srcURL: Source item requested by the production publisher.
+       - dstURL: Destination item requested by the production publisher.
+     - Side effects: Throws before mutating the selected destination; delegates all other copies to
+       `FileManager`.
+     - Failure modes: Throws `CocoaError.fileWriteNoPermission` for the selected final MyBible
+       directory; delegated filesystem failures otherwise propagate.
+     */
+    override func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        if dstURL.lastPathComponent == failingDirectoryName,
+           dstURL.deletingLastPathComponent().lastPathComponent == "mybible" {
+            observationLock.withLock {
+                storedObservedRequiredOwnerBackedUp = !fileExists(
+                    atPath: requiredBackedUpURL.path
+                )
+            }
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        try super.copyItem(at: srcURL, to: dstURL)
     }
 }
 


### PR DESCRIPTION
## Summary

Aligns remote MyBible catalog identity, category parsing, abbreviation presentation, and durable publication with Android current-stable behavior.

## Scope

- Projects manifest filenames through Android's exact last-extension, historical ASCII-range sanitizer, abbreviation, and case-sensitive category rules.
- Keeps installed-database-derived MyBible identity unchanged.
- Carries Android abbreviations through catalog caching and Downloads display, search, accessibility, and stable locale-aware sorting.
- Migrates only a proven pre-parity iOS package owner during the same rollback-capable publication transaction.

## Contract references

- Android current-stable commit `00b4ea24cb2e3f4aefb251328ab7ae005388f70d`, especially `MyBibleInstaller.kt` and `MyBibleBook.kt`.
- GitHub issue #400 acceptance criteria.
- Stacked parent: PR #409 (`fix/font-addons-shared-admission`).

## Change details

- Adds one shared immutable MyBible filename projection used by remote catalog and installed payload readers.
- Removes duplicated Unicode-alphanumeric and case-folded remote identity logic.
- Requires exact raw UTF-16 agreement among staged sidecar name, Android package-derived initials, and destination owner before publication.
- Locates the single earlier iOS directory identity from staged package metadata, verifies its bounded sidecar ownership, and moves it through rollback storage before replacement.
- Adds Android-parity fixtures for nested/special filenames, uppercase category markers, historical `[\\]^_\`` preservation, ordinary SWORD abbreviations, Turkish sorting, equal-key stability, migration success, rollback, and wrong-owner rejection.

## Validation evidence

- SwordKit iOS Simulator suite: 272 passed, 0 failed.
- BibleUI iOS Simulator suite: 991 passed, 0 failed.
- Full AndBible iOS Simulator build: succeeded.
- Repository guard unit tests: 37 passed.
- Static source/docblock guard: 804 tracked Swift files passed.
- `git diff --check`: passed.
- GitNexus final impact: HIGH, 114 symbols across 6 flows; no unexpected execution-flow family.

## Risks and follow-ups

- This intentionally changes remote MyBible identifiers/categories that did not match Android.
- Earlier iOS packages are handled by a bounded one-way migration during publication; there is no parallel legacy lookup or new-publication path.
- This PR depends on the stacked parent #409 and must not merge before it.

## Issue closure

Closes #400
