### PR TITLE
fix(sword): align installed MyBible features

### DIFF
--- a/Sources/BibleUI/Tests/BibleUITests/SQLiteReaderRuntimeIntegrationTests.swift
+++ b/Sources/BibleUI/Tests/BibleUITests/SQLiteReaderRuntimeIntegrationTests.swift
@@ -190,6 +190,94 @@ final class SQLiteReaderRuntimeIntegrationTests: BibleUISwordFixtureTestCase {
     }
 
     /**
+     Verifies one installed MyBible projection drives Android's automatic reference defaults and
+     emitted reader metadata without a sidecar-owned capability path.
+
+     - Setup: Installs the checked-in Strong's/Words-of-Christ Bible and Strong's-definition
+       dictionary as package-owned MyBible books whose sidecars advertise unrelated version data.
+       It resolves the globally admitted BookSet inventory, automatic AI reference defaults, and a
+       real Genesis fragment through the production installed-source resolver.
+     - Expected result: Both rows expose Android's generated version `0.0`; Find All accepts the
+       Strong's Bible; Hebrew and Greek defaults select the payload-proven dictionary while
+       morphology retains Android's `Robinson` placeholder; and the emitted fragment advertises
+       Strong's from the same installed Bible metadata.
+     - Failure meaning: Automatic Search/prompt selection or reader output re-derives capabilities
+       independently from the payload-owned installed projection.
+     - Side effects: Copies two checked-in SQLite fixtures into an isolated temporary SWORD tree,
+       performs read-only discovery/content reads, and removes the tree in inherited teardown.
+     - Failure modes: Fixture installation, registry admission, or content rendering can throw or
+       fail closed and cause the corresponding assertion to fail.
+     */
+    func testInstalledMyBibleFeaturesDriveAutomaticReferencesAndFragmentMetadata() throws {
+        let modulePath = try makeTemporarySwordFixturePath()
+        let bibleInitials = "FeatureBible"
+        let dictionaryInitials = "FeatureDictionary"
+        try installMyBiblePackage(
+            initials: bibleInitials,
+            directoryName: "feature-bible",
+            in: modulePath
+        )
+        try installMyBibleAuxiliaryPackage(
+            initials: dictionaryInitials,
+            directoryName: "feature-dictionary",
+            fixtureName: "mybible-dictionary.SQLite3",
+            category: "Lexicons / Dictionaries",
+            in: modulePath
+        )
+
+        let manager = try XCTUnwrap(SwordManager(modulePath: modulePath))
+        let library = SQLiteDocumentModuleLibrary(
+            moduleRootURL: URL(fileURLWithPath: modulePath, isDirectory: true)
+        )
+        let resolver = BibleReaderInstalledModuleResolver(
+            swordManager: manager,
+            sqliteLibrary: library
+        )
+        let installed = resolver.registeredBookMetadata()
+        let bible = try XCTUnwrap(installed.first { $0.name == bibleInitials })
+        let dictionary = try XCTUnwrap(installed.first { $0.name == dictionaryInitials })
+
+        XCTAssertEqual(bible.version, "0.0")
+        XCTAssertTrue(bible.features.contains(.strongsNumbers))
+        XCTAssertTrue(bible.features.contains(.redLetterWords))
+        XCTAssertEqual(dictionary.version, "0.0")
+        XCTAssertTrue(dictionary.features.contains(.hebrewDef))
+        XCTAssertTrue(dictionary.features.contains(.greekDef))
+        XCTAssertFalse(dictionary.features.contains(.greekParse))
+
+        let strongsCandidates = SearchTranslationSelectionPolicy.candidateModules(
+            from: installed.filter { $0.category == .bible },
+            isStrongsFindAll: true
+        )
+        XCTAssertTrue(strongsCandidates.contains { $0.name == bibleInitials })
+
+        let environment = AIReaderReferenceEnvironmentResolver.resolve(
+            installedModules: installed,
+            excludedInitials: [],
+            indexedModule: { _ in false },
+            selectedStrongsHebrew: [],
+            selectedStrongsGreek: [],
+            selectedGreekMorphology: []
+        )
+        XCTAssertEqual(environment.preferredStrongsHebrew, dictionaryInitials)
+        XCTAssertEqual(environment.preferredStrongsGreek, dictionaryInitials)
+        XCTAssertEqual(environment.preferredGreekMorphology, "Robinson")
+
+        let source = try XCTUnwrap(resolver.scripture(named: bibleInitials))
+        let ordinal = try XCTUnwrap(
+            source.verseOrdinal(osisBookId: "Gen", chapter: 1, verse: 1)
+        )
+        let reference = try XCTUnwrap(source.verseReference(ordinal: ordinal))
+        let fragment = try XCTUnwrap(BibleReaderInstalledScriptureFragmentBuilder.build(
+            source: source,
+            references: [reference],
+            requiresCompleteContent: true
+        ))
+        XCTAssertTrue(fragment.hasStrongs)
+        XCTAssertEqual(fragment.bookInitials, bibleInitials)
+    }
+
+    /**
      Verifies downstream catalog consumers use SQLite's exact JSword KJVA ordinal domain.
 
      - Setup: Creates a non-SWORD catalog over the real Genesis row shape exposed by SQLite.

--- a/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleBookReader.swift
+++ b/Sources/SwordKit/Sources/SwordKit/InstalledMyBibleBookReader.swift
@@ -33,10 +33,11 @@ struct InstalledMyBibleBookRegistration: Sendable {
  Reads Android-compatible installed-book metadata from one MyBible sidecar module directory.
 
  Android's `SqliteVerseBackendState` derives identity from the actual database filename, reads
- `description` and `language` from the database `info` table, and classifies the payload by exact
- table names. The sidecar remains authoritative only for repository/version fields that the database
- does not carry. This reader deliberately performs no registration or collision handling; it emits
- ordered payload-owned values for `SwordManager` to admit against the combined installed registry.
+ `description`, `language`, and feature evidence from the database, classifies the payload by exact
+ table names, and emits the generated version `0.0`. The sidecar remains authoritative only for
+ repository/install provenance. This reader deliberately performs no registration or collision
+ handling; it emits ordered payload-owned values for `SwordManager` to admit against the combined
+ installed registry.
 
  Every SQLite handle is opened read-only, used on the calling thread, and closed before the call
  returns. The type owns no shared mutable state and is safe to call concurrently for different or
@@ -44,7 +45,7 @@ struct InstalledMyBibleBookRegistration: Sendable {
  */
 enum InstalledMyBibleBookReader {
     /**
-     Metadata read from the two Android `info` values and exact table-name classification.
+     Metadata read from Android's `info` values, content evidence, and exact table classification.
 
      This intermediate value prevents sidecar fields from accidentally replacing database-owned
      metadata before the final `ModuleInfo` is constructed. It has no behavior or side effects after
@@ -59,6 +60,9 @@ enum InstalledMyBibleBookReader {
 
         /// Category selected by exact table-name priority: verses, commentaries, then dictionary.
         let category: ModuleCategory
+
+        /// Independent Strong's-definition, Strong's-number, and Words-of-Christ capabilities.
+        let features: ModuleFeatures
     }
 
     /**
@@ -92,7 +96,7 @@ enum InstalledMyBibleBookReader {
 
      - Parameters:
        - payloadURL: Immediate SQLite/MyBible file whose basename and database own the book metadata.
-       - sidecar: Repository metadata supplying the installed version and source attribution.
+       - sidecar: Repository metadata supplying source attribution only.
      - Returns: A payload-owned registration, or `nil` when the file cannot prove the Android schema
        and metadata contract.
      - Side effects: Opens `payloadURL` with `SQLITE_OPEN_READONLY`, executes metadata-only queries,
@@ -132,7 +136,8 @@ enum InstalledMyBibleBookReader {
             category: metadata.category,
             language: metadata.language,
             moduleDriver: driver,
-            version: sidecar.version,
+            version: "0.0",
+            features: metadata.features,
             aboutMetadata: ModuleAboutMetadata(
                 versification: "KJVA",
                 osisId: initials,
@@ -148,11 +153,12 @@ enum InstalledMyBibleBookReader {
     }
 
     /**
-     Reads the Android-owned description, language, and content-table category from one database.
+     Reads Android-owned description, language, category, version-independent feature evidence.
 
      - Parameter database: Open read-only SQLite handle valid for the duration of this call.
      - Returns: Complete payload metadata when `info` is queryable and a recognized content table is
-       present; otherwise `nil`.
+       present; otherwise `nil`. Feature flags stay independent of category except that Android only
+       detects Words-of-Christ for Bible schemas.
      - Side effects: Prepares, steps, and finalizes read-only SQLite statements.
      - Failure modes: A missing/malformed `info` table, SQLite step error, or schema without `verses`,
        `commentaries`, or `dictionary` returns `nil`. Missing individual info rows use Android's
@@ -169,22 +175,112 @@ enum InstalledMyBibleBookReader {
             named: "language",
             defaultValue: "en",
             database: database
+        ), let strongsDefinitions = infoValue(
+            named: "is_strong",
+            defaultValue: "",
+            database: database
+        ), let strongsNumbers = infoValue(
+            named: "strong_numbers",
+            defaultValue: "",
+            database: database
         ), let tableNames = tableNames(in: database),
            let category = moduleCategory(for: tableNames) else {
             return nil
         }
+        var features: ModuleFeatures = []
+        if strongsDefinitions == "true" {
+            features.formUnion([.greekDef, .hebrewDef])
+        }
+        if strongsNumbers == "true" {
+            features.insert(.strongsNumbers)
+        }
+        if wordsOfChristAvailable(in: database, category: category) {
+            features.insert(.redLetterWords)
+        }
         return DatabaseMetadata(
             description: description,
             language: language,
-            category: category
+            category: category,
+            features: features
         )
+    }
+
+    /**
+     Detects Android's Words-of-Christ feature from exact info aliases or verse markup.
+
+     - Parameters:
+       - database: Open read-only SQLite handle.
+       - category: Payload category already proven from exact table names.
+     - Returns: `true` only for a Bible with a truthy Android metadata alias or at least one verse
+       containing a case-insensitive `<J>` marker.
+     - Side effects: Prepares, steps, and finalizes at most two read-only SQLite statements.
+     - Failure modes: Non-Bible categories and any prepare/step failure return `false`, matching
+       Android's caught `SQLiteException` path without rejecting otherwise readable metadata.
+     */
+    private static func wordsOfChristAvailable(
+        in database: OpaquePointer,
+        category: ModuleCategory
+    ) -> Bool {
+        guard category == .bible else { return false }
+
+        let flagSQL = """
+        SELECT value FROM info
+        WHERE name IN ('is_words_of_christ', 'words_of_christ', 'is_red_letter', 'red_letter')
+        """
+        var flagStatement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, flagSQL, -1, &flagStatement, nil) == SQLITE_OK,
+              let flagStatement else {
+            return false
+        }
+        var flagQuerySucceeded = false
+        while true {
+            switch sqlite3_step(flagStatement) {
+            case SQLITE_ROW:
+                let value = sqlite3_column_type(flagStatement, 0) == SQLITE_NULL
+                    ? nil
+                    : sqlite3_column_text(flagStatement, 0).map { String(cString: $0) }
+                if parseMyBibleBoolean(value) {
+                    sqlite3_finalize(flagStatement)
+                    return true
+                }
+            case SQLITE_DONE:
+                flagQuerySucceeded = true
+                sqlite3_finalize(flagStatement)
+                break
+            default:
+                sqlite3_finalize(flagStatement)
+                return false
+            }
+            if flagQuerySucceeded { break }
+        }
+
+        let verseSQL = "SELECT 1 FROM verses WHERE instr(lower(text), '<j>') > 0 LIMIT 1"
+        var verseStatement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, verseSQL, -1, &verseStatement, nil) == SQLITE_OK,
+              let verseStatement else {
+            return false
+        }
+        defer { sqlite3_finalize(verseStatement) }
+        return sqlite3_step(verseStatement) == SQLITE_ROW
+    }
+
+    /**
+     Parses the boolean forms Android accepts for Words-of-Christ aliases.
+
+     - Parameter value: Nullable SQLite text from one supported info row.
+     - Returns: `true` for case-insensitive `true` or exact `1`; `false` otherwise.
+     - Side effects: None.
+     - Failure modes: None; missing and unsupported values are false.
+     */
+    private static func parseMyBibleBoolean(_ value: String?) -> Bool {
+        value?.caseInsensitiveCompare("true") == .orderedSame || value == "1"
     }
 
     /**
      Reads the first exact-name value from Android's MyBible `info` table.
 
      - Parameters:
-       - name: Trusted fixed metadata key (`description` or `language`).
+       - name: Trusted exact metadata key for description, language, or a feature flag.
        - defaultValue: Android fallback returned for a missing row or SQL `NULL` value.
        - database: Open read-only SQLite handle.
      - Returns: Exact UTF-8 text, the supplied fallback for no value, or `nil` when preparation or

--- a/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
+++ b/Sources/SwordKit/Sources/SwordKit/ModuleInfo.swift
@@ -343,7 +343,8 @@ extension ModuleFeatures {
         if value.contains("Headings") || value.contains("OSISHeadings") {
             insert(.headings)
         }
-        if value.contains("RedLetterWords") || value.contains("OSISRedLetterWords") {
+        if value.contains("RedLetterWords") || value.contains("OSISRedLetterWords")
+            || value.contains("WordsOfChrist") {
             insert(.redLetterWords)
         }
         if value.contains("GreekDef") { insert(.greekDef) }

--- a/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
+++ b/Sources/SwordKit/Tests/SwordKitTests/SwordManagerTests.swift
@@ -1043,6 +1043,23 @@ final class SwordManagerTests: XCTestCase {
     }
 
     /**
+     Verifies restored Android MyBible configuration retains the Words-of-Christ capability.
+
+     - Setup: Projects Android's generated `Feature=WordsOfChrist` value through the shared SWORD
+       feature parser.
+     - Expected result: The reader-facing red-letter feature is present without inventing unrelated
+       Strong's or morphology flags.
+     - Side effects: None.
+     - Failure meaning: Android backup-restored MyBible Bibles lose the same capability that direct
+       package discovery reads from their payload.
+     */
+    func testWordsOfChristConfigFeatureMapsToRedLetterWords() {
+        let features = ModuleFeatures.fromConfigValues(["WordsOfChrist"])
+
+        XCTAssertEqual(features.rawValue, ModuleFeatures.redLetterWords.rawValue)
+    }
+
+    /**
      Verifies installed module rows retain Android `CommonUtils.showAbout` metadata from SWORD config.
 
      JSword reloads `SwordBookMetaData` before opening About and exposes fields such as `About`,
@@ -2993,6 +3010,135 @@ final class SwordManagerTests: XCTestCase {
     }
 
     /**
+     Verifies installed MyBible version and capability metadata comes only from Android's payload
+     evidence.
+
+     - Setup: Writes four package-owned databases: a Strong's Bible with `<J>` content, a Strong's
+       dictionary, a Words-of-Christ-info Bible, and a Bible with unsupported near-match flag
+       values. Every sidecar advertises a deliberately conflicting version.
+     - Expected result: Every installed row reports version `0.0`; exact Strong's flags remain
+       independent, Words-of-Christ is Bible-only and maps only to red-letter support, near-match
+       values stay disabled, and a fresh manager reproduces the same metadata.
+     - Side effects: Creates, opens read-only, and removes four isolated SQLite package fixtures.
+     - Failure meaning: Manifest provenance overrides Android's generated configuration, feature
+       inference depends on category, or cached inventory disagrees with a reopened manager.
+     */
+    func testInstalledMyBibleVersionAndFeaturesMatchAndroidPayloadEvidence() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let myBibleRoot = root.appendingPathComponent("mybible", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        /** Immutable payload evidence and exact feature oracle for one package fixture. */
+        struct Definition {
+            /// ASCII directory/payload stem whose Android initials remain deterministic.
+            let directory: String
+
+            /// Exact content-table family materialized in SQLite.
+            let category: ModuleCategory
+
+            /// Additional Android `info` rows that independently drive capabilities.
+            let infoValues: [(String, String)]
+
+            /// Optional Bible verse text used to exercise the `<J>` fallback.
+            let verseText: String?
+
+            /// Exact `ModuleFeatures` expected from the payload.
+            let expectedFeatures: ModuleFeatures
+        }
+        let definitions = [
+            Definition(
+                directory: "strong-bible",
+                category: .bible,
+                infoValues: [("strong_numbers", "true")],
+                verseText: "In the <J>beginning</J>",
+                expectedFeatures: [.strongsNumbers, .redLetterWords]
+            ),
+            Definition(
+                directory: "strong-dictionary",
+                category: .dictionary,
+                infoValues: [("is_strong", "true"), ("is_red_letter", "1")],
+                verseText: nil,
+                expectedFeatures: [.greekDef, .hebrewDef]
+            ),
+            Definition(
+                directory: "words-bible",
+                category: .bible,
+                infoValues: [("words_of_christ", "TrUe")],
+                verseText: "Plain verse",
+                expectedFeatures: [.redLetterWords]
+            ),
+            Definition(
+                directory: "near-match-bible",
+                category: .bible,
+                infoValues: [("is_strong", "TRUE"), ("strong_numbers", "1")],
+                verseText: "Plain verse",
+                expectedFeatures: []
+            ),
+        ]
+
+        for definition in definitions {
+            let directory = myBibleRoot.appendingPathComponent(
+                definition.directory,
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            let payloadName = "\(definition.directory).SQLite3"
+            let sidecar = InstalledMyBibleModule(
+                name: "Remote-\(definition.directory)",
+                description: "Manifest metadata",
+                category: definition.category.rawValue,
+                language: "zz",
+                version: "9999.0",
+                sourceName: "Fixture",
+                packageFileName: "\(payloadName).zip",
+                downloadURL: "https://example.invalid/\(payloadName).zip",
+                installedAt: Date(timeIntervalSince1970: 0)
+            )
+            try JSONEncoder().encode(sidecar).write(
+                to: directory.appendingPathComponent("module.json"),
+                options: .atomic
+            )
+            try makeInstalledMyBibleDatabase(
+                at: directory.appendingPathComponent(payloadName),
+                description: definition.directory,
+                language: "en",
+                category: definition.category,
+                infoValues: definition.infoValues,
+                verseText: definition.verseText
+            )
+        }
+
+        let expected = Dictionary(uniqueKeysWithValues: definitions.map {
+            ("MyBible-\($0.directory.replacingOccurrences(of: "-", with: "_"))", $0)
+        })
+        let firstManager = try XCTUnwrap(SwordManager(modulePath: root.path))
+        let firstRows = firstManager.installedModules().filter { expected[$0.name] != nil }
+        XCTAssertEqual(firstRows.count, definitions.count)
+        for row in firstRows {
+            let definition = try XCTUnwrap(expected[row.name])
+            XCTAssertEqual(row.version, "0.0", row.name)
+            XCTAssertEqual(row.features.rawValue, definition.expectedFeatures.rawValue, row.name)
+        }
+
+        let reopenedManager = try XCTUnwrap(SwordManager(modulePath: root.path))
+        let reopened = Dictionary(uniqueKeysWithValues: reopenedManager.installedModules()
+            .filter { expected[$0.name] != nil }
+            .map { ($0.name, ($0.version, $0.features.rawValue)) })
+        XCTAssertEqual(
+            reopened.mapValues { $0.0 },
+            Dictionary(uniqueKeysWithValues: expected.keys.map { ($0, "0.0") })
+        )
+        XCTAssertEqual(
+            reopened.mapValues { $0.1 },
+            Dictionary(uniqueKeysWithValues: expected.map { ($0.key, $0.value.expectedFeatures.rawValue) })
+        )
+    }
+
+    /**
      Verifies stale MyBible sidecar metadata does not produce an installed-book row.
 
      Android's MyBible import only adds a book when the SQLite payload can be opened. iOS should not
@@ -3227,6 +3373,8 @@ final class SwordManagerTests: XCTestCase {
        - description: Value stored under `info.description`.
        - language: Value stored under `info.language`.
        - category: Bible, commentary, or dictionary content table to materialize.
+       - infoValues: Additional exact `info` rows used by feature-projection tests.
+       - verseText: Optional single Bible verse used to exercise content-derived capabilities.
      - Side effects: Creates and writes one SQLite database at `databaseURL`.
      - Failure modes: Throws for unsupported categories or SQLite open/write failures.
      */
@@ -3234,7 +3382,9 @@ final class SwordManagerTests: XCTestCase {
         at databaseURL: URL,
         description: String,
         language: String,
-        category: ModuleCategory
+        category: ModuleCategory,
+        infoValues: [(String, String)] = [],
+        verseText: String? = nil
     ) throws {
         let contentTable: String
         switch category {
@@ -3260,14 +3410,36 @@ final class SwordManagerTests: XCTestCase {
         }
         defer { sqlite3_close(database) }
 
-        let escapedDescription = description.replacingOccurrences(of: "'", with: "''")
-        let escapedLanguage = language.replacingOccurrences(of: "'", with: "''")
-        let sql = """
-        CREATE TABLE info (name TEXT PRIMARY KEY, value TEXT);
-        INSERT INTO info (name, value) VALUES ('description', '\(escapedDescription)');
-        INSERT INTO info (name, value) VALUES ('language', '\(escapedLanguage)');
-        CREATE TABLE \(contentTable) (fixture_id INTEGER);
-        """
+        /**
+         Escapes one trusted fixture value for the generated SQLite statement batch.
+
+         - Parameter value: Exact test metadata or verse content to encode as a SQL string literal.
+         - Returns: The same value with apostrophes doubled for SQLite literal syntax.
+         - Side effects: None.
+         - Failure modes: None; fixture values are valid Swift strings and no SQL is executed here.
+         */
+        func sqlLiteral(_ value: String) -> String {
+            value.replacingOccurrences(of: "'", with: "''")
+        }
+        var statements = [
+            "CREATE TABLE info (name TEXT PRIMARY KEY, value TEXT)",
+            "INSERT INTO info (name, value) VALUES ('description', '\(sqlLiteral(description))')",
+            "INSERT INTO info (name, value) VALUES ('language', '\(sqlLiteral(language))')",
+        ]
+        statements.append(contentsOf: infoValues.map {
+            "INSERT INTO info (name, value) VALUES ('\(sqlLiteral($0.0))', '\(sqlLiteral($0.1))')"
+        })
+        if category == .bible {
+            statements.append("CREATE TABLE verses (fixture_id INTEGER, text TEXT)")
+            if let verseText {
+                statements.append(
+                    "INSERT INTO verses (fixture_id, text) VALUES (1, '\(sqlLiteral(verseText))')"
+                )
+            }
+        } else {
+            statements.append("CREATE TABLE \(contentTable) (fixture_id INTEGER)")
+        }
+        let sql = statements.joined(separator: ";\n") + ";"
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw SwordManagerMyBibleFixtureError.writeFailed
         }


### PR DESCRIPTION
## Summary

Align installed MyBible version and feature metadata with the current Android implementation. The installed-book projection now derives version and capabilities from SQLite payload evidence, so Search, AI reference defaults, and reader output consume one consistent source of truth.

## Scope

- Installed package-owned MyBible metadata projection.
- Restored Android `Feature=WordsOfChrist` parsing.
- Physical SQLite and runtime integration coverage for downstream consumers.
- No compatibility fallback, migration path, UI redesign, or unrelated module-discovery change.

## Contract references

- Android `MyBibleBook`: generated `Version=0.0`.
- Android exact `is_strong == "true"` mapping to Greek/Hebrew definitions.
- Android exact `strong_numbers == "true"` mapping to OSIS Strong's support.
- Android Bible-only Words-of-Christ detection from accepted info aliases or `<J>` content.

## Change details

- Read Strong's-definition, Strong's-number, and Words-of-Christ evidence from the installed SQLite payload.
- Emit installed version `0.0`; sidecar metadata remains install/repository provenance only.
- Map Android's generated `WordsOfChrist` config feature to reader red-letter support.
- Verify a fresh manager reproduces the same projection and automatic Search/AI/reader consumers agree.

## Validation evidence

- SwordKitTests: 274 passed, 0 failed.
- BibleCoreTests: 968 passed, 0 failed.
- BibleUITests: 992 passed, 0 failed.
- AndBible Debug iOS Simulator build succeeded.
- Repository docblock guard: 805/805 tracked Swift files.
- Static source guards and `git diff --check`: passed.
- GitNexus post-edit result: 4 files, 37 symbols, 0 affected processes, low risk.

## Risks and follow-ups

- This PR intentionally removes sidecar version authority for installed MyBible books to match Android; there is no retained legacy behavior.
- The PR is stacked on `fix/mybible-catalog-identity` and should be reviewed/merged after its base.
- No additional follow-up is required for issue #401.

Closes #401
